### PR TITLE
PHP 4.3: new php_uname() $mode parameter

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -606,8 +606,8 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         'php_uname' => array(
             0 => array(
                 'name' => 'mode',
-                '5.6'  => false,
-                '7.0'  => true,
+                '4.2'  => false,
+                '4.3'  => true,
             ),
         ),
         'preg_replace' => array(

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -152,7 +152,7 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('pg_lo_create', 'object_id', '5.2', array(66), '5.3'),
             array('pg_lo_import', 'object_id', '5.2', array(67), '5.3'),
             array('pg_select', 'result_type', '7.0', array(101), '7.1'),
-            array('php_uname', 'mode', '5.6', array(104), '7.0'),
+            array('php_uname', 'mode', '4.2', array(104), '4.3'),
             array('preg_replace', 'count', '5.0', array(68), '5.1'),
             array('preg_replace_callback', 'count', '5.0', array(69), '5.1'),
             array('round', 'mode', '5.2', array(70), '5.3'),


### PR DESCRIPTION
@jrfnl I did not see any other PHP 4 entries, so if this isn't the format that you want, please let me know.

Ref: https://github.com/php/php-src/commit/7f89d8c13a7c4d86a4efb8b15609533bf2928d9e
Updates: https://github.com/PHPCompatibility/PHPCompatibility/commit/eba7501e48209d933ddb930f08830529fe6931a5