### PR TITLE
PHP 7.3: DeprecatedIniDirectives: add deprecation of pdo_odbc.db2_instance_name

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -224,6 +224,9 @@ class DeprecatedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             '5.3' => false, // Soft deprecated, i.e. ignored.
             '7.3' => true,
         ),
+        'pdo_odbc.db2_instance_name' => array(
+            '7.3' => false, // Has been marked as deprecated in the manual from before this time. Now hard-deprecated.
+        ),
     );
 
     /**

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -152,6 +152,8 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
 
             array('mbstring.func_overload', '7.2', array(166, 167), '7.1'),
             array('track_errors', '7.2', array(172, 173), '7.1'),
+
+            array('pdo_odbc.db2_instance_name', '7.3', array(184, 185), '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_ini_directives.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_ini_directives.php
@@ -180,3 +180,6 @@ $a = ini_get('birdstep.max_links');
 
 ini_set('opcache.inherited_hack', true);
 $a = ini_get('opcache.inherited_hack');
+
+ini_set('pdo_odbc.db2_instance_name', 'string');
+$a = ini_get('pdo_odbc.db2_instance_name');


### PR DESCRIPTION
> The pdo_odbc.db2_instance_name ini setting has been formally deprecated. It
    has already been deprecated in the documentation since PHP 5.1.1.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_3#pdo_odbcdb2_instance_name_phpini_directive
* https://github.com/php/php-src/blob/cf3b852109a88a11370d0207cd3b72a53b6a64c3/UPGRADING#L302-L304
* https://github.com/php/php-src/commit/fb0e8c65b9d196db44c7d92890e3540f863b6c8b