### PR TITLE
PHP 7.3: NewClasses: account for new CompileError and JsonException

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
@@ -535,6 +535,15 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '7.0' => false,
             '7.1' => true,
         ),
+
+        'CompileError' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
+        'JsonException' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -187,6 +187,8 @@ class NewClassesSniffTest extends BaseSniffTest
             array('UI\Exception\InvalidArgumentException', '5.6', array(192, 210, 246, 322), '7.0'),
             array('UI\Exception\RuntimeException', '5.6', array(188, 199, 247), '7.0'),
             array('ArgumentCountError', '7.0', array(248), '7.1'),
+            array('CompileError', '7.2', array(249), '7.3'),
+            array('JsonException', '7.2', array(250, 339), '7.3'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_classes.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_classes.php
@@ -246,9 +246,9 @@ try {
 } catch (UI\Exception\InvalidArgumentException $e) {
 } catch (UI\Exception\RuntimeException $e) {
 } catch (ArgumentCountError $e) {
+} catch (CompileError $e) {
+} catch (JsonException $e) {
 }
-
-
 
 // Multi-catch.
 try {
@@ -335,3 +335,5 @@ class TestThis {
 interface TestThat {
 	public function InterfaceMethodParamAndReturnTypeHint( XMLReader $a ) : \SplFileObject;
 }
+
+throw new JsonException();


### PR DESCRIPTION
Refs:
* https://github.com/php/php-src/blob/600cb4b46755a9170eaa32606528a6908bc98975/UPGRADING#L231
* https://github.com/php/php-src/blob/3f53b02a53448ec5e7d2d0733668da92a9463730/UPGRADING#L106
* https://github.com/php/php-src/commit/d04917c7b361fd07e098fe29ae931fb6fac1d9e0
* https://github.com/php/php-src/commit/e823770515bd0530bd3c09ea273c720b4df33734