### PR TITLE
MbstringReplaceEModifier: also recognize the use of the /e modifier when alias functions are used

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/MbstringReplaceEModifierSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/MbstringReplaceEModifierSniff.php
@@ -36,6 +36,8 @@ class MbstringReplaceEModifierSniff extends AbstractFunctionCallParameterSniff
         'mb_ereg_replace'      => 4,
         'mb_eregi_replace'     => 4,
         'mb_regex_set_options' => 1,
+        'mbereg_replace'       => 4, // Undocumented, but valid function alias.
+        'mberegi_replace'      => 4, // Undocumented, but valid function alias.
     );
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
@@ -59,6 +59,8 @@ class MbstringReplaceEModifierSniffTest extends BaseSniffTest
             array(24),
             array(25),
             array(26),
+            array(29),
+            array(30),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/mbstring_replace_e_modifier.php
+++ b/PHPCompatibility/Tests/sniff-examples/mbstring_replace_e_modifier.php
@@ -24,3 +24,7 @@ mb_regex_set_options( 'im' . "$se" );
 mb_ereg_replace( $pattern, $replace, $subject, "e$m" );
 mb_eregi_replace( $pattern, $replace, $subject, "me$i" );
 mb_regex_set_options( 'im' . "{$se}e" );
+
+// Verify the sniff also pick up on the function aliases.
+mbereg_replace( $pattern, $replace, $subject, 'e' );
+mberegi_replace( $pattern, $replace, $subject, "me$i" );


### PR DESCRIPTION
Loosely related to #714.