### PR TITLE
Remove unused `use` statements

### DIFF
--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -12,7 +12,6 @@
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
 use PHPCompatibility\Sniff;
-use PHPCompatibility\PHPCSHelper;
 
 /**
  * \PHPCompatibility\Sniffs\ControlStructures\DiscouragedSwitchContinue.

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -9,8 +9,6 @@
 
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
-use PHPCompatibility\PHPCSHelper;
-
 /**
  * \PHPCompatibility\Sniffs\FunctionNameRestrictions\ReservedFunctionNamesSniff.
  *

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -11,7 +11,6 @@
 namespace PHPCompatibility\Sniffs\Keywords;
 
 use PHPCompatibility\Sniff;
-use PHPCompatibility\PHPCSHelper;
 
 /**
  * \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesSniff.

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -12,7 +12,6 @@
 namespace PHPCompatibility\Sniffs\Lists;
 
 use PHPCompatibility\Sniff;
-use PHPCompatibility\PHPCSHelper;
 
 /**
  * \PHPCompatibility\Sniffs\Lists\ForbiddenEmptyListAssignmentSniff.

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
@@ -8,7 +8,6 @@
 namespace PHPCompatibility\Tests\ControlStructures;
 
 use PHPCompatibility\Tests\BaseSniffTest;
-use PHPCompatibility\PHPCSHelper;
 
 /**
  * Discouraged use of continue within switch sniff test.


### PR DESCRIPTION
These are a left-over from when PHPCS 1.x support got removed in PR #699 and are no longer needed.