### PR TITLE
NewKeyword: bug fix - magic constants are case insensitive

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
@@ -166,7 +166,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
                 $tokens[] = constant($token);
             }
             if (isset($versions['content'])) {
-                $translate[$versions['content']] = $token;
+                $translate[strtolower($versions['content'])] = $token;
             }
         }
 
@@ -203,10 +203,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
 
         // Translate T_STRING token if necessary.
         if ($tokens[$stackPtr]['type'] === 'T_STRING') {
-            $content = $tokens[$stackPtr]['content'];
-            if (strpos($content, '__') !== 0) {
-                $content = strtolower($tokens[$stackPtr]['content']);
-            }
+            $content = strtolower($tokens[$stackPtr]['content']);
 
             if (isset($this->translateContentToToken[$content]) === false) {
                 // Not one of the tokens we're looking for.

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -34,9 +34,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
         $this->assertError($file, 3, '__DIR__ magic constant is not present in PHP version 5.2 or earlier');
+        $this->assertError($file, 122, '__DIR__ magic constant is not present in PHP version 5.2 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file, 3);
+        $this->assertNoViolation($file, 122);
     }
 
     /**
@@ -381,7 +383,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
         if (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION === 3) {
             // PHP 5.3 actually shows the warning.
             $file = $this->sniffFile(self::TEST_FILE, '5.0');
-            $this->assertError($file, 122, '"__halt_compiler" keyword is not present in PHP version 5.0 or earlier');
+            $this->assertError($file, 124, '"__halt_compiler" keyword is not present in PHP version 5.0 or earlier');
         } else {
             /*
              * Usage of `__halt_compiler()` cannot be tested on its own token as the compiler
@@ -390,7 +392,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
              * not be reported.
              */
             $file = $this->sniffFile(self::TEST_FILE, '5.2');
-            $this->assertNoViolation($file, 125);
+            $this->assertNoViolation($file, 127);
         }
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_keywords.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_keywords.php
@@ -119,6 +119,8 @@ $response->header( 'Location', rest_url( sprintf( '%s/%s/%d', $this->namespace, 
 // yield used as a class constant.
 echo MyClass::yield;
 
+echo __dir__; // Magic constants are also case-insensitive.
+
 __halt_compiler();
 
 bla();


### PR DESCRIPTION
You learn something new every day and today I learned that the PHP magic constants are case _insensitive_. Who knew ?

Proof: https://3v4l.org/8l1GP

Found via: https://wiki.php.net/rfc/case_insensitive_constant_deprecation#unaffected_php_functionality

Includes additional unit test.