### PR TITLE
NewGeneratorReturn: bug fix for generator return with nested functions

### DIFF
--- a/PHPCompatibility/Tests/Sniffs/PHP/NewGeneratorReturnSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewGeneratorReturnSniffTest.php
@@ -52,6 +52,9 @@ class NewGeneratorReturnSniffTest extends BaseSniffTest
             array(30),
             array(35),
             array(39),
+            array(64),
+            array(83),
+            array(101),
         );
     }
 
@@ -84,6 +87,8 @@ class NewGeneratorReturnSniffTest extends BaseSniffTest
             array(6),
             array(15),
             array(21),
+            array(53),
+            array(107),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_generator_return.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_generator_return.php
@@ -39,3 +39,76 @@ function gen() {
     return $foo;
     yield;
 }
+
+// Issue #724 - nested generator functions.
+  class test {
+      final public function trigger()
+      {
+          $result = (
+              function() {
+                  yield 1;
+                  yield 2;
+              }
+          );
+          return $result(); // OK.
+      }
+    }
+
+  class test {
+      final public function trigger()
+      {
+          $result = (
+              function() {
+                  yield 1;
+                  yield 2;
+                  return 3; // Not OK.
+              }
+          );
+          return $result();
+      }
+    }
+
+// Make sure the correct scoped conditions are found.
+function xrange($start, $limit, $step = 1) {
+    if ($start < $limit) {
+        if ($step <= 0) {
+            throw new LogicException('Step must be +ve');
+        }
+
+        for ($i = $start; $i <= $limit; $i += $step) {
+            yield $i;
+        }
+    }
+    
+    return 100; // Not OK.
+}
+
+function nestedConditions( $a, $b ) {
+	try {
+		switch( $a ) {
+			case 'A':
+				if ( $b > $a ) {
+					for($a; $a < $b; $a++) {
+						yield $a;
+					}
+				}
+				break;
+			case 'B':
+				yield 2;
+				break;
+		}
+	} finally {
+		return 10; // Not OK.
+	}
+}
+
+function nestedClosureReturn() {
+	$a = function() {
+		return 10; // OK.
+	};
+	
+	$a();
+
+	yield 20;
+}
+


### PR DESCRIPTION
The sniff didn't take well enough into account that generator functions could be nested within other (anonymous) functions or could have other nested constructs within the generator within which a `return` statement was fine.

Previously, it would check if the `yield` had a (named) `function` scope and if not, if it had a anonymous function scope.
This caused the false positive as reported by @mjrider as for a `yield` in a closure nested within a named function, the named function would be examined, not the closure.

The fix in this PR changes that logic to find the deepest nested function òr closure within which the `yield` exist.

Additionally, this fix makes sure that the sniff doesn't get confused over `return` statements found in even deeper nested scopes, such as a closure nested within the generator.

Includes additional unit tests.

Fixes #724