### PR TITLE
Drop support for PHPCS < 2.3.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To start contributing, fork the repository, create a new branch in your fork, ma
 
 Please make sure that your pull request contains unit tests covering what's being addressed by it.
 
-* All code should be compatible with PHPCS 1.5.6, PHPCS 2.x and PHPCS 3.x.
+* All code should be compatible with PHPCS > 2.3.0 and PHPCS > 3.0.2.
 * All code should be compatible with PHP 5.3 to PHP nightly.
 * All code should comply with the PHPCompatibility coding standards.
     The [ruleset used by PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility/blob/master/phpcs.xml.dist) is largely based on PSR-2 with minor variations and some additional checks for documentation and such.

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ env:
   matrix:
     # `master`, i.e PHPCS 3.x.
     - PHPCS_VERSION="dev-master" LINT=1
-    # PHPCS 1.5.x
-    - PHPCS_VERSION=">=1.5.1,<2.0"
+    # Lowest supported PHPCS version.
+    - PHPCS_VERSION="2.3.0"
 
 matrix:
   fast_finish: true
@@ -44,29 +44,27 @@ matrix:
           packages:
             - libxml2-utils
     - php: 7.2
-      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="^2.0"
+      env: PHPCS_VERSION="2.3.0" COVERALLS_VERSION="^2.0"
 
     # PHPCS 3.x cannot be run on PHP 5.3.
     - php: 5.3
       dist: precise
-      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="^1.0" PHPUNIT_VERSION="~4.5"
+      env: PHPCS_VERSION="2.3.0" COVERALLS_VERSION="^1.0" PHPUNIT_VERSION="~4.5"
     - php: 5.3
       dist: precise
       env: PHPCS_VERSION=">=2.0,<3.0" LINT=1 COVERALLS_VERSION="^1.0" PHPUNIT_VERSION="~4.5"
 
-    # PHP 5.4 with low PHPCS needs "precise" + one build with Coveralls.
+    # PHP 5.4 with low PHPCS needs PHPUnit 4.5 + one build with Coveralls.
     - php: 5.4
-      env: PHPCS_VERSION=">=1.5.1,<2.0" PHPUNIT_VERSION="~4.5"
-    - php: 5.4
-      env: PHPCS_VERSION="2.2.*" PHPUNIT_VERSION="~4.5"
+      env: PHPCS_VERSION="2.3.0" PHPUNIT_VERSION="~4.5"
     - php: 5.4
       env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="^1.0"
 
-    # Test against a variation of PHPCS 2.x versions and the lowest supported PHPCS 3.x version.
+    # Test against a variation of PHPCS 2.x and 3.x versions.
     - php: 5.5
       env: PHPCS_VERSION="2.4.*"
     - php: 5.5
-      env: PHPCS_VERSION="3.0.2"
+      env: PHPCS_VERSION="3.2.*"
     - php: 5.6
       env: PHPCS_VERSION="2.8.*"
     - php: 7.0
@@ -74,7 +72,7 @@ matrix:
     - php: 7.1
       env: PHPCS_VERSION="2.7.*"
     - php: 7.2
-      env: PHPCS_VERSION="2.3.*" COVERALLS_VERSION="^2.0"
+      env: PHPCS_VERSION="3.0.2" COVERALLS_VERSION="^2.0"
     - php: nightly
       env: PHPCS_VERSION=">=2.0,<3.0"
 

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -37,7 +37,7 @@ class PHPCSHelper
             // PHPCS 3.x.
             return \PHP_CodeSniffer\Config::VERSION;
         } else {
-            // PHPCS 1.x & 2.x.
+            // PHPCS 2.x.
             return \PHP_CodeSniffer::VERSION;
         }
     }
@@ -62,7 +62,7 @@ class PHPCSHelper
             // PHPCS 3.x.
             \PHP_CodeSniffer\Config::setConfigData($key, $value, $temp);
         } else {
-            // PHPCS 1.x & 2.x.
+            // PHPCS 2.x.
             \PHP_CodeSniffer::setConfigData($key, $value, $temp);
         }
     }
@@ -81,7 +81,7 @@ class PHPCSHelper
             // PHPCS 3.x.
             return \PHP_CodeSniffer\Config::getConfigData($key);
         } else {
-            // PHPCS 1.x & 2.x.
+            // PHPCS 2.x.
             return \PHP_CodeSniffer::getConfigData($key);
         }
     }
@@ -107,7 +107,7 @@ class PHPCSHelper
                 return $config->{$key};
             }
         } else {
-            // PHPCS 1.x & 2.x.
+            // PHPCS 2.x.
             $config = $phpcsFile->phpcs->cli->getCommandLineValues();
             if (isset($config[$key])) {
                 return $config[$key];

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -608,53 +608,6 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
 
 
     /**
-     * Verify whether a token is within a scoped use statement.
-     *
-     * PHPCS cross-version compatibility method.
-     *
-     * In PHPCS 1.x no conditions are set for a scoped use statement.
-     * This method works around that limitation.
-     *
-     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                   $stackPtr  The position of the token.
-     *
-     * @return bool True if within use scope, false otherwise.
-     */
-    public function inUseScope(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        static $isLowPHPCS, $ignoreTokens;
-
-        if (isset($isLowPHPCS) === false) {
-            $isLowPHPCS = version_compare(PHPCSHelper::getVersion(), '2.3.0', '<');
-        }
-        if (isset($ignoreTokens) === false) {
-            $ignoreTokens              = \PHP_CodeSniffer_Tokens::$emptyTokens;
-            $ignoreTokens[T_STRING]    = T_STRING;
-            $ignoreTokens[T_AS]        = T_AS;
-            $ignoreTokens[T_PUBLIC]    = T_PUBLIC;
-            $ignoreTokens[T_PROTECTED] = T_PROTECTED;
-            $ignoreTokens[T_PRIVATE]   = T_PRIVATE;
-        }
-
-        // PHPCS 2.0.
-        if ($isLowPHPCS === false) {
-            return $phpcsFile->hasCondition($stackPtr, T_USE);
-        } else {
-            // PHPCS 1.x.
-            $tokens         = $phpcsFile->getTokens();
-            $maybeCurlyOpen = $phpcsFile->findPrevious($ignoreTokens, ($stackPtr - 1), null, true);
-            if ($tokens[$maybeCurlyOpen]['code'] === T_OPEN_CURLY_BRACKET) {
-                $maybeUseStatement = $phpcsFile->findPrevious($ignoreTokens, ($maybeCurlyOpen - 1), null, true);
-                if ($tokens[$maybeUseStatement]['code'] === T_USE) {
-                    return true;
-                }
-            }
-            return false;
-        }
-    }
-
-
-    /**
      * Returns the fully qualified class name for a new class instantiation.
      *
      * Returns an empty string if the class name could not be reliably inferred.

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1029,13 +1029,11 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
             return;
         }
 
-        $emptyTokens = array_flip(\PHP_CodeSniffer_Tokens::$emptyTokens); // PHPCS 1.x compat.
-
         $returnTypeHint = '';
         for ($i = ($colon + 1); $i <= $stackPtr; $i++) {
             // As of PHPCS 3.3.0+, all tokens are tokenized as "normal", so T_CALLABLE, T_SELF etc are
             // all possible, just exclude anything that's regarded as empty and the nullable indicator.
-            if (isset($emptyTokens[$tokens[$i]['code']])) {
+            if (isset(\PHP_CodeSniffer_Tokens::$emptyTokens[$tokens[$i]['code']])) {
                 continue;
             }
 
@@ -1480,8 +1478,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
      */
     protected function isNumber(\PHP_CodeSniffer_File $phpcsFile, $start, $end, $allowFloats = false)
     {
-        $stringTokens  = array_flip(\PHP_CodeSniffer_Tokens::$heredocTokens); // Flipping for PHPCS 1.x compat.
-        $stringTokens += array_flip(\PHP_CodeSniffer_Tokens::$stringTokens); // Flipping for PHPCS 1.x compat.
+        $stringTokens  = \PHP_CodeSniffer_Tokens::$heredocTokens + \PHP_CodeSniffer_Tokens::$stringTokens;
 
         $validTokens            = array();
         $validTokens[T_LNUMBER] = true;

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -596,11 +596,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
 
         if ($strict === false) {
             $validScopes[] = T_INTERFACE;
-
-            if (defined('T_TRAIT')) {
-                // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
-                $validScopes[] = T_TRAIT;
-            }
+            $validScopes[] = T_TRAIT;
         }
 
         return $phpcsFile->hasCondition($stackPtr, $validScopes);

--- a/PHPCompatibility/Sniffs/PHP/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DiscouragedSwitchContinueSniff.php
@@ -64,12 +64,6 @@ class DiscouragedSwitchContinueSniff extends Sniff
         \T_CLOSE_PARENTHESIS => \T_CLOSE_PARENTHESIS,
     );
 
-    /**
-     * PHPCS cross-version compatible version of the Tokens::$emptyTokens array.
-     *
-     * @var array
-     */
-    private $emptyTokens = array();
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -78,14 +72,8 @@ class DiscouragedSwitchContinueSniff extends Sniff
      */
     public function register()
     {
-        $arithmeticTokens  = \PHP_CodeSniffer_Tokens::$arithmeticTokens;
-        $this->emptyTokens = \PHP_CodeSniffer_Tokens::$emptyTokens;
-        if (version_compare(PHPCSHelper::getVersion(), '2.0', '<')) {
-            $arithmeticTokens  = array_combine($arithmeticTokens, $arithmeticTokens);
-            $this->emptyTokens = array_combine($this->emptyTokens, $this->emptyTokens);
-        }
-
-        $this->acceptedLevelTokens = $this->acceptedLevelTokens + $arithmeticTokens + $this->emptyTokens;
+        $this->acceptedLevelTokens += \PHP_CodeSniffer_Tokens::$arithmeticTokens;
+        $this->acceptedLevelTokens += \PHP_CodeSniffer_Tokens::$emptyTokens;
 
         return array(\T_SWITCH);
     }
@@ -178,7 +166,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
                         continue 2;
                     }
 
-                    if (isset($this->emptyTokens[$tokens[$i]['code']]) === true) {
+                    if (isset(\PHP_CodeSniffer_Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
                         continue;
                     }
 

--- a/PHPCompatibility/Sniffs/PHP/EmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/EmptyNonVariableSniff.php
@@ -54,19 +54,18 @@ class EmptyNonVariableSniff extends Sniff
     public function register()
     {
         // Set the token blacklist only once.
-        $tokenBlackList = array_unique(
-            array_merge(
-                \PHP_CodeSniffer_Tokens::$assignmentTokens,
-                \PHP_CodeSniffer_Tokens::$equalityTokens,
-                \PHP_CodeSniffer_Tokens::$comparisonTokens,
-                \PHP_CodeSniffer_Tokens::$operators,
-                \PHP_CodeSniffer_Tokens::$booleanOperators,
-                \PHP_CodeSniffer_Tokens::$castTokens,
-                array(T_OPEN_PARENTHESIS, T_STRING_CONCAT)
-            )
+        $tokenBlackList  = array(
+            T_OPEN_PARENTHESIS => T_OPEN_PARENTHESIS,
+            T_STRING_CONCAT    => T_STRING_CONCAT,
         );
+        $tokenBlackList += \PHP_CodeSniffer_Tokens::$assignmentTokens;
+        $tokenBlackList += \PHP_CodeSniffer_Tokens::$equalityTokens;
+        $tokenBlackList += \PHP_CodeSniffer_Tokens::$comparisonTokens;
+        $tokenBlackList += \PHP_CodeSniffer_Tokens::$operators;
+        $tokenBlackList += \PHP_CodeSniffer_Tokens::$booleanOperators;
+        $tokenBlackList += \PHP_CodeSniffer_Tokens::$castTokens;
 
-        $this->tokenBlackList = array_combine($tokenBlackList, $tokenBlackList);
+        $this->tokenBlackList = array_unique($tokenBlackList);
 
         return array(T_EMPTY);
     }

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
@@ -44,10 +44,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
     {
         // Set up a list of tokens to disregard when determining whether the list() is empty.
         // Only needs to be set up once.
-        $this->ignoreTokens = \PHP_CodeSniffer_Tokens::$emptyTokens;
-        if (version_compare(PHPCSHelper::getVersion(), '2.0', '<')) {
-            $this->ignoreTokens = array_combine($this->ignoreTokens, $this->ignoreTokens);
-        }
+        $this->ignoreTokens                      = \PHP_CodeSniffer_Tokens::$emptyTokens;
         $this->ignoreTokens[T_COMMA]             = T_COMMA;
         $this->ignoreTokens[T_OPEN_PARENTHESIS]  = T_OPEN_PARENTHESIS;
         $this->ignoreTokens[T_CLOSE_PARENTHESIS] = T_CLOSE_PARENTHESIS;

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -99,14 +99,10 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
         $targets = array(
             T_CLASS,
             T_INTERFACE,
+            T_TRAIT,
             T_NAMESPACE,
             T_STRING, // Compat for PHPCS 1.x and PHP < 5.3.
         );
-
-        if (defined('T_TRAIT')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
-            $targets[] = T_TRAIT;
-        }
 
         return $targets;
 

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -101,7 +101,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
             T_INTERFACE,
             T_TRAIT,
             T_NAMESPACE,
-            T_STRING, // Compat for PHPCS 1.x and PHP < 5.3.
+            T_STRING, // Compat for PHPCS < 2.4.0 and PHP < 5.3.
         );
 
         return $targets;

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -35,14 +35,17 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
         T_CALLABLE   => '5.4',
         T_CATCH      => '5.0',
         T_FINAL      => '5.0',
+        T_FINALLY    => '5.5',
         T_GOTO       => '5.3',
         T_IMPLEMENTS => '5.0',
         T_INTERFACE  => '5.0',
         T_INSTANCEOF => '5.0',
+        T_INSTEADOF  => '5.4',
         T_NAMESPACE  => '5.3',
         T_PRIVATE    => '5.0',
         T_PROTECTED  => '5.0',
         T_PUBLIC     => '5.0',
+        T_TRAIT      => '5.4',
         T_TRY        => '5.0',
     );
 
@@ -81,19 +84,6 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
      */
     public function register()
     {
-        if (defined('T_FINALLY')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_finallyFound
-            $this->targetedTokens[T_FINALLY] = '5.5';
-        }
-        if (defined('T_INSTEADOF')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_insteadofFound
-            $this->targetedTokens[T_INSTEADOF] = '5.4';
-        }
-        if (defined('T_TRAIT')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
-            $this->targetedTokens[T_TRAIT] = '5.4';
-        }
-
         $tokens   = array_keys($this->targetedTokens);
         $tokens[] = T_STRING;
 

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -103,13 +103,6 @@ class ForbiddenNamesSniff extends Sniff
     );
 
     /**
-     * Whether PHPCS 1.x is used or not.
-     *
-     * @var bool
-     */
-    protected $isLowPHPCS = false;
-
-    /**
      * Scope modifiers and other keywords allowed in trait use statements.
      *
      * @var array
@@ -141,8 +134,6 @@ class ForbiddenNamesSniff extends Sniff
      */
     public function register()
     {
-        $this->isLowPHPCS = version_compare(PHPCSHelper::getVersion(), '2.0', '<');
-
         $this->allowedModifiers          = \PHP_CodeSniffer_Tokens::$scopeModifiers;
         $this->allowedModifiers[T_FINAL] = T_FINAL;
 
@@ -219,10 +210,6 @@ class ForbiddenNamesSniff extends Sniff
         ) {
             $maybeUseNext = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext !== false && $this->isEndOfUseStatement($tokens[$maybeUseNext]) === false) {
-                // Prevent duplicate messages: `const` is T_CONST in PHPCS 1.x and T_STRING in PHPCS 2.x.
-                if ($this->isLowPHPCS === true) {
-                    return;
-                }
                 $nextNonEmpty = $maybeUseNext;
             }
         }

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -327,7 +327,6 @@ class ForbiddenNamesSniff extends Sniff
         /*
          * Special case for PHP versions where the target is not yet identified as
          * its own token, but presents as T_STRING.
-         * - namespace keyword in PHP < 5.3
          * - trait keyword in PHP < 5.4
          */
         if (version_compare(PHP_VERSION_ID, '50400', '<') && $tokenContentLc === 'trait') {

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -131,6 +131,7 @@ class ForbiddenNamesSniff extends Sniff
         T_AS,
         T_EXTENDS,
         T_INTERFACE,
+        T_TRAIT,
     );
 
     /**
@@ -149,11 +150,6 @@ class ForbiddenNamesSniff extends Sniff
         $this->allowedModifiers[T_FINAL] = T_FINAL;
 
         $tokens = $this->targetedTokens;
-
-        if (defined('T_TRAIT')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
-            $tokens[] = T_TRAIT;
-        }
 
         if (defined('T_ANON_CLASS')) {
             // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -241,7 +241,7 @@ class ForbiddenNamesSniff extends Sniff
          */
         elseif ($tokens[$stackPtr]['type'] === 'T_AS'
             && isset($this->allowedModifiers[$tokens[$nextNonEmpty]['code']]) === true
-            && $this->inUseScope($phpcsFile, $stackPtr) === true
+            && $phpcsFile->hasCondition($stackPtr, T_USE) === true
         ) {
             $maybeUseNext = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext === false || $this->isEndOfUseStatement($tokens[$maybeUseNext]) === true) {

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -143,10 +143,7 @@ class ForbiddenNamesSniff extends Sniff
     {
         $this->isLowPHPCS = version_compare(PHPCSHelper::getVersion(), '2.0', '<');
 
-        $this->allowedModifiers          = array_combine(
-            \PHP_CodeSniffer_Tokens::$scopeModifiers,
-            \PHP_CodeSniffer_Tokens::$scopeModifiers
-        );
+        $this->allowedModifiers          = \PHP_CodeSniffer_Tokens::$scopeModifiers;
         $this->allowedModifiers[T_FINAL] = T_FINAL;
 
         $tokens = $this->targetedTokens;

--- a/PHPCompatibility/Sniffs/PHP/MbstringReplaceEModifierSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/MbstringReplaceEModifierSniff.php
@@ -89,7 +89,7 @@ class MbstringReplaceEModifierSniff extends AbstractFunctionCallParameterSniff
          * Get the content of any string tokens in the options parameter and remove the quotes and variables.
          */
         for ($i = $stringToken; $i <= $optionsParam['end']; $i++) {
-            if (in_array($tokens[$i]['code'], \PHP_CodeSniffer_Tokens::$stringTokens, true) === false) {
+            if (isset(\PHP_CodeSniffer_Tokens::$stringTokens[$tokens[$i]['code']]) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/PHP/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewConstVisibilitySniff.php
@@ -56,7 +56,7 @@ class NewConstVisibilitySniff extends Sniff
         $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
 
         // Is the previous token a visibility indicator ?
-        if ($prevToken === false || in_array($tokens[$prevToken]['code'], \PHP_CodeSniffer_Tokens::$scopeModifiers, true) === false) {
+        if ($prevToken === false || isset(\PHP_CodeSniffer_Tokens::$scopeModifiers[$tokens[$prevToken]['code']]) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/PHP/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewConstantScalarExpressionsSniff.php
@@ -111,15 +111,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
      */
     public function setProperties()
     {
-        $emptyTokens   = \PHP_CodeSniffer_Tokens::$emptyTokens;
-        $heredocTokens = \PHP_CodeSniffer_Tokens::$heredocTokens;
-        if (version_compare(PHPCSHelper::getVersion(), '2.0', '<')) {
-            // PHPCS 1.x compat.
-            $emptyTokens   = array_combine($emptyTokens, $emptyTokens);
-            $heredocTokens = array_combine($heredocTokens, $heredocTokens);
-        }
-
-        $this->safeOperands = $this->safeOperands + $heredocTokens + $emptyTokens;
+        $this->safeOperands += \PHP_CodeSniffer_Tokens::$heredocTokens;
+        $this->safeOperands += \PHP_CodeSniffer_Tokens::$emptyTokens;
     }
 
 

--- a/PHPCompatibility/Sniffs/PHP/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewConstantScalarExpressionsSniff.php
@@ -70,6 +70,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
         T_DIR                      => T_DIR,
         T_FUNC_C                   => T_FUNC_C,
         T_CLASS_C                  => T_CLASS_C,
+        T_TRAIT_C                  => T_TRAIT_C,
         T_METHOD_C                 => T_METHOD_C,
         T_NS_C                     => T_NS_C,
 
@@ -110,16 +111,6 @@ class NewConstantScalarExpressionsSniff extends Sniff
      */
     public function setProperties()
     {
-        /*
-         * Not available on PHPCS 1.x icw PHP 5.3.
-         * Not a problem for recognition as when the token is not available
-         * __TRAIT__ will be tokenized as T_STRING which will pass.
-         */
-        if (defined('T_TRAIT_C') === true) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_trait_cFound
-            $this->safeOperands[T_TRAIT_C] = T_TRAIT_C;
-        }
-
         $emptyTokens   = \PHP_CodeSniffer_Tokens::$emptyTokens;
         $heredocTokens = \PHP_CodeSniffer_Tokens::$heredocTokens;
         if (version_compare(PHPCSHelper::getVersion(), '2.0', '<')) {

--- a/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -94,7 +94,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
                 return;
             }
 
-            // Deal with PHPCS 1.x which does not set the parenthesis properly for declare statements.
+            // Deal with PHPCS 2.3.0-2.3.3 which do not yet set the parenthesis properly for declare statements.
             $openParenthesis = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($stackPtr + 1), null, false, null, true);
             if ($openParenthesis === false || isset($tokens[$openParenthesis]['parenthesis_closer']) === false) {
                 return;

--- a/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -264,7 +264,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $value = $tokens[$stackPtr]['content'];
-        if (in_array($tokens[$stackPtr]['code'], \PHP_CodeSniffer_Tokens::$stringTokens, true) === true) {
+        if (isset(\PHP_CodeSniffer_Tokens::$stringTokens[$tokens[$stackPtr]['code']]) === true) {
             $value = $this->stripQuotes($value);
         }
 

--- a/PHPCompatibility/Sniffs/PHP/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewGeneratorReturnSniff.php
@@ -35,14 +35,16 @@ class NewGeneratorReturnSniff extends Sniff
      */
     public function register()
     {
-        $targets = array();
+        $targets = array(
+            T_YIELD,
+        );
 
         /*
          * The `yield` keyword was introduced in PHP 5.5 with the token T_YIELD.
          * The `yield from` keyword was introduced in PHP 7.0 and tokenizes as
          * "T_YIELD T_WHITESPACE T_STRING".
          *
-         * Pre-PHPCS 3.1.0, the T_YIELD token was not back-filled for PHP < 5.5.
+         * Pre-PHPCS 3.1.0, the T_YIELD token was not correctly back-filled for PHP < 5.5.
          * Also, as of PHPCS 3.1.0, the PHPCS tokenizer adds a new T_YIELD_FROM
          * token.
          *
@@ -54,11 +56,6 @@ class NewGeneratorReturnSniff extends Sniff
             && version_compare(PHPCSHelper::getVersion(), '3.1.0', '<') === true
         ) {
             $targets[] = T_STRING;
-        }
-
-        if (defined('T_YIELD')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_yieldFound
-            $targets[] = T_YIELD;
         }
 
         if (defined('T_YIELD_FROM')) {

--- a/PHPCompatibility/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -41,12 +41,12 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
             '5.5' => false,
             '5.6' => true,
             'description' => 'power operator (**)',
-        ), // Identified in PHPCS 1.5 as T_MULTIPLY + T_MULTIPLY.
+        ), // Identified in PHP < 5.6 icw PHPCS < 2.4.0 as T_MULTIPLY + T_MULTIPLY.
         'T_POW_EQUAL' => array(
             '5.5' => false,
             '5.6' => true,
             'description' => 'power assignment operator (**=)',
-        ), // Identified in PHPCS 1.5 as T_MULTIPLY + T_MUL_EQUAL.
+        ), // Identified in PHP < 5.6 icw PHPCS < 2.6.0 as T_MULTIPLY + T_MUL_EQUAL.
         'T_ELLIPSIS' => array(
             '5.5' => false,
             '5.6' => true,
@@ -56,12 +56,12 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
             '5.6' => false,
             '7.0' => true,
             'description' => 'spaceship operator (<=>)',
-        ), // Identified in PHPCS 1.5 as T_IS_SMALLER_OR_EQUAL + T_GREATER_THAN.
+        ), // Identified in PHP < 7.0 icw PHPCS < 2.5.1 as T_IS_SMALLER_OR_EQUAL + T_GREATER_THAN.
         'T_COALESCE' => array(
             '5.6' => false,
             '7.0' => true,
             'description' => 'null coalescing operator (??)',
-        ), // Identified in PHPCS 1.5 as T_INLINE_THEN + T_INLINE_THEN.
+        ), // Identified in PHP < 7.0 icw PHPCS < 2.6.2 as T_INLINE_THEN + T_INLINE_THEN.
         /*
          * Was slated for 7.2, but still not implemented. PHPCS however does already tokenize it.
          * @link https://wiki.php.net/rfc/null_coalesce_equal_operator
@@ -70,12 +70,12 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
             '7.2' => false,
             '7.3' => true,
             'description' => 'null coalesce equal operator (??=)',
-        ), // Identified in PHPCS 1.5 as T_INLINE_THEN + T_INLINE_THEN + T_EQUAL and pre-PHPCS 2.8.1 as T_COALESCE + T_EQUAL.
+        ), // Identified in PHP < 7.0 icw PHPCS < 2.6.2 as T_INLINE_THEN + T_INLINE_THEN + T_EQUAL and between PHPCS 2.6.2 and PHPCS 2.8.1 as T_COALESCE + T_EQUAL.
     );
 
 
     /**
-     * A list of new language constructs which are not recognized in PHPCS 1.x.
+     * A list of new language constructs which are not recognized in older PHPCS versions.
      *
      * The array lists an alternative token to listen for.
      *
@@ -90,7 +90,7 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
     );
 
     /**
-     * Translation table for PHPCS 1.x and older 2.x tokens.
+     * Token translation table for older PHPCS versions.
      *
      * The 'before' index lists the token which would have to be directly before the
      * token found for it to be one of the new language constructs.

--- a/PHPCompatibility/Sniffs/PHP/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewNullableTypesSniff.php
@@ -135,13 +135,13 @@ class NewNullableTypesSniff extends Sniff
 
         // Deal with namespaced class names.
         if ($tokens[$previous]['code'] === T_NS_SEPARATOR) {
-            $validTokens   = \PHP_CodeSniffer_Tokens::$emptyTokens;
-            $validTokens[] = T_STRING;
-            $validTokens[] = T_NS_SEPARATOR;
+            $validTokens                 = \PHP_CodeSniffer_Tokens::$emptyTokens;
+            $validTokens[T_STRING]       = true;
+            $validTokens[T_NS_SEPARATOR] = true;
 
             $stackPtr--;
 
-            while (in_array($tokens[($stackPtr - 1)]['code'], $validTokens, true) === true) {
+            while (isset($validTokens[$tokens[($stackPtr - 1)]['code']]) === true) {
                 $stackPtr--;
             }
 

--- a/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -85,12 +85,8 @@ class NonStaticMagicMethodsSniff extends Sniff
         $targets = array(
             T_CLASS,
             T_INTERFACE,
+            T_TRAIT,
         );
-
-        if (defined('T_TRAIT')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
-            $targets[] = T_TRAIT;
-        }
 
         if (defined('T_ANON_CLASS')) {
             // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound

--- a/PHPCompatibility/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -145,7 +145,7 @@ class PregReplaceEModifierSniff extends AbstractFunctionCallParameterSniff
          */
         $regex = '';
         for ($i = $pattern['start']; $i <= $pattern['end']; $i++) {
-            if (in_array($tokens[$i]['code'], \PHP_CodeSniffer_Tokens::$stringTokens, true) === true) {
+            if (isset(\PHP_CodeSniffer_Tokens::$stringTokens[$tokens[$i]['code']]) === true) {
                 $content = $this->stripQuotes($tokens[$i]['content']);
                 if ($tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
                     $content = $this->stripVariables($content);

--- a/PHPCompatibility/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -243,7 +243,7 @@ class RemovedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
         // Is this a variable assignment ?
         if ($nextNonEmpty !== false
-            && in_array($tokens[$nextNonEmpty]['code'], \PHP_CodeSniffer_Tokens::$assignmentTokens, true)
+            && isset(\PHP_CodeSniffer_Tokens::$assignmentTokens[$tokens[$nextNonEmpty]['code']]) === true
         ) {
             return false;
         }
@@ -292,7 +292,7 @@ class RemovedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
             );
 
             if ($nextNonEmpty !== false
-                && in_array($tokens[$nextNonEmpty]['code'], \PHP_CodeSniffer_Tokens::$assignmentTokens, true)
+                && isset(\PHP_CodeSniffer_Tokens::$assignmentTokens[$tokens[$nextNonEmpty]['code']]) === true
             ) {
                 return false;
             }

--- a/PHPCompatibility/Sniffs/PHP/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ReservedFunctionNamesSniff.php
@@ -39,11 +39,7 @@ class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_Camel
      */
     public function __construct()
     {
-        $scopeTokens = array(T_CLASS, T_INTERFACE);
-        if (defined('T_TRAIT')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
-            $scopeTokens[] = T_TRAIT;
-        }
+        $scopeTokens = array(T_CLASS, T_INTERFACE, T_TRAIT);
         if (defined('T_ANON_CLASS')) {
             // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
             $scopeTokens[] = T_ANON_CLASS;

--- a/PHPCompatibility/Sniffs/PHP/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ReservedFunctionNamesSniff.php
@@ -48,14 +48,6 @@ class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_Camel
         // Call the grand-parent constructor directly.
         \PHP_CodeSniffer_Standards_AbstractScopeSniff::__construct($scopeTokens, array(T_FUNCTION), true);
 
-        $phpcsVersion = PHPCSHelper::getVersion();
-
-        if (version_compare($phpcsVersion, '2.0.0', '<') === true) {
-            $this->magicMethods            = array_flip($this->magicMethods);
-            $this->methodsDoubleUnderscore = array_flip($this->methodsDoubleUnderscore);
-            $this->magicFunctions          = array_flip($this->magicFunctions);
-        }
-
         // Make sure debuginfo is included in the array. Upstream only includes it since 2.5.1.
         $this->magicMethods['debuginfo'] = true;
     }

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -17,8 +17,8 @@ use PHPCompatibility\PHPCSHelper;
  *
  * Add a notification for users of low PHPCS versions.
  *
- * Originally PHPCompatibility supported PHPCS 1.5.x, 2.x, 3.x.
- * Support for PHPCS <2.3.0 will be dropped in PHPCompatibility 9.0.0.
+ * Originally PHPCompatibility supported PHPCS 1.5.x, 2.x and since PHPCompatibility 8.0.0, 3.x.
+ * Support for PHPCS < 2.3.0 has been dropped in PHPCompatibility 9.0.0.
  *
  * The standard will - up to a point - still work for users of lower
  * PHPCS versions, but will give less accurate results and may throw
@@ -40,7 +40,7 @@ class LowPHPCSSniff extends Sniff
      *
      * @var string
      */
-    protected $minSupportedVersion = '1.5.6';
+    protected $minSupportedVersion = '2.3.0';
 
     /**
      * The minimum recommended PHPCS version.

--- a/PHPCompatibility/Tests/BaseClass/MethodTestFrame.php
+++ b/PHPCompatibility/Tests/BaseClass/MethodTestFrame.php
@@ -85,27 +85,14 @@ abstract class MethodTestFrame extends \PHPUnit_Framework_TestCase
             $this->phpcsFile->process();
 
         } else {
-            $phpcs = new \PHP_CodeSniffer();
-
-            if (version_compare(PHPCSHelper::getVersion(), '1.99.99', '>')) {
-                // PHPCS 2.x.
-                $this->phpcsFile = new \PHP_CodeSniffer_File(
-                    $filename,
-                    array(),
-                    array(),
-                    $phpcs
-                );
-            } else {
-                // PHPCS 1.x.
-                $this->phpcsFile = new \PHP_CodeSniffer_File(
-                    $filename,
-                    array(),
-                    array(),
-                    array(),
-                    array(),
-                    $phpcs
-                );
-            }
+            // PHPCS 2.x.
+            $phpcs           = new \PHP_CodeSniffer();
+            $this->phpcsFile = new \PHP_CodeSniffer_File(
+                $filename,
+                array(),
+                array(),
+                $phpcs
+            );
 
             $this->phpcsFile->start($contents);
         }

--- a/PHPCompatibility/Tests/BaseClass/TokenScopeTest.php
+++ b/PHPCompatibility/Tests/BaseClass/TokenScopeTest.php
@@ -131,48 +131,4 @@ class TokenScopeTest extends MethodTestFrame
             array('/* Case C5 */', T_FUNCTION, true), // function in anon class
         );
     }
-
-
-    /**
-     * testInUseScope
-     *
-     * @dataProvider dataInUseScope
-     *
-     * @covers \PHPCompatibility\Sniff::inUseScope
-     *
-     * @param string $commentString The comment which prefaces the target token in the test file.
-     * @param int    $targetType    The token type for the target token.
-     * @param string $expected      The expected boolean return value.
-     *
-     * @return void
-     */
-    public function testInUseScope($commentString, $targetType, $expected)
-    {
-        $stackPtr = $this->getTargetToken($commentString, $targetType);
-        $result   = $this->helperClass->inUseScope($this->phpcsFile, $stackPtr);
-        $this->assertSame($expected, $result);
-    }
-
-    /**
-     * dataInClassScope
-     *
-     * @see testInClassScope()
-     *
-     * @return array
-     */
-    public function dataInUseScope()
-    {
-        return array(
-            array('/* Case U1 */', T_STRING, false),
-            array('/* Case U2 */', T_AS, false),
-            array('/* Case U3 */', T_STRING, false),
-            array('/* Case U4 */', T_STRING, false),
-            array('/* Case U5 */', T_STRING, false),
-            array('/* Case U6 */', T_AS, true),
-            array('/* Case U7 */', T_PUBLIC, true),
-            array('/* Case U8 */', T_PROTECTED, true),
-            array('/* Case U9 */', T_PRIVATE, true),
-        );
-    }
-
 }

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -26,7 +26,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
     /**
      * The PHP_CodeSniffer object used for testing.
      *
-     * Used by PHPCS 1.x and 2.x.
+     * Used by PHPCS 2.x.
      *
      * @var \PHP_CodeSniffer
      */
@@ -59,24 +59,16 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
     {
         if (class_exists('\PHP_CodeSniffer') === true) {
             /*
-             * PHPCS 1.x and 2.x.
+             * PHPCS 2.x.
              */
             if (self::$phpcs === null) {
                 self::$phpcs = new \PHP_CodeSniffer();
             }
 
-            if (method_exists('\PHP_CodeSniffer_CLI', 'setCommandLineValues')) {
-                // For PHPCS 2.x.
-                self::$phpcs->cli->setCommandLineValues(array('-pq', '--colors'));
-            }
+            self::$phpcs->cli->setCommandLineValues(array('-pq', '--colors'));
 
             // Restrict the sniffing of the test case files to the particular sniff being tested.
-            if (method_exists('\PHP_CodeSniffer', 'initStandard')) {
-                self::$phpcs->initStandard(self::STANDARD_NAME, array($this->getSniffCode()));
-            } else {
-                // PHPCS 1.x.
-                self::$phpcs->process(array(), dirname(__DIR__) . '/', array($this->getSniffCode()));
-            }
+            self::$phpcs->initStandard(self::STANDARD_NAME, array($this->getSniffCode()));
 
             self::$phpcs->setIgnorePatterns(array());
         }
@@ -151,12 +143,9 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
 
                 self::$sniffFiles[$filename][$targetPhpVersion] = new \PHP_CodeSniffer\Files\LocalFile($pathToFile, $ruleset, $config);
                 self::$sniffFiles[$filename][$targetPhpVersion]->process();
-            } elseif (method_exists('\PHP_CodeSniffer', 'initStandard')) {
+            } else {
                 // PHPCS 2.x.
                 self::$sniffFiles[$filename][$targetPhpVersion] = self::$phpcs->processFile($pathToFile);
-            } else {
-                // PHPCS 1.x - Sniff code restrictions have to be passed via the function call.
-                self::$sniffFiles[$filename][$targetPhpVersion] = self::$phpcs->processFile($pathToFile, null, array($this->getSniffCode()));
             }
 
         } catch (\Exception $e) {

--- a/PHPCompatibility/Tests/Sniffs/PHP/DiscouragedSwitchContinueSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DiscouragedSwitchContinueSniffTest.php
@@ -31,19 +31,12 @@ class DiscouragedSwitchContinueSniffTest extends BaseSniffTest
      *
      * @dataProvider dataDiscouragedSwitchContinue
      *
-     * @param int  $line           The line number.
-     * @param bool $skipOnLowPHPCS Whether this test needs to be skipped on low PHPCS versions.
+     * @param int $line The line number.
      *
      * @return void
      */
-    public function testDiscouragedSwitchContinue($line, $skipOnLowPHPCS = false)
+    public function testDiscouragedSwitchContinue($line)
     {
-        // When using PHPCS 2.2.0 or lower, control structure conditions are not available.
-        if ($skipOnLowPHPCS === true && version_compare(PHPCSHelper::getVersion(), '2.3.0', '<')) {
-            $this->markTestSkipped('Control structure conditions are not reliable in PHPCS < 2.3.0');
-            return;
-        }
-
         $file = $this->sniffFile(self::TEST_FILE, '7.3');
         $this->assertWarning($file, $line, "Targeting a 'switch' control structure with a 'continue' statement is strongly discouraged and will throw a warning as of PHP 7.3.");
     }
@@ -70,10 +63,10 @@ class DiscouragedSwitchContinueSniffTest extends BaseSniffTest
             array(95),
             array(100),
             array(102),
-            array(114, true),
-            array(120, true),
-            array(149, true),
-            array(174, true),
+            array(114),
+            array(120),
+            array(149),
+            array(174),
 
             /*
             @todo: False negatives. Unscoped control structure within case.

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewConstantScalarExpressionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewConstantScalarExpressionsSniffTest.php
@@ -56,8 +56,8 @@ class NewConstantScalarExpressionsSniffTest extends BaseSniffTest
     {
         $phpcsVersion = PHPCSHelper::getVersion();
 
-        // When using PHPCS 1.x combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare($phpcsVersion, '2.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
+        // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare($phpcsVersion, '2.4.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
             self::$recognizesTraits = false;
         }
 
@@ -81,7 +81,7 @@ class NewConstantScalarExpressionsSniffTest extends BaseSniffTest
     public function testNewConstantScalarExpressions($line, $type, $extra = '', $isTrait = false)
     {
         if ($isTrait === true && self::$recognizesTraits === false) {
-            $this->markTestSkipped('Traits are not recognized on PHPCS 1.5.x in combination with PHP < 5.4');
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
             return;
         }
 
@@ -163,7 +163,7 @@ class NewConstantScalarExpressionsSniffTest extends BaseSniffTest
             array(202, 'property', '', true),
             array(203, 'property', '', true),
             array(208, 'property', '', true),
-            array(210, 'default', '', true),
+            array(210, 'default', ''), // In a trait, but approached from function token, so will be fine.
 
             array(216, 'default', '$a = 5 * MINUTEINSECONDS'),
             array(216, 'default', '$b = [ \'a\', 1 + 2 ]'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -56,7 +56,7 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
      * - one covering classes and interfaces
      * - one covering traits
      *
-     * This is to avoid test failing because PHPCS 1.x gets confused about the scope
+     * This is to avoid test failing because PHPCS < 2.4.0 gets confused about the scope
      * openers/closers when run on PHP 5.3 or lower.
      * In a 'normal' situation you won't often find classes, interfaces and traits all
      * mixed in one file anyway, so this issue for which this is a work-around,

--- a/PHPCompatibility/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -56,7 +56,7 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
      * - one covering classes and interfaces
      * - one covering traits
      *
-     * This is to avoid test failing because PHPCS 1.x gets confused about the scope
+     * This is to avoid test failing because PHPCS < 2.4.0 gets confused about the scope
      * openers/closers when run on PHP 5.3 or lower.
      * In a 'normal' situation you won't often find classes, interfaces and traits all
      * mixed in one file anyway, so this issue for which this is a work-around,

--- a/PHPCompatibility/Tests/bootstrap.php
+++ b/PHPCompatibility/Tests/bootstrap.php
@@ -44,7 +44,7 @@ if ($phpcsDir !== false && file_exists($phpcsDir . $ds . 'autoload.php')) {
     include_once dirname(dirname(__DIR__)) . $ds . 'PHPCSAliases.php';
 
 } elseif ($phpcsDir !== false && file_exists($phpcsDir . $ds . 'CodeSniffer.php')) {
-    // PHPCS 1.x, 2.x.
+    // PHPCS 2.x.
     require_once $phpcsDir . $ds . 'CodeSniffer.php';
 
     if (isset($vendorDir) && file_exists($vendorDir . $ds . 'autoload.php')) {

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/token_has_scope.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/token_has_scope.php
@@ -61,25 +61,6 @@ namespace {
     }
 }
 
-/* Case U1 */
-use Baz;
-/* Case U2 */
-use Foobar as Baz;
-/* Case U3- */
-class Foobar { use /* Case U3 */ Baz }
-/* Case U4- */
-class Foobar { use /* Case U4 */ const Baz }
-/* Case U5- */
-class Foobar { use /* Case U5 */ function Baz }
-/* Case U6 */
-class Foobar { use BazTrait { oldfunction as Baz } }
-/* Case U7 */
-class Foobar { use BazTrait { oldfunction as public Baz } }
-/* Case U8 */
-class Foobar { use BazTrait { oldfunction as protected Baz } }
-/* Case U9 */
-class Foobar { use BazTrait { oldfunction as private Baz } }
-
 /* Case C5 */
 new class {
     function something() {}

--- a/README.md
+++ b/README.md
@@ -27,18 +27,18 @@ Pull requests that check for compatibility issues in PHP 4 code - in particular 
 Requirements
 -------
 
-* PHP 5.3+ for use with PHP CodeSniffer 1.x and 2.x.
+* PHP 5.3+ for use with PHP CodeSniffer 2.x.
 * PHP 5.4+ for use with PHP CodeSniffer 3.x.
 
-PHP CodeSniffer: 1.5.6, 2.3.0+ or 3.0.2+.
+PHP CodeSniffer: 2.3.0+ or 3.0.2+.
 
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP CodeSniffer. You should get reasonably consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on PHP 5.4 or higher.
 
-PHP CodeSniffer 1.5.6 is required for 90% of the sniffs, PHP CodeSniffer 2.6.0 or later is required for full support, notices may be thrown on older versions.
+PHP CodeSniffer 2.3.0 is required for 90% of the sniffs, PHP CodeSniffer 2.6.0 or later is required for full support, notices may be thrown on older versions.
 
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP CodeSniffer 3.x.
 
-Note: support for PHP CodeSniffer < 2.3.0 will be dropped in the near future.
+As of version 9.0.0, support for PHP CodeSniffer 1.5.x and low 2.x versions < 2.3.0 has been dropped.
 
 
 Thank you

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -24,7 +24,16 @@
         PHP cross version compatibility ;-).
     -->
     <config name="testVersion" value="5.3-99.0"/>
-    <rule ref="PHPCompatibility"/>
+    <rule ref="PHPCompatibility">
+        <!-- Exclude PHP constants back-filled by PHPCS 2.3.0+. -->
+        <exclude name="PHPCompatibility.PHP.NewConstants.t_trait_cFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.t_traitFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.t_insteadofFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.t_callableFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.t_finallyFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.t_yieldFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.t_ellipsisFound"/>
+    </rule>
 
     <!--
         Minimal code style check.


### PR DESCRIPTION
See the individual commits for more detail and easier review.

* Remove the `\PHPCompatibility\Sniff::inUseScope()` method as it is no longer needed.
* Remove all work-arounds I could think off for PHPCS 1.x.
* Where relevant, update inline documentation for work-arounds which remain.
* Update the `PHPCompatibility.Upgrade.LowPHPCS` sniff to reflect the new minimum supported PHPCS version.
* Update the Readme & Contributing docs to reflect the new minimum supported PHPCS version.
* Travis: Stop testing the builds against PHPCS < 2.3.0
* CS: Update the PHPCompatibility native CS ruleset to allow for constants back-filled by PHPCS 2.3.0.

Having gone through the files again now, I'd like to suggest dropping support for PHPCS 2.4.0 in the `10.0.0` release as that will allow us to get rid of all the work-arounds for Traits not being tokenized correctly.