### PR TITLE
PHP 5.3: New sniff to detect a non-integer $initial parameter value passed to array_reduce()

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1646,6 +1646,15 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
      */
     protected function isNumericCalculation(\PHP_CodeSniffer_File $phpcsFile, $start, $end)
     {
+        $arithmeticTokens = \PHP_CodeSniffer_Tokens::$arithmeticTokens;
+
+        // phpcs:disable PHPCompatibility.PHP.NewConstants.t_powFound
+        if (defined('T_POW') && isset($arithmeticTokens[T_POW]) === false) {
+            // T_POW was not added to the arithmetic array until PHPCS 2.9.0.
+            $arithmeticTokens[T_POW] = T_POW;
+        }
+        // phpcs:enable
+
         $skipTokens   = \PHP_CodeSniffer_Tokens::$emptyTokens;
         $skipTokens[] = T_MINUS;
         $skipTokens[] = T_PLUS;
@@ -1654,7 +1663,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         $nextNonEmpty = ($start - 1);
         do {
             $nextNonEmpty       = $phpcsFile->findNext($skipTokens, ($nextNonEmpty + 1), ($end + 1), true);
-            $arithmeticOperator = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$arithmeticTokens, ($nextNonEmpty + 1), ($end + 1));
+            $arithmeticOperator = $phpcsFile->findNext($arithmeticTokens, ($nextNonEmpty + 1), ($end + 1));
         } while ($nextNonEmpty !== false && $arithmeticOperator !== false && $nextNonEmpty === $arithmeticOperator);
 
         if ($arithmeticOperator === false) {
@@ -1666,13 +1675,23 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         $subsetEnd   = ($arithmeticOperator - 1);
 
         while ($this->isNumber($phpcsFile, $subsetStart, $subsetEnd, true) !== false
-            && isset($tokens[$arithmeticOperator + 1]) === true
+            && isset($tokens[($arithmeticOperator + 1)]) === true
         ) {
+            // Recognize T_POW for PHPCS < 2.4.0 on low PHP versions.
+            if (defined('T_POW') === false
+                && $tokens[$arithmeticOperator]['code'] === T_MULTIPLY
+                && $tokens[($arithmeticOperator + 1)]['code'] === T_MULTIPLY
+                && isset($tokens[$arithmeticOperator + 2]) === true
+            ) {
+                // Move operator one forward to the second * in T_POW.
+                ++$arithmeticOperator;
+            }
+
             $subsetStart  = ($arithmeticOperator + 1);
             $nextNonEmpty = $arithmeticOperator;
             do {
                 $nextNonEmpty       = $phpcsFile->findNext($skipTokens, ($nextNonEmpty + 1), ($end + 1), true);
-                $arithmeticOperator = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$arithmeticTokens, ($nextNonEmpty + 1), ($end + 1));
+                $arithmeticOperator = $phpcsFile->findNext($arithmeticTokens, ($nextNonEmpty + 1), ($end + 1));
             } while ($nextNonEmpty !== false && $arithmeticOperator !== false && $nextNonEmpty === $arithmeticOperator);
 
             if ($arithmeticOperator === false) {

--- a/PHPCompatibility/Sniffs/FunctionParameters/ArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionParameters/ArrayReduceInitialTypeSniff.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\FunctionParameters\ArrayReduceInitialTypeSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionParameters;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+
+/**
+ * \PHPCompatibility\Sniffs\FunctionParameters\ArrayReduceInitialTypeSniff.
+ *
+ * Detect: In PHP 5.2 and lower, the $initial parameter had to be an integer.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'array_reduce' => true,
+    );
+
+    /**
+     * Tokens which, for the purposes of this sniff, indicate that there is
+     * a variable element to the value passed.
+     *
+     * @var array
+     */
+    private $variableValueTokens = array(
+        T_VARIABLE,
+        T_STRING,
+        T_SELF,
+        T_PARENT,
+        T_STATIC,
+        T_DOUBLE_QUOTED_STRING,
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('5.2') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[3]) === false) {
+            return;
+        }
+
+        $targetParam = $parameters[3];
+        if ($this->isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], true) !== false) {
+            return;
+        }
+
+        if ($this->isNumericCalculation($phpcsFile, $targetParam['start'], $targetParam['end']) === true) {
+            return;
+        }
+
+        $error = 'Passing a non-integer as the value for $initial to array_reduce() is not supported in PHP 5.2 or lower.';
+        if ($phpcsFile->findNext($this->variableValueTokens, $targetParam['start'], ($targetParam['end'] + 1)) === false) {
+            $phpcsFile->addError(
+                $error . ' Found %s',
+                $targetParam['start'],
+                'InvalidTypeFound',
+                array($targetParam['raw'])
+            );
+        } else {
+            $phpcsFile->addWarning(
+                $error . ' Variable value found. Found %s',
+                $targetParam['start'],
+                'VariableFound',
+                array($targetParam['raw'])
+            );
+        }
+    }
+}

--- a/PHPCompatibility/Tests/BaseClass/IsNumericCalculationTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsNumericCalculationTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Will a certain token combination be recognized as a numeric calculation by PHP ?
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\BaseClass;
+
+/**
+ * isNumericCalculation() function tests
+ *
+ * @group utilityIsNumericCalculation
+ * @group utilityFunctions
+ *
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class IsNumericCalculationTest extends MethodTestFrame
+{
+
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'is_numeric_calculation.php';
+
+    /**
+     * testIsNumericCalculation
+     *
+     * @dataProvider dataIsNumericCalculation
+     *
+     * @covers \PHPCompatibility\Sniff::isNumericCalculation
+     *
+     * @param string $commentString The comment which prefaces the target snippet in the test file.
+     * @param bool   $isCalc        The expected return value for isNumericCalculation().
+     *
+     * @return void
+     */
+    public function testIsNumericCalculation($commentString, $isCalc)
+    {
+        $start = ($this->getTargetToken($commentString, T_EQUAL) + 1);
+        $end   = ($this->getTargetToken($commentString, T_SEMICOLON) - 1);
+
+        $result = $this->helperClass->isNumericCalculation($this->phpcsFile, $start, $end);
+        $this->assertSame($isCalc, $result);
+    }
+
+    /**
+     * dataIsNumericCalculation
+     *
+     * @see testIsNumericCalculation()
+     *
+     * @return array
+     */
+    public function dataIsNumericCalculation()
+    {
+        return array(
+            array('/* Case A1 */', false),
+            array('/* Case A2 */', false),
+            array('/* Case A3 */', false),
+            array('/* Case A4 */', false),
+            array('/* Case A5 */', false),
+
+            array('/* Case B1 */', true),
+            array('/* Case B2 */', true),
+            array('/* Case B3 */', true),
+            array('/* Case B4 */', true),
+            array('/* Case B5 */', true),
+            array('/* Case B6 */', true),
+            array('/* Case B7 */', true),
+        );
+    }
+}

--- a/PHPCompatibility/Tests/BaseClass/TestHelperPHPCompatibility.php
+++ b/PHPCompatibility/Tests/BaseClass/TestHelperPHPCompatibility.php
@@ -56,4 +56,20 @@ class TestHelperPHPCompatibility extends Sniff
     {
         return parent::isNumber($phpcsFile, $start, $end, $allowFloats);
     }
+
+    /**
+     * Wrapper to make the protected parent::isNumericCalculation() method testable.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $start     Start of the snippet (inclusive), i.e. this
+     *                                         token will be examined as part of the snippet.
+     * @param int                   $end       End of the snippet (inclusive), i.e. this
+     *                                         token will be examined as part of the snippet.
+     *
+     * @return bool
+     */
+    public function isNumericCalculation(\PHP_CodeSniffer_File $phpcsFile, $start, $end)
+    {
+        return parent::isNumericCalculation($phpcsFile, $start, $end);
+    }
 }

--- a/PHPCompatibility/Tests/Sniffs/FunctionParameters/ArrayReduceInitialTypeSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/FunctionParameters/ArrayReduceInitialTypeSniffTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Parameter type of the array_reduce() $initial param sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\FunctionParameters;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Parameter type of the array_reduce() $initial param sniff tests.
+ *
+ * @group arrayReduceInitialType
+ * @group functionParameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionParameters\ArrayReduceInitialTypeSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ArrayReduceInitialTypeSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'Sniffs/FunctionParameters/ArrayReduceInitialTypeTestCases.inc';
+
+    /**
+     * testArrayReduceInitialType
+     *
+     * @dataProvider dataArrayReduceInitialType
+     *
+     * @param int  $line    Line number where the error should occur.
+     * @param bool $isError Whether an error or a warning is expected.
+     *                      Defaults to `true` (= error).
+     *
+     * @return void
+     */
+    public function testArrayReduceInitialType($line, $isError = true)
+    {
+        $file  = $this->sniffFile(self::TEST_FILE, '5.2');
+        $error = 'Passing a non-integer as the value for $initial to array_reduce() is not supported in PHP 5.2 or lower.';
+
+        if ($isError === true) {
+            $this->assertError($file, $line, $error);
+        } else {
+            $this->assertWarning($file, $line, $error);
+        }
+    }
+
+    /**
+     * dataArrayReduceInitialType
+     *
+     * @see testArrayReduceInitialType()
+     *
+     * @return array
+     */
+    public function dataArrayReduceInitialType()
+    {
+        return array(
+            array(16),
+
+            array(19, false),
+            array(20, false),
+            array(21, false),
+            array(22, false),
+            array(23, false),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+
+        // No errors expected on the first 14 lines.
+        for ($line = 1; $line <= 14; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/FunctionParameters/ArrayReduceInitialTypeTestCases.inc
+++ b/PHPCompatibility/Tests/Sniffs/FunctionParameters/ArrayReduceInitialTypeTestCases.inc
@@ -1,0 +1,23 @@
+<?php
+
+// OK.
+array_reduce( $array, $callback );
+array_reduce( $array, $callback, 0 );
+array_reduce( $array, $callback, 15 );
+array_reduce( $array, $callback, 15 * 3 );
+array_reduce( $array, $callback, 24 * 60 * 60 );
+array_reduce( $array, $callback, /*initial*/ -100 /*initial*/ );
+array_reduce( $array, $callback, 'string' ); // Will be typecast by PHP.
+array_reduce( $array, $callback, 20.5 ); // Will be typecast by PHP.
+array_reduce( $array, $callback, false ); // Will be typecast by PHP.
+array_reduce( $array, $callback, null ); // Will be typecast by PHP.
+
+// Not OK - error.
+array_reduce( $array, $callback, array() );
+
+// Not OK - warning.
+array_reduce( $array, $callback, $initial );
+array_reduce( $array, $callback, $this->initial );
+array_reduce( $array, $callback, self::INITIAL );
+array_reduce( $array, $callback, 15 * $initial );
+array_reduce( $array, $callback, new stdClass );

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/is_numeric_calculation.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/is_numeric_calculation.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Make sure that numeric calculations are correctly identified.
+ *
+ * The below should *NOT* be recognized as numeric calculations.
+ */
+
+/* Case A1 */
+$a = 10;
+
+/* Case A2 */
+$a = [] + array();
+
+/* Case A3 */
+$a = $b + $c;
+
+/* Case A4 */
+$a = 'not a numeric string' . 'nor this';
+
+/* Case A5 */
+$a = 10 << 2;
+
+
+/*
+ * The below should be recognized as numeric calculations.
+ */
+
+/* Case B1 */
+$a = 10 * 5;
+
+/* Case B2 */
+$a = 10 + 5;
+
+/* Case B3 */
+$a = -10 - +-+5;
+
+/* Case B4 */
+$a = 10 + 5 * -3.2 - 20 / 2.1 % 1 ** 3;
+
+/* Case B5 */
+$b = - false + '0';
+
+/* Case B6 */
+$a = 10 + 'not a numeric string' * 3;
+
+/* Case B7 */
+$a = 10 * 3 + '123 numeric start of string';


### PR DESCRIPTION
> Version | Description
> --- | ---
> 5.3.0 | Changed initial to allow mixed, previously integer.

Refs:
* http://php.net/manual/en/function.array-reduce.php#refsect1-function.array-reduce-changelog
* http://php.net/manual/en/migration53.other.php#migration53.other

Fixes #649

----

In support of this sniff, a new utility method is introduced. `isNumericCalculation()`

This utility function can determine whether the tokens between a `$start` and `$end` token would be evaluated as a numeric calculation by PHP.

Mainly useful for verifying function call parameters, where a numeric value is expected, but a calculation can be passed to create the number.

Includes unit tests.