### PR TITLE
PHP 5.5: New sniff to detect referenced expressions prior to PHP 5.5

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1868,4 +1868,93 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
 
         return false;
     }
+
+
+    /**
+     * Determine whether the tokens between $start and $end could together represent a variable.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile          The file being scanned.
+     * @param int                   $start              Starting point stack pointer. Inclusive.
+     *                                                  I.e. this token should be taken into account.
+     * @param int                   $end                End point stack pointer. Exclusive.
+     *                                                  I.e. this token should not be taken into account.
+     * @param int                   $targetNestingLevel The nesting level the variable should be at.
+     *
+     * @return bool
+     */
+    public function isVariable($phpcsFile, $start, $end, $targetNestingLevel)
+    {
+        static $tokenBlackList, $bracketTokens;
+
+        // Create the token arrays only once.
+        if (isset($tokenBlackList, $bracketTokens) === false) {
+
+            $tokenBlackList  = array(
+                T_OPEN_PARENTHESIS => T_OPEN_PARENTHESIS,
+                T_STRING_CONCAT    => T_STRING_CONCAT,
+            );
+            $tokenBlackList += \PHP_CodeSniffer_Tokens::$assignmentTokens;
+            $tokenBlackList += \PHP_CodeSniffer_Tokens::$equalityTokens;
+            $tokenBlackList += \PHP_CodeSniffer_Tokens::$comparisonTokens;
+            $tokenBlackList += \PHP_CodeSniffer_Tokens::$operators;
+            $tokenBlackList += \PHP_CodeSniffer_Tokens::$booleanOperators;
+            $tokenBlackList += \PHP_CodeSniffer_Tokens::$castTokens;
+
+            /*
+             * List of brackets which can be part of a variable variable.
+             *
+             * Key is the open bracket token, value the close bracket token.
+             */
+            $bracketTokens = array(
+                T_OPEN_CURLY_BRACKET  => T_CLOSE_CURLY_BRACKET,
+                T_OPEN_SQUARE_BRACKET => T_CLOSE_SQUARE_BRACKET,
+            );
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // If no variable at all was found, then it's definitely a no-no.
+        $hasVariable = $phpcsFile->findNext(T_VARIABLE, $start, $end);
+        if ($hasVariable === false) {
+            return false;
+        }
+
+        // Check if the variable found is at the right level. Deeper levels are always an error.
+        if (isset($tokens[$hasVariable]['nested_parenthesis'])
+            && count($tokens[$hasVariable]['nested_parenthesis']) !== $targetNestingLevel
+        ) {
+                return false;
+        }
+
+        // Ok, so the first variable is at the right level, now are there any
+        // blacklisted tokens within the empty() ?
+        $hasBadToken = $phpcsFile->findNext($tokenBlackList, $start, $end);
+        if ($hasBadToken === false) {
+            return true;
+        }
+
+        // If there are also bracket tokens, the blacklisted token might be part of a variable
+        // variable, but if there are no bracket tokens, we know we have an error.
+        $hasBrackets = $phpcsFile->findNext($bracketTokens, $start, $end);
+        if ($hasBrackets === false) {
+            return false;
+        }
+
+        // Ok, we have both a blacklisted token as well as brackets, so we need to walk
+        // the tokens of the variable variable.
+        for ($i = $start; $i < $end; $i++) {
+            // If this is a bracket token, skip to the end of the bracketed expression.
+            if (isset($bracketTokens[$tokens[$i]['code']], $tokens[$i]['bracket_closer'])) {
+                $i = $tokens[$i]['bracket_closer'];
+                continue;
+            }
+
+            // If it's a blacklisted token, not within brackets, we have an error.
+            if (isset($tokenBlackList[$tokens[$i]['code']])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }//end class

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\ControlStructures\NewForeachExpressionReferencingSniff.
+ *
+ * PHP version 5.5
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\ControlStructures;
+
+use PHPCompatibility\Sniff;
+
+/**
+ * New `foreach` Expression Referencing.
+ *
+ * Before PHP 5.5.0, referencing $value is only possible if the iterated array
+ * can be referenced (i.e. if it is a variable).
+ *
+ * PHP version 5.5
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewForeachExpressionReferencingSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_FOREACH);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {
+            return;
+        }
+
+        $opener = $tokens[$stackPtr]['parenthesis_opener'];
+        $closer = $tokens[$stackPtr]['parenthesis_closer'];
+
+        $asToken = $phpcsFile->findNext(T_AS, ($opener + 1), $closer);
+        if ($asToken === false) {
+            return;
+        }
+
+        /*
+         * Note: referencing $key is not allowed in any version, so this should only find referenced $values.
+         * If it does find a referenced key, it would be a parse error anyway.
+         */
+        $hasReference = $phpcsFile->findNext(T_BITWISE_AND, ($asToken + 1), $closer);
+        if ($hasReference === false) {
+            return;
+        }
+
+        $nestingLevel = 0;
+        if ($asToken !== ($opener + 1) && isset($tokens[$opener + 1]['nested_parenthesis'])) {
+            $nestingLevel = count($tokens[$opener + 1]['nested_parenthesis']);
+        }
+
+        if ($this->isVariable($phpcsFile, ($opener + 1), $asToken, $nestingLevel) === true) {
+            return;
+        }
+
+        // Non-variable detected before the `as` keyword.
+        $phpcsFile->addError(
+            'Referencing $value is only possible if the iterated array is a variable in PHP 5.4 or earlier.',
+            $hasReference,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Sniffs/PHP/EmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/EmptyNonVariableSniff.php
@@ -26,25 +26,6 @@ use PHPCompatibility\Sniff;
  */
 class EmptyNonVariableSniff extends Sniff
 {
-    /**
-     * List of tokens to check against.
-     *
-     * @var array
-     */
-    protected $tokenBlackList = array();
-
-    /**
-     * List of brackets which can be part of a variable variable.
-     *
-     * Key is the open bracket token, value the close bracket token.
-     *
-     * @var array
-     */
-    protected $bracketTokens = array(
-        T_OPEN_CURLY_BRACKET  => T_CLOSE_CURLY_BRACKET,
-        T_OPEN_SQUARE_BRACKET => T_CLOSE_SQUARE_BRACKET,
-    );
-
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -53,20 +34,6 @@ class EmptyNonVariableSniff extends Sniff
      */
     public function register()
     {
-        // Set the token blacklist only once.
-        $tokenBlackList  = array(
-            T_OPEN_PARENTHESIS => T_OPEN_PARENTHESIS,
-            T_STRING_CONCAT    => T_STRING_CONCAT,
-        );
-        $tokenBlackList += \PHP_CodeSniffer_Tokens::$assignmentTokens;
-        $tokenBlackList += \PHP_CodeSniffer_Tokens::$equalityTokens;
-        $tokenBlackList += \PHP_CodeSniffer_Tokens::$comparisonTokens;
-        $tokenBlackList += \PHP_CodeSniffer_Tokens::$operators;
-        $tokenBlackList += \PHP_CodeSniffer_Tokens::$booleanOperators;
-        $tokenBlackList += \PHP_CodeSniffer_Tokens::$castTokens;
-
-        $this->tokenBlackList = array_unique($tokenBlackList);
-
         return array(T_EMPTY);
     }
 
@@ -87,73 +54,25 @@ class EmptyNonVariableSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $open = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, null, false, null, true);
-        if ($open === false || isset($tokens[$open]['parenthesis_closer']) === false) {
+        $open = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        if ($open === false
+            || $tokens[$open]['code'] !== T_OPEN_PARENTHESIS
+            || isset($tokens[$open]['parenthesis_closer']) === false
+        ) {
             return;
         }
 
         $close = $tokens[$open]['parenthesis_closer'];
 
-        // If no variable at all was found, then it's definitely a no-no.
-        $hasVariable = $phpcsFile->findNext(T_VARIABLE, $open + 1, $close);
-        if ($hasVariable === false) {
-            $this->addError($phpcsFile, $stackPtr);
-            return;
-        }
-
-        // Check if the variable found is at the right level. Deeper levels are always an error.
-        if (isset($tokens[$open + 1]['nested_parenthesis'], $tokens[$hasVariable]['nested_parenthesis'])) {
+        $nestingLevel = 0;
+        if ($close !== ($open + 1) && isset($tokens[$open + 1]['nested_parenthesis'])) {
             $nestingLevel = count($tokens[$open + 1]['nested_parenthesis']);
-            if (count($tokens[$hasVariable]['nested_parenthesis']) !== $nestingLevel) {
-                $this->addError($phpcsFile, $stackPtr);
-                return;
-            }
         }
 
-        // Ok, so the first variable is at the right level, now are there any
-        // blacklisted tokens within the empty() ?
-        $hasBadToken = $phpcsFile->findNext($this->tokenBlackList, $open + 1, $close);
-        if ($hasBadToken === false) {
+        if ($this->isVariable($phpcsFile, ($open + 1), $close, $nestingLevel) === true) {
             return;
         }
 
-        // If there are also bracket tokens, the blacklisted token might be part of a variable
-        // variable, but if there are no bracket tokens, we know we have an error.
-        $hasBrackets = $phpcsFile->findNext($this->bracketTokens, $open + 1, $close);
-        if ($hasBrackets === false) {
-            $this->addError($phpcsFile, $stackPtr);
-            return;
-        }
-
-        // Ok, we have both a blacklisted token as well as brackets, so we need to walk
-        // the tokens of the variable variable.
-        for ($i = ($open + 1); $i < $close; $i++) {
-            // If this is a bracket token, skip to the end of the bracketed expression.
-            if (isset($this->bracketTokens[$tokens[$i]['code']], $tokens[$i]['bracket_closer'])) {
-                $i = $tokens[$i]['bracket_closer'];
-                continue;
-            }
-
-            // If it's a blacklisted token, not within brackets, we have an error.
-            if (isset($this->tokenBlackList[$tokens[$i]['code']])) {
-                $this->addError($phpcsFile, $stackPtr);
-                return;
-            }
-        }
-    }
-
-
-    /**
-     * Add the error message.
-     *
-     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                   $stackPtr  The position of the current token in the
-     *                                         stack passed in $tokens.
-     *
-     * @return void
-     */
-    protected function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
         $phpcsFile->addError(
             'Only variables can be passed to empty() prior to PHP 5.5.',
             $stackPtr,

--- a/PHPCompatibility/Tests/Sniffs/ControlStructures/NewForeachExpressionReferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Sniffs/ControlStructures/NewForeachExpressionReferencingUnitTest.inc
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * OK prior to PHP 5.5.
+ */
+foreach ($array as &$value) {}
+foreach ($array as $key => $value) {}
+foreach ($array as $key => &$value) {}
+foreach( $variable[1] as &$value );
+foreach(stdClass::$property as &$value);
+foreach($myObject->property as &$value);
+foreach(${$variable}->property as &$value);
+
+/*
+ * PHP 5.5: referencing expressions in foreach.
+ */
+foreach (array(1, 2, 3, 4) as &$value) {}
+foreach ([1, 2, 3, 4] as &$value) {}
+
+foreach (array('a' => 1, 'b' => 2) as $key => &$value) {}
+foreach (['a' => 1, 'b' => 2] as $key => &$value) {}
+
+foreach (array_combine($array,$array) as &$value) {}
+foreach (($array + [5]) as &$value) {}

--- a/PHPCompatibility/Tests/Sniffs/ControlStructures/NewForeachExpressionReferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Sniffs/ControlStructures/NewForeachExpressionReferencingUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHP 5.5 referencing expressions in foreach sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * PHP 5.5 referencing expressions in foreach sniff test file.
+ *
+ * @group newForeachExpressionReferencing
+ * @group controlStructures
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\NewForeachExpressionReferencingSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewForeachExpressionReferencingUnitTest extends BaseSniffTest
+{
+    const TEST_FILE = 'Sniffs/ControlStructures/NewForeachExpressionReferencingUnitTest.inc';
+
+    /**
+     * testNewForeachExpressionReferencing
+     *
+     * @dataProvider dataNewForeachExpressionReferencing
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testNewForeachExpressionReferencing($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertError($file, $line, 'Referencing $value is only possible if the iterated array is a variable in PHP 5.4 or earlier.');
+    }
+
+    /**
+     * dataNewForeachExpressionReferencing
+     *
+     * @see testNewForeachExpressionReferencing()
+     *
+     * @return array
+     */
+    public function dataNewForeachExpressionReferencing()
+    {
+        return array(
+            array(17),
+            array(18),
+            array(20),
+            array(21),
+            array(23),
+            array(24),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number with a valid list assignment.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataNoFalsePositives
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(6),
+            array(7),
+            array(8),
+            array(9),
+            array(10),
+            array(11),
+            array(12),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> 5.5.0 	Referencing of $value is supported for expressions. Formerly, only variables have been supported.

> Before PHP 5.5.0, referencing $value is only possible if the iterated array can be referenced (i.e. if it is a variable).

Ref: http://php.net/manual/en/control-structures.foreach.php

**Note:** this change is not mentioned anywhere in the PHP 5.5 changelog, but tests show it has been implemented and that the documentation is correct.
See: https://3v4l.org/gFvaZ

----

Updated the PR after I found a false positive. The "is this a variable ?" determination is now based on the same code as the `EmptyNonVariable` sniff uses. This code has been abstracted to a utility method in the `Sniff` class.