### PR TITLE
PHP 7.3: New `DiscouragedSwitchContinue` sniff

### DIFF
--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -496,7 +496,7 @@ class PHPCSHelper
                     // If it's null, then there must be no parameters for this
                     // method.
                     if ($currVar === null) {
-                        continue;
+                        break;
                     }
 
                     $vars[$paramCount]            = array();

--- a/PHPCompatibility/Sniffs/PHP/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DiscouragedSwitchContinueSniff.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\DiscouragedSwitchContinue.
+ *
+ * PHP version 7.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+use PHPCompatibility\PHPCSHelper;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\DiscouragedSwitchContinue.
+ *
+ * PHP 7.3 will throw a warning when continue is used to target a switch control structure.
+ *
+ * PHP version 7.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class DiscouragedSwitchContinueSniff extends Sniff
+{
+
+    /**
+     * Token codes of control structures which can be targeted using continue.
+     *
+     * @var array
+     */
+    protected $loopStructures = array(
+        \T_FOR     => \T_FOR,
+        \T_FOREACH => \T_FOREACH,
+        \T_WHILE   => \T_WHILE,
+        \T_DO      => \T_DO,
+        \T_SWITCH  => \T_SWITCH,
+    );
+
+    /**
+     * Tokens which start a new case within a switch.
+     *
+     * @var array
+     */
+    protected $caseTokens = array(
+        \T_CASE    => \T_CASE,
+        \T_DEFAULT => \T_DEFAULT,
+    );
+
+    /**
+     * Token codes which are accepted to determine the level for the continue.
+     *
+     * This array is enriched with the arithmetic operators in the register() method.
+     *
+     * @var array
+     */
+    protected $acceptedLevelTokens = array(
+        \T_LNUMBER           => \T_LNUMBER,
+        \T_OPEN_PARENTHESIS  => \T_OPEN_PARENTHESIS,
+        \T_CLOSE_PARENTHESIS => \T_CLOSE_PARENTHESIS,
+    );
+
+    /**
+     * PHPCS cross-version compatible version of the Tokens::$emptyTokens array.
+     *
+     * @var array
+     */
+    private $emptyTokens = array();
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $arithmeticTokens  = \PHP_CodeSniffer_Tokens::$arithmeticTokens;
+        $this->emptyTokens = \PHP_CodeSniffer_Tokens::$emptyTokens;
+        if (version_compare(PHPCSHelper::getVersion(), '2.0', '<')) {
+            $arithmeticTokens  = array_combine($arithmeticTokens, $arithmeticTokens);
+            $this->emptyTokens = array_combine($this->emptyTokens, $this->emptyTokens);
+        }
+
+        $this->acceptedLevelTokens = $this->acceptedLevelTokens + $arithmeticTokens + $this->emptyTokens;
+
+        return array(\T_SWITCH);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.3') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
+            return;
+        }
+
+        $switchOpener = $tokens[$stackPtr]['scope_opener'];
+        $switchCloser = $tokens[$stackPtr]['scope_closer'];
+
+        // Quick check whether we need to bother with the more complex logic.
+        $hasContinue = $phpcsFile->findNext(\T_CONTINUE, ($switchOpener + 1), $switchCloser);
+        if ($hasContinue === false) {
+            return;
+        }
+
+        $caseDefault = $switchOpener;
+
+        do {
+            $caseDefault = $phpcsFile->findNext($this->caseTokens, ($caseDefault + 1), $switchCloser);
+            if ($caseDefault === false) {
+                break;
+            }
+
+            if (isset($tokens[$caseDefault]['scope_opener']) === false) {
+                // Unknown start of the case, skip.
+                continue;
+            }
+
+            $caseOpener      = $tokens[$caseDefault]['scope_opener'];
+            $nextCaseDefault = $phpcsFile->findNext($this->caseTokens, ($caseDefault + 1), $switchCloser);
+            if ($nextCaseDefault === false) {
+                $caseCloser = $switchCloser;
+            } else {
+                $caseCloser = $nextCaseDefault;
+            }
+
+            // Check for unscoped control structures within the case.
+            $controlStructure = $caseOpener;
+            $doCount          = 0;
+            while (($controlStructure = $phpcsFile->findNext($this->loopStructures, ($controlStructure + 1), $caseCloser)) !== false) {
+                if ($tokens[$controlStructure]['code'] === \T_DO) {
+                    $doCount++;
+                }
+
+                if (isset($tokens[$controlStructure]['scope_opener'], $tokens[$controlStructure]['scope_closer']) === false) {
+                    if ($tokens[$controlStructure]['code'] === \T_WHILE && $doCount > 0) {
+                        // While in a do-while construct.
+                        $doCount--;
+                        continue;
+                    }
+
+                    // Control structure without braces found within the case, ignore this case.
+                    continue 2;
+                }
+            }
+
+            // Examine the contents of the case.
+            $continue = $caseOpener;
+
+            do {
+                $continue = $phpcsFile->findNext(\T_CONTINUE, ($continue + 1), $caseCloser);
+                if ($continue === false) {
+                    break;
+                }
+
+                $nextSemicolon = $phpcsFile->findNext(array(\T_SEMICOLON, \T_CLOSE_TAG), ($continue + 1), $caseCloser);
+                $codeString    = '';
+                for ($i = ($continue + 1); $i < $nextSemicolon; $i++) {
+                    if (isset($this->acceptedLevelTokens[$tokens[$i]['code']]) === false) {
+                        // Function call/variable or other token which make numeric level impossible to determine.
+                        continue 2;
+                    }
+
+                    if (isset($this->emptyTokens[$tokens[$i]['code']]) === true) {
+                        continue;
+                    }
+
+                    $codeString .= $tokens[$i]['content'];
+                }
+
+                $level = null;
+                if ($codeString !== '') {
+                    if (is_numeric($codeString)) {
+                        $level = (int) $codeString;
+                    } else {
+                        // With the above logic, the string can only contain digits and operators, eval!
+                        $level = eval("return ( $codeString );");
+                    }
+                }
+
+                if (isset($level) === false || $level === 0) {
+                    $level = 1;
+                }
+
+                // Examine which control structure is being targeted by the continue statement.
+                if (isset($tokens[$continue]['conditions']) === false) {
+                    continue;
+                }
+
+                $conditions = array_reverse($tokens[$continue]['conditions'], true);
+                // PHPCS adds more structures to the conditions array than we want to take into
+                // consideration, so clean up the array.
+                foreach ($conditions as $tokenPtr => $tokenCode) {
+                    if (isset($this->loopStructures[$tokenCode]) === false) {
+                        unset($conditions[$tokenPtr]);
+                    }
+                }
+
+                $targetCondition = \array_slice($conditions, ($level - 1), 1, true);
+                if (empty($targetCondition)) {
+                    continue;
+                }
+
+                $conditionToken = key($targetCondition);
+                if ($conditionToken === $stackPtr) {
+                    $phpcsFile->addWarning(
+                        "Targeting a 'switch' control structure with a 'continue' statement is strongly discouraged and will throw a warning as of PHP 7.3.",
+                        $continue,
+                        'Found'
+                    );
+                }
+
+            } while ($continue < $caseCloser);
+
+        } while ($caseDefault < $switchCloser);
+    }
+
+}

--- a/PHPCompatibility/Tests/Sniffs/PHP/DiscouragedSwitchContinueSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DiscouragedSwitchContinueSniffTest.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Discouraged use of continue within switch sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
+
+/**
+ * Discouraged use of continue within switch sniff test.
+ *
+ * @group discouragedSwitchContinue
+ * @group breakContinue
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\DiscouragedSwitchContinueSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class DiscouragedSwitchContinueSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/discouraged_switch_continue.php';
+
+    /**
+     * testDiscouragedSwitchContinue
+     *
+     * @dataProvider dataDiscouragedSwitchContinue
+     *
+     * @param int  $line           The line number.
+     * @param bool $skipOnLowPHPCS Whether this test needs to be skipped on low PHPCS versions.
+     *
+     * @return void
+     */
+    public function testDiscouragedSwitchContinue($line, $skipOnLowPHPCS = false)
+    {
+        // When using PHPCS 2.2.0 or lower, control structure conditions are not available.
+        if ($skipOnLowPHPCS === true && version_compare(PHPCSHelper::getVersion(), '2.3.0', '<')) {
+            $this->markTestSkipped('Control structure conditions are not reliable in PHPCS < 2.3.0');
+            return;
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.3');
+        $this->assertWarning($file, $line, "Targeting a 'switch' control structure with a 'continue' statement is strongly discouraged and will throw a warning as of PHP 7.3.");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDiscouragedSwitchContinue()
+     *
+     * @return array
+     */
+    public function dataDiscouragedSwitchContinue()
+    {
+        return array(
+            array(16),
+            array(24),
+            array(28),
+            array(30),
+            array(40),
+            array(44),
+            array(59),
+            array(77),
+            array(87),
+            array(95),
+            array(100),
+            array(102),
+            array(114, true),
+            array(120, true),
+            array(149, true),
+            array(174, true),
+
+            /*
+            @todo: False negatives. Unscoped control structure within case.
+            array(133),
+            array(145),
+            array(156),
+            array(184),
+            */
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(6),
+            array(8),
+            array(18),
+            array(26),
+            array(32),
+            array(34),
+            array(36),
+            array(38),
+            array(42),
+            array(49),
+            array(51),
+            array(63),
+            array(67),
+            array(79),
+            array(85),
+            array(93),
+            array(104),
+            array(122),
+            array(129),
+            array(137),
+            array(143),
+            array(147),
+            array(160),
+            array(164),
+            array(176),
+            array(188),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.2');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/sniff-examples/discouraged_switch_continue.php
+++ b/PHPCompatibility/Tests/sniff-examples/discouraged_switch_continue.php
@@ -1,0 +1,191 @@
+<?php
+
+// Test skipping out early, no continue.
+switch ($foo) {
+    case 0:
+        break;
+    case 1:
+        break;
+}
+
+/*
+ * Test switch in combination with scoped control structures.
+ */
+switch ($foo) {
+    case 0:
+        continue; // Invalid.
+    case 1:
+        break;
+}
+
+while ($foo) {
+    switch ($bar) {
+        case 0:
+            continue; // Invalid.
+        case 1:
+            continue 2;
+        case 2:
+            continue (1); // Invalid.
+        case 3:
+            continue 0; // Invalid. The fact that 0 is not the concern of this sniff.
+        case 4:
+            continue $var; // Undetermined. Outside the scope of this sniff.
+        case 5:
+            continue function_call(); // Undetermined. Outside the scope of this sniff.
+        case 6:
+            continue \E_WARNING; // Undetermined. Outside the scope of this sniff.
+        case 7:
+            continue (1 * 2);
+        case 8:
+            continue (1 * 1); // Invalid. The fact that calculations are no longer valid is not the concern of this sniff.
+        case 9:
+            continue (1 /* comment */ * 2);
+        case 10:
+            continue
+                (
+                    1 * 1
+                ); // Invalid. The fact that calculations are no longer valid is not the concern of this sniff.
+        case 11:
+            continue function () { return 1; }; // Undetermined. Outside the scope of this sniff.
+        case 12:
+            continue 3; // Impossible level, not our concern.
+    }
+}
+
+while ($foo) {
+    switch ($bar) {
+        case 0:
+            while ($xyz) {
+                continue 2; // Invalid.
+            }
+        case 1:
+            while ($xyz) {
+                continue 3;
+            }
+        case 2:
+            while ($xyz) {
+                break 2;
+            }
+    }
+}
+
+foreach ($foo as $k => $v) {
+    switch ($k) {
+        case 0:
+            for ($i = 0; $i < $k; $i++) {
+                if ($i === true) {
+                    continue 2; // Invalid.
+                } else {
+                    continue; // Valid.
+                }
+            }
+        case 1: {
+            do {
+                if ($a) {
+                    continue 3; // Valid.
+                } else {
+                    continue 2; // Invalid.
+                }
+            } while ( $v );
+        }
+        case 2:
+            if ($xyz) {
+                continue 2; // Valid.
+            } else {
+                continue 1; // Invalid.
+            }
+        case 3:
+            switch ($v) {
+                case 'a':
+                    continue; // Invalid.
+                case 'b':
+                    continue 2; // Invalid.
+                case 'c':
+                    continue 3; // Valid.
+            }
+    }
+}
+
+/*
+ * Test switch in combination with unscoped and alternative control structures.
+ */
+switch ($foo):
+    case 0:
+        continue; // Invalid.
+endswitch;
+
+while ($foo)
+    switch ($bar):
+        case 0:
+            continue; // Invalid.
+        case 1:
+            continue 2;
+    endswitch;
+
+while ($foo)
+    switch ($bar):
+        case 0:
+            while ($xyz)
+                continue 1;
+
+        case 1:
+            while ($xyz)
+                continue 2; // Invalid, but ignored as it's in an unscoped control structure (false negative).
+
+        case 2:
+            while ($xyz)
+                continue 3;
+        case 3:
+            while ($xyz)
+                while ($yzx)
+                    while ($zyx)
+                        if ($a)
+                            continue;
+                        elseif ($b)
+                            continue 4; // Invalid, but ignored as it's in an unscoped control structure (false negative).
+                        elseif ($c)
+                            continue 5;
+        case 4:
+            continue; // Invalid.
+    endswitch;
+
+foreach ($foo as $k => $v)
+    switch ($k):
+        case 0;
+            for ($i = 0; $i < $k; $i++)
+                continue 2; // Invalid, but ignored as it's in an unscoped control structure (false negative).
+
+        case 1:
+            do
+                continue 3;
+            while ( $v );
+        case 2;
+            if ($xyz)
+                continue 2;
+    endswitch;
+
+
+/*
+ * Test switch in combination with mixed scoped/unscoped/alternative control structures.
+ */
+while ($foo) {
+    switch ($bar):
+        case 0:
+            continue; // Invalid.
+        case 1:
+            continue 2;
+    endswitch;
+}
+
+while ($foo)
+    switch ($bar) {
+        case 0:
+            while ($xyz)
+                continue 2; // Invalid, but ignored as it's in an unscoped control structure (false negative).
+
+        case 1: {
+            while ($xyz) {
+                continue 3;
+            }
+        }
+    }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require" : {
     "php" : ">=5.3",
-    "squizlabs/php_codesniffer" : "^2.2 || ^3.0.2"
+    "squizlabs/php_codesniffer" : "^2.3 || ^3.0.2"
   },
   "require-dev" : {
     "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"


### PR DESCRIPTION
As of PHP 7.3, using `continue` to target `switch` will start throwing an `E_WARNING`.

> . "continue" statements targeting "switch" control flow structures will now
> generate a warning. In PHP such "continue" statements are equivalent to
> "break", while they behave as "continue 2" in other languages.

Refs:
* https://github.com/php/php-src/blob/04e3523b7d095341f65ed5e71a3cac82fca690e4/UPGRADING#L47-L58
* https://github.com/php/php-src/commit/04e3523b7d095341f65ed5e71a3cac82fca690e4
* https://wiki.php.net/rfc/continue_on_switch_deprecation

This PR adds a new sniff to detect this.

Notes:
* This sniff runs into the same difficulties with unscoped control structures as the `ForbiddenBreakContinueOutsideLoop` sniff.
    For this sniff, I've elected to prevent the false positives which plague the other sniff, though this does mean that the sniff will underreport (false negatives) for `continue` targeting `switch` when nested control structures without braces are encountered.
    This underreporting is minimized by examining each `case` individually. `Case`s with unscoped control structures will be ignored by this sniff. `Case`s within the same `switch` _without_ unscoped control structures will be handled correctly.
* Due to differences in the tokenizer array in the various PHPCS versions, this new sniff will only work on PHPCS 2.3.0+.
    The minimum PHPCS requirement in Composer has been adjusted to reflect this.
    As PHPCS 2.3.0 was released over three years ago, I would expect this not to be an issue.
* Includes one fix for an instance in PHPCompatibility itself which is affected by this PHP 7.3 change (in a copy of an upstream PHPCS method).
* Note: PHPCS 3.x is also affected by this and until the PR I've pulled upstream to fix this has been merged, the build for PHPCompatibility against PHPCS 3.x on PHP `nightly` will fail.

Fixes #686

As this issue will start breaking build for anyone running unit tests against PHP `nightly`, I've targeted the `8.2.0` release for this sniff.