### PR TITLE
Fixing php_codesniffer dependency to depend on a stable version instead of dev-master

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installation
 * Install [PHP_CodeSniffer](http://pear.php.net/PHP_CodeSniffer) with `pear install PHP_CodeSniffer` (PHP_CodeSniffer 1.47 or later is required for full support, notices may be thrown on older versions).
 * Checkout this repository as `PHPCompatibility` into the `PHP/CodeSniffer/Standards` directory.
 * Use the coding standard with `phpcs --standard=PHPCompatibility`
-* You can specify which PHP version you want to test against by specifying `--runtime-set testVersion 5.5` - note that this requires PHP_CodeSniffer from the Github master branch. This feature will be in the next official PHP_CodeSniffer release.
+* You can specify which PHP version you want to test against by specifying `--runtime-set testVersion 5.5`.
 
 More information can be found on Wim Godden's [blog](http://techblog.wimgodden.be/tag/codesniffer).
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "require" : {
     "php" : ">=5.1.2",
     "ext-tokenizer" : "*",
-    "squizlabs/php_codesniffer" : "~1.5.1",
+    "squizlabs/php_codesniffer" : ">=1.5.1,<2.0",
     "simplyadmire/composer-plugins" : "@dev"
   },
   "authors" : [ {


### PR DESCRIPTION
1.5.1 was released that has the required feature. Would be nice to be based on stable instead of dev-master.
