### PR TITLE
ForbiddenCallTimePassByReference: fix some false positives and false negatives

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -304,7 +304,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
     /**
      * Checks if a function call has parameters.
      *
-     * Expects to be passed the T_STRING stack pointer for the function call.
+     * Expects to be passed the T_STRING or T_VARIABLE stack pointer for the function call.
      * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
      *
      * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer, it
@@ -328,7 +328,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         }
 
         // Is this one of the tokens this function handles ?
-        if (in_array($tokens[$stackPtr]['code'], array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY), true) === false) {
+        if (in_array($tokens[$stackPtr]['code'], array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY, T_VARIABLE), true) === false) {
             return false;
         }
 
@@ -373,7 +373,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
     /**
      * Count the number of parameters a function call has been passed.
      *
-     * Expects to be passed the T_STRING stack pointer for the function call.
+     * Expects to be passed the T_STRING or T_VARIABLE stack pointer for the function call.
      * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
      *
      * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
@@ -401,7 +401,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
     /**
      * Get information on all parameters passed to a function call.
      *
-     * Expects to be passed the T_STRING stack pointer for the function call.
+     * Expects to be passed the T_STRING or T_VARIABLE stack pointer for the function call.
      * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
      *
      * Will return an multi-dimentional array with the start token pointer, end token
@@ -422,7 +422,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
             return array();
         }
 
-        // Ok, we know we have a T_STRING, T_ARRAY or T_OPEN_SHORT_ARRAY with parameters
+        // Ok, we know we have a T_STRING, T_VARIABLE, T_ARRAY or T_OPEN_SHORT_ARRAY with parameters
         // and valid open & close brackets/parenthesis.
         $tokens = $phpcsFile->getTokens();
 
@@ -510,7 +510,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
     /**
      * Get information on a specific parameter passed to a function call.
      *
-     * Expects to be passed the T_STRING stack pointer for the function call.
+     * Expects to be passed the T_STRING or T_VARIABLE stack pointer for the function call.
      * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
      *
      * Will return a array with the start token pointer, end token pointer and the raw value

--- a/PHPCompatibility/Tests/BaseClass/GetFunctionParametersTest.php
+++ b/PHPCompatibility/Tests/BaseClass/GetFunctionParametersTest.php
@@ -42,7 +42,18 @@ class GetFunctionParametersTest extends MethodTestFrame
      */
     public function testGetFunctionCallParameters($commentString, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY));
+        switch ($commentString[8]) {
+            case 'S':
+                $stackPtr = $this->getTargetToken($commentString, array(T_STRING));
+                break;
+            case 'A':
+                $stackPtr = $this->getTargetToken($commentString, array(T_ARRAY, T_OPEN_SHORT_ARRAY));
+                break;
+            case 'V':
+                $stackPtr = $this->getTargetToken($commentString, array(T_VARIABLE));
+                break;
+        }
+
         /*
          * Start/end token position values in the expected array are set as offsets
          * in relation to the target token.
@@ -289,6 +300,43 @@ class GetFunctionParametersTest extends MethodTestFrame
                         'raw'   => '\'~\'.function_call().\'~i\' => function ($match) {
             echo strlen($match[0]), \' matches for "b" found\', PHP_EOL;
         }',
+                    ),
+                ),
+            ),
+
+            // Function calling closure in variable.
+            array(
+                '/* Case V1 */',
+                array(
+                    1 => array(
+                        'start' => 2,
+                        'end'   => 3,
+                        'raw'   => '&$a',
+                    ),
+                    2 => array(
+                        'start' => 5,
+                        'end'   => 12,
+                        'raw'   => '(1 + 20)',
+                    ),
+                    3 => array(
+                        'start' => 14,
+                        'end'   => 20,
+                        'raw'   => '$a & $b',
+                    ),
+                ),
+            ),
+            array(
+                '/* Case V2 */',
+                array(
+                    1 => array(
+                        'start' => 2,
+                        'end'   => 4,
+                        'raw'   => '$a->property',
+                    ),
+                    2 => array(
+                        'start' => 6,
+                        'end'   => 12,
+                        'raw'   => '$b->call()',
                     ),
                 ),
             ),

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -62,6 +62,7 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
             array(45), // Bad: call time pass by reference.
             array(49), // Bad: multiple call time pass by reference.
             array(71), // Bad: call time pass by reference.
+            array(93), // Bad: call time pass by reference.
         );
     }
 
@@ -131,6 +132,16 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
             array(78),
             array(79),
             array(80),
+
+            // References in combination with closures.
+            array(83),
+            array(85),
+            array(90),
+
+            // Reference within an array argument.
+            array(96),
+            array(97),
+            array(99),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/call_time_pass_by_reference.php
+++ b/PHPCompatibility/Tests/sniff-examples/call_time_pass_by_reference.php
@@ -78,3 +78,22 @@ efg( true === &$b );
 foo(Bar::FOO & $a);
 $foo = self::FLAG_GETDATA & $flags ? 'SQL_CALC_FOUND_ROWS' : '';
 $handler->throwAt(E_ALL & $handler->thrownErrors, true);
+
+// Closures and passing by reference appear to allow declaring with references.
+$d = function ( &$a ) {};
+
+abc(function ($a, &$b, $c) {
+    return array($a,$b,$c);
+});
+
+abc(function ($a, $b, $c) {
+    return array($a,$b,&$c);
+});
+
+$d(&$a); // Bad: pass by reference.
+
+// From PHPCS native Generic.Functions.CallTimePassByReference test file.
+Hooks::run( 'SecondaryDataUpdates', array( $title, $old, $recursive, $parserOutput, &$updates ) );
+Hooks::run( 'SecondaryDataUpdates', [ $title, $old, $recursive, $parserOutput, &$updates ] );
+// Similar, but live coding, parse error.
+Hooks::run( 'SecondaryDataUpdates', [ $title, $old,

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/get_function_parameters.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/get_function_parameters.php
@@ -59,3 +59,9 @@ preg_replace_callback_array(
     ],
     $subject
 );
+
+/* Case V1 */
+$closure(&$a, (1 + 20), $a & $b );
+
+/* Case V2 */
+self::$closureInStaticProperty($a->property, $b->call() );


### PR DESCRIPTION
Inspired by upstream PHPCS PR https://github.com/squizlabs/PHP_CodeSniffer/pull/2109, I ran the upstream sniff against the unit test cases from PHPCompatibility and the PHPCompatibility sniff against the upstream unit test cases.

The PHPCompatibility sniff already took the test case which is addressed in the upstream PR into account.
All the same, it didn't catch the `$foo(&$myvar);` test case (line 25 PHPCS unit test case file) and it gave a false positive for `Hooks::run( [ &$updates ] );` (line 30 PHPCS unit test case file).

Both are now addressed in this PR.

### Sniff:getFunctionCallParameter() and related functions: allow for calling closure via variable

This minor adjustments allows these functions also to be used for retrieving the function call parameters of calls to a closure contained in a variable, like so `$d( $a, $b );`.

Includes additional unit tests.

### ForbiddenCallTimePassByReference: fix some false positives and false negatives

Fixes the following:
* False negative for closure called via a variable `$c(&$a);`.
* False positive for references in arrays and closures passed as function call parameters.

Includes unit tests.

