### PR TITLE
Sniff::getFunctionCallParameters(): correctly handle closures when passed as param

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -450,7 +450,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         $nextComma  = $opener;
         $paramStart = $opener + 1;
         $cnt        = 1;
-        while (($nextComma = $phpcsFile->findNext(array(T_COMMA, $tokens[$closer]['code'], T_OPEN_SHORT_ARRAY), $nextComma + 1, $closer + 1)) !== false) {
+        while (($nextComma = $phpcsFile->findNext(array(T_COMMA, $tokens[$closer]['code'], T_OPEN_SHORT_ARRAY, T_CLOSURE), $nextComma + 1, $closer + 1)) !== false) {
             // Ignore anything within short array definition brackets.
             if ($tokens[$nextComma]['type'] === 'T_OPEN_SHORT_ARRAY'
                 && (isset($tokens[$nextComma]['bracket_opener'])
@@ -459,6 +459,17 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
             ) {
                 // Skip forward to the end of the short array definition.
                 $nextComma = $tokens[$nextComma]['bracket_closer'];
+                continue;
+            }
+
+            // Skip past closures passed as function parameters.
+            if ($tokens[$nextComma]['type'] === 'T_CLOSURE'
+                && (isset($tokens[$nextComma]['scope_condition'])
+                    && $tokens[$nextComma]['scope_condition'] === $nextComma)
+                && isset($tokens[$nextComma]['scope_closer'])
+            ) {
+                // Skip forward to the end of the closure declaration.
+                $nextComma = $tokens[$nextComma]['scope_closer'];
                 continue;
             }
 

--- a/PHPCompatibility/Tests/BaseClass/GetFunctionParametersTest.php
+++ b/PHPCompatibility/Tests/BaseClass/GetFunctionParametersTest.php
@@ -174,6 +174,29 @@ class GetFunctionParametersTest extends MethodTestFrame
                     ),
                 ),
             ),
+            array(
+                '/* Case S6 */',
+                array(
+                    1 => array(
+                        'start' => 2,
+                        'end'   => 90,
+                        'raw'   => '/* Case A7 */
+    [
+        \'~\'.$dyn.\'~J\' => function ($match) {
+            echo strlen($match[0]), \' matches for "a" found\', PHP_EOL;
+        },
+        \'~\'.function_call().\'~i\' => function ($match) {
+            echo strlen($match[0]), \' matches for "b" found\', PHP_EOL;
+        },
+    ]',
+                    ),
+                    2 => array(
+                        'start' => 92,
+                        'end'   => 95,
+                        'raw'   => '$subject',
+                    ),
+                ),
+            ),
 
             // Long array.
             array(
@@ -245,6 +268,27 @@ class GetFunctionParametersTest extends MethodTestFrame
                         'start' => 24,
                         'end'   => 28,
                         'raw'   => 'date(\'Y\')',
+                    ),
+                ),
+            ),
+
+            // Array containing closure.
+            array(
+                '/* Case A7 */',
+                array(
+                    1 => array(
+                        'start' => 1,
+                        'end'   => 38,
+                        'raw'   => '\'~\'.$dyn.\'~J\' => function ($match) {
+            echo strlen($match[0]), \' matches for "a" found\', PHP_EOL;
+        }',
+                    ),
+                    2 => array(
+                        'start' => 40,
+                        'end'   => 79,
+                        'raw'   => '\'~\'.function_call().\'~i\' => function ($match) {
+            echo strlen($match[0]), \' matches for "b" found\', PHP_EOL;
+        }',
                     ),
                 ),
             ),

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/get_function_parameters.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/get_function_parameters.php
@@ -4,7 +4,7 @@
 myfunction( 1, 2, 3, 4, 5, 6, true );
 
 /*
- * Propertly deal with nested parenthesis.
+ * Properly deal with nested parenthesis.
  * Also see Github issues #111 / #114 / #151.
  */
 /* Case S2 */
@@ -42,3 +42,20 @@ $bar = [0, 0, date('s'), date('m'), date('d'), date('Y')]; // 6
 $bar = [str_replace("../", "/", trim($value))]; // 1
 /* Case A6 */
 $bar = [0 => $a, 2 => $b, (isset($c) ? 6 => $c : 6 => null)];
+
+/*
+ * Properly deal with closures passed as function call parameters.
+ */
+/* Case S6 */
+preg_replace_callback_array(
+	/* Case A7 */
+    [
+        '~'.$dyn.'~J' => function ($match) {
+            echo strlen($match[0]), ' matches for "a" found', PHP_EOL;
+        },
+        '~'.function_call().'~i' => function ($match) {
+            echo strlen($match[0]), ' matches for "b" found', PHP_EOL;
+        },
+    ],
+    $subject
+);


### PR DESCRIPTION
Closures can be declared within function calls when the function expects a call-back.
This situation was only partially handled within the `Sniff::getFunctionCallParameters()` method.

Most of the time when a comma is encountered within a closure, it will be at a different nesting level than the original function call/array, which meant it would be disregarded and the method would return the correct results.
However, there are some, albeit rare, situations in which the comma would be at the target nesting level, causing the method to split the closure into two or more "parameters".

I came across this while working on a PR for WPCS which uses the same utility function.
As far as I know, this bug has not caused any issues for any of the PHPCompatibility sniffs so far, but the situation should be handled correctly even so.

Includes unit tests.