### PR TITLE
Changelog and other documentation updates for version 9.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,8 @@
 # https://blog.madewithlove.be/post/gitattributes/
 #
 /.coveralls.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
 /.scrutinizer.yml export-ignore
 /.travis.yml export-ignore
 /phpcs.xml.dist export-ignore

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,24 +31,24 @@ Please make sure that your pull request contains unit tests covering what's bein
 
 ### Framework/CMS specific rulesets
 
-Since mid 2018, framework/CMS specific rulesets will be accepted to be hosted in separate repositories in the PHPCompatibility organisation. If you are interested in adding a ruleset for a framework/CMS, you can request a repository for it by [opening an issue](https://github.com/PHPCompatibility/PHPCompatibility/issues/new) in this repo.
+Since mid 2018, framework/CMS/polyfill specific rulesets will be accepted to be hosted in separate repositories in the PHPCompatibility organisation. If you are interested in adding a ruleset for a framework/CMS/PHP polyfill library, you can request a repository for it by [opening an issue](https://github.com/PHPCompatibility/PHPCompatibility/issues/new) in this repo.
 
 #### Guidelines for framework/CMS specific rulesets
 
-A framework/CMS specific ruleset will generally contain `<exclude ...>` directives for backfills/polyfills provided by the framework/CMS to prevent false positives.
+A framework/CMS/polyfill specific ruleset will generally contain `<exclude ...>` directives for backfills/polyfills provided by the framework/CMS/polyfill to prevent false positives.
 
 > A backfill is a function/constant/class (etc) which has been added to PHP in a later version than the minimum supported version of the framework/CMS and for which a function/constant/class of the same name is included in the framework/CMS when a PHP version is detected in which the function/constant/class did not yet exist.
 
 These rulesets will not be actively maintained by the maintainers of PHPCompatibility.
 
-The communities behind these PHP frameworks/CMSes are strongly encouraged to maintain these rulesets and pull requests with updates will be accepted gladly.
+The communities behind these PHP frameworks/CMSes/polyfill libraries are strongly encouraged to maintain these rulesets and pull requests with updates will be accepted gladly.
 
 **Note:**
-* It is recommended to include a link to the framework/CMS source file where the backfill is declared when sending in a pull request adding a new backfill for one of these rulesets.
-* If the backfills provided by different major versions of frameworks/CMSes are signficantly different, separate rulesets for the relevant major versions of frameworks/CMSes will be accepted.
+* It is recommended to include a link to the framework/CMS/polyfill source file where the backfill is declared when sending in a pull request adding a new backfill for one of these rulesets.
+* If the backfills provided by different major versions of frameworks/CMSes/polyfill libraries are signficantly different, separate rulesets for the relevant major versions of frameworks/CMSes/polyfill libraries will be accepted.
 * Framework/CMS specific ruleset should **_not_** contain a `<config name="testVersion" value="..."/>` directive.
 
-    While a framework/CMS may have a certain minimum PHP version, projects based on the framework/CMS might have a different (higher) minimum PHP version.
+    While a framework/CMS/polyfill may have a certain minimum PHP version, projects based on or using the framework/CMS/polyfill might have a different (higher) minimum PHP version.
     As support for overruling a `<config>` directive [is patchy](https://github.com/squizlabs/PHP_CodeSniffer/issues/1821), it should be recommended to set the desired `testVersion` either from the command line or in a project-specific custom ruleset.
 
 
@@ -78,7 +78,9 @@ Naming conventions and repository structure
 
 Running the Sniff Tests
 -----------------------
-All the sniffs are fully tested with PHPUnit tests. In order to run the tests on the sniffs, the following installation steps are required.
+All the sniffs are fully tested with PHPUnit tests and have `@group` annotations matching their categorization to allow for running subsets of the unit tests more easily.
+
+In order to run the tests on the sniffs, the following installation steps are required.
 
 1. Install PHP CodeSniffer and PHP Compatibility by following the instructions in the Readme for either [installing with Composer](https://github.com/PHPCompatibility/PHPCompatibility/blob/master/README.md#installation-in-a-composer-project-method-1) or via a [Git Checkout to an arbitrary directory](https://github.com/PHPCompatibility/PHPCompatibility/blob/master/README.md#installation-via-a-git-check-out-to-an-arbitrary-directory-method-2).
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /vendor/
 composer.phar
 composer.lock
+.phpcs.xml
 phpcs.xml
 phpunit.xml
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,194 @@ This projects adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 Up to version 8.0.0, the `major.minor` version numbers were based on the PHP version for which compatibility check support was added, with `patch` version numbers being specific to this library.
 From version 8.0.0 onwards, [Semantic Versioning](http://semver.org/) is used.
 
-**IMPORTANT**: The 8.0.0 release contains a **breaking change**. Please read the v [8.0.0 changelog](CHANGELOG.md#800---2017-08-03) carefully before upgrading.
-
 <!-- Legend to the icons used: https://github.com/PHPCompatibility/PHPCompatibility/pull/506#discussion_r131650488 -->
 
 
 ## [Unreleased]
 
 _Nothing yet._
+
+## [9.0.0] - 2018-10-07
+
+**IMPORTANT**: This release contains **breaking changes**. Please read the below information carefully before upgrading!
+
+All sniffs have been placed in meaningful categories and a number of sniffs have been renamed to have more consistent, meaningful and future-proof names.
+
+Both the `PHPCompatibilityJoomla` [[GH](https://github.com/PHPCompatibility/PHPCompatibilityJoomla) | [Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-joomla)] as well as the `PHPCompatibilityWP` [[GH](https://github.com/PHPCompatibility/PHPCompatibilityWP)|[Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-wp)] rulesets have already been adjusted for this change and have released a new version which is compatible with this version of PHPCompatibility.
+
+Aside from those CMS-based rulesets, this project now also offers a number of polyfill-library specific rulesets, such as `PHPCompatibilityPasswordCompat` [[GH](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat) | [Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat)] for @ircmaxell's [`password_compat`](https://github.com/ircmaxell/password_compat) libary, `PHPCompatibilityParagonieRandomCompat` and `PHPCompatibilityParagonieSodiumCompat` [[GH](https://github.com/PHPCompatibility/PHPCompatibilityParagonie)|[Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-paragonie)] for the [Paragonie polyfills](https://github.com/paragonie?utf8=?&q=polyfill) and a number of rulesets related to various [polyfills offered by the Symfony project](https://github.com/symfony?utf8=?&q=polyfill) [[GH](https://github.com/PHPCompatibility/PHPCompatibilitySymfony)|[Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-symfony)].
+
+If your project uses one of these polyfills, please consider using these special polyfill rulesets to prevent false positives.
+
+Also as of this version, [Juliette Reinders Folmer] is now officially a co-maintainer of this package.
+
+### Upgrade instructions
+
+* If you have `<exclude name="..."/>` directives in your own project's custom ruleset which relate to sniffs from the PHPCompatibility library, you will need to update your ruleset to use the new sniff names.
+* If you use the new [PHPCS 3.2+ inline annotations](https://github.com/squizlabs/PHP_CodeSniffer/releases/3.2.0), i.e. `// phpcs:ignore Standard.Category.SniffName`, in combination with PHPCompatibility sniff names, you will need to update these annotations.
+* If you use neither of the above, you should be fine and upgrading should be painless.
+
+### Overview of all the sniff renames:
+
+Old Category.SniffName | New Category.SniffName
+--- | ---
+**PHP**.ArgumentFunctionsUsage | **FunctionUse**.ArgumentFunctionsUsage
+**PHP**.CaseSensitiveKeywords | **Keywords**.CaseSensitiveKeywords
+**PHP**.ConstantArraysUsingConst | **InitialValue**.**New**ConstantArraysUsingConst
+**PHP**.ConstantArraysUsingDefine | **InitialValue**.**New**ConstantArraysUsingDefine
+**PHP**.**Deprecated**Functions | **FunctionUse**.**Removed**Functions
+**PHP**.**Deprecated**IniDirectives | **IniDirectives**.**Removed**IniDirectives
+**PHP**.**Deprecated**MagicAutoload | **FunctionNameRestrictions**.**Removed**MagicAutoload
+**PHP**.**Deprecated**NewReference | **Syntax**.**Removed**NewReference
+**PHP**.**Deprecated**PHP4StyleConstructors | **FunctionNameRestrictions**.**Removed**PHP4StyleConstructors
+**PHP**.**Deprecated**TypeCasts | **TypeCasts**.**Removed**TypeCasts
+**PHP**.DiscouragedSwitchContinue | **ControlStructures**.DiscouragedSwitchContinue
+**PHP**.DynamicAccessToStatic | **Syntax**.**New**DynamicAccessToStatic
+**PHP**.EmptyNonVariable | **LanguageConstructs**.**New**EmptyNonVariable
+**PHP**.ForbiddenBreakContinueOutsideLoop | **ControlStructures**.ForbiddenBreakContinueOutsideLoop
+**PHP**.ForbiddenBreakContinueVariableArguments | **ControlStructures**.ForbiddenBreakContinueVariableArguments
+**PHP**.ForbiddenCallTimePassByReference | **Syntax**.ForbiddenCallTimePassByReference
+**PHP**.Forbidden**ClosureUseVariableNames** | **FunctionDeclarations**.Forbidden**VariableNamesInClosureUse**
+**PHP**.ForbiddenEmptyListAssignment | **Lists**.ForbiddenEmptyListAssignment
+**PHP**.Forbidden**Function**ParametersWithSameName | **FunctionDeclarations**.ForbiddenParametersWithSameName
+**PHP**.ForbiddenGlobalVariableVariable | **Variables**.ForbiddenGlobalVariableVariable
+**PHP**.ForbiddenNames | **Keywords**.ForbiddenNames
+**PHP**.ForbiddenNamesAsDeclared | **Keywords**.ForbiddenNamesAsDeclared
+**PHP**.ForbiddenNamesAsInvokedFunctions | **Keywords**.ForbiddenNamesAsInvokedFunctions
+**PHP**.ForbiddenNegativeBitshift | **Operators**.ForbiddenNegativeBitshift
+**PHP**.ForbiddenSwitchWithMultipleDefaultBlocks | **ControlStructures**.ForbiddenSwitchWithMultipleDefaultBlocks
+**PHP**.InternalInterfaces | **Interfaces**.InternalInterfaces
+**PHP**.LateStaticBinding | **Classes**.**New**LateStaticBinding
+**PHP**.**MbstringReplaceE**Modifier | **ParameterValues**.**RemovedMbstring**Modifier**s**
+**PHP**.NewAnonymousClasses | **Classes**.NewAnonymousClasses
+**PHP**.NewArrayStringDereferencing | **Syntax**.NewArrayStringDereferencing
+**PHP**.NewClasses | **Classes**.NewClasses
+**PHP**.NewClassMemberAccess | **Syntax**.NewClassMemberAccess
+**PHP**.NewClosure | **FunctionDeclarations**.NewClosure
+**PHP**.NewConstants | **Constants**.NewConstants
+**PHP**.NewConstantScalarExpressions | **InitialValue**.NewConstantScalarExpressions
+**PHP**.NewConstVisibility | **Classes**.NewConstVisibility
+**PHP**.NewExecutionDirectives | **ControlStructures**.NewExecutionDirectives
+**PHP**.NewFunctionArrayDereferencing | **Syntax**.NewFunctionArrayDereferencing
+**PHP**.NewFunctionParameters | **FunctionUse**.NewFunctionParameters
+**PHP**.NewFunctions | **FunctionUse**.NewFunctions
+**PHP**.NewGeneratorReturn | **Generators**.NewGeneratorReturn
+**PHP**.NewGroupUseDeclarations | **UseDeclarations**.NewGroupUseDeclarations
+**PHP**.NewHashAlgorithms | **ParameterValues**.NewHashAlgorithms
+**PHP**.NewHeredoc**Initialize** | **InitialValue**.NewHeredoc
+**PHP**.NewIniDirectives | **IniDirectives**.NewIniDirectives
+**PHP**.NewInterfaces | **Interfaces**.NewInterfaces
+**PHP**.NewKeywords | **Keywords**.NewKeywords
+**PHP**.NewLanguageConstructs | **LanguageConstructs**.NewLanguageConstructs
+**PHP**.NewMagicClassConstant | **Constants**.NewMagicClassConstant
+**PHP**.NewMagicMethods | **FunctionNameRestrictions**.NewMagicMethods
+**PHP**.NewMultiCatch | **ControlStructures**.NewMultiCatch
+**PHP**.NewNullableTypes | **FunctionDeclarations**.NewNullableTypes
+**PHP**.NewReturnTypeDeclarations | **FunctionDeclarations**.NewReturnTypeDeclarations
+**PHP**.New**Scalar**TypeDeclarations | **FunctionDeclarations**.New**Param**TypeDeclarations
+**PHP**.NewTrailingComma | **Syntax**.New**FunctionCall**TrailingComma
+**PHP**.NewTypeCasts | **TypeCasts**.NewTypeCasts
+**PHP**.NewUseConstFunction | **UseDeclarations**.NewUseConstFunction
+**PHP**.NonStaticMagicMethods | **FunctionDeclarations**.NonStaticMagicMethods
+**PHP**.OptionalRequiredFunctionParameters | **FunctionUse**.Optional**To**RequiredFunctionParameters
+**PHP**.ParameterShadowSuperGlobals | **FunctionDeclarations**.**Forbidden**ParameterShadowSuperGlobals
+**PHP**.**PCRENew**Modifiers | **ParameterValues**.**NewPCRE**Modifiers
+**PHP**.**PregReplaceE**Modifier | **ParameterValues**.**RemovedPCRE**Modifier**s**
+**PHP**.RemovedAlternativePHPTags | **Miscellaneous**.RemovedAlternativePHPTags
+**PHP**.RemovedConstants | **Constants**.RemovedConstants
+**PHP**.RemovedExtensions | **Extensions**.RemovedExtensions
+**PHP**.RemovedFunctionParameters | **FunctionUse**.RemovedFunctionParameters
+**PHP**.RemovedGlobalVariables | **Variables**.Removed**Predefined**GlobalVariables
+**PHP**.RemovedHashAlgorithms | **ParameterValues**.RemovedHashAlgorithms
+**PHP**.ReservedFunctionNames | **FunctionNameRestrictions**.ReservedFunctionNames
+**PHP**.RequiredOptionalFunctionParameters | **FunctionUse**.Required**To**OptionalFunctionParameters
+**PHP**.ShortArray | **Syntax**.**New**ShortArray
+**PHP**.Ternary**Operators** | **Operators**.**NewShort**Ternary
+**PHP**.ValidIntegers | **Miscellaneous**.ValidIntegers
+**PHP**.**VariableVariables** | **Variables**.**NewUniformVariableSyntax**
+
+### Changelog for version 9.0.0
+
+See all related issues and PRs in the [9.0.0 milestone].
+
+### Added
+- :star2: New `PHPCompatibility.ControlStructures.NewForeachExpressionReferencing` sniff to detect referencing of `$value` within a `foreach()` when the iterated array is not a variable. This was not supported prior to PHP 5.5. [#664](https://github.com/PHPCompatibility/PHPCompatibility/pull/664)
+- :star2: New `PHPCompatibility.ControlStructures.NewListInForeach` sniff to detect unpacking nested arrays into separate variables via the `list()` construct in a `foreach()` statement. This was not supported prior to PHP 5.5. [#657](https://github.com/PHPCompatibility/PHPCompatibility/pull/657)
+- :star2: New `PHPCompatibility.FunctionNameRestrictions.RemovedNamespacedAssert` sniff to detect declaring a function called `assert()` within a namespace. This has been deprecated as of PHP 7.3. [#735](https://github.com/PHPCompatibility/PHPCompatibility/pull/735). Partially fixes [#718](https://github.com/PHPCompatibility/PHPCompatibility/issues/718).
+- :star2: New `PHPCompatibility.Lists.AssignmentOrder` sniff to detect `list()` constructs affected by the change in assignment order in PHP 7.0. [#656](https://github.com/PHPCompatibility/PHPCompatibility/pull/656)
+- :star2: New `PHPCompatibility.Lists.NewKeyedList` sniff to detect usage of keys in `list()`, support for which was added in PHP 7.1. [#655](https://github.com/PHPCompatibility/PHPCompatibility/pull/655). Fixes [#252](https://github.com/PHPCompatibility/PHPCompatibility/issues/252).
+- :star2: New `PHPCompatibility.Lists.NewListReferenceAssignment` sniff to detect reference assignments being used in `list()` constructs, support for which has been added in PHP 7.3. [#731](https://github.com/PHPCompatibility/PHPCompatibility/pull/731)
+- :star2: New `PHPCompatibility.Lists.NewShortList` sniff to detect the shorthand array syntax `[]` being used for symmetric array destructuring as introduced in PHP 7.1. [#654](https://github.com/PHPCompatibility/PHPCompatibility/pull/654). Fixes [#248](https://github.com/PHPCompatibility/PHPCompatibility/issues/248).
+- :star2: New `PHPCompatibility.Operators.NewOperators` sniff which checks for usage of the pow, pow equals, spaceship and coalesce (equals) operators. [#738](https://github.com/PHPCompatibility/PHPCompatibility/pull/738)
+    These checks were previously contained within the `PHPCompatibility.LanguageConstructs.NewLanguageConstructs` sniff.
+- :star2: New `PHPCompatibility.ParameterValues.ForbiddenGetClassNull` sniff to detect `null` being passed to `get_class()`, support for which has been removed in PHP 7.2 [#659](https://github.com/PHPCompatibility/PHPCompatibility/pull/659). Fixes [#557](https://github.com/PHPCompatibility/PHPCompatibility/issues/557).
+- :star2: New `PHPCompatibility.ParameterValues.NewArrayReduceInitialType` sniff to detect non-integers being passed as the `$initial` parameter to the `array_reduce()` function, which was not supported before PHP 5.3. [#666](https://github.com/PHPCompatibility/PHPCompatibility/pull/666). Fixes [#649](https://github.com/PHPCompatibility/PHPCompatibility/issues/649)
+- :star2: New `PHPCompatibility.ParameterValues.NewFopenModes` sniff to examine the `$mode` parameter passed to `fopen()` for modes not available in older PHP versions. [#658](https://github.com/PHPCompatibility/PHPCompatibility/pull/658)
+- :star2: New `PHPCompatibility.ParameterValues.NewNegativeStringOffset` sniff to detect negative string offsets being passed to string manipulation functions which was not supported before PHP 7.1. [#662](https://github.com/PHPCompatibility/PHPCompatibility/pull/662). Partially fixes [#253](https://github.com/PHPCompatibility/PHPCompatibility/issues/253).
+- :star2: New `PHPCompatibility.ParameterValues.NewPackFormats` sniff to examine the `$format` parameter passed to `pack()` for formats not available in older PHP versions. [#665](https://github.com/PHPCompatibility/PHPCompatibility/pull/665)
+- :star2: New `PHPCompatibility.ParameterValues.RemovedIconvEncoding` sniff to detect the PHP 5.6 deprecated encoding `$type`s being passed to `iconv_set_encoding()`. [#660](https://github.com/PHPCompatibility/PHPCompatibility/pull/660). Fixes [#475](https://github.com/PHPCompatibility/PHPCompatibility/issues/475).
+- :star2: New `PHPCompatibility.ParameterValues.RemovedNonCryptoHashes` sniff to detect non-cryptographic hash algorithms being passed to various `hash_*()` functions. This is no longer accepted as of PHP 7.2. [#663](https://github.com/PHPCompatibility/PHPCompatibility/pull/663). Fixes [#559](https://github.com/PHPCompatibility/PHPCompatibility/issues/559)
+- :star2: New `PHPCompatibility.ParameterValues.RemovedSetlocaleString` sniff to detect string literals being passed to the `$category` parameter of the `setlocale()` function. This behaviour was deprecated in PHP 4.2 and support has been removed in PHP 7.0. [#661](https://github.com/PHPCompatibility/PHPCompatibility/pull/661)
+- :star2: New `PHPCompatibility.Syntax.NewFlexibleHeredocNowdoc` sniff to detect the new heredoc/nowdoc format as allowed as of PHP 7.3. [#736](https://github.com/PHPCompatibility/PHPCompatibility/pull/736). Fixes [#705](https://github.com/PHPCompatibility/PHPCompatibility/issues/705).
+    Note: This sniff is only supported in combination with PHP_CodeSniffer 2.6.0 and higher.
+- :star: `PHPCompatibility.Classes.NewClasses` sniff: recognize the new `CompileError` and `JsonException` classes as introduced in PHP 7.3. [#676](https://github.com/PHPCompatibility/PHPCompatibility/pull/676)
+- :star: `PHPCompatibility.Constants.NewConstants` sniff: recognize new constants which are being introduced in PHP 7.3. [#678](https://github.com/PHPCompatibility/PHPCompatibility/pull/678)
+- :star: `PHPCompatibility.Constants.RemovedConstants` sniff: recognize constants which have been deprecated or removed in PHP 7.3. [#710](https://github.com/PHPCompatibility/PHPCompatibility/pull/710). Partially fixes [#718](https://github.com/PHPCompatibility/PHPCompatibility/issues/718).
+- :star: `PHPCompatibility.FunctionUse.NewFunctions` sniff: recognize various new functions being introduced in PHP 7.3. [#679](https://github.com/PHPCompatibility/PHPCompatibility/pull/679)
+- :star: `PHPCompatibility.FunctionUse.NewFunctions` sniff: recognize the `sapi_windows_*()`, `hash_hkdf()` and `pcntl_signal_get_handler()` functions as introduced in PHP 7.1. [#728](https://github.com/PHPCompatibility/PHPCompatibility/pull/728)
+- :star: `PHPCompatibility.FunctionUse.RemovedFunctionParameters` sniff: recognize the deprecation of the `$case_insensitive` parameter for the `define()` function in PHP 7.3. [#706](https://github.com/PHPCompatibility/PHPCompatibility/pull/706)
+- :star: `PHPCompatibility.FunctionUse.RemovedFunctions` sniff: recognize the PHP 7.3 deprecation of the `image2wbmp()`, `fgetss()` and `gzgetss()` functions, as well as the deprecation of undocumented Mbstring function aliases. [#681](https://github.com/PHPCompatibility/PHPCompatibility/pull/681), [#714](https://github.com/PHPCompatibility/PHPCompatibility/pull/714), [#720](https://github.com/PHPCompatibility/PHPCompatibility/pull/720). Partially fixes [#718](https://github.com/PHPCompatibility/PHPCompatibility/issues/718).
+- :star: `PHPCompatibility.FunctionUse.RequiredToOptionalFunctionParameters` sniff: account for the second parameter for `array_push()` and `array_unshift()` becoming optional in PHP 7.3, as well as for the `$mode` parameter for a range of `ftp_*()` functions becoming optional. [#680](https://github.com/PHPCompatibility/PHPCompatibility/pull/680)
+- :star: `PHPCompatibility.IniDirectives.NewIniDirectives` sniff: recognize new `syslog` and `session` ini directives as introduced in PHP 7.3. [#702](https://github.com/PHPCompatibility/PHPCompatibility/pull/702), [#719](https://github.com/PHPCompatibility/PHPCompatibility/pull/719), [#730](https://github.com/PHPCompatibility/PHPCompatibility/pull/730)
+- :star: `PHPCompatibility.IniDirectives.NewIniDirectives` sniff: recognize some more ini directives which were introduced in PHP 7.1. [#727](https://github.com/PHPCompatibility/PHPCompatibility/pull/727)
+- :star: `PHPCompatibility.IniDirectives.RemovedIniDirectived` sniff: recognize ini directives removed in PHP 7.3. [#677](https://github.com/PHPCompatibility/PHPCompatibility/pull/677), [#717](https://github.com/PHPCompatibility/PHPCompatibility/pull/717). Partially fixes [#718](https://github.com/PHPCompatibility/PHPCompatibility/issues/718).
+- :star: New `isNumericCalculation()` and `isVariable()` utility methods to the `PHPCompatibility\Sniff` class. [#664](https://github.com/PHPCompatibility/PHPCompatibility/pull/664), [#666](https://github.com/PHPCompatibility/PHPCompatibility/pull/666)
+- :books: A section about the new sniff naming conventions to the `Contributing` file. [#738](https://github.com/PHPCompatibility/PHPCompatibility/pull/738)
+
+### Changed
+- :fire: All sniffs have been placed in meaningful categories and a number of sniffs have been renamed to have more consistent, meaningful and future-proof names. [#738](https://github.com/PHPCompatibility/PHPCompatibility/pull/738). Fixes [#601](https://github.com/PHPCompatibility/PHPCompatibility/issues/601), [#692](https://github.com/PHPCompatibility/PHPCompatibility/issues/692)
+    See the table at the top of this changelog for details of all the file renames.
+- :umbrella: The unit test files have been moved about as well. [#738](https://github.com/PHPCompatibility/PHPCompatibility/pull/738)
+    * The directory structure for these now mirrors the default directory structure used by PHPCS itself.
+    * The file names of the unit test files have been adjusted for the changes made in the sniffs.
+    * The unit test case files have been renamed and moved to the same directory as the actual test file they apply to.
+    * The `BaseSniffTest::sniffFile()` method has been adjusted to match. The signature of this method has changed. Where it previously expected a relative path to the unit test case file, it now expects an absolute path.
+    * The unit tests for the utility methods in the `PHPCompatibility\Sniff` class have been moved to a new `PHPCompatibility\Util\Tests\Core` subdirectory.
+    * The bootstrap file used for PHPUnit has been moved to the project root directory and renamed `phpunit-bootstrap.php`.
+- :twisted_rightwards_arrows: The `PHPCompatibility.LanguageConstructs.NewLanguageConstructs` sniff has been split into two sniffs. [#738](https://github.com/PHPCompatibility/PHPCompatibility/pull/738)
+    The `PHPCompatibility.LanguageConstructs.NewLanguageConstructs` sniff now contains just the checks for the namespace separator and the ellipsis.
+    The new `PHPCompatibility.Operators.NewOperators` sniff now contains the checks regarding the pow, pow equals, spaceship and coalesce (equals) operators.
+- :pushpin: The `PHPCompatibility.ParameterValues.RemovedMbstringModifiers` sniff will now also recognize removed regex modifiers when used within a function call to one of the undocumented Mbstring function aliases for the Mbstring regex functions. [#715](https://github.com/PHPCompatibility/PHPCompatibility/pull/715)
+- :pushpin: The `PHPCompatibility\Sniff::getFunctionCallParameter()` utility method now allows for closures called via a variable. [#723](https://github.com/PHPCompatibility/PHPCompatibility/pull/723)
+- :pencil2: `PHPCompatibility.Upgrade.LowPHPCS`: the minimum supported PHPCS version is now 2.3.0. [#699](https://github.com/PHPCompatibility/PHPCompatibility/pull/699)
+- :pencil2: Minor inline documentation improvements. [#738](https://github.com/PHPCompatibility/PHPCompatibility/pull/738)
+- :umbrella: Minor improvements to the unit tests for the `PHPCompatibility.FunctionNameRestrctions.RemovedMagicAutoload` sniff. [#716](https://github.com/PHPCompatibility/PHPCompatibility/pull/716)
+- :recycle: Minor other optimizations. [#698](https://github.com/PHPCompatibility/PHPCompatibility/pull/698), [#697](https://github.com/PHPCompatibility/PHPCompatibility/pull/697)
+- :wrench: Minor improvements to the build tools. [#701](https://github.com/PHPCompatibility/PHPCompatibility/pull/701)
+- :wrench: Removed some unnecessary inline annotations. [#700](https://github.com/PHPCompatibility/PHPCompatibility/pull/700)
+- :books: Replaced some of the badges in the Readme file. [#721](https://github.com/PHPCompatibility/PHPCompatibility/pull/721), [#722](https://github.com/PHPCompatibility/PHPCompatibility/pull/722)
+- :books: Composer: updated the list of package authors. [#739](https://github.com/PHPCompatibility/PHPCompatibility/pull/739)
+
+### Removed
+- :no_entry_sign: Support for PHP_CodeSniffer 1.x and low 2.x versions. The new minimum version of PHP_CodeSniffer to be able to use this library is 2.3.0. [#699](https://github.com/PHPCompatibility/PHPCompatibility/pull/699). Fixes [#691](https://github.com/PHPCompatibility/PHPCompatibility/issues/691).
+    The minimum _recommended_ version of PHP_CodeSniffer remains the same, i.e. 2.6.0.
+- :no_entry_sign: The `\PHPCompatibility\Sniff::inUseScope()` method has been removed as it is no longer needed now support for PHPCS 1.x has been dropped. [#699](https://github.com/PHPCompatibility/PHPCompatibility/pull/699)
+- :no_entry_sign: Composer: The `autoload` section has been removed from the `composer.json` file. [#738](https://github.com/PHPCompatibility/PHPCompatibility/pull/738). Fixes [#568](https://github.com/PHPCompatibility/PHPCompatibility/issues/568).
+    Autoloading for this library is done via the PHP_CodeSniffer default mechanism, enhanced with our own autoloader, so the Composer autoloader shouldn't be needed and was causing issues in a particular use-case.
+
+### Fixed
+- :bug: `PHPCompatibility.FunctionUse.NewFunctionParameters` sniff: The new `$mode` parameter of the `php_uname()` function was added in PHP 4.3, not in PHP 7.0 as was previously being reported.
+    The previous implementation of this check was based on an error in the PHP documentation. The error in the PHP documentation has been rectified and the sniff has followed suit. [#711](https://github.com/PHPCompatibility/PHPCompatibility/pull/711)
+- :bug: `PHPCompatibility.Generators.NewGeneratorReturn` sniff: The sniff would throw false positives for `return` statements in nested constructs and did not correctly detect the scope which should be examined. [#725](https://github.com/PHPCompatibility/PHPCompatibility/pull/725). Fixes [#724](https://github.com/PHPCompatibility/PHPCompatibility/pull/724).
+- :bug: `PHPCompatibility.Keywords.NewKeywords` sniff: PHP magic constants are case _in_sensitive. This sniff now accounts for this. [#707](https://github.com/PHPCompatibility/PHPCompatibility/pull/707)
+- :bug: Various bugs in the `PHPCompatibility.Syntax.ForbiddenCallTimePassByReference` sniff [#723](https://github.com/PHPCompatibility/PHPCompatibility/pull/723):
+    - Closures called via a variable will now also be examined. (false negative)
+    - References within arrays/closures passed as function call parameters would incorrectly trigger an error. (false positive)
+- :green_heart: Compatibility with PHPUnit 7.2. [#712](https://github.com/PHPCompatibility/PHPCompatibility/pull/712)
+
+### Credits
+Thanks go out to [Jonathan Champ] for his contribution to this version. :clap:
+
 
 ## [8.2.0] - 2018-07-17
 
@@ -947,7 +1127,8 @@ See all related issues and PRs in the [5.5 milestone].
 
 
 
-[Unreleased]: https://github.com/wimg/PHPCompatibility/compare/8.2.0...HEAD
+[Unreleased]: https://github.com/wimg/PHPCompatibility/compare/9.0.0...HEAD
+[9.0.0]: https://github.com/wimg/PHPCompatibility/compare/8.2.0...9.0.0
 [8.2.0]: https://github.com/wimg/PHPCompatibility/compare/8.1.0...8.2.0
 [8.1.0]: https://github.com/wimg/PHPCompatibility/compare/8.0.1...8.1.0
 [8.0.1]: https://github.com/wimg/PHPCompatibility/compare/8.0.0...8.0.1
@@ -969,6 +1150,7 @@ See all related issues and PRs in the [5.5 milestone].
 [7.0]: https://github.com/wimg/PHPCompatibility/compare/5.6...7.0
 [5.6]: https://github.com/wimg/PHPCompatibility/compare/5.5...5.6
 
+[9.0.0 milestone]: https://github.com/wimg/PHPCompatibility/milestone/24
 [8.2.0 milestone]: https://github.com/wimg/PHPCompatibility/milestone/22
 [8.1.0 milestone]: https://github.com/wimg/PHPCompatibility/milestone/21
 [8.0.1 milestone]: https://github.com/wimg/PHPCompatibility/milestone/20
@@ -1001,6 +1183,7 @@ See all related issues and PRs in the [5.5 milestone].
 [Gary Jones]: https://github.com/GaryJones
 [Jaap van Otterdijk]: https://github.com/jaapio
 [Jason Stallings]: https://github.com/octalmage
+[Jonathan Champ]: https://github.com/jrchamp
 [Jonathan Van Belle]: https://github.com/Grummfy
 [Juliette Reinders Folmer]: https://github.com/jrfnl
 [Ken Guest]: https://github.com/kenguest

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PHP Compatibility Coding Standard for PHP CodeSniffer
 [![Tested on PHP 5.3 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.3%20|%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%20nightly-brightgreen.svg?maxAge=2419200)](https://travis-ci.org/PHPCompatibility/PHPCompatibility)
 
 
-This is a set of sniffs for [PHP CodeSniffer](http://pear.php.net/PHP_CodeSniffer) that checks for PHP version compatibility.
+This is a set of sniffs for [PHP CodeSniffer](http://pear.php.net/PHP_CodeSniffer) that checks for PHP cross-version compatibility.
 It will allow you to analyse your code for compatibility with higher and lower versions of PHP. 
 
 
@@ -51,11 +51,16 @@ Thanks to all [contributors](https://github.com/PHPCompatibility/PHPCompatibilit
 Thanks to [WP Engine](https://wpengine.com) for their support on the PHP 7.0 sniffs.
 
 
-:warning: Upgrading to PHPCompatibility 8.0.0 :warning:
+:warning: Upgrading to PHPCompatibility 9.0.0 :warning:
 --------
-As of version 8.0.0, the installation instructions have changed. For most users, this means they will have to run a one-time-only extra command, make a change to their Composer configuration and/or adjust their build scripts.
+This library has been reorganized. All sniffs have been placed in categories and a significant number of sniffs have been renamed.
 
-Please read the changelog for version [8.0.0](https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/8.0.0) carefully before upgrading.
+If you use the complete `PHPCompatibility` standard without `exclude` directives in a custom ruleset and do not (yet) use the new-style PHP_CodeSniffer annotation as introduced in [PHP_CodeSniffer 3.2.0](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.2.0), this will have no noticeable effect and everything should work as before.
+
+However, if you do use `exclude` directives for PHPCompatibility sniffs in a custom ruleset or if you use the [new-style PHP_CodeSniffer inline annotations](https://github.com/squizlabs/PHP_CodeSniffer/releases/3.2.0), you will need to update these when upgrading. This should be a one-time only change.
+The changelog contains detailed information about all the sniff renames.
+
+Please read the changelog for version [9.0.0](https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0) carefully before upgrading.
 
 
 Installation in a Composer project (method 1)
@@ -137,20 +142,21 @@ Sniffing your code for compatibility with specific PHP version(s)
 * By default the report will be sent to the console, if you want to save the report to a file, add the following to the command line command: `--report-full=path/to/report-file`.
     For more information and other reporting options, check the [PHP CodeSniffer wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting).
 
-More information can be found on Wim Godden's [blog](http://techblog.wimgodden.be/tag/codesniffer).
 
+### Using a framework/CMS/polyfill specific ruleset
 
-### Using a framework/CMS specific ruleset
+As of mid 2018, a limited set of framework/CMS specific rulesets is available. These rulesets are hosted in their own repositories.
+* `PHPCompatibilityJoomla` [GitHub](https://github.com/PHPCompatibility/PHPCompatibilityJoomla) | [Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-joomla)
+* `PHPCompatibilityWP` [GitHub](https://github.com/PHPCompatibility/PHPCompatibilityWP) | [Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-wp)
 
-As of mid 2018, a limited set of framework/CMS specific ruleset(s) is available.
+Since the autumn of 2018, there are also a number of PHP polyfill specific rulesets available:
+* `PHPCompatibilityPasswordCompat` [GitHub](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat) | [Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat): accounts for @ircmaxell's [`password_compat`](https://github.com/ircmaxell/password_compat) polyfill library.
+* `PHPCompatibilityParagonie` [GitHub](https://github.com/PHPCompatibility/PHPCompatibilityParagonie) | [Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-paragonie): contains two rulesets which account for the Paragonie [`random_compat`](https://github.com/paragonie/random_compat) and [`sodium_compat`](https://github.com/paragonie/sodium_compat) polyfill libraries respectively.
+* `PHPCompatibilitySymfony` [GitHub](https://github.com/PHPCompatibility/PHPCompatibilitySymfony) | [Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-symfony): contains a number of rulesets which account for various PHP polyfill libraries offered by the Symfony project. For more details about the available rulesets, please check out the [README of the PHPCompatibilitySymfony](https://github.com/PHPCompatibility/PHPCompatibilitySymfony/blob/master/README.md) repository.
 
-These ruleset are hosted in their own repositories:
-* PHPCompatibilityJoomla [GitHub](https://github.com/PHPCompatibility/PHPCompatibilityJoomla)|[Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-joomla)
-* PHPCompatibilityWP [GitHub](https://github.com/PHPCompatibility/PHPCompatibilityWP)|[Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-wp)
+If you want to make sure you have all PHPCompatibility rulesets available at any time, you can use the `PHPCompatibilityAll` package [GitHub](https://github.com/PHPCompatibility/PHPCompatibilityAll) | [Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-all).
 
-If you want to make sure you have all PHPCompatibility rulesets available at any time, you can use the PHPCompatibilityAll package [GitHub](https://github.com/PHPCompatibility/PHPCompatibilityAll)|[Packagist](https://packagist.org/packages/phpcompatibility/phpcompatibility-all).
-
-**Note:** Framework/CMS specific ruleset do not set the minimum PHP version for your project, so you will still need to pass a `testVersion` to get the most accurate results.
+**IMPORTANT:** Framework/CMS/Polyfill specific rulesets do not set the minimum PHP version for your project, so you will still need to pass a `testVersion` to get the most accurate results.
 
 
 Using a custom ruleset
@@ -182,7 +188,7 @@ Other advanced options, such as changing the message type or severity of select 
 #### `testVersion` in the ruleset versus command-line
 
 In PHPCS 3.2.0 and lower, once you set the `testVersion` in the ruleset, you could not overrule it from the command-line anymore.
-Starting with PHPCS 3.3.0, the `testVersion` set via the command-line will overrule the `testVersion` in the ruleset.
+Starting with PHPCS 3.3.0, a `testVersion` set via the command-line will overrule the `testVersion` in the ruleset.
 
 This allows for more flexibility when, for instance, your project needs to comply with PHP `5.5-`, but you have a bootstrap file which needs to be compatible with PHP `5.2-`.
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name" : "phpcompatibility/php-compatibility",
-  "description" : "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+  "description" : "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
   "type" : "phpcodesniffer-standard",
   "keywords" : [ "compatibility", "phpcs", "standards" ],
   "homepage" : "http://techblog.wimgodden.be/tag/codesniffer/",


### PR DESCRIPTION
See: https://github.com/wimg/PHPCompatibility/milestone/24

#### Changelog:
* Add detailed changelog for version 9.0.0. Includes entry for - as of yet unmerged - PR #739.

#### Readme:
* Replace section about upgrading to v 8.0.0 with section about upgrading to v 9.0.0.
* Remove link to @wimg's blog as the information on it is out of date.
* Add information about the polyfill based rulesets.

#### Contributing:
* Adjust the information about specific sub-rulesets to cover the polyfill based rulesets.
* Mention the unit test `@group` annotations.

#### Other:
* `.gitattributes`: export-ignore the git files.
* `.gitignore`: add the new PHPCS 3.1+ local override file.
* `composer.json`: minor textual improvement to the project description.



### To Do for releasing this version:
- [x] Add info on all changes merged into `master` since the previous release
- [x] Add release date - **tentatively set at Sunday October 7th**
- [x] Remove unused bullets/sections
- [x] If necessary, rebase & squash commits in this PR & merge
- [ ] Tag the release
- [ ] If any open PRs which were milestoned for 9.0.0 will not make it into the release, update their milestone.
- [ ] Close the milestone for this version
- [x] Open a new milestone for the next version - `9.x Next` has been opened.
- [ ] Tweet about the release and where relevant, mention it in Slack channels etc.

### To Do after release:
- [ ] Restart the builds for the open PRs to fill the `PasswordCompat` and `Paragonie` polyfill repos.
- [ ] Once the builds have passed, merge those PRs and tag the releases.
- [ ] Add these repos to Packagist. (can't be done until there is a `composer.json` file in the repo).
- [ ] Restart the builds for the open PR to fill the `Symfony` polyfill repo and to update the `WP` ruleset repo.
- [ ] Once the builds have passed, merge those PRs and tag the releases.
- [ ] Add the Symfony repo to Packagist.
- [ ] Restart the builds for the open PR to update the `Joomla` ruleset.
- [ ] Once the builds have passed, merge the PR and tag the release.
- [ ] Restart the builds for the open PR to update the `All` repo.
- [ ] Once the builds have passed, merge the PR and tag the release.
- [ ] Open issues in the repos for the various polyfills to inform the repo owners and watchers of the availability of these rulesets.

[ci skip]