### PR TITLE
packagist compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name" : "wimg/PHPCompatibility",
+  "name" : "wimg/php-compatibility",
   "description" : "This is a set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
   "require" : {
     "php" : ">=5.1.2",


### PR DESCRIPTION
The package name wimg/PHPCompatibility is invalid, it should not contain uppercase characters. We suggest using wimg/php-compatibility instead.
