### PR TITLE
PHP 7.1: NewIniDirectives: add some more new directives

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -454,11 +454,27 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '7.0' => true,
         ),
 
+        'hard_timeout' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
         'session.sid_length' => array(
             '7.0' => false,
             '7.1' => true,
         ),
         'session.sid_bits_per_character' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'session.trans_sid_hosts' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'session.trans_sid_tags' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'url_rewriter.hosts' => array(
             '7.0' => false,
             '7.1' => true,
         ),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -180,8 +180,12 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
             array('session.lazy_write', '7.0', array(299, 300), '5.6'),
             array('zend.assertions', '7.0', array(302, 303), '5.6'),
 
+            array('hard_timeout', '7.1', array(320, 321), '7.0'),
             array('session.sid_length', '7.1', array(305, 306), '7.0'),
             array('session.sid_bits_per_character', '7.1', array(308, 309), '7.0'),
+            array('session.trans_sid_hosts', '7.1', array(323, 324), '7.0'),
+            array('session.trans_sid_tags', '7.1', array(326, 327), '7.0'),
+            array('url_rewriter.hosts', '7.1', array(329, 330), '7.0'),
 
             array('syslog.facility', '7.3', array(311, 312), '7.2'),
             array('syslog.ident', '7.3', array(314, 315), '7.2'),

--- a/PHPCompatibility/Tests/sniff-examples/new_ini_directives.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_ini_directives.php
@@ -316,3 +316,16 @@ $test = ini_get('syslog.ident');
 
 ini_set('syslog.filter', 1);
 $test = ini_get('syslog.filter');
+
+ini_set('hard_timeout', 1);
+$test = ini_get('hard_timeout');
+
+ini_set('session.trans_sid_hosts', 1);
+$test = ini_get('session.trans_sid_hosts');
+
+ini_set('session.trans_sid_tags', 1);
+$test = ini_get('session.trans_sid_tags');
+
+ini_set('url_rewriter.hosts', 1);
+$test = ini_get('url_rewriter.hosts');
+


### PR DESCRIPTION
_Yeah_ for incomplete changelogs.

These changes are **not** explicitly mentioned in the `ini` section of the in the [`UPGRADING`](https://github.com/php/php-src/blob/PHP-7.1.21/UPGRADING) file for PHP 7.1 nor in the [Migrating to PHP 7.1.x](http://php.net/manual/en/migration71.php).

They are, however, annotated in the manual.

Refs:
* http://php.net/manual/en/ini.core.php#ini.sect.language-options
* https://github.com/php/php-src/commit/650c1c0a7d94d3bb052a93407b6e280df9c265a4

Refs:
* http://php.net/manual/en/outcontrol.configuration.php
* http://php.net/manual/en/session.configuration.php
* https://github.com/php/php-src/commit/a53a6b3fb4060c9c71a84b0acaaa0211777f6e17