### PR TITLE
PHP 7.3: NewIniDirectives: add new syslog.filter

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -467,6 +467,10 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '7.2' => false,
             '7.3' => true,
         ),
+        'syslog.filter' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
         'syslog.ident' => array(
             '7.2' => false,
             '7.3' => true,

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -185,6 +185,7 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
 
             array('syslog.facility', '7.3', array(311, 312), '7.2'),
             array('syslog.ident', '7.3', array(314, 315), '7.2'),
+            array('syslog.filter', '7.3', array(317, 318), '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_ini_directives.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_ini_directives.php
@@ -313,3 +313,6 @@ $test = ini_get('syslog.facility');
 
 ini_set('syslog.ident', 1);
 $test = ini_get('syslog.ident');
+
+ini_set('syslog.filter', 1);
+$test = ini_get('syslog.filter');


### PR DESCRIPTION
> syslog.filter
> New INI to set syslog filter type to filter the logged messages. There are
    3 supported filter types - all, no-ctrl and ascii. It is used only when
    error_log is set to syslog.

Refs:
* https://github.com/php/php-src/blob/cf3b852109a88a11370d0207cd3b72a53b6a64c3/UPGRADING#L514-L517
* https://github.com/php/php-src/commit/2010c02e5c3c70880a53cb0403ce696708f4d590
* https://github.com/php/php-src/commit/c85504386d16f943cc79263187710a05cefea265
* https://github.com/php/php-src/commit/e5a99563363a656c06f836957002550ff7fdb720