### PR TITLE
Sniff speed: apply some efficiency fixes

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -33,15 +33,15 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
      * @var array
      */
     protected $superglobals = array(
-        '$GLOBALS',
-        '$_SERVER',
-        '$_GET',
-        '$_POST',
-        '$_FILES',
-        '$_COOKIE',
-        '$_SESSION',
-        '$_REQUEST',
-        '$_ENV',
+        '$GLOBALS'  => true,
+        '$_SERVER'  => true,
+        '$_GET'     => true,
+        '$_POST'    => true,
+        '$_FILES'   => true,
+        '$_COOKIE'  => true,
+        '$_SESSION' => true,
+        '$_REQUEST' => true,
+        '$_ENV'     => true,
     );
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
@@ -55,14 +55,14 @@ class ConstantArraysUsingDefineSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON,
-            T_OBJECT_OPERATOR,
-            T_FUNCTION,
-            T_CONST,
+            T_DOUBLE_COLON    => true,
+            T_OBJECT_OPERATOR => true,
+            T_FUNCTION        => true,
+            T_CONST           => true,
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
+        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -846,17 +846,17 @@ class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON,
-            T_OBJECT_OPERATOR,
-            T_FUNCTION,
-            T_CLASS,
-            T_CONST,
-            T_USE,
-            T_NS_SEPARATOR,
+            T_DOUBLE_COLON    => true,
+            T_OBJECT_OPERATOR => true,
+            T_FUNCTION        => true,
+            T_CLASS           => true,
+            T_CONST           => true,
+            T_USE             => true,
+            T_NS_SEPARATOR    => true,
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
+        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -243,14 +243,14 @@ class DeprecatedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON,
-            T_OBJECT_OPERATOR,
-            T_FUNCTION,
-            T_CONST,
+            T_DOUBLE_COLON    => true,
+            T_OBJECT_OPERATOR => true,
+            T_FUNCTION        => true,
+            T_CONST           => true,
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
+        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniff.php
@@ -98,7 +98,7 @@ class ForbiddenClosureUseVariableNamesSniff extends Sniff
                 continue;
             }
 
-            if (in_array($variableName, $this->superglobals, true) === true) {
+            if (isset($this->superglobals[$variableName]) === true) {
                 $phpcsFile->addError($errorMsg, $i, 'FoundSuperglobal', array($variableName));
                 continue;
             }

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
@@ -66,15 +66,15 @@ class NewFunctionArrayDereferencingSniff extends Sniff
         $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevToken !== false && in_array($tokens[$prevToken]['code'], array(T_DOUBLE_COLON, T_OBJECT_OPERATOR), true) === false) {
             $ignore = array(
-                T_FUNCTION,
-                T_CONST,
-                T_USE,
-                T_NEW,
-                T_CLASS,
-                T_INTERFACE,
+                T_FUNCTION  => true,
+                T_CONST     => true,
+                T_USE       => true,
+                T_NEW       => true,
+                T_CLASS     => true,
+                T_INTERFACE => true,
             );
 
-            if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
+            if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
                 // Not a call to a PHP function or method.
                 return;
             }

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -863,14 +863,14 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON,
-            T_OBJECT_OPERATOR,
-            T_FUNCTION,
-            T_CONST,
+            T_DOUBLE_COLON    => true,
+            T_OBJECT_OPERATOR => true,
+            T_FUNCTION        => true,
+            T_CONST           => true,
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
+        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
@@ -1757,14 +1757,14 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON,
-            T_OBJECT_OPERATOR,
-            T_FUNCTION,
-            T_CONST,
+            T_DOUBLE_COLON    => true,
+            T_OBJECT_OPERATOR => true,
+            T_FUNCTION        => true,
+            T_CONST           => true,
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
+        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
 

--- a/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -489,14 +489,14 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON,
-            T_OBJECT_OPERATOR,
-            T_FUNCTION,
-            T_CONST,
+            T_DOUBLE_COLON    => true,
+            T_OBJECT_OPERATOR => true,
+            T_FUNCTION        => true,
+            T_CONST           => true,
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
+        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -66,7 +66,7 @@ class ParameterShadowSuperGlobalsSniff extends Sniff
         }
 
         foreach ($parameters as $param) {
-            if (in_array($param['name'], $this->superglobals, true)) {
+            if (isset($this->superglobals[$param['name']]) === true) {
                 $error     = 'Parameter shadowing super global (%s) causes fatal error since PHP 5.4';
                 $errorCode = $this->stringToErrorCode(substr($param['name'], 1)) . 'Found';
                 $data      = array($param['name']);

--- a/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -86,14 +86,14 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON,
-            T_OBJECT_OPERATOR,
-            T_FUNCTION,
-            T_CONST,
+            T_DOUBLE_COLON    => true,
+            T_OBJECT_OPERATOR => true,
+            T_FUNCTION        => true,
+            T_CONST           => true,
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
+        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
@@ -90,14 +90,14 @@ class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSnif
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON,
-            T_OBJECT_OPERATOR,
-            T_FUNCTION,
-            T_CONST,
+            T_DOUBLE_COLON    => true,
+            T_OBJECT_OPERATOR => true,
+            T_FUNCTION        => true,
+            T_CONST           => true,
         );
 
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
+        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
         }


### PR DESCRIPTION
Where possible, change `in_array()` calls to `isset()` by changing array values to array keys.