### PR TITLE
PHP 7.1: New sniff to detect negative string offsets being passed as parameters

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionParameters/NegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionParameters/NegativeStringOffsetSniff.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\FunctionParameters\NegativeStringOffsetSniff.
+ *
+ * PHP version 7.1
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionParameters;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+
+/**
+ * \PHPCompatibility\Sniffs\FunctionParameters\NegativeStringOffsetSniff.
+ *
+ * Detect: negative string offsets as parameters passed to functions where this
+ * was not allowed prior to PHP 7.1.
+ *
+ * PHP version 7.1
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @var array Function name => 1-based parameter offset of the affected parameters => parameter name.
+     */
+    protected $targetFunctions = array(
+        'file_get_contents'     => array(
+            4 => 'offset',
+        ),
+        'grapheme_extract'      => array(
+            4 => 'start',
+        ),
+        'grapheme_stripos'      => array(
+            3 => 'offset',
+        ),
+        'grapheme_strpos'       => array(
+            3 => 'offset',
+        ),
+        'iconv_strpos'          => array(
+            3 => 'offset',
+        ),
+        'mb_ereg_search_setpos' => array(
+            1 => 'position',
+        ),
+        'mb_strimwidth'         => array(
+            2 => 'start',
+            3 => 'width',
+        ),
+        'mb_stripos'            => array(
+            3 => 'offset',
+        ),
+        'mb_strpos'             => array(
+            3 => 'offset',
+        ),
+        'stripos'               => array(
+            3 => 'offset',
+        ),
+        'strpos'                => array(
+            3 => 'offset',
+        ),
+        'substr_count'          => array(
+            3 => 'offset',
+            4 => 'length',
+        ),
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('7.0') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $functionLC = strtolower($functionName);
+        foreach ($this->targetFunctions[$functionLC] as $pos => $name) {
+            if (isset($parameters[$pos]) === false) {
+                continue;
+            }
+
+            $targetParam = $parameters[$pos];
+
+            if ($this->isNegativeNumber($phpcsFile, $targetParam['start'], $targetParam['end']) === false) {
+                continue;
+            }
+
+            $phpcsFile->addError(
+                'Negative string offsets were not supported for the $%s parameter in %s() in PHP 7.0 or lower. Found %s',
+                $targetParam['start'],
+                'Found',
+                array(
+                    $name,
+                    $functionName,
+                    $targetParam['raw'],
+                )
+            );
+        }
+    }
+}//end class

--- a/PHPCompatibility/Tests/Sniffs/FunctionParameters/NegativeStringOffsetSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/FunctionParameters/NegativeStringOffsetSniffTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Negative string offsets as parameters sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\FunctionParameters;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Negative string offsets as parameters sniff tests.
+ *
+ * @group negativeStringOffset
+ * @group functionParameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionParameters\NegativeStringOffsetSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NegativeStringOffsetSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'Sniffs/FunctionParameters/NegativeStringOffsetTestCases.inc';
+
+    /**
+     * testNegativeStringOffset
+     *
+     * @dataProvider dataNegativeStringOffset
+     *
+     * @param int    $line         Line number where the error should occur.
+     * @param string $paramName    The name of the parameter being passed a negative offset.
+     * @param string $functionName The name of the function which was called.
+     *
+     * @return void
+     */
+    public function testNegativeStringOffset($line, $paramName, $functionName)
+    {
+        $file  = $this->sniffFile(self::TEST_FILE, '7.0');
+        $error = sprintf(
+            'Negative string offsets were not supported for the $%1$s parameter in %2$s() in PHP 7.0 or lower.',
+            $paramName,
+            $functionName
+        );
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * dataNegativeStringOffset
+     *
+     * @see testNegativeStringOffset()
+     *
+     * @return array
+     */
+    public function dataNegativeStringOffset()
+    {
+        return array(
+            array(28, 'position', 'mb_ereg_search_setpos'),
+            array(34, 'position', 'mb_ereg_search_setpos'),
+            array(36, 'offset', 'file_get_contents'),
+            array(37, 'start', 'grapheme_extract'),
+            array(38, 'offset', 'grapheme_stripos'),
+            array(39, 'offset', 'grapheme_strpos'),
+            array(40, 'offset', 'iconv_strpos'),
+            array(41, 'start', 'mb_strimwidth'),
+            array(41, 'width', 'mb_strimwidth'),
+            array(42, 'offset', 'mb_stripos'),
+            array(43, 'offset', 'mb_strpos'),
+            array(44, 'offset', 'stripos'),
+            array(45, 'offset', 'strpos'),
+            array(46, 'offset', 'substr_count'),
+            array(46, 'length', 'substr_count'),
+            array(47, 'offset', 'substr_count'),
+            array(48, 'length', 'substr_count'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+
+        // No errors expected on the first 26 lines.
+        for ($line = 1; $line <= 26; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/FunctionParameters/NegativeStringOffsetTestCases.inc
+++ b/PHPCompatibility/Tests/Sniffs/FunctionParameters/NegativeStringOffsetTestCases.inc
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Test functions which allow negative string offsets since PHP 7.1.
+ */
+
+// OK.
+mb_ereg_search_setpos();
+mb_ereg_search_setpos( 0 );
+mb_ereg_search_setpos( /* Some comment. */ );
+mb_ereg_search_setpos(
+	// Some comment.
+	0
+	// phpcs:ignore Standard.Category.Sniff -- for reasons.
+);
+mb_ereg_search_setpos($position);
+mb_ereg_search_setpos( -1 + 10 );
+mb_ereg_search_setpos( 100 - 10 );
+mb_ereg_search_setpos( 100- );
+
+$content = file_get_contents( $filename, false, $context, 0, 100 );
+$content = file_get_contents( $filename, false, $context, 100 );
+
+$content = file_get_contents( $filename, false, $context, $offset ); // Not necessarily OK, but we can't determine it.
+
+$content = file_get_contents( $filename, false, $context, ($previous_offset + $chunk_size) ); // Not necessarily OK, but we can't determine it.
+
+// Not OK.
+mb_ereg_search_setpos(
+	// Some comment.
+	-100
+	// phpcs:ignore Standard.Category.Sniff -- for reasons.
+);
+
+mb_ereg_search_setpos( -     100);
+
+$a = file_get_contents($filename, true, $context, -1024, 1024 );
+$a = grapheme_extract($haystack, $size, $extract_type, -10 );
+$a = grapheme_stripos($haystack, $needle, -1000 );
+$a = grapheme_strpos($haystack, $needle, -3 );
+$a = iconv_strpos($haystack, $needle, -052 );
+$a = mb_strimwidth($str, -100, -10, '' );
+$a = mb_stripos($haystack, $needle, -2 );
+$a = mb_strpos($haystack, $needle, -5 );
+$a = stripos($haystack, $needle, -42 );
+$a = strpos($haystack, $needle, -30 );
+$a = substr_count($haystack, $needle, -20, -10 );
+$a = substr_count($haystack, $needle, -20, 10 );
+$a = substr_count($haystack, $needle, 20, -+-+-10 );


### PR DESCRIPTION
> "Support for negative string offsets has been added to the string manipulation functions accepting offsets [...]. In such cases, a negative offset is interpreted as being an offset from the end of the string."

Refs:
* http://php.net/manual/en/migration71.new-features.php#migration71.new-features.support-for-negative-string-offsets
* https://wiki.php.net/rfc/negative-string-offsets

Fixes part 1 of issue #253