### PR TITLE
NewOperators: Update the version number for T_COALESCE_EQUAL

### DIFF
--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -57,8 +57,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
          * @link https://wiki.php.net/rfc/null_coalesce_equal_operator
          */
         'T_COALESCE_EQUAL' => array(
-            '7.2' => false,
-            '7.3' => true,
+            '7.3' => false,
+            '7.4' => true,
             'description' => 'null coalesce equal operator (??=)',
         ), // Identified in PHP < 7.0 icw PHPCS < 2.6.2 as T_INLINE_THEN + T_INLINE_THEN + T_EQUAL and between PHPCS 2.6.2 and PHPCS 2.8.1 as T_COALESCE + T_EQUAL.
     );

--- a/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
@@ -87,10 +87,10 @@ class NewOperatorsUnitTest extends BaseSniffTest
      */
     public function testCoalesceEquals()
     {
-        $file = $this->sniffFile(__FILE__, '7.2');
-        $this->assertError($file, 7, 'null coalesce equal operator (??=) is not present in PHP version 7.2 or earlier');
-
         $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertError($file, 7, 'null coalesce equal operator (??=) is not present in PHP version 7.3 or earlier');
+
+        $file = $this->sniffFile(__FILE__, '7.4');
         $this->assertNoViolation($file, 7);
     }
 


### PR DESCRIPTION
While this language construct is already tokenized correctly in PHPCS, PHP itself has not yet implemented it.

The RFC has been approved a while back and it was slated to go into PHP 7.2, but as of PHP 7.3 RC2 no implementation has been merged and it is not expected to go into PHP 7.3 anymore.

As PHPCS already recognized the token, it was already added to the `NewOperators` sniff a while back.

All this PR does is up the PHP version number used for the compares.

Also see #523.