### PR TITLE
PHP 7.3: DeprecatedFunctionParameters: account for change to define()

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -30,6 +30,12 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
      * @var array
      */
     protected $removedFunctionParameters = array(
+        'define' => array(
+            2 => array(
+                'name' => 'case_insensitive',
+                '7.3'  => false, // Slated for removal in PHP 8.0.0.
+            ),
+        ),
         'gmmktime' => array(
             6 => array(
                 'name' => 'is_dst',

--- a/PHPCompatibility/Tests/Sniffs/PHP/RemovedFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RemovedFunctionParametersSniffTest.php
@@ -122,6 +122,50 @@ class RemovedFunctionParametersSniffTest extends BaseSniffTest
 
 
     /**
+     * testDeprecatedParameter
+     *
+     * @dataProvider dataDeprecatedParameter
+     *
+     * @param string $functionName  Function name.
+     * @param string $parameterName Parameter name.
+     * @param string $deprecatedIn  The PHP version in which the parameter was deprecated.
+     * @param array  $lines         The line numbers in the test file which apply to this class.
+     * @param string $okVersion     A PHP version in which the parameter was ok to be used.
+     * @param string $testVersion   Optional. A PHP version in which to test for the deprecation message.
+     *
+     * @return void
+     */
+    public function testDeprecatedParameter($functionName, $parameterName, $deprecatedIn, $lines, $okVersion, $testVersion = null)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        $errorVersion = (isset($testVersion)) ? $testVersion : $deprecatedIn;
+        $file         = $this->sniffFile(self::TEST_FILE, $errorVersion);
+        $error        = "The \"{$parameterName}\" parameter for function {$functionName}() is deprecated since PHP {$deprecatedIn}";
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, $error);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDeprecatedParameter()
+     *
+     * @return array
+     */
+    public function dataDeprecatedParameter()
+    {
+        return array(
+            array('define', 'case_insensitive', '7.3', array(15), '7.2'),
+        );
+    }
+
+
+    /**
      * testNoFalsePositives
      *
      * @dataProvider dataNoFalsePositives
@@ -148,6 +192,7 @@ class RemovedFunctionParametersSniffTest extends BaseSniffTest
         return array(
             array(4),
             array(5),
+            array(14),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/removed_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/removed_function_parameter.php
@@ -10,3 +10,6 @@ gmmktime(1, 2, 3, 4, 5, 6, true);
 
 ldap_first_attribute( $link_identifier, $result_entry_identifier, $ber_identifier );
 ldap_next_attribute( $link_identifier, $result_entry_identifier, $ber_identifier );
+
+define('CONSTANT', 'foo'); // OK.
+define( 'CONSTANT', 'foo', true, );


### PR DESCRIPTION
> The declaration of case-insensitive constants has been deprecated. Passing `true` as the third argument to `define()` will now generate a deprecation warning. The use of case-insensitive constants with a case that differs from the declaration is also deprecated.

Refs:
* https://wiki.php.net/rfc/case_insensitive_constant_deprecation
* https://github.com/php/php-src/blob/3b6e1ee4ee05678b5d717cd926a35ffdc1335929/UPGRADING#L262-L266
* https://github.com/php/php-src/commit/3588d8af129489eda3e3fdb9612b09a4da16dcfd

N.B.: sniffing for the _"use of case-insensitive constants"_  is not covered and would be neigh impossible to sniff anyway.