### PR TITLE
PHP 5.6: New sniff to detect passing deprecated $type values to iconv_get_encoding

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionParameters/IconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionParameters/IconvEncodingSniff.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\FunctionParameters\IconvEncodingSniff.
+ *
+ * PHP version 5.6
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionParameters;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+
+/**
+ * \PHPCompatibility\Sniffs\FunctionParameters\IconvEncodingSniff.
+ *
+ * Detect: "The iconv and mbstring configuration options related to encoding
+ * have been deprecated in favour of default_charset."
+ *
+ * {@internal It is unclear which mbstring functions should be targetted, so for now,
+ * only the iconv function is handled.}}
+ *
+ * PHP version 5.6
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class IconvEncodingSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'iconv_set_encoding' => true,
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('5.6') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[1]) === false) {
+            return;
+        }
+
+        $phpcsFile->addWarning(
+            'All previously accepted values for the $type parameter of iconv_set_encoding() have been deprecated since PHP 5.6. Found %s',
+            $parameters[1]['start'],
+            'DeprecatedValueFound',
+            $parameters[1]['raw']
+        );
+    }
+}//end class

--- a/PHPCompatibility/Tests/Sniffs/FunctionParameters/IconvEncodingSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/FunctionParameters/IconvEncodingSniffTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Deprecated Iconv encoding types sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\FunctionParameters;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Deprecated Iconv encoding types sniff tests.
+ *
+ * @group iconvEncoding
+ * @group functionParameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionParameters\IconvEncodingSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class IconvEncodingSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'Sniffs/FunctionParameters/IconvEncodingTestCases.inc';
+
+    /**
+     * testIconvEncoding
+     *
+     * @dataProvider dataIconvEncoding
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testIconvEncoding($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertWarning($file, $line, 'All previously accepted values for the $type parameter of iconv_set_encoding() have been deprecated since PHP 5.6.');
+    }
+
+    /**
+     * dataIconvEncoding
+     *
+     * @see testIconvEncoding()
+     *
+     * @return array
+     */
+    public function dataIconvEncoding()
+    {
+        return array(
+            array(14),
+            array(15),
+            array(16),
+            array(17),
+            array(18),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+
+        // No errors expected on the first 10 lines.
+        for ($line = 1; $line <= 10; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/FunctionParameters/IconvEncodingTestCases.inc
+++ b/PHPCompatibility/Tests/Sniffs/FunctionParameters/IconvEncodingTestCases.inc
@@ -1,0 +1,18 @@
+<?php
+/*
+ * OK.
+ */
+iconv_set_encoding();
+
+MyNS\iconv_set_encoding('internal_encoding', 'UTF-8');
+
+$a = iconv_get_encoding('internal_encoding');
+
+/*
+ * Test iconv_set_encoding() PHP 5.6 change in accepted values.
+ */
+iconv_set_encoding('internal_encoding', 'UTF-8');
+\iconv_set_encoding( 'input_encoding', 'ISO-8859-1' );
+iconv_set_encoding("output_encoding", "ISO-8859-1");
+iconv_set_encoding( $type, "ISO-8859-1");
+iconv_set_encoding('all', 'UTF-8'); // Not a valid $type value.


### PR DESCRIPTION
> "The iconv and mbstring configuration options related to encoding have been deprecated in favour of default_charset."

Refs:
* http://php.net/manual/en/migration56.deprecated.php#migration56.deprecated.iconv-mbstring-encoding
* https://wiki.php.net/rfc/default_encoding

**Note:**
As it is unclear which MBString functions to target, the sniff only checks the affected `iconv` function.
Based on the commit and the other documentation, I get the impression that for MBString, this only affects the ini directives.

Fixes #475