### PR TITLE
PHP 5.5: New sniff to detect unpacking nested arrays with list in foreach

### DIFF
--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\ControlStructures\NewListInForeachSniff.
+ *
+ * PHP version 5.5
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\ControlStructures;
+
+use PHPCompatibility\Sniff;
+
+/**
+ * Detect unpacking nested arrays with list() in a foreach().
+ *
+ * PHP version 5.5
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewListInForeachSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_FOREACH);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {
+            return;
+        }
+
+        $opener = $tokens[$stackPtr]['parenthesis_opener'];
+        $closer = $tokens[$stackPtr]['parenthesis_closer'];
+
+        $asToken = $phpcsFile->findNext(T_AS, ($opener + 1), $closer);
+        if ($asToken === false) {
+            return;
+        }
+
+        $hasList = $phpcsFile->findNext(array(T_LIST, T_OPEN_SHORT_ARRAY), ($asToken + 1), $closer);
+        if ($hasList === false) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Unpacking nested arrays with list() in a foreach is not supported in PHP 5.4 or earlier.',
+            $hasList,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/ControlStructures/NewListInForeachUnitTest.inc
+++ b/PHPCompatibility/Tests/Sniffs/ControlStructures/NewListInForeachUnitTest.inc
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Valid cross-version.
+ */
+foreach ([1, 2, 3, 4, 5] as $user) {
+	list($id, $name) = $user;
+}
+
+
+/*
+ * PHP 5.5: support for unpacking nested arrays with list() in foreach.
+ */
+foreach ($data as list($id, $name)) {}
+
+// Make sure it's also detected when using PHP 7.1 syntax.
+foreach ( $data as [ $id, $name ] ) {}
+foreach ($data as list("id" => $id, "name" => $name)) {}
+foreach ($data as ['id' => $id, 'name' => $name]) {}

--- a/PHPCompatibility/Tests/Sniffs/ControlStructures/NewListInForeachUnitTest.php
+++ b/PHPCompatibility/Tests/Sniffs/ControlStructures/NewListInForeachUnitTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * PHP 5.5 list() in foreach sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * PHP 5.5 list() in foreach sniff test file.
+ *
+ * @group newListInForeach
+ * @group controlStructures
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\NewListInForeachSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewListInForeachUnitTest extends BaseSniffTest
+{
+    const TEST_FILE = 'Sniffs/ControlStructures/NewListInForeachUnitTest.inc';
+
+    /**
+     * testNewListInForeach
+     *
+     * @dataProvider dataNewListInForeach
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testNewListInForeach($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertError($file, $line, 'Unpacking nested arrays with list() in a foreach is not supported in PHP 5.4 or earlier.');
+    }
+
+    /**
+     * dataNewListInForeach
+     *
+     * @see testNewListInForeach()
+     *
+     * @return array
+     */
+    public function dataNewListInForeach()
+    {
+        return array(
+            array(14),
+            array(17),
+            array(18),
+            array(19),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number with a valid list assignment.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataNoFalsePositives
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(6),
+            array(7),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> `foreach` now supports `list()`
>
> The `foreach` control structure now supports unpacking nested arrays into separate variables via the `list()` construct.

Refs:
* http://php.net/manual/en/migration55.new-features.php#migration55.new-features.foreach-list
* http://php.net/manual/en/control-structures.foreach.php#control-structures.foreach.list
* https://wiki.php.net/rfc/foreachlist