### PR TITLE
phpcs is listed on packagist, no vcs entry needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,7 @@ on the sniffs, the following installation steps are required.
             "require": {
                 "phpunit/phpunit": "3.7.*",
                 "squizlabs/php_codesniffer": "dev-master"
-            },
-            "repositories": [
-                {
-                    "type": "vcs",
-                    "url": "https://github.com/squizlabs/PHP_CodeSniffer.git"
-                }
-            ]
+            }
         }
 
 2. Run the following command to compose in the versions indicated in the above


### PR DESCRIPTION
No vcs-entry needed for composer.json: phpcs is listed on [packagist.org](https://packagist.org/packages/squizlabs/php_codesniffer).

Question on this: why did you not list your standard on packagist.org?
That way you can extend reach and phpcs can call sniffs/ standards from path anyway.
