### PR TITLE
PHP 7.1: New sniff to detect short list syntax for symmetric array destructuring

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/ShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ShortListSniff.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\Lists\ShortListSniff.
+ *
+ * PHP version 7.1
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\Lists;
+
+use PHPCompatibility\Sniff;
+
+/**
+ * \PHPCompatibility\Sniffs\Lists\ShortListSniff.
+ *
+ * "The shorthand array syntax ([]) may now be used to destructure arrays for
+ * assignments (including within foreach), as an alternative to the existing
+ * list() syntax, which is still supported."
+ *
+ * PHP version 7.1
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ShortListSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_OPEN_SHORT_ARRAY);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.0') === false) {
+            return;
+        }
+
+        if ($this->isShortList($phpcsFile, $stackPtr) === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $closer = $tokens[$stackPtr]['bracket_closer'];
+
+        $hasVariable = $phpcsFile->findNext(T_VARIABLE, ($stackPtr + 1), $closer);
+        if ($hasVariable === false) {
+            // List syntax is only valid if there are variables in it.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'The shorthand list syntax "[]" to destructure arrays is not available in PHP 7.0 or earlier.',
+            $stackPtr,
+            'Found'
+        );
+
+        return ($closer + 1);
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/Lists/ShortListSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/Lists/ShortListSniffTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHP 7.1 symmetric array destructuring sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\Lists;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * PHP 7.1 symmetric array destructuring sniff test file.
+ *
+ * @group shortList
+ * @group listAssignments
+ *
+ * @covers \PHPCompatibility\Sniffs\Lists\ShortListSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ShortListSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'Sniffs/Lists/ShortListTestCases.inc';
+
+    /**
+     * testShortList
+     *
+     * @dataProvider dataShortList
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testShortList($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'The shorthand list syntax "[]" to destructure arrays is not available in PHP 7.0 or earlier.');
+    }
+
+    /**
+     * dataShortList
+     *
+     * @see testShortList()
+     *
+     * @return array
+     */
+    public function dataShortList()
+    {
+        return array(
+            array(17),
+            array(18),
+            array(19),
+            array(21),
+            array(23),
+            array(25), // x2.
+            array(28),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number with a valid list assignment.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataNoFalsePositives
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(6),
+            array(8),
+            array(10),
+            array(12),
+            array(31),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/Sniffs/Lists/ShortListTestCases.inc
+++ b/PHPCompatibility/Tests/Sniffs/Lists/ShortListTestCases.inc
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Valid cross-version.
+ */
+list($id1, $name1) = $data[0];
+
+foreach ($data as list($id, $name)) {}
+
+list($a, list($b, $c)) = array(1, array(2, 3));
+
+list($foo, $bar) = list($baz, $bat) = [$a, $b];
+
+/*
+ * PHP 7.1: symmetric array destructuring.
+ */
+[$id1, $name1] = $data[0];
+[$a, $b, $c] = [1, 2 => 'x', 'z' => 'c'];
+[$a, [$b]] = array(new stdclass, array(new stdclass));
+
+foreach ($data as [$id, $name]) {}
+
+[[$a, $b], [$c, $d]] = [[1, 2], [3, 4]];
+
+[$foo, $bar] = [$baz, $bat] = [$a, $b];
+
+// Mixing long and short list syntax. Parse error, but that's not our concern.
+[list($a, $b), list($c, $d)] = [[1, 2], [3, 4]];
+
+// List does not contain variables.
+[42] = [1];


### PR DESCRIPTION
:warning: **DO NOT MERGE YET. This PR is targeted at v 9.0.0** :warning: 

----

> The shorthand array syntax ([]) may now be used to destructure arrays for assignments (including within foreach), as an alternative to the existing list() syntax, which is still supported.

Refs:
* http://php.net/manual/en/migration71.new-features.php#migration71.new-features.symmetric-array-destructuring
* https://wiki.php.net/rfc/short_list_syntax
* https://github.com/php/php-src/commit/4f077aee836ad7d8335cf62629a8364bdf939db9

Fixes #248