### PR TITLE
PHPCSHelper: minor bugfix

### DIFF
--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -157,8 +157,8 @@ class PHPCSHelper
                 && ($i === $tokens[$i]['scope_opener']
                 || $i === $tokens[$i]['scope_condition'])
             ) {
-                if ($i === $start && isset(Util\Tokens::$scopeOpeners[$this->tokens[$i]['code']]) === true) {
-                    return $this->tokens[$i]['scope_closer'];
+                if ($i === $start && isset(Util\Tokens::$scopeOpeners[$tokens[$i]['code']]) === true) {
+                    return $tokens[$i]['scope_closer'];
                 }
 
                 $i = $tokens[$i]['scope_closer'];


### PR DESCRIPTION
Found via Scrutinizer.

`$this` does not exist in a static method, nor has `$tokens` been set as a property (copy/paste artefact).

Not a bug which was actively encountered so far.