### PR TITLE
CS: remove unnecessary cs-ignore annotations

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -156,7 +156,6 @@ class ForbiddenNamesSniff extends Sniff
         }
 
         if (defined('T_ANON_CLASS')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
             $tokens[] = T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/InternalInterfacesSniff.php
@@ -49,7 +49,6 @@ class InternalInterfacesSniff extends Sniff
         $targets = array(T_CLASS);
 
         if (defined('T_ANON_CLASS')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
             $targets[] = T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
@@ -562,7 +562,6 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         );
 
         if (defined('T_ANON_CLASS')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
             $targets[] = T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
@@ -120,7 +120,6 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
         );
 
         if (defined('T_ANON_CLASS')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
             $targets[] = T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -93,7 +93,6 @@ class NonStaticMagicMethodsSniff extends Sniff
         }
 
         if (defined('T_ANON_CLASS')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
             $targets[] = T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/PHP/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ReservedFunctionNamesSniff.php
@@ -45,7 +45,6 @@ class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_Camel
             $scopeTokens[] = T_TRAIT;
         }
         if (defined('T_ANON_CLASS')) {
-            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
             $scopeTokens[] = T_ANON_CLASS;
         }
 


### PR DESCRIPTION
The `T_ANON_CLASS` token is a PHPCS native constant, not a back-filled constant.