### PR TITLE
PHP 7.2: New sniff to detect passing `null` to get_class()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionParameters/GetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionParameters/GetClassNullSniff.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\FunctionParameters\GetClassNullSniff.
+ *
+ * PHP version 7.2
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionParameters;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+
+/**
+ * \PHPCompatibility\Sniffs\FunctionParameters\GetClassNullSniff.
+ *
+ * Detect: Passing `null` to get_class() is no longer allowed as of PHP 7.2.
+ * This will now result in an E_WARNING being thrown.
+ *
+ * PHP version 7.2
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class GetClassNullSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'get_class' => true,
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('7.2') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[1]) === false) {
+            return;
+        }
+
+        if ($parameters[1]['raw'] !== 'null') {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Passing "null" as the $object to get_class() is not allowed since PHP 7.2.',
+            $parameters[1]['start'],
+            'Found'
+        );
+    }
+}//end class

--- a/PHPCompatibility/Tests/Sniffs/FunctionParameters/GetClassNullSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/FunctionParameters/GetClassNullSniffTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Passing `null` to get_class() sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\FunctionParameters;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Passing `null` to get_class() sniff tests.
+ *
+ * @group getClassNull
+ * @group functionParameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionParameters\GetClassNullSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class GetClassNullSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'Sniffs/FunctionParameters/GetClassNullTestCases.inc';
+
+    /**
+     * testGetClassNull
+     *
+     * @dataProvider dataGetClassNull
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testGetClassNull($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.2');
+        $this->assertError($file, $line, 'Passing "null" as the $object to get_class() is not allowed since PHP 7.2.');
+    }
+
+    /**
+     * dataGetClassNull
+     *
+     * @see testGetClassNull()
+     *
+     * @return array
+     */
+    public function dataGetClassNull()
+    {
+        return array(
+            array(11),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.2');
+
+        // No errors expected on the first 9 lines.
+        for ($line = 1; $line <= 9; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/FunctionParameters/GetClassNullTestCases.inc
+++ b/PHPCompatibility/Tests/Sniffs/FunctionParameters/GetClassNullTestCases.inc
@@ -1,0 +1,11 @@
+<?php
+/*
+ * Test get_class() PHP 7.2 change in accepted values.
+ */
+
+//OK.
+get_class($object);
+get_class();
+
+// Not OK.
+get_class(null);


### PR DESCRIPTION
:warning: **DO NOT MERGE YET. This PR is targeted at v 9.0.0** :warning: 

----

> "Previously, passing NULL to the get_class() function would output the name of the enclosing class. This behaviour has now been removed, where an E_WARNING will be output instead.
> To achieve the same behaviour as before, the argument should simply be omitted."

Refs:
* http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.no-null-to-get_class
* https://wiki.php.net/rfc/get_class_disallow_null_parameter
* http://php.net/manual/en/function.get-class.php

Fixes #557