### PR TITLE
New sniff to detect new modes available to fopen()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionParameters/FopenModeSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionParameters/FopenModeSniff.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\FunctionParameters\FopenModeSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionParameters;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+
+/**
+ * \PHPCompatibility\Sniffs\FunctionParameters\FopenModeSniff.
+ *
+ * Detect: Changes in allowed values for the fopen() $mode parameter.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class FopenModeSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'fopen' => true,
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        // Version used here should be (above) the highest version from the `$newModes` array,
+        // i.e. the last PHP version in which a new mode was introduced.
+        return ($this->supportsBelow('7.1') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[2]) === false) {
+            return;
+        }
+
+        $tokens      = $phpcsFile->getTokens();
+        $targetParam = $parameters[2];
+        $errors      = array();
+
+        for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
+            if ($tokens[$i]['code'] !== T_CONSTANT_ENCAPSED_STRING) {
+                continue;
+            }
+
+            if (strpos($tokens[$i]['content'], 'c+') !== false && $this->supportsBelow('5.2.5')) {
+                $errors['cplusFound'] = array(
+                    'c+',
+                    '5.2.5',
+                    $targetParam['raw'],
+                );
+            } elseif (strpos($tokens[$i]['content'], 'c') !== false && $this->supportsBelow('5.2.5')) {
+                $errors['cFound'] = array(
+                    'c',
+                    '5.2.5',
+                    $targetParam['raw'],
+                );
+            }
+
+            if (strpos($tokens[$i]['content'], 'e') !== false && $this->supportsBelow('7.0.15')) {
+                $errors['eFound'] = array(
+                    'e',
+                    '7.0.15',
+                    $targetParam['raw'],
+                );
+            }
+        }
+
+        if (empty($errors) === true) {
+            return;
+        }
+
+        foreach ($errors as $errorCode => $errorData) {
+            $phpcsFile->addError(
+                'Passing "%s" as the $mode to fopen() is not supported in PHP %s or lower. Found %s',
+                $targetParam['start'],
+                $errorCode,
+                $errorData
+            );
+        }
+    }
+}//end class

--- a/PHPCompatibility/Tests/Sniffs/FunctionParameters/FopenModeSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/FunctionParameters/FopenModeSniffTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Allowed values for the fopen() $mode parameter sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\FunctionParameters;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Allowed values for the fopen() $mode parameter sniff tests.
+ *
+ * @group fopenMode
+ * @group functionParameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionParameters\FopenModeSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class FopenModeSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'Sniffs/FunctionParameters/FopenModeTestCases.inc';
+
+    /**
+     * testFopenMode
+     *
+     * @dataProvider dataFopenMode
+     *
+     * @param int    $line           Line number where the error should occur.
+     * @param string $mode           The fopen() $mode which should be detected.
+     * @param string $errorVersion   The PHP version to use to test for the error.
+     * @param string $okVersion      A PHP version in which the mode is valid.
+     * @param string $displayVersion Optional PHP version which is shown in the error message
+     *                               if different from the $errorVersion.
+     *
+     * @return void
+     */
+    public function testFopenMode($line, $mode, $errorVersion, $okVersion, $displayVersion = null)
+    {
+        $file  = $this->sniffFile(self::TEST_FILE, $errorVersion);
+        $error = sprintf(
+            'Passing "%s" as the $mode to fopen() is not supported in PHP %s or lower.',
+            $mode,
+            isset($displayVersion) ? $displayVersion : $errorVersion
+        );
+        $this->assertError($file, $line, $error);
+
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataFopenMode
+     *
+     * @see testFopenMode()
+     *
+     * @return array
+     */
+    public function dataFopenMode()
+    {
+        return array(
+            array(9, 'e', '7.0', '7.1', '7.0.15'),
+            array(10, 'c+', '5.2', '5.3', '5.2.5'),
+            array(11, 'c', '5.2', '5.3', '5.2.5'),
+            array(12, 'c', '5.2', '7.1', '5.2.5'), // High okVersion, to pass by the second violation.
+            array(12, 'e', '7.0', '7.1', '7.0.15'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2'); // Version below first new mode was added.
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(4),
+            array(5),
+            array(6),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1'); // Above last new mode added.
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/FunctionParameters/FopenModeTestCases.inc
+++ b/PHPCompatibility/Tests/Sniffs/FunctionParameters/FopenModeTestCases.inc
@@ -1,0 +1,12 @@
+<?php
+
+// OK.
+$handle = fopen("/home/rasmus/file.txt", "r");
+$handle = fopen("/home/rasmus/file.gif", 'wb');
+$handle = fopen("/home/rasmus/file.gif", 'a' . $additional_modes);
+
+// Not OK.
+$handle = fopen("/home/rasmus/file.txt", "re"); // PHP 7.0.16+
+$handle = fopen("/home/rasmus/file.gif", 'c+'); // PHP 5.2.6+
+$handle = fopen("/home/rasmus/file.gif", 'c'); // PHP 5.2.6+
+$handle = fopen("/home/rasmus/file.gif", 'c'.'e'); // PHP 5.2.6+ and PHP 7.0.16+


### PR DESCRIPTION
:warning: **DO NOT MERGE YET. This PR is targeted at v 9.0.0** :warning: 

----

> Version | Description
> --- | ---
> 7.0.16, 7.1.2 | The `e` option were added.
> 5.2.6 | The `c` and `c+` options were added

Ref: http://php.net/manual/en/function.fopen.php#refsect1-function.fopen-changelog