### PR TITLE
Fix PHPUnit 7.2 compatibility

### DIFF
--- a/phpunit-travis.xml
+++ b/phpunit-travis.xml
@@ -11,6 +11,8 @@
             <directory>./PHPCompatibility/Sniffs/</directory>
         </whitelist>
     </filter>
-    <log type="coverage-clover" target="build/logs/clover.xml"/>
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>
 


### PR DESCRIPTION
As of PHPUnit 7.2 the XML configuration is validated against the XSD and throws a warning.

The `<log>` element should, according to the PHPUnit manual, be nested within a `<logging>` element.

```
PHPUnit 7.2.7 by Sebastian Bergmann and contributors.
  Warning - The configuration file did not pass validation!
  The following problems have been detected:
  Line 14:
  - Element 'log': This element is not expected.
  Test results may not be as expected.
```
From: https://travis-ci.org/PHPCompatibility/PHPCompatibility/jobs/407612965#L799-L805

Refs:
* https://phpunit.readthedocs.io/en/7.1/configuration.html#logging
* https://phpunit.de/manual/5.7/en/appendixes.configuration.html#appendixes.configuration.logging
* https://github.com/sebastianbergmann/phpunit/issues/3066
* https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-7.2.md#720---2018-06-01