### PR TITLE
PHP 7.3: DeprecatedFunctions: add deprecation of fgetss() and gzgetss() functions

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -875,6 +875,14 @@ class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.3' => false,
             'alternative' => 'mb_ereg_search_setpos()',
         ),
+        'fgetss' => array(
+            '7.3' => false,
+            'alternative' => null,
+        ),
+        'gzgetss' => array(
+            '7.3' => false,
+            'alternative' => null,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -69,6 +69,8 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             array('dl', '5.3', array(6), '5.2'),
             array('ocifetchinto', '5.4', array(63), '5.3'),
             array('ldap_sort', '7.0', array(97), '5.6'),
+            array('fgetss', '7.3', array(167), '7.2'),
+            array('gzgetss', '7.3', array(168), '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
@@ -164,3 +164,5 @@ mbereg_search_init();
 mbereg_search_getregs();
 mbereg_search_getpos();
 mbereg_search_setpos();
+fgetss();
+gzgetss();


### PR DESCRIPTION
> The fgetss() function and the string.strip_tags stream filter have been deprecated.
    This also affects the SplFileObject::fgetss() method and gzgetss() function.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_3#fgetss_function_and_stringstrip_tags_filter
* https://github.com/php/php-src/blob/cf3b852109a88a11370d0207cd3b72a53b6a64c3/UPGRADING#L320-L321
* https://github.com/php/php-src/commit/d9acfa45b849a9444ae5f341fd016137e4212066