### PR TITLE
PHP 7.1: NewFunctions: add more new functions

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
@@ -1275,6 +1275,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.0' => false,
             '7.1' => true,
         ),
+        'pcntl_signal_get_handler' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
         'session_create_id' => array(
             '7.0' => false,
             '7.1' => true,

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
@@ -1283,6 +1283,22 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.0' => false,
             '7.1' => true,
         ),
+        'sapi_windows_cp_set' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'sapi_windows_cp_get' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'sapi_windows_cp_is_utf8' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'sapi_windows_cp_conv' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
 
         'oci_register_taf_callback' => array(
             '7.1.6' => false,

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
@@ -1300,6 +1300,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.1' => true,
         ),
 
+        'hash_hkdf' => array(
+            '7.1.1' => false,
+            '7.1.2' => true,
+        ),
         'oci_register_taf_callback' => array(
             '7.1.6' => false,
             '7.1.7' => true,

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -379,6 +379,7 @@ class NewFunctionsSniffTest extends BaseSniffTest
             array('sapi_windows_cp_is_utf8', '7.0', array(464), '7.1'),
             array('sapi_windows_cp_conv', '7.0', array(465), '7.1'),
 
+            array('hash_hkdf', '7.1.1', array(466), '7.2', '7.1'),
             array('oci_register_taf_callback', '7.1.6', array(322), '7.2', '7.1'),
             array('oci_unregister_taf_callback', '7.1.8', array(323), '7.2', '7.1'),
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -374,6 +374,10 @@ class NewFunctionsSniffTest extends BaseSniffTest
             array('pcntl_async_signals', '7.0', array(318), '7.1'),
             array('session_create_id', '7.0', array(319), '7.1'),
             array('session_gc', '7.0', array(320), '7.1'),
+            array('sapi_windows_cp_set', '7.0', array(462), '7.1'),
+            array('sapi_windows_cp_get', '7.0', array(463), '7.1'),
+            array('sapi_windows_cp_is_utf8', '7.0', array(464), '7.1'),
+            array('sapi_windows_cp_conv', '7.0', array(465), '7.1'),
 
             array('oci_register_taf_callback', '7.1.6', array(322), '7.2', '7.1'),
             array('oci_unregister_taf_callback', '7.1.8', array(323), '7.2', '7.1'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -372,6 +372,7 @@ class NewFunctionsSniffTest extends BaseSniffTest
             array('curl_share_strerror', '7.0', array(316), '7.1'),
             array('is_iterable', '7.0', array(317), '7.1'),
             array('pcntl_async_signals', '7.0', array(318), '7.1'),
+            array('pcntl_signal_get_handler', '7.0', array(467), '7.1'),
             array('session_create_id', '7.0', array(319), '7.1'),
             array('session_gc', '7.0', array(320), '7.1'),
             array('sapi_windows_cp_set', '7.0', array(462), '7.1'),

--- a/PHPCompatibility/Tests/sniff-examples/new_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_functions.php
@@ -463,3 +463,4 @@ sapi_windows_cp_set();
 sapi_windows_cp_get();
 sapi_windows_cp_is_utf8();
 sapi_windows_cp_conv();
+hash_hkdf();

--- a/PHPCompatibility/Tests/sniff-examples/new_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_functions.php
@@ -458,3 +458,8 @@ sapi_add_request_header();
 socket_wsaprotocol_info_export();
 socket_wsaprotocol_info_import();
 socket_wsaprotocol_info_release();
+
+sapi_windows_cp_set();
+sapi_windows_cp_get();
+sapi_windows_cp_is_utf8();
+sapi_windows_cp_conv();

--- a/PHPCompatibility/Tests/sniff-examples/new_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_functions.php
@@ -464,3 +464,4 @@ sapi_windows_cp_get();
 sapi_windows_cp_is_utf8();
 sapi_windows_cp_conv();
 hash_hkdf();
+pcntl_signal_get_handler();


### PR DESCRIPTION
### PHP 7.1: NewFunctions: add new `sapi_windows_*()` functions

> Added sapi_windows_cp_set(), sapi_windows_cp_get(), sapi_windows_cp_is_utf8(), sapi_windows_cp_conv() for codepage handling.

Refs:
* https://github.com/php/php-src/blob/6acee09f40fd16320ccadc0f662033ddff75d053/UPGRADING#L251-L253
* php/php-src@3d3f11e

### PHP 7.1.2: NewFunctions: add new `hash_hkdf()` function

> In PHP 7.1.2: Added hash_hkdf() function, which implements the HMAC-based Derivation Function (HKDF) algorithm according to RFC 5869. The implementation combines the Extract and Expand steps.

Refs:
* https://github.com/php/php-src/blob/6acee09f40fd16320ccadc0f662033ddff75d053/UPGRADING#L261-L264
* php/php-src@4bf7ef0

### PHP 7.1: NewFunctions: add new `pcntl_signal_get_handler()` function

> Added pcntl_signal_get_handler() that returns the current signal handler for a particular signal.

Refs:
* https://github.com/php/php-src/blob/6acee09f40fd16320ccadc0f662033ddff75d053/UPGRADING#L266-L268
* php/php-src@217dcbc

