### PR TITLE
PHPCSHelper: minor fix

### DIFF
--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -100,7 +100,7 @@ class PHPCSHelper
      */
     public static function getCommandLineData($phpcsFile, $key)
     {
-        if (method_exists('\PHP_CodeSniffer\Config', 'getAllConfigData')) {
+        if (class_exists('\PHP_CodeSniffer\Config')) {
             // PHPCS 3.x.
             $config = $phpcsFile->config;
             if (isset($config->{$key})) {


### PR DESCRIPTION
No need to check the method as it's not actually used (didn't give correct results on runtime). The class however is needed, so is a good enough indicator of being on PHPCS 3.x.