### PR TITLE
Various minor cs fixes

### DIFF
--- a/PHPCompatibility/AbstractNewFeatureSniff.php
+++ b/PHPCompatibility/AbstractNewFeatureSniff.php
@@ -92,7 +92,7 @@ abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
         $itemName = $this->getItemName($itemInfo, $errorInfo);
         $error    = $this->getErrorMsgTemplate();
 
-        $errorCode = $this->stringToErrorCode($itemName).'Found';
+        $errorCode = $this->stringToErrorCode($itemName) . 'Found';
         $data      = array(
             $itemName,
             $errorInfo['not_in_version'],

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -230,7 +230,7 @@ class PHPCSHelper
 
         $classCloserIndex = $tokens[$stackPtr]['scope_closer'];
         $extendsIndex     = $phpcsFile->findNext(T_EXTENDS, $stackPtr, $classCloserIndex);
-        if (false === $extendsIndex) {
+        if ($extendsIndex === false) {
             return false;
         }
 

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -135,8 +135,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
                             E_USER_WARNING
                         );
                         return $default;
-                    }
-                    else {
+                    } else {
                         $arrTestVersions[$testVersion] = array($min, $max);
                         return $arrTestVersions[$testVersion];
                     }
@@ -1551,7 +1550,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         ) {
 
             if ($tokens[$nextNonEmpty]['code'] === T_MINUS) {
-                $negativeNumber = ($negativeNumber === false ) ? true : false;
+                $negativeNumber = ($negativeNumber === false) ? true : false;
             }
 
             $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), $searchEnd, true);

--- a/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
@@ -62,7 +62,7 @@ class ConstantArraysUsingDefineSniff extends Sniff
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
+        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -856,7 +856,7 @@ class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
+        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -250,7 +250,7 @@ class DeprecatedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
+        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/EmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/EmptyNonVariableSniff.php
@@ -65,6 +65,7 @@ class EmptyNonVariableSniff extends Sniff
                 array(T_OPEN_PARENTHESIS, T_STRING_CONCAT)
             )
         );
+
         $this->tokenBlackList = array_combine($tokenBlackList, $tokenBlackList);
 
         return array(T_EMPTY);

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -91,7 +91,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
 
         if ($errorType !== '') {
             $error     = 'Using %s on break or continue is forbidden since PHP 5.4';
-            $errorCode = $errorType.'Found';
+            $errorCode = $errorType . 'Found';
             $data      = array($this->errorTypes[$errorType]);
 
             $phpcsFile->addError($error, $stackPtr, $errorCode, $data);

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -217,7 +217,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
         // Build up the error message.
         $error     = "'%s' is a";
         $isError   = null;
-        $errorCode = $this->stringToErrorCode($nameLc).'Found';
+        $errorCode = $this->stringToErrorCode($nameLc) . 'Found';
         $data      = array(
             $nameLc,
         );

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -175,7 +175,7 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
 
         if ($this->supportsAbove($version)) {
             $error     = "'%s' is a reserved keyword introduced in PHP version %s and cannot be invoked as a function (%s)";
-            $errorCode = $this->stringToErrorCode($tokenContentLc).'Found';
+            $errorCode = $this->stringToErrorCode($tokenContentLc) . 'Found';
             $data      = array(
                 $tokenContentLc,
                 $version,

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -393,7 +393,7 @@ class ForbiddenNamesSniff extends Sniff
     protected function addError($phpcsFile, $stackPtr, $content, $data)
     {
         $error     = "Function name, class name, namespace name or constant name can not be reserved keyword '%s' (since version %s)";
-        $errorCode = $this->stringToErrorCode($content).'Found';
+        $errorCode = $this->stringToErrorCode($content) . 'Found';
         $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
     }
 

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
@@ -77,8 +77,8 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Determine the start and end of the part of the statement we need to examine.
-        $start  = ($stackPtr + 1);
-        $next   = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $start, null, true);
+        $start = ($stackPtr + 1);
+        $next  = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $start, null, true);
         if ($next !== false && $tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
             $start = ($next + 1);
         }

--- a/PHPCompatibility/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/InternalInterfacesSniff.php
@@ -79,7 +79,7 @@ class InternalInterfacesSniff extends Sniff
             $interfaceLc = strtolower($interface);
             if (isset($this->internalInterfaces[$interfaceLc]) === true) {
                 $error     = 'The interface %s %s';
-                $errorCode = $this->stringToErrorCode($interfaceLc).'Found';
+                $errorCode = $this->stringToErrorCode($interfaceLc) . 'Found';
                 $data      = array(
                     $interface,
                     $this->internalInterfaces[$interfaceLc],

--- a/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
@@ -811,7 +811,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      */
     protected function getErrorMsgTemplate()
     {
-        return 'The built-in class '.parent::getErrorMsgTemplate();
+        return 'The built-in class ' . parent::getErrorMsgTemplate();
     }
 
 

--- a/PHPCompatibility/Sniffs/PHP/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewConstantScalarExpressionsSniff.php
@@ -269,7 +269,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                 }
 
                 $targetNestingLevel = 0;
-                if (isset($tokens[$stackPtr]['nested_parenthesis']) == true) {
+                if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
                     $targetNestingLevel = count($tokens[$stackPtr]['nested_parenthesis']);
                 }
 
@@ -552,7 +552,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
         if ($tokens[$endPtr]['code'] === T_COMMA) {
             // Check if a comma is at the nesting level we're targetting.
             $nestingLevel = 0;
-            if (isset($tokens[$endPtr]['nested_parenthesis']) == true) {
+            if (isset($tokens[$endPtr]['nested_parenthesis']) === true) {
                 $nestingLevel = count($tokens[$endPtr]['nested_parenthesis']);
             }
             if ($nestingLevel > $targetLevel) {

--- a/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -214,7 +214,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      */
     protected function getErrorMsgTemplate()
     {
-        return 'Directive '.parent::getErrorMsgTemplate();
+        return 'Directive ' . parent::getErrorMsgTemplate();
     }
 
 
@@ -236,7 +236,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
             parent::addError($phpcsFile, $stackPtr, $itemInfo, $errorInfo);
         } elseif ($errorInfo['conditional_version'] !== '') {
             $error     = 'Directive %s is present in PHP version %s but will be disregarded unless PHP is compiled with %s';
-            $errorCode = $this->stringToErrorCode($itemInfo['name']).'WithConditionFound';
+            $errorCode = $this->stringToErrorCode($itemInfo['name']) . 'WithConditionFound';
             $data      = array(
                 $itemInfo['name'],
                 $errorInfo['conditional_version'],
@@ -282,7 +282,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
         if ($isError === true) {
             $error     = 'The execution directive %s does not seem to have a valid value. Please review. Found: %s';
-            $errorCode = $this->stringToErrorCode($directive).'InvalidValueFound';
+            $errorCode = $this->stringToErrorCode($directive) . 'InvalidValueFound';
             $data      = array(
                 $directive,
                 $value,

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -192,9 +192,9 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         ),
         'getenv' => array(
             1 => array(
-                'name' => 'local_only',
-                '5.5.37'  => false,
-                '5.5.38'  => true, // Also introduced in PHP 5.6.24 and 7.0.9.
+                'name'   => 'local_only',
+                '5.5.37' => false,
+                '5.5.38' => true, // Also introduced in PHP 5.6.24 and 7.0.9.
             ),
         ),
         'getopt' => array(
@@ -659,9 +659,9 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.5.1' => true,
             ),
             7 => array(
-                'name'  => 'validate_sid',
-                '5.6' => false,
-                '7.0' => true,
+                'name' => 'validate_sid',
+                '5.6'  => false,
+                '7.0'  => true,
             ),
             8 => array(
                 'name' => 'update_timestamp',
@@ -939,7 +939,7 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
      */
     public function getErrorInfo(array $itemArray, array $itemInfo)
     {
-        $errorInfo = parent::getErrorInfo($itemArray, $itemInfo);
+        $errorInfo              = parent::getErrorInfo($itemArray, $itemInfo);
         $errorInfo['paramName'] = $itemArray['name'];
 
         return $errorInfo;
@@ -956,7 +956,7 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
      */
     protected function getItemName(array $itemInfo, array $errorInfo)
     {
-        return $itemInfo['name'].'_'.$errorInfo['paramName'];
+        return $itemInfo['name'] . '_' . $errorInfo['paramName'];
     }
 
 

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -870,7 +870,7 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
+        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
@@ -1764,7 +1764,7 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
+        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
             // Not a call to a PHP function.
             return;
 

--- a/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -559,7 +559,7 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
      */
     public function getErrorInfo(array $itemArray, array $itemInfo)
     {
-        $errorInfo = parent::getErrorInfo($itemArray, $itemInfo);
+        $errorInfo                = parent::getErrorInfo($itemArray, $itemInfo);
         $errorInfo['alternative'] = '';
 
         if (isset($itemArray['alternative']) === true) {

--- a/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -496,7 +496,7 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
+        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
@@ -226,7 +226,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
 
                     if (isset($this->unsupportedMethods[$interfaceLc][$funcNameLc]) === true) {
                         $error     = 'Classes that implement interface %s do not support the method %s(). See %s';
-                        $errorCode = $this->stringToErrorCode($interface).'UnsupportedMethod';
+                        $errorCode = $this->stringToErrorCode($interface) . 'UnsupportedMethod';
                         $data      = array(
                             $interface,
                             $funcName,
@@ -324,7 +324,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      */
     protected function getErrorMsgTemplate()
     {
-        return 'The built-in interface '.parent::getErrorMsgTemplate();
+        return 'The built-in interface ' . parent::getErrorMsgTemplate();
     }
 
 

--- a/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
@@ -326,7 +326,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
      */
     public function getErrorInfo(array $itemArray, array $itemInfo)
     {
-        $errorInfo = parent::getErrorInfo($itemArray, $itemInfo);
+        $errorInfo                = parent::getErrorInfo($itemArray, $itemInfo);
         $errorInfo['description'] = $itemArray['description'];
 
         return $errorInfo;

--- a/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
@@ -356,9 +356,9 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
      * A double quoted identifier will have the opening quote on position 3
      * in the string: `<<<"ID"`.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return bool
      */

--- a/PHPCompatibility/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -186,7 +186,7 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
         }
 
         $itemInfo = array(
-            'name'   => $tokenType,
+            'name' => $tokenType,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
 
@@ -227,7 +227,7 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
      */
     public function getErrorInfo(array $itemArray, array $itemInfo)
     {
-        $errorInfo = parent::getErrorInfo($itemArray, $itemInfo);
+        $errorInfo                = parent::getErrorInfo($itemArray, $itemInfo);
         $errorInfo['description'] = $itemArray['description'];
 
         return $errorInfo;

--- a/PHPCompatibility/Sniffs/PHP/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewTypeCastsSniff.php
@@ -97,6 +97,7 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
 
                     $tokenType = 'T_BINARY_CAST';
                     break;
+
                 case 'T_CONSTANT_ENCAPSED_STRING':
                     if (strpos($tokenContent, 'b"') === 0 && substr($tokenContent, -1) === '"') {
                         $tokenType = 'T_BINARY_CAST';
@@ -156,7 +157,7 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
      */
     public function getErrorInfo(array $itemArray, array $itemInfo)
     {
-        $errorInfo = parent::getErrorInfo($itemArray, $itemInfo);
+        $errorInfo                = parent::getErrorInfo($itemArray, $itemInfo);
         $errorInfo['description'] = $itemArray['description'];
 
         return $errorInfo;

--- a/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -153,7 +153,7 @@ class NonStaticMagicMethodsSniff extends Sniff
 
             if (isset($this->magicMethods[$methodNameLc]['visibility']) && $this->magicMethods[$methodNameLc]['visibility'] !== $methodProperties['scope']) {
                 $error     = 'Visibility for magic method %s must be %s. Found: %s';
-                $errorCode = $errorCodeBase.'MethodVisibility';
+                $errorCode = $errorCodeBase . 'MethodVisibility';
                 $data      = array(
                     $methodName,
                     $this->magicMethods[$methodNameLc]['visibility'],
@@ -165,12 +165,12 @@ class NonStaticMagicMethodsSniff extends Sniff
 
             if (isset($this->magicMethods[$methodNameLc]['static']) && $this->magicMethods[$methodNameLc]['static'] !== $methodProperties['is_static']) {
                 $error     = 'Magic method %s cannot be defined as static.';
-                $errorCode = $errorCodeBase.'MethodStatic';
+                $errorCode = $errorCodeBase . 'MethodStatic';
                 $data      = array($methodName);
 
                 if ($this->magicMethods[$methodNameLc]['static'] === true) {
                     $error     = 'Magic method %s must be defined as static.';
-                    $errorCode = $errorCodeBase.'MethodNonStatic';
+                    $errorCode = $errorCodeBase . 'MethodNonStatic';
                 }
 
                 $phpcsFile->addError($error, $functionToken, $errorCode, $data);

--- a/PHPCompatibility/Sniffs/PHP/OptionalRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/OptionalRequiredFunctionParametersSniff.php
@@ -127,7 +127,7 @@ class OptionalRequiredFunctionParametersSniff extends RequiredOptionalFunctionPa
             $error .= 'strongly recommended ';
         }
 
-        $errorCode = $this->stringToErrorCode($itemInfo['name'].'_'.$errorInfo['paramName']);
+        $errorCode = $this->stringToErrorCode($itemInfo['name'] . '_' . $errorInfo['paramName']);
         $data      = array(
             $errorInfo['paramName'],
             $itemInfo['name'],
@@ -151,7 +151,7 @@ class OptionalRequiredFunctionParametersSniff extends RequiredOptionalFunctionPa
             }
 
             // Remove the last 'and' from the message.
-            $error      = substr($error, 0, (strlen($error) - 5));
+            $error = substr($error, 0, (strlen($error) - 5));
         }
 
         $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);

--- a/PHPCompatibility/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -68,7 +68,7 @@ class ParameterShadowSuperGlobalsSniff extends Sniff
         foreach ($parameters as $param) {
             if (in_array($param['name'], $this->superglobals, true)) {
                 $error     = 'Parameter shadowing super global (%s) causes fatal error since PHP 5.4';
-                $errorCode = $this->stringToErrorCode(substr($param['name'], 1)).'Found';
+                $errorCode = $this->stringToErrorCode(substr($param['name'], 1)) . 'Found';
                 $data      = array($param['name']);
 
                 $phpcsFile->addError($error, $param['token'], $errorCode, $data);

--- a/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
@@ -46,7 +46,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
     {
         if (version_compare(PHP_VERSION_ID, '70000', '<') === true) {
             // phpcs:ignore PHPCompatibility.PHP.DeprecatedIniDirectives.asp_tagsRemoved
-            $this->aspTags = (boolean) ini_get('asp_tags');
+            $this->aspTags = (bool) ini_get('asp_tags');
         }
 
         return array(

--- a/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
@@ -84,14 +84,14 @@ class RemovedAlternativePHPTagsSniff extends Sniff
         if ($openTag['code'] === T_OPEN_TAG || $openTag['code'] === T_OPEN_TAG_WITH_ECHO) {
 
             if ($content === '<%' || $content === '<%=') {
-                $data = array(
+                $data      = array(
                     'ASP',
                     $content,
                 );
                 $errorCode = 'ASPOpenTagFound';
 
             } elseif (strpos($content, '<script ') !== false) {
-                $data = array(
+                $data      = array(
                     'Script',
                     $content,
                 );
@@ -105,8 +105,8 @@ class RemovedAlternativePHPTagsSniff extends Sniff
         elseif ($openTag['code'] === T_INLINE_HTML
             && preg_match('`((?:<s)?cript (?:[^>]+)?language=[\'"]?php[\'"]?(?:[^>]+)?>)`i', $content, $match) === 1
         ) {
-            $found = $match[1];
-            $data  = array(
+            $found     = $match[1];
+            $data      = array(
                 'Script',
                 $found,
             );
@@ -128,7 +128,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
             if (strpos($content, '<%') !== false) {
                 $error   = 'Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: %s';
                 $snippet = $this->getSnippet($content, '<%');
-                $data    = array('<%'.$snippet);
+                $data    = array('<%' . $snippet);
 
                 $phpcsFile->addWarning($error, $stackPtr, 'MaybeASPOpenTagFound', $data);
             }

--- a/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -93,7 +93,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
+        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -162,7 +162,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
      */
     public function getErrorInfo(array $itemArray, array $itemInfo)
     {
-        $errorInfo = parent::getErrorInfo($itemArray, $itemInfo);
+        $errorInfo              = parent::getErrorInfo($itemArray, $itemInfo);
         $errorInfo['paramName'] = $itemArray['name'];
 
         return $errorInfo;
@@ -179,7 +179,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
      */
     protected function getItemName(array $itemInfo, array $errorInfo)
     {
-        return $itemInfo['name'].'_'.$errorInfo['paramName'];
+        return $itemInfo['name'] . '_' . $errorInfo['paramName'];
     }
 
 

--- a/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
@@ -97,7 +97,7 @@ class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSnif
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
+        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
@@ -228,7 +228,7 @@ class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSnif
     public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
     {
         $error     = $this->getErrorMsgTemplate();
-        $errorCode = $this->stringToErrorCode($itemInfo['name'].'_'.$errorInfo['paramName']).'Missing';
+        $errorCode = $this->stringToErrorCode($itemInfo['name'] . '_' . $errorInfo['paramName']) . 'Missing';
         $data      = array(
             $errorInfo['paramName'],
             $itemInfo['name'],

--- a/PHPCompatibility/Sniffs/PHP/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ReservedFunctionNamesSniff.php
@@ -100,7 +100,7 @@ class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_Camel
                     'Method name "%s" is discouraged; PHP has reserved all method names with a double underscore prefix for future use.',
                     $stackPtr,
                     'MethodDoubleUnderscore',
-                    array($className.'::'.$methodName)
+                    array($className . '::' . $methodName)
                 );
             }
         }

--- a/PHPCompatibility/Sniffs/PHP/VariableVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/VariableVariablesSniff.php
@@ -95,8 +95,7 @@ class VariableVariablesSniff extends Sniff
             if ($classToken !== false) {
                 if ($tokens[$classToken]['code'] === T_STATIC || $tokens[$classToken]['code'] === T_SELF) {
                     return;
-                }
-                elseif ($tokens[$classToken]['code'] === T_STRING && $tokens[$classToken]['content'] === 'self') {
+                } elseif ($tokens[$classToken]['code'] === T_STRING && $tokens[$classToken]['content'] === 'self') {
                     return;
                 }
             }

--- a/PHPCompatibility/Tests/BaseClass/FunctionsTest.php
+++ b/PHPCompatibility/Tests/BaseClass/FunctionsTest.php
@@ -50,7 +50,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->helperClass = new TestHelperPHPCompatibility;
+        $this->helperClass = new TestHelperPHPCompatibility();
     }
 
     /**

--- a/PHPCompatibility/Tests/BaseClass/MethodTestFrame.php
+++ b/PHPCompatibility/Tests/BaseClass/MethodTestFrame.php
@@ -69,7 +69,7 @@ abstract class MethodTestFrame extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->helperClass = new TestHelperPHPCompatibility;
+        $this->helperClass = new TestHelperPHPCompatibility();
 
         $filename = realpath(__DIR__) . DIRECTORY_SEPARATOR . $this->testcasePath . $this->filename;
         $contents = file_get_contents($filename);

--- a/PHPCompatibility/Tests/BaseClass/TokenScopeTest.php
+++ b/PHPCompatibility/Tests/BaseClass/TokenScopeTest.php
@@ -110,7 +110,7 @@ class TokenScopeTest extends MethodTestFrame
     public function testInClassScope($commentString, $targetType, $expected)
     {
         $stackPtr = $this->getTargetToken($commentString, $targetType);
-        $result = $this->helperClass->inClassScope($this->phpcsFile, $stackPtr);
+        $result   = $this->helperClass->inClassScope($this->phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
 

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -28,7 +28,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
      *
      * Used by PHPCS 1.x and 2.x.
      *
-     * @var PHP_CodeSniffer
+     * @var \PHP_CodeSniffer
      */
     protected static $phpcs = null;
 

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -134,7 +134,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
             return self::$sniffFiles[$filename][$targetPhpVersion];
         }
 
-        if ('none' !== $targetPhpVersion) {
+        if ($targetPhpVersion !== 'none') {
             PHPCSHelper::setConfigData('testVersion', $targetPhpVersion, true);
         }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/RemovedAlternativePHPTagsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RemovedAlternativePHPTagsSniffTest.php
@@ -41,7 +41,7 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
     {
         if (version_compare(PHP_VERSION_ID, '70000', '<')) {
             // phpcs:ignore PHPCompatibility.PHP.DeprecatedIniDirectives.asp_tagsRemoved
-            self::$aspTags = (boolean) ini_get('asp_tags');
+            self::$aspTags = (bool) ini_get('asp_tags');
         }
 
         parent::setUpBeforeClass();

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -70,6 +70,11 @@
         <severity>5</severity>
     </rule>
 
+    <rule ref="Generic.PHP.LowerCaseType"/>
+    <rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing"/>
+    <rule ref="PSR12.Classes.ClassInstantiation"/>
+    <rule ref="PSR12.Keywords.ShortFormTypeKeywords"/>
+    <rule ref="PSR12.Operators.OperatorSpacing"/>
 
     <!-- Use normalized array indentation. -->
     <rule ref="Generic.Arrays.ArrayIndent"/>


### PR DESCRIPTION
PHPCS 3.3.0 contained a few more sniffs which this library largely complied with already anyway, so formalizing these CS standards by adding them to the ruleset seemed appropriate.

In separate commits the necessary code changes are made, including some for rules already in the ruleset which were throwing warnings and therefore not breaking the build.