### PR TITLE
PHP 7.3: DeprecatedFunctions: add deprecation of undocumented Mbstring function aliases

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -819,6 +819,62 @@ class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.3' => false,
             'alternative' => 'imagewbmp()',
         ),
+        'mbregex_encoding' => array(
+            '7.3' => false,
+            'alternative' => 'mb_regex_encoding()',
+        ),
+        'mbereg' => array(
+            '7.3' => false,
+            'alternative' => 'mb_ereg()',
+        ),
+        'mberegi' => array(
+            '7.3' => false,
+            'alternative' => 'mb_eregi()',
+        ),
+        'mbereg_replace' => array(
+            '7.3' => false,
+            'alternative' => 'mb_ereg_replace()',
+        ),
+        'mberegi_replace' => array(
+            '7.3' => false,
+            'alternative' => 'mb_eregi_replace()',
+        ),
+        'mbsplit' => array(
+            '7.3' => false,
+            'alternative' => 'mb_split()',
+        ),
+        'mbereg_match' => array(
+            '7.3' => false,
+            'alternative' => 'mb_ereg_match()',
+        ),
+        'mbereg_search' => array(
+            '7.3' => false,
+            'alternative' => 'mb_ereg_search()',
+        ),
+        'mbereg_search_pos' => array(
+            '7.3' => false,
+            'alternative' => 'mb_ereg_search_pos()',
+        ),
+        'mbereg_search_regs' => array(
+            '7.3' => false,
+            'alternative' => 'mb_ereg_search_regs()',
+        ),
+        'mbereg_search_init' => array(
+            '7.3' => false,
+            'alternative' => 'mb_ereg_search_init()',
+        ),
+        'mbereg_search_getregs' => array(
+            '7.3' => false,
+            'alternative' => 'mb_ereg_search_getregs()',
+        ),
+        'mbereg_search_getpos' => array(
+            '7.3' => false,
+            'alternative' => 'mb_ereg_search_getpos()',
+        ),
+        'mbereg_search_setpos' => array(
+            '7.3' => false,
+            'alternative' => 'mb_ereg_search_setpos()',
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -170,6 +170,20 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             array('read_exif_data', '7.2', 'exif_read_data()', array(149), '7.1'),
 
             array('image2wbmp', '7.3', 'imagewbmp()', array(152), '7.2'),
+            array('mbregex_encoding', '7.3', 'mb_regex_encoding()', array(153), '7.2'),
+            array('mbereg', '7.3', 'mb_ereg()', array(154), '7.2'),
+            array('mberegi', '7.3', 'mb_eregi()', array(155), '7.2'),
+            array('mbereg_replace', '7.3', 'mb_ereg_replace()', array(156), '7.2'),
+            array('mberegi_replace', '7.3', 'mb_eregi_replace()', array(157), '7.2'),
+            array('mbsplit', '7.3', 'mb_split()', array(158), '7.2'),
+            array('mbereg_match', '7.3', 'mb_ereg_match()', array(159), '7.2'),
+            array('mbereg_search', '7.3', 'mb_ereg_search()', array(160), '7.2'),
+            array('mbereg_search_pos', '7.3', 'mb_ereg_search_pos()', array(161), '7.2'),
+            array('mbereg_search_regs', '7.3', 'mb_ereg_search_regs()', array(162), '7.2'),
+            array('mbereg_search_init', '7.3', 'mb_ereg_search_init()', array(163), '7.2'),
+            array('mbereg_search_getregs', '7.3', 'mb_ereg_search_getregs()', array(164), '7.2'),
+            array('mbereg_search_getpos', '7.3', 'mb_ereg_search_getpos()', array(165), '7.2'),
+            array('mbereg_search_setpos', '7.3', 'mb_ereg_search_setpos()', array(166), '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
@@ -150,3 +150,17 @@ read_exif_data();
 
 // PHP 7.3.
 image2wbmp();
+mbregex_encoding();
+mbereg();
+mberegi();
+mbereg_replace();
+mberegi_replace();
+mbsplit();
+mbereg_match();
+mbereg_search();
+mbereg_search_pos();
+mbereg_search_regs();
+mbereg_search_init();
+mbereg_search_getregs();
+mbereg_search_getpos();
+mbereg_search_setpos();


### PR DESCRIPTION
Refs:
* https://wiki.php.net/rfc/deprecations_php_7_3#undocumented_mbstring_function_aliases
* https://github.com/php/php-src/blob/cf3b852109a88a11370d0207cd3b72a53b6a64c3/UPGRADING#L284-L300
* https://github.com/php/php-src/commit/e6016ab20d6699cac9441686903051b3a815cbba