### PR TITLE
PHP 7.3: NewIniDirectives: add new session ini directive

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -491,6 +491,10 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '7.2' => false,
             '7.3' => true,
         ),
+        'session.cookie_samesite' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
     );
 
     /**

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -190,6 +190,7 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
             array('syslog.facility', '7.3', array(311, 312), '7.2'),
             array('syslog.ident', '7.3', array(314, 315), '7.2'),
             array('syslog.filter', '7.3', array(317, 318), '7.2'),
+            array('session.cookie_samesite', '7.3', array(332, 333), '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_ini_directives.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_ini_directives.php
@@ -329,3 +329,5 @@ $test = ini_get('session.trans_sid_tags');
 ini_set('url_rewriter.hosts', 1);
 $test = ini_get('url_rewriter.hosts');
 
+ini_set('session.cookie_samesite', 1);
+$test = ini_get('session.cookie_samesite');


### PR DESCRIPTION
> - session.cookie_samesite
>    New INI option to allow to set the SameSite directive for cookies. Defaults to "" (empty string), so no SameSite directive is set. Can be set to "Lax" or "Strict", which sets the respective SameSite directive.

Refs:
* https://wiki.php.net/rfc/same-site-cookie
* https://github.com/php/php-src/blob/d22ddd8cf12b5582b11dcba84d93f1b558ce30ae/UPGRADING#L524-L527
* https://github.com/php/php-src/commit/2b58ab23c6ad3301b31a2015f5faa31801147dfd