### PR TITLE
PHP 7.3: New sniff to detect flexible heredoc/nowdoc cross-version incompatibilities

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\Syntax\NewFlexibleHeredocNowdocSniff.
+ *
+ * PHP version 7.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\Syntax;
+
+use PHPCompatibility\Sniff;
+use PHPCompatibility\PHPCSHelper;
+
+/**
+ * New Flexible Heredoc Nowdoc.
+ *
+ * As of PHP 7.3:
+ * - The body and the closing marker of a Heredoc/nowdoc can be indented;
+ * - The closing marker no longer needs to be on a line by itself;
+ * - The heredoc/nowdoc body may no longer contain the closing marker at the
+ *   start of any of its lines.
+ *
+ * PHP version 7.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewFlexibleHeredocNowdocSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $targets = array(
+            T_END_HEREDOC,
+            T_END_NOWDOC,
+        );
+
+        if (version_compare(PHP_VERSION_ID, '70299', '>') === false) {
+            // Start identifier of a PHP 7.3 flexible heredoc/nowdoc.
+            $targets[] = T_STRING;
+        }
+
+        return $targets;
+    }
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        /*
+         * Due to a tokenizer bug which gets hit when the PHP 7.3 heredoc/nowdoc syntax
+         * is used, this part of the sniff cannot possibly work on PHPCS < 2.6.0.
+         * See upstream issue #928.
+         */
+        if ($this->supportsBelow('7.2') === true && version_compare(PHPCSHelper::getVersion(), '2.6.0', '>=')) {
+            $this->detectIndentedNonStandAloneClosingMarker($phpcsFile, $stackPtr);
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        if ($this->supportsAbove('7.3') === true && $tokens[$stackPtr]['code'] !== T_STRING) {
+            $this->detectClosingMarkerInBody($phpcsFile, $stackPtr);
+        }
+    }
+
+
+    /**
+     * Detect indented and/or non-stand alone closing markers.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function detectIndentedNonStandAloneClosingMarker(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens            = $phpcsFile->getTokens();
+        $indentError       = 'Heredoc/nowdoc with an indented closing marker is not supported in PHP 7.2 or earlier.';
+        $indentErrorCode   = 'IndentedClosingMarker';
+        $trailingError     = 'Having code - other than a semi-colon or new line - after the closing marker of a heredoc/nowdoc is not supported in PHP 7.2 or earlier.';
+        $trailingErrorCode = 'ClosingMarkerNoNewLine';
+
+        if (version_compare(PHP_VERSION_ID, '70299', '>') === true) {
+
+            /*
+             * Check for indented closing marker.
+             */
+            if (ltrim($tokens[$stackPtr]['content']) !== $tokens[$stackPtr]['content']) {
+                $phpcsFile->addError($indentError, $stackPtr, $indentErrorCode);
+            }
+
+            /*
+             * Check for tokens after the closing marker.
+             */
+            $nextNonWhitespace = $phpcsFile->findNext(array(T_WHITESPACE, T_SEMICOLON), ($stackPtr + 1), null, true);
+            if ($tokens[$stackPtr]['line'] === $tokens[$nextNonWhitespace]['line']) {
+                $phpcsFile->addError($trailingError, $stackPtr, $trailingErrorCode);
+            }
+        } else {
+            // For PHP < 7.3, we're only interested in T_STRING tokens.
+            if ($tokens[$stackPtr]['code'] !== T_STRING) {
+                return;
+            }
+
+            if (preg_match('`^<<<([\'"]?)([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)\1[\r\n]+`', $tokens[$stackPtr]['content'], $matches) !== 1) {
+                // Not the start of a PHP 7.3 flexible heredoc/nowdoc.
+                return;
+            }
+
+            $identifier = $matches[2];
+
+            for ($i = ($stackPtr + 1); $i <= $phpcsFile->numTokens; $i++) {
+                if ($tokens[$i]['code'] !== T_ENCAPSED_AND_WHITESPACE) {
+                    continue;
+                }
+
+                $trimmed = ltrim($tokens[$i]['content']);
+
+                if (strpos($trimmed, $identifier) !== 0) {
+                    continue;
+                }
+
+                // OK, we've found the PHP 7.3 flexible heredoc/nowdoc closing marker.
+
+                /*
+                 * Check for indented closing marker.
+                 */
+                if ($trimmed !== $tokens[$i]['content']) {
+                    // Indent found before closing marker.
+                    $phpcsFile->addError($indentError, $i, $indentErrorCode);
+                }
+
+                /*
+                 * Check for tokens after the closing marker.
+                 */
+                // Remove the identifier.
+                $afterMarker = substr($trimmed, strlen($identifier));
+                // Remove a potential semi-colon at the beginning of what's left of the string.
+                $afterMarker = ltrim($afterMarker, ';');
+                // Remove new line characters at the end of the string.
+                $afterMarker = rtrim($afterMarker, "\r\n");
+
+                if ($afterMarker !== '') {
+                    $phpcsFile->addError($trailingError, $i, $trailingErrorCode);
+                }
+
+                break;
+            }
+        }
+    }
+
+
+    /**
+     * Detect heredoc/nowdoc identifiers at the start of lines in the heredoc/nowdoc body.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function detectClosingMarkerInBody(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $error     = 'The body of a heredoc/nowdoc can not contain the heredoc/nowdoc closing marker as text at the start of a line since PHP 7.3.';
+        $errorCode = 'ClosingMarkerNoNewLine';
+
+        if (version_compare(PHP_VERSION_ID, '70299', '>') === true) {
+            $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true, null, true);
+            if ($nextNonWhitespace === false
+                || $tokens[$nextNonWhitespace]['code'] === T_SEMICOLON
+                || (($tokens[$nextNonWhitespace]['code'] === T_COMMA
+                    || $tokens[$nextNonWhitespace]['code'] === T_STRING_CONCAT)
+                    && $tokens[$nextNonWhitespace]['line'] !== $tokens[$stackPtr]['line'])
+            ) {
+                // This is most likely a correctly identified closing marker.
+                return;
+            }
+
+            // The real closing tag has to be before the next heredoc/nowdoc.
+            $nextHereNowDoc = $phpcsFile->findNext(array(T_START_HEREDOC, T_START_NOWDOC), ($stackPtr + 1));
+            if ($nextHereNowDoc === false) {
+                $nextHereNowDoc = null;
+            }
+
+            $identifier        = trim($tokens[$stackPtr]['content']);
+            $realClosingMarker = $stackPtr;
+
+            while (($realClosingMarker = $phpcsFile->findNext(T_STRING, ($realClosingMarker + 1), $nextHereNowDoc, false, $identifier)) !== false) {
+
+                $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($realClosingMarker - 1), null, true);
+                if ($prevNonWhitespace === false
+                    || $tokens[$prevNonWhitespace]['line'] === $tokens[$realClosingMarker]['line']
+                ) {
+                    // Marker text found, but not at the start of the line.
+                    continue;
+                }
+
+                // The original T_END_HEREDOC/T_END_NOWDOC was most likely incorrect as we've found
+                // a possible alternative closing marker.
+                $phpcsFile->addError($error, $stackPtr, $errorCode);
+
+                break;
+            }
+
+        } else {
+            if (isset($tokens[$stackPtr]['scope_closer'], $tokens[$stackPtr]['scope_opener']) === true
+                && $tokens[$stackPtr]['scope_closer'] === $stackPtr
+            ) {
+                $opener = $tokens[$stackPtr]['scope_opener'];
+            } else {
+                // PHPCS < 3.0.2 did not add scope_* values for Nowdocs.
+                $opener = $phpcsFile->findPrevious(T_START_NOWDOC, ($stackPtr - 1));
+                if ($opener === false) {
+                    return;
+                }
+            }
+
+            $identifier       = $tokens[$stackPtr]['content'];
+            $quotedIdentifier = preg_quote($tokens[$stackPtr]['content'], '`');
+
+            // Throw an error for each line in the body which starts with the identifier.
+            for ($i = ($opener + 1); $i < $stackPtr; $i++) {
+                if (preg_match('`^[ \t]*' . $quotedIdentifier . '\b`', $tokens[$i]['content']) === 1) {
+                    $phpcsFile->addError($error, $i, $errorCode);
+                }
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -108,6 +108,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
         $parts    = explode('\\', $class);
         $sniff    = array_pop($parts);
         $sniff    = str_replace('SniffTest', '', $sniff);
+        $sniff    = str_replace('UnitTest', '', $sniff);
         $category = array_pop($parts);
         return self::STANDARD_NAME . '.' . $category . '.' . $sniff;
     }

--- a/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.1.inc
+++ b/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.1.inc
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Prevent false positives.
+ */
+// OK pre-PHP 7.3 as well as in PHP 7.3+: closing marker on line by itself followed by semi-colon.
+        $foo = <<<EOT
+foo
+EOT;
+
+        $bar = <<<'EOT'
+bar
+EOT;
+
+echo <<<END
+      a
+     b
+    c
+END;
+
+// OK pre-PHP 7.3 as well as in PHP 7.3+: closing marker on line by itself, follow on code on next line.
+stringManipulator(<<<"END"
+   a
+  b
+ c
+END
+);
+
+$values = [<<<'END'
+a
+b
+c
+END
+, 'd e f'];
+
+// OK pre-PHP 7.3 as well as in PHP 7.3+: text body contains a line starting with text resembling the closing marker.
+$values = [<<<END
+a
+b
+ENDING
+END
+, 'd e f'];
+
+// OK pre-PHP 7.3 as well as in PHP 7.3+: text body contains the closing marker not at the start of the line.
+$values = [<<<END
+a
+b
+some more text END
+END
+, 'd e f'];

--- a/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.2.inc
+++ b/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.2.inc
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Test for "identifier found in body" errors.
+ */
+
+// This was ok pre-PHP 7.3, but will be a parse error in PHP 7.3+ because the
+// Heredoc body contains text which can be confused with the closing marker.
+$values = [<<<'END'
+a
+b
+END ING
+c
+END
+, 'd e f'];
+
+echo <<<END
+END{$var}
+END;
+
+echo <<<"FOOBAR"
+	something
+	FOOBAR
+	something
+FOOBAR;
+
+// Test detecting the correct end in PHP 7.3+.
+echo <<<END
+    something
+    END
+    something END
+END
+. 'more text';
+
+// Test throwing an error for each detected "END" at the start of a line in PHP < 7.3.
+echo <<<END
+something
+END something
+something
+END something
+something
+END something
+something
+END
+. 'more text';

--- a/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.3.inc
+++ b/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.3.inc
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * Test for errors.
+ * Each test case using PHP 7.3 syntax has to be in its own file as otherwise they can't
+ * be tested using PHP < 7.3.
+ * Everything after the first test case in PHP < 7.3 will be tokennized as T_ENCAPSED_AND_WHITESPACE.
+ */
+
+// PHP 7.3+ indented content and closing marker - heredoc & spaces.
+        $foo = <<<thelabeldoesnotneedtobeuppercaseandcancontainnumb3rs
+            foo
+            thelabeldoesnotneedtobeuppercaseandcancontainnumb3rs;

--- a/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.4.inc
+++ b/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.4.inc
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * Test for errors.
+ * Each test case using PHP 7.3 syntax has to be in its own file as otherwise they can't
+ * be tested using PHP < 7.3.
+ * Everything after the first test case in PHP < 7.3 will be tokennized as T_ENCAPSED_AND_WHITESPACE.
+ */
+
+// PHP 7.3+ indented content and closing marker - nowdoc & tabs.
+        $bar = <<<'EOT'
+		bar
+		EOT;

--- a/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.5.inc
+++ b/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.5.inc
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * Test for errors.
+ * Each test case using PHP 7.3 syntax has to be in its own file as otherwise they can't
+ * be tested using PHP < 7.3.
+ * Everything after the first test case in PHP < 7.3 will be tokennized as T_ENCAPSED_AND_WHITESPACE.
+ */
+
+// PHP 7.3+ indented content and closing marker - quoted heredoc & spaces.
+echo <<<"END"
+      a
+     b
+    c
+    END;

--- a/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.6.inc
+++ b/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.6.inc
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * Test for errors.
+ * Each test case using PHP 7.3 syntax has to be in its own file as otherwise they can't
+ * be tested using PHP < 7.3.
+ * Everything after the first test case in PHP < 7.3 will be tokennized as T_ENCAPSED_AND_WHITESPACE.
+ */
+
+// Closing marker is indented further than any lines of the body is a parse error, but not our concern.
+    echo <<<END
+      a
+     b
+    c
+        END;

--- a/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.7.inc
+++ b/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.7.inc
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * Test for errors.
+ * Each test case using PHP 7.3 syntax has to be in its own file as otherwise they can't
+ * be tested using PHP < 7.3.
+ * Everything after the first test case in PHP < 7.3 will be tokennized as T_ENCAPSED_AND_WHITESPACE.
+ */
+
+// Mixing tabs and spaces for the indentation of the body and the closing marker is a parse error, but not our concern.
+	echo <<<END
+	    a
+    	END;

--- a/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.8.inc
+++ b/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.8.inc
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * Test for errors.
+ * Each test case using PHP 7.3 syntax has to be in its own file as otherwise they can't
+ * be tested using PHP < 7.3.
+ * Everything after the first test case in PHP < 7.3 will be tokennized as T_ENCAPSED_AND_WHITESPACE.
+ */
+
+// PHP 7.3+ follow on code allowed on the same line as the closing marker.
+$values = [<<<END
+a
+b
+c
+END, 'd e f'];

--- a/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.9.inc
+++ b/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.9.inc
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * Test for errors.
+ * Each test case using PHP 7.3 syntax has to be in its own file as otherwise they can't
+ * be tested using PHP < 7.3.
+ * Everything after the first test case in PHP < 7.3 will be tokennized as T_ENCAPSED_AND_WHITESPACE.
+ */
+
+// PHP 7.3+ follow on code allowed on the same line as the closing marker.
+$values = [<<<'END'
+a
+b
+c
+END, 'd e f'];

--- a/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * NewFlexibleHeredocNowdocSniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
+
+/**
+ * Use of flexible heredoc/nowdoc syntax and identifiers in heredoc/nowdoc body tests.
+ *
+ * @group newFlexibleHeredocNowdoc
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewFlexibleHeredocNowdocSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
+{
+    const TEST_FILE = 'Sniffs/Syntax/NewFlexibleHeredocNowdocUnitTest.%d.inc';
+
+    /**
+     * Whether PHP 7.3+ is used.
+     *
+     * @var bool
+     */
+    protected static $php73plus;
+
+    /**
+     * Whether PHPCS < 2.6.0 is detected.
+     *
+     * @var bool
+     */
+    protected static $isLowPHPCS = false;
+
+
+    /**
+     * Set up skip condition based on used PHP version.
+     *
+     * {@internal The data providers are run before the setUpClass method is run, so
+     * we can't use that method for this skip condition.}}
+     *
+     * @return void
+     */
+    public static function getSetSkipCondition()
+    {
+        if (isset(self::$php73plus) === false) {
+            self::$php73plus = false;
+            // When using PHP 7.3+, the closing marker will be misidentified if the
+            // body contains the heredoc/nowdoc identifier.
+            if (version_compare(PHP_VERSION_ID, '70299', '>') === true) {
+                self::$php73plus = true;
+            }
+        }
+
+        return self::$php73plus;
+    }
+
+
+    /**
+     * Set up skip condition for low PHPCS versions.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        // When using PHPCS 2.5.1 and lower, the tokenizer has an insurmountable bug
+        // parsing flexible heredoc/nowdocs.
+        if (version_compare(PHPCSHelper::getVersion(), '2.6.0', '<')) {
+            self::$isLowPHPCS = true;
+        }
+
+        parent::setUpBeforeClass();
+    }
+
+
+    /**
+     * Test detection of indented heredoc/nowdoc closing markers.
+     *
+     * @dataProvider dataIndentedHeredocNowdoc
+     *
+     * @param int  $fileNumber      The number of the test case file.
+     * @param int  $line            The line number.
+     * @param bool $skipNoViolation Whether to skip the no violation test on PHP 7.3.
+     *
+     * @return void
+     */
+    public function testIndentedHeredocNowdoc($fileNumber, $line, $skipNoViolation = false)
+    {
+        if (self::$isLowPHPCS === true) {
+            $this->markTestSkipped('Flexible heredoc/nowdoc can not be detected due to Tokenizer errors in PHPCS < 2.6.0.');
+            return;
+        }
+
+        $fileName = sprintf(self::TEST_FILE, $fileNumber);
+
+        $file = $this->sniffFile($fileName, '7.2');
+        $this->assertError($file, $line, 'Heredoc/nowdoc with an indented closing marker is not supported in PHP 7.2 or earlier.');
+
+        if ($skipNoViolation === false || self::getSetSkipCondition() === false) {
+            $file = $this->sniffFile($fileName, '7.3');
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIndentedHeredocNowdoc()
+     *
+     * @return array
+     */
+    public function dataIndentedHeredocNowdoc()
+    {
+        $data = array(
+            array(3, 13),
+            array(4, 13),
+            array(5, 15),
+            array(6, 15),
+            array(7, 13),
+        );
+
+        if (self::getSetSkipCondition() === true) {
+            // PHP 7.3+ will misidentify the closing marker (parse error) when the identifier is in the body.
+            $data[] = array(2, 23, true);
+            $data[] = array(2, 30, true);
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Test detection of non-stand alone heredoc/nowdoc closing markers.
+     *
+     * @dataProvider dataCodeAfterHeredocNowdoc
+     *
+     * @param int  $fileNumber      The number of the test case file.
+     * @param int  $line            The line number.
+     * @param bool $skipNoViolation Whether to skip the no violation test on PHP 7.3.
+     *
+     * @return void
+     */
+    public function testCodeAfterHeredocNowdoc($fileNumber, $line, $skipNoViolation = false)
+    {
+        if (self::$isLowPHPCS === true) {
+            $this->markTestSkipped('Flexible heredoc/nowdoc can not be detected due to Tokenizer errors in PHPCS < 2.6.0.');
+            return;
+        }
+
+        $fileName = sprintf(self::TEST_FILE, $fileNumber);
+
+        $file = $this->sniffFile($fileName, '7.2');
+        $this->assertError($file, $line, 'Having code - other than a semi-colon or new line - after the closing marker of a heredoc/nowdoc is not supported in PHP 7.2 or earlier.');
+
+        if ($skipNoViolation === false || self::getSetSkipCondition() === false) {
+            $file = $this->sniffFile($fileName, '7.3');
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testCodeAfterHeredocNowdoc()
+     *
+     * @return array
+     */
+    public function dataCodeAfterHeredocNowdoc()
+    {
+        $data = array(
+            array(8, 15),
+            array(9, 15),
+        );
+
+        if (self::getSetSkipCondition() === true) {
+            // PHP 7.3+ will misidentify the closing marker (parse error) when the identifier is in the body.
+            $data[] = array(2, 12, true);
+            $data[] = array(2, 18, true);
+            $data[] = array(2, 38, true);
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Test detection of closing marker within the heredoc/nowdoc body.
+     *
+     * @dataProvider dataForbiddenClosingMarkerInBody
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testForbiddenClosingMarkerInBody($line)
+    {
+        $fileName = sprintf(self::TEST_FILE, 2);
+
+        $file = $this->sniffFile($fileName, '7.3');
+        $this->assertError($file, $line, 'The body of a heredoc/nowdoc can not contain the heredoc/nowdoc closing marker as text at the start of a line since PHP 7.3.');
+
+        if (self::getSetSkipCondition() === false) {
+            $file = $this->sniffFile($fileName, '7.2');
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenClosingMarkerInBody()
+     *
+     * @return array
+     */
+    public function dataForbiddenClosingMarkerInBody()
+    {
+        $lines = array(
+            array(12),
+            array(18),
+            array(23),
+            array(30),
+            array(38),
+        );
+
+        if (self::getSetSkipCondition() === false) {
+            // PHP < 7.3 can reliably throw errors for all lines in the heredoc/nowdoc containing the identifier.
+            $lines[] = array(40);
+            $lines[] = array(42);
+        }
+
+        return $lines;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all on the file containing cross-version compatible code.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $fileName = sprintf(self::TEST_FILE, 1);
+
+        $file = $this->sniffFile($fileName, '7.2');
+        $this->assertNoViolation($file);
+
+        $file = $this->sniffFile($fileName, '7.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Implemented flexible heredoc and nowdoc syntax: The closing marker for doc strings is no longer required to be followed by a semicolon or newline.
> Additionally the closing marker may be indented, in which case the indentation will be stripped from all lines in the doc string.

> Due to the introduction of flexible heredoc/nowdoc syntax, doc strings that contain the ending label inside their body may cause syntax errors or change in interpretation. For example in
> ```php
>         $str = <<<FOO
>         abcdefg
>             FOO
>         FOO;
> ```
> the indented occurrence of "FOO" did not previously have any special meaning. Now it will be interpreted as the end of the heredoc string and the following "FOO;" will cause a syntax error. This issue can always be resolved by choosing an ending label that does not occur within the contents of the string.

Refs:
* https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes
* https://github.com/php/php-src/blob/069f82bf0876c274b64dabb5336921487458cfdb/UPGRADING#L33-L46
* https://github.com/php/php-src/blob/069f82bf0876c274b64dabb5336921487458cfdb/UPGRADING#L165-L169

Notes:
* The tokenizer in PHP has been adjusted due to this change and this causes significant differences between how cross-version _incompatible_ heredoc/nowdoc code is tokenized pre-PHP 7.3 vs in PHP 7.3+.
    See: https://github.com/squizlabs/PHP_CodeSniffer/issues/2055 for a discussion about this in PHPCS upstream.
    In effect this means that:
    - In PHP 7.2 and lower, only the first flexible heredoc/nowdoc can be detected in a file as the rest of the tokens in the file will be garbage.
    - In PHP 7.3 and higher, the closing marker may be misidentified when the identifier is used in the heredoc/nowdoc body (= parse error in PHP 7.3+), which leaves the rest of the heredoc/nowdoc up to the *real* closing marker as semi-unpredictable tokens.
* This means that the sniff needs to have completely different code for PHP < 7.3 and PHP 7.3+ to identify the same issues and that the identification, while correct, gives slightly different results when run on PHP < 7.3 vs PHP 7.3+.
    This is reflected in the unit test set up which, of course, had to account for this.
* In PHPCS < 3.0.2, there is a tokenizer inconsistency which affects nowdocs. The sniff contains a work-around for that.
* In PHPCS < 2.6.0, there is a tokenizer bug which prevents the tokenizer from finishing when flexible heredoc/nowdoc syntax is used, so that part of the sniff will be skipped when run on PHPCS 2.6.0.

Fixes #705 

--- 
Note: This sniff has already been adjusted for the new repo structure.