### PR TITLE
PHP 7.3: DeprecatedFunctions: account for deprecation of image2wbmp()

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -814,6 +814,11 @@ class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.2' => false,
             'alternative' => 'exif_read_data()',
         ),
+
+        'image2wbmp' => array(
+            '7.3' => false,
+            'alternative' => 'imagewbmp()',
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -168,6 +168,8 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             array('each', '7.2', 'a foreach loop', array(147), '7.1'),
             array('gmp_random', '7.2', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
             array('read_exif_data', '7.2', 'exif_read_data()', array(149), '7.1'),
+
+            array('image2wbmp', '7.3', 'imagewbmp()', array(152), '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
@@ -147,3 +147,6 @@ create_function();
 while (list($key, $val) = each($array)) {}
 gmp_random(2);
 read_exif_data();
+
+// PHP 7.3.
+image2wbmp();


### PR DESCRIPTION
Refs:
* https://wiki.php.net/rfc/image2wbmp
* https://github.com/php/php-src/blob/3f53b02a53448ec5e7d2d0733668da92a9463730/UPGRADING#L162
* https://github.com/php/php-src/commit/3cbf594dfd0708dc36f1655c50e16fa963e61501