### PR TITLE
PHP 7.1: New sniff to detect keys in list()

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\Lists\NewKeyedListSniff.
+ *
+ * PHP version 7.1
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\Lists;
+
+use PHPCompatibility\Sniff;
+
+/**
+ * \PHPCompatibility\Sniffs\Lists\NewKeyedListSniff.
+ *
+ * "You can now specify keys in list(), or its new shorthand [] syntax. "
+ *
+ * PHP version 7.1
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewKeyedListSniff extends Sniff
+{
+    /**
+     * Tokens which represent the start of a list construct.
+     *
+     * @var array
+     */
+    protected $sniffTargets =  array(
+        T_LIST             => T_LIST,
+        T_OPEN_SHORT_ARRAY => T_OPEN_SHORT_ARRAY,
+    );
+
+    /**
+     * The token(s) within the list construct which is being targeted.
+     *
+     * @var array
+     */
+    protected $targetsInList = array(
+        T_DOUBLE_ARROW => T_DOUBLE_ARROW,
+    );
+
+    /**
+     * All tokens needed to walk through the list construct and
+     * determine whether the target token is contained within.
+     *
+     * Set by the setUpAllTargets() method which is called from within register().
+     *
+     * @var array
+     */
+    protected $allTargets;
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $this->setUpAllTargets();
+
+        return $this->sniffTargets;
+    }
+
+    /**
+     * Prepare the $allTargets array only once.
+     *
+     * @return array
+     */
+    public function setUpAllTargets()
+    {
+        $this->allTargets = $this->sniffTargets + $this->targetsInList;
+    }
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('7.0') === false);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->bowOutEarly() === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY
+            && $this->isShortList($phpcsFile, $stackPtr) === false
+        ) {
+            // Short array, not short list.
+            return;
+        }
+
+        if ($tokens[$stackPtr]['code'] === T_LIST) {
+            $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($nextNonEmpty === false
+                || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS
+                || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
+            ) {
+                // Parse error or live coding.
+                return;
+            }
+
+            $opener = $nextNonEmpty;
+            $closer = $tokens[$nextNonEmpty]['parenthesis_closer'];
+        } else {
+            // Short list syntax.
+            $opener = $stackPtr;
+
+            if (isset($tokens[$stackPtr]['bracket_closer'])) {
+                $closer = $tokens[$stackPtr]['bracket_closer'];
+            }
+        }
+
+        if (isset($opener, $closer) === false) {
+            return;
+        }
+
+        $this->examineList($phpcsFile, $opener, $closer);
+    }
+
+
+    /**
+     * Examine the contents of a list construct to determine whether an error needs to be thrown.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $opener    The position of the list open token.
+     * @param int                   $closer    The position of the list close token.
+     *
+     * @return void
+     */
+    protected function examineList(\PHP_CodeSniffer_File $phpcsFile, $opener, $closer)
+    {
+        $start = $opener;
+        while (($start = $this->hasTargetInList($phpcsFile, $start, $closer)) !== false) {
+            $phpcsFile->addError(
+                'Specifying keys in list constructs is not supported in PHP 7.0 or earlier.',
+                $start,
+                'Found'
+            );
+        }
+    }
+
+
+    /**
+     * Check whether a certain target token exists within a list construct.
+     *
+     * Skips past nested list constructs, so these can be examined based on their own token.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $start     The position of the list open token or a token
+     *                                         within the list to start (resume) the examination from.
+     * @param int                   $closer    The position of the list close token.
+     *
+     * @return int|bool Stack pointer to the target token if encountered. False otherwise.
+     */
+    protected function hasTargetInList(\PHP_CodeSniffer_File $phpcsFile, $start, $closer)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = ($start + 1); $i < $closer; $i++) {
+            if (isset($this->allTargets[$tokens[$i]['code']]) === false) {
+                continue;
+            }
+
+            if (isset($this->targetsInList[$tokens[$i]['code']]) === true) {
+                return $i;
+            }
+
+            // Skip past nested list constructs.
+            if ($tokens[$i]['code'] === T_LIST) {
+                $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($i + 1), null, true);
+                if ($nextNonEmpty !== false
+                    && $tokens[$nextNonEmpty]['code'] === T_OPEN_PARENTHESIS
+                    && isset($tokens[$nextNonEmpty]['parenthesis_closer']) === true
+                ) {
+                    $i = $tokens[$nextNonEmpty]['parenthesis_closer'];
+                }
+            } elseif ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY
+                && isset($tokens[$i]['bracket_closer'])
+            ) {
+                $i = $tokens[$i]['bracket_closer'];
+            }
+        }
+
+        return false;
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/Lists/NewKeyedListSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/Lists/NewKeyedListSniffTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * PHP 7.1 keyed lists sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\Lists;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * PHP 7.1 keyed lists sniff test file.
+ *
+ * @group newKeyedList
+ * @group listAssignments
+ *
+ * @covers \PHPCompatibility\Sniffs\Lists\NewKeyedListSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewKeyedListSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'Sniffs/Lists/NewKeyedListTestCases.inc';
+
+    /**
+     * testNewKeyedList
+     *
+     * @dataProvider dataNewKeyedList
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testNewKeyedList($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'Specifying keys in list constructs is not supported in PHP 7.0 or earlier.');
+    }
+
+    /**
+     * dataNewKeyedList
+     *
+     * @see testNewKeyedList()
+     *
+     * @return array
+     */
+    public function dataNewKeyedList()
+    {
+        return array(
+            array(15), // x3.
+            array(16), // x2.
+            array(17), // x2.
+            array(18),
+            array(19), // x2.
+            array(20), // x2.
+            array(22), // x3.
+            array(23), // x2.
+            array(28),
+            array(29),
+            array(30),
+            array(31),
+            array(36), // x2.
+            array(37), // x2.
+            array(41), // x2.
+            array(42), // x2.
+            array(46),
+            array(48),
+            array(58),
+            array(62),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number with a valid list assignment.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataNoFalsePositives
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(6),
+            array(8),
+            array(10),
+            array(27),
+            array(35),
+            array(40),
+            array(45),
+            array(47),
+            array(49),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/Sniffs/Lists/NewKeyedListTestCases.inc
+++ b/PHPCompatibility/Tests/Sniffs/Lists/NewKeyedListTestCases.inc
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Valid cross-version.
+ */
+list($id1, $name1) = $data[0];
+
+foreach ($data as list($id, $name)) {}
+
+list($a, list($b, $c)) = array(1, array(2, 3));
+
+/*
+ * PHP 7.1: support for keys in list().
+ */
+list(1 => $oneBit, 2 => $twoBit, 3 => $threeBit) = $powersOfTwo;
+list("id" => $id1, "name" => $name1) = $data[0];
+["id" => $id1, "name" => $name1] = $data[0];
+[$foo => $bar] = $bar;
+list(7 => $seven, "elePHPant" => $elePHPant) = $contrivedMixedKeyTypesExample;
+list((string)$a => $store["B"], (string)$c => $store["D"]) = $e->getIndexable();
+
+foreach ($data as list("id" => $id, "name" => $name)) {}
+foreach ($data as ['id' => $id, 'name' => $name]) {}
+
+// Test multi-line handling.
+// Test with trailing comma in list(). Turns out this has been allowed since forever.
+        list(
+            "name" => $this->name,
+            "colour" => $this->colour,
+            "age" => $this->age,
+            "cuteness" => $this->cuteness,
+        ) = $attributes;
+
+// Test detecting nested keyed lists and throwing the error at the correct line.
+list(
+	list("x" => $x1, "y" => $y1),
+	list("x" => $x2, "y" => $y2)
+) = $points;
+
+[
+	["x" => $x1, "y" => $y1],
+	["x" => $x2, "y" => $y2],
+] = $points;
+
+list(
+	'a' => 
+		list($x1, $y1),
+	'b' =>
+		list($x2, $y2),
+) = $points;
+
+/*
+ * Invalid syntaxes.
+ */
+
+// Mixed keyed and unkeyed.
+// Parse error, but not our concern, throw an error anyway for the key found.
+list($unkeyed, "key" => $keyed) = $array;
+
+// Empty elements are not allowed where keys are specified.
+// Parse error, but not our concern, throw an error anyway for the key found.
+list(,,,, "key" => $keyed) = $array;


### PR DESCRIPTION
> Support for keys in list()
>
> You can now specify keys in `list()`, or its new shorthand `[]` syntax. This enables destructuring of arrays with non-integer or non-sequential keys.

Refs:
* http://php.net/manual/en/migration71.new-features.php#migration71.new-features.support-for-keys-in-list
* https://wiki.php.net/rfc/list_keys
* https://github.com/php/php-src/commit/37c8bb58686b2d86f145ebe4fe39854f5951dcd7

Notes:
* An error will be thrown for each double arrow encountered. The error will be linked to the double arrow token to provide the closest indication of where the list key was found.
* The sniff has been set up to allow for easily extending it to re-use the logic to a) determine the open/close tokens and b) to check within a list construct.
    I already have another sniff lined up which needs the same logic.
* Includes extensive unit tests.

Fixes #252