### PR TITLE
Don't fail namespaces with names matching deprecated functions

### DIFF
--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -258,6 +258,8 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends Generic_Sniff
                 T_OBJECT_OPERATOR,
                 T_FUNCTION,
                 T_CONST,
+                T_USE,
+                T_NS_SEPARATOR,
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);


### PR DESCRIPTION
Fixes warnings for deprecated functions in the following examples (not limited to):

``` php
use \DL\App;
use DL\App;
```

Warning thrown:
"The use of function dl is discouraged in PHP version 5.3 and discouraged in PHP version 5.4 and discouraged in PHP version 5.5"
