### PR TITLE
Fixes: mysql_ extension still supported until PHP 5.4

### DIFF
--- a/Sniffs/PHP/RemovedExtensionsSniff.php
+++ b/Sniffs/PHP/RemovedExtensionsSniff.php
@@ -184,11 +184,11 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff implements PHP_CodeSnif
                 'alternative' => null
         ),
         'mysql_' => array(
-                '5.0' => 0,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
+                '5.0' => 1,
+                '5.1' => 1,
+                '5.2' => 1,
+                '5.3' => 1,
+                '5.4' => 1,
                 '5.5' => -1,
                 'alternative' => 'mysqli',
         ),


### PR DESCRIPTION
Sorry, I was not aware that opening a pull request also opened an issue. So I'm keeping this one (#9) and deleting the previous one (#8):

See: http://www.php.net/manual/en/intro.mysql.php. mysql_ is only "deprecated" since 5.5 It works perfectly well in 5.0 .. 5.4. So there is a bug in the array in Sniffs/PHP/RemovedExtensionsSniff.php. Should read:

``` php
        'mysql_' => array(
                '5.0' => 1,
                '5.1' => 1,
                '5.2' => 1,
                '5.3' => 1,
                '5.4' => 1,
                '5.5' => -1,
                'alternative' => 'mysqli',
        ),
```

instead of

``` php
        'mysql_' => array(
                '5.0' => 0,
                '5.1' => 0,
                '5.2' => 0,
                '5.3' => 0,
                '5.4' => 0,
                '5.5' => -1,
                'alternative' => 'mysqli',
        ),
```
