### PR TITLE
New sniff to detect incompatible $formats passed to pack()

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\ParameterValues\NewPackFormatSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+
+/**
+ * \PHPCompatibility\Sniffs\ParameterValues\NewPackFormatSniff.
+ *
+ * Detect: Changes in the allowed values for $format passed to pack().
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'pack' => true,
+    );
+
+    /**
+     * List of new format character codes added to pack().
+     *
+     * @var array Regex pattern => Version array.
+     */
+    protected $newFormats = array(
+        '`([Z])`'    => array(
+            '5.4' => false,
+            '5.5' => true,
+        ),
+        '`([qQJP])`' => array(
+            '5.6.2' => false,
+            '5.6.3' => true,
+        ),
+        '`([eEgG])`' => array(
+            '7.0.14' => false,
+            '7.0.15' => true, // And 7.1.1.
+        ),
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('7.1') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[1]) === false) {
+            return;
+        }
+
+        $tokens      = $phpcsFile->getTokens();
+        $targetParam = $parameters[1];
+
+        for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
+            if ($tokens[$i]['code'] !== T_CONSTANT_ENCAPSED_STRING
+                && $tokens[$i]['code'] !== T_DOUBLE_QUOTED_STRING
+            ) {
+                continue;
+            }
+
+            $content = $tokens[$i]['content'];
+            if ($tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
+                $content = $this->stripVariables($content);
+            }
+
+            foreach ($this->newFormats as $pattern => $versionArray) {
+                if (preg_match($pattern, $content, $matches) !== 1) {
+                    continue;
+                }
+
+                foreach ($versionArray as $version => $present) {
+                    if ($present === false && $this->supportsBelow($version) === true) {
+                        $phpcsFile->addError(
+                            'Passing the $format(s) "%s" to pack() is not supported in PHP %s or lower. Found %s',
+                            $targetParam['start'],
+                            'NewFormatFound',
+                            array(
+                                $matches[1],
+                                $version,
+                                $targetParam['raw'],
+                            )
+                        );
+                        continue 2;
+                    }
+                }
+            }
+        }
+    }
+}//end class

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -108,6 +108,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
         $parts    = explode('\\', $class);
         $sniff    = array_pop($parts);
         $sniff    = str_replace('SniffTest', '', $sniff);
+        $sniff    = str_replace('UnitTest', '', $sniff);
         $category = array_pop($parts);
         return self::STANDARD_NAME . '.' . $category . '.' . $sniff;
     }

--- a/PHPCompatibility/Tests/Sniffs/ParameterValues/NewPackFormatUnitTest.inc
+++ b/PHPCompatibility/Tests/Sniffs/ParameterValues/NewPackFormatUnitTest.inc
@@ -1,0 +1,18 @@
+<?php
+
+// OK.
+$binarydata = pack("nvc*", 0x1234, 0x5678, 65, 66);
+$binarydata = pack("n{$e}vc*", 0x1234, 0x5678, 65, 66);
+
+// Not OK.
+$binarydata = pack("nZc*", 0x1234, 0x5678, 65, 66);
+$binarydata = pack("nvq*", 0x1234, 0x5678, 65, 66);
+$binarydata = pack("Qnvc*", 0x1234, 0x5678, 65, 66);
+$binarydata = pack("nJc*", 0x1234, 0x5678, 65, 66);
+$binarydata = pack('nvPc*', 0x1234, 0x5678, 65, 66);
+$binarydata = pack("nec*", 0x1234, 0x5678, 65, 66);
+$binarydata = pack("Envc*", 0x1234, 0x5678, 65, 66);
+$binarydata = pack('nvcgG*', 0x1234, 0x5678, 65, 66);
+$binarydata = pack("n{$s}vGc*", 0x1234, 0x5678, 65, 66);
+
+$binarydata = pack("ZJE*", 0x1234, 0x5678, 65, 66); // Error x 3.

--- a/PHPCompatibility/Tests/Sniffs/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/Sniffs/ParameterValues/NewPackFormatUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Use of new pack() formats sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Use of new pack() formats sniff tests.
+ *
+ * @group newPackFormat
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewPackFormatSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewPackFormatUnitTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'Sniffs/ParameterValues/NewPackFormatUnitTest.inc';
+
+    /**
+     * testNewPackFormat
+     *
+     * @dataProvider dataNewPackFormat
+     *
+     * @param int    $line           Line number where the error should occur.
+     * @param string $code           Format code which should be detected.
+     * @param string $errorVersion   The PHP version to use to test for the error.
+     * @param string $okVersion      A PHP version in which the code is valid.
+     * @param string $displayVersion Optional PHP version which is shown in the error message
+     *                               if different from the $errorVersion.
+     *
+     * @return void
+     */
+    public function testNewPackFormat($line, $code, $errorVersion, $okVersion, $displayVersion = null)
+    {
+        $file  = $this->sniffFile(self::TEST_FILE, $errorVersion);
+        $error = sprintf(
+            'Passing the $format(s) "%s" to pack() is not supported in PHP %s or lower.',
+            $code,
+            isset($displayVersion) ? $displayVersion : $errorVersion
+        );
+        $this->assertError($file, $line, $error);
+
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataNewPackFormat
+     *
+     * @see testNewPackFormat()
+     *
+     * @return array
+     */
+    public function dataNewPackFormat()
+    {
+        return array(
+            array(8, 'Z', '5.4', '5.5'),
+            array(9, 'q', '5.6', '7.0', '5.6.2'),
+            array(10, 'Q', '5.6', '7.0', '5.6.2'),
+            array(11, 'J', '5.6', '7.0', '5.6.2'),
+            array(12, 'P', '5.6', '7.0', '5.6.2'),
+            array(13, 'e', '7.0', '7.1', '7.0.14'),
+            array(14, 'E', '7.0', '7.1', '7.0.14'),
+            array(15, 'g', '7.0', '7.1', '7.0.14'),
+            array(16, 'G', '7.0', '7.1', '7.0.14'),
+            array(18, 'Z', '5.4', '7.1'), // OK version set to beyond last error.
+            array(18, 'J', '5.6', '7.1', '5.6.2'), // OK version set to beyond last error.
+            array(18, 'E', '7.0', '7.1', '7.0.14'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+
+        // No errors expected on the first 6 lines.
+        for ($line = 1; $line <= 6; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Version | Description
> --- | ---
> 7.0.15,7.1.1 | The "e", "E", "g" and "G" codes were added to enable byte order support for float and double.
> 5.6.3 | The "q", "Q", "J" and "P" codes were added to enable working with 64-bit numbers.
> 5.5.0 | The "Z" code was added with equivalent functionality to "a" for Perl compatibility.

Ref: http://php.net/manual/en/function.pack.php#refsect1-function.pack-changelog