### PR TITLE
PHP 7.0: New sniff to detect list()s affected by the assignment order change

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\Lists\AssignmentOrderSniff.
+ *
+ * PHP version 7.0
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\Lists;
+
+use PHPCompatibility\Sniff;
+
+/**
+ * List assignment order.
+ *
+ * The list() construct no longer assigns variables in reverse order.
+ * This affects all list constructs where non-unique variables are used.
+ *
+ * PHP version 7.0
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class AssignmentOrderSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            T_LIST,
+            T_OPEN_SHORT_ARRAY,
+        );
+    }
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void|int Void if not a valid list. If a list construct has been
+     *                  examined, the stack pointer to the list closer to skip
+     *                  passed any nested lists which don't need to be examined again.
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.0') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY
+            && $this->isShortList($phpcsFile, $stackPtr) === false
+        ) {
+            // Short array, not short list.
+            return;
+        }
+
+        if ($tokens[$stackPtr]['code'] === T_LIST) {
+            $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($nextNonEmpty === false
+                || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS
+                || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
+            ) {
+                // Parse error or live coding.
+                return;
+            }
+
+            $opener = $nextNonEmpty;
+            $closer = $tokens[$nextNonEmpty]['parenthesis_closer'];
+        } else {
+            // Short list syntax.
+            $opener = $stackPtr;
+
+            if (isset($tokens[$stackPtr]['bracket_closer'])) {
+                $closer = $tokens[$stackPtr]['bracket_closer'];
+            }
+        }
+
+        if (isset($opener, $closer) === false) {
+            return;
+        }
+
+        /*
+         * OK, so we have the opener & closer, now we need to check all the variables in the
+         * list() to see if there are duplicates as that's the problem.
+         */
+        $hasVars = $phpcsFile->findNext(array(T_VARIABLE, T_DOLLAR), ($opener + 1), $closer);
+        if ($hasVars === false) {
+            // Empty list, not our concern.
+            return ($closer + 1);
+        }
+
+        // Set the variable delimiters based on the list type being examined.
+        $stopPoints = array(T_COMMA);
+        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
+            $stopPoints[] = T_CLOSE_SHORT_ARRAY;
+        } else {
+            $stopPoints[] = T_CLOSE_PARENTHESIS;
+        }
+
+        $listVars      = array();
+        $lastStopPoint = $opener;
+
+        /*
+         * Create a list of all variables used within the `list()` construct.
+         * We're not concerned with whether these are nested or not, as any duplicate
+         * variable name used will be problematic, independent of nesting.
+         */
+        do {
+            $nextStopPoint = $phpcsFile->findNext($stopPoints, ($lastStopPoint + 1), $closer);
+            if ($nextStopPoint === false) {
+                $nextStopPoint = $closer;
+            }
+
+            // Also detect this in PHP 7.1 keyed lists.
+            $hasDoubleArrow = $phpcsFile->findNext(T_DOUBLE_ARROW, ($lastStopPoint + 1), $nextStopPoint);
+            if ($hasDoubleArrow !== false) {
+                $lastStopPoint = $hasDoubleArrow;
+            }
+
+            // Find the start of the variable, allowing for variable variables.
+            $nextStartPoint = $phpcsFile->findNext(array(T_VARIABLE, T_DOLLAR), ($lastStopPoint + 1), $nextStopPoint);
+            if ($nextStartPoint === false) {
+                // Skip past empty bits in the list, i.e. `list( $a, , ,)`.
+                $lastStopPoint = $nextStopPoint;
+                continue;
+            }
+
+            /*
+             * Gather the content of all non-empty tokens to determine the "variable name".
+             * Variable name in this context includes array or object property syntaxes, such
+             * as `$a['name']` and `$b->property`.
+             */
+            $varContent = '';
+
+            for ($i = $nextStartPoint; $i < $nextStopPoint; $i++) {
+                if (isset(\PHP_CodeSniffer_Tokens::$emptyTokens[$tokens[$i]['code']])) {
+                    continue;
+                }
+
+                $varContent .= $tokens[$i]['content'];
+            }
+
+            if ($varContent !== '') {
+                $listVars[] = $varContent;
+            }
+
+            $lastStopPoint = $nextStopPoint;
+
+        } while ($lastStopPoint < $closer);
+
+        if (empty($listVars)) {
+            // Shouldn't be possible, but just in case.
+            return ($closer + 1);
+        }
+
+        // Verify that all variables used in the list() construct are unique.
+        if (count($listVars) !== count(array_unique($listVars))) {
+            $phpcsFile->addError(
+                'list() will assign variable from left-to-right since PHP 7.0. Ensure all variables in list() are unique to prevent unexpected results.',
+                $stackPtr,
+                'Affected'
+            );
+        }
+
+        return ($closer + 1);
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/Lists/AssignmentOrderUnitTest.inc
+++ b/PHPCompatibility/Tests/Sniffs/Lists/AssignmentOrderUnitTest.inc
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Same behaviour cross-version.
+ */
+list($id, $name) = $data;
+
+foreach ($data as list($id, $name)) {}
+
+list($a, list($b, $c)) = array(1, array(2, 3));
+
+list( , , , ) = $data; // Empty list, not our concern and no variables to examine anyway.
+
+/*
+ * PHP 7.0: list() no longer assigns variables in reverse order.
+ */
+list($a[], $a[], $a[]) = [1, 2, 3];
+list($a[], $a[0], $a[]) = [1, 2, 3];
+list($a, $b, $a) = [1, 2, 3];
+[$a->propA, $a->propB, $a      ->     propA] = [1, 2, 3];
+
+list($a, list($b, $a)) = array(1, array(2, 3));
+
+list(list($a, $b), list($b, $a)) = array(array(10, 11), array(2, 3));
+
+// Also detect this in short list syntax.
+[$a[], $a[], $a[]] = [1, 2, 3];
+[$a[], $a[0], $a [ ] ] = [1, 2, 3];
+[$a, $b, $a] = [1, 2, 3];
+[$a->propA, $a->propB, $a->propA] = [1, 2, 3];
+
+[$a, [$b, $a]] = array(1, array(2, 3));
+
+[[$a, $b], [$b, $a]] = array(array(10, 11), array(2, 3));
+
+// Also detect this in keyed lists.
+list('name' => $a, 'id' => $b, 'field' => $a) = ['name' => 1, 'id' => 2, 'field' => 3];
+['name' => $a, 'id' => $b, 'field' => $a] = ['name' => 1, 'id' => 2, 'field' => 3];
+
+// Don't get confused with variable keys.
+list($foo => $a, $bar => $b, 'field' => $c) = ['name' => 1, 'id' => 2, 'field' => 3];
+list($b => $a, $a => $b, 'field' => $c) = ['name' => 1, 'id' => 2, 'field' => 3];
+
+// Don't get confused when some of the entries are empty.
+list( , $a, , $b, , $a, ,) = array[1, 2, 3, 4, 5, 6, 7, 8];

--- a/PHPCompatibility/Tests/Sniffs/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Sniffs/Lists/AssignmentOrderUnitTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * PHP 7.0 assignment order change sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\Lists;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * PHP 7.0 assignment order change sniff test file.
+ *
+ * @group assignmentOrder
+ * @group lists
+ *
+ * @covers \PHPCompatibility\Sniffs\Lists\AssignmentOrderSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class AssignmentOrderUnitTest extends BaseSniffTest
+{
+    const TEST_FILE = 'Sniffs/Lists/AssignmentOrderUnitTest.inc';
+
+    /**
+     * testAssignmentOrder
+     *
+     * @dataProvider dataAssignmentOrder
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testAssignmentOrder($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'list() will assign variable from left-to-right since PHP 7.0. Ensure all variables in list() are unique to prevent unexpected results.');
+    }
+
+    /**
+     * dataAssignmentOrder
+     *
+     * @see testAssignmentOrder()
+     *
+     * @return array
+     */
+    public function dataAssignmentOrder()
+    {
+        return array(
+            array(17),
+            array(18),
+            array(19),
+            array(20),
+            array(22),
+            array(24),
+            array(27),
+            array(28),
+            array(29),
+            array(30),
+            array(32),
+            array(34),
+            array(37),
+            array(38),
+            array(45),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number with a valid list assignment.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataNoFalsePositives
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(6),
+            array(8),
+            array(10),
+            array(12),
+            array(41),
+            array(42),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
>  `list()` no longer assigns variables in reverse order
>
> `list()` will now assign values to variables in the order they are defined, rather than reverse order. In general, this only affects the case where `list()` is being used in conjunction with the array [] operator

Refs:
* http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.list.order
* https://wiki.php.net/rfc/abstract_syntax_tree#changes_to_list
* http://php.net/manual/en/function.list.php

**Note:** in contrast to the changelog entry, this actually affects all lists which use the same variable twice in the `list()` construct, so that is the premise the sniff has been based on now.
See: https://3v4l.org/LpUl6

**Open question:**
I've set the sniff up now to throw an error if non-unique list variables are found and PHP 7.0 or higher is supported.
It could be argued that this sniff should always throw an error when non-unique list variables are encountered as this will make the resulting variable values unpredictable.
It could also be argued that the sniff should only throw an error if the `testVersion` contains both PHP 5.x as well as 7.x. I.e. no error when only PHP 5 is supported and no error when only PHP 7 is supported, but an error when 5.5-7.2 is supported.

Opinions ?