### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.3
   - nightly
 
 env:
@@ -73,6 +74,8 @@ matrix:
       env: PHPCS_VERSION="2.7.*"
     - php: 7.2
       env: PHPCS_VERSION="3.0.2" COVERALLS_VERSION="^2.0"
+    - php: 7.3
+      env: PHPCS_VERSION="3.2.*"
     - php: nightly
       env: PHPCS_VERSION=">=2.0,<3.0"
 

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility;
 
 use PHPCompatibility\PHPCSHelper;
+use PHPCompatibility\Util\TestVersionException;
 
 /**
  * \PHPCompatibility\Sniff.
@@ -130,9 +131,8 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
                     $max = empty($matches[2]) ? '99.9' : $matches[2];
 
                     if (version_compare($min, $max, '>')) {
-                        trigger_error(
-                            "Invalid range in testVersion setting: '" . $testVersion . "'",
-                            E_USER_WARNING
+                        throw new TestVersionException(
+                            "Invalid range in testVersion setting: '" . $testVersion . "'"
                         );
                         return $default;
                     } else {
@@ -142,9 +142,8 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
                 }
             }
 
-            trigger_error(
-                "Invalid testVersion setting: '" . $testVersion . "'",
-                E_USER_WARNING
+            throw new TestVersionException(
+                "Invalid testVersion setting: '" . $testVersion . "'"
             );
             return $default;
         }

--- a/PHPCompatibility/Util/TestVersionException.php
+++ b/PHPCompatibility/Util/TestVersionException.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2018 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Util;
+
+/**
+ * Exception for when an invalid testVersion setting has been passed to PHPCompatibility.
+ *
+ * @since 9.1.0
+ */
+class TestVersionException extends \Exception
+{
+}

--- a/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
@@ -138,11 +138,11 @@ class FunctionsUnitTest extends \PHPUnit_Framework_TestCase
     {
         if (method_exists($this, 'setExpectedException')) {
             $this->setExpectedException(
-                'PHPUnit_Framework_Error_Warning',
+                'PHPCompatibility\Util\TestVersionException',
                 sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion)
             );
         } else {
-            $this->expectException('PHPUnit\Framework\Error\Warning');
+            $this->expectException('PHPCompatibility\Util\TestVersionException');
             $this->expectExceptionMessage(sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion));
         }
 
@@ -186,11 +186,11 @@ class FunctionsUnitTest extends \PHPUnit_Framework_TestCase
     {
         if (method_exists($this, 'setExpectedException')) {
             $this->setExpectedException(
-                'PHPUnit_Framework_Error_Warning',
+                'PHPCompatibility\Util\TestVersionException',
                 sprintf('Invalid testVersion setting: \'%s\'', trim($testVersion))
             );
         } else {
-            $this->expectException('PHPUnit\Framework\Error\Warning');
+            $this->expectException('PHPCompatibility\Util\TestVersionException');
             $this->expectExceptionMessage(sprintf('Invalid testVersion setting: \'%s\'', trim($testVersion)));
         }
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The sniffs are designed to give the same results regardless of which PHP version
 
 PHP CodeSniffer 2.3.0 is required for 90% of the sniffs, PHP CodeSniffer 2.6.0 or later is required for full support, notices may be thrown on older versions.
 
+As PHP_CodeSniffer < 3.3.1 is not fully compatible with PHP 7.3, PHPCompatibility can't be either, so if using the sniffs on PHP 7.3, make sure you use PHP_CodeSniffer 3.3.1 or higher.
+
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP CodeSniffer 3.x.
 
 As of version 9.0.0, support for PHP CodeSniffer 1.5.x and low 2.x versions < 2.3.0 has been dropped.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PHP Compatibility Coding Standard for PHP CodeSniffer
 [![Coverage Status](https://coveralls.io/repos/github/PHPCompatibility/PHPCompatibility/badge.svg?branch=master)](https://coveralls.io/github/PHPCompatibility/PHPCompatibility?branch=master)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcompatibility/php-compatibility.svg?maxAge=3600)](https://packagist.org/packages/phpcompatibility/php-compatibility)
-[![Tested on PHP 5.3 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.3%20|%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%20nightly-brightgreen.svg?maxAge=2419200)](https://travis-ci.org/PHPCompatibility/PHPCompatibility)
+[![Tested on PHP 5.3 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.3%20|%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%20nightly-brightgreen.svg?maxAge=2419200)](https://travis-ci.org/PHPCompatibility/PHPCompatibility)
 
 
 This is a set of sniffs for [PHP CodeSniffer](http://pear.php.net/PHP_CodeSniffer) that checks for PHP cross-version compatibility.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -145,17 +145,23 @@
     <rule ref="PEAR.Commenting.FileComment.MissingCategoryTag">
         <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
         <exclude-pattern>*/PHPCompatibility/Tests/*\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
+        <exclude-pattern>*/PHPCompatibility/Util/*\.php</exclude-pattern>
     </rule>
     <rule ref="PEAR.Commenting.FileComment.MissingAuthorTag">
         <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
         <exclude-pattern>*/PHPCompatibility/Tests/*\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
+        <exclude-pattern>*/PHPCompatibility/Util/*\.php</exclude-pattern>
     </rule>
     <rule ref="PEAR.Commenting.ClassComment.MissingCategoryTag">
         <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
         <exclude-pattern>*/PHPCompatibility/Tests/*\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
+        <exclude-pattern>*/PHPCompatibility/Util/*\.php</exclude-pattern>
+    </rule>
+    <rule ref="PEAR.Commenting.ClassComment.MissingPackageTag">
+        <exclude-pattern>*/PHPCompatibility/Util/*\.php</exclude-pattern>
+    </rule>
+    <rule ref="PEAR.Commenting.ClassComment.MissingAuthorTag">
+        <exclude-pattern>*/PHPCompatibility/Util/*\.php</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/phpunit-travis.xml
+++ b/phpunit-travis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="phpunit-bootstrap.php" colors="true" backupGlobals="true">
+<phpunit bootstrap="phpunit-bootstrap.php" colors="true" backupGlobals="true" convertWarningsToExceptions="false">
     <testsuites>
         <testsuite name="PHPCompatibility Utilities Tests">
             <directory suffix="UnitTest.php">./PHPCompatibility/Util/Tests/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="phpunit-bootstrap.php" colors="true" backupGlobals="true">
+<phpunit bootstrap="phpunit-bootstrap.php" colors="true" backupGlobals="true" convertWarningsToExceptions="false">
     <testsuites>
         <testsuite name="PHPCompatibility Utilities Tests">
             <directory suffix="UnitTest.php">./PHPCompatibility/Util/Tests/</directory>


### PR DESCRIPTION
Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and builds haven't been tested against PHP 7.3 for months now.

Luckily, Travis has *finally* deemed it appropriate to set up a PHP 7.3 alias now RC3 is out, so I've added  PHP 7.3 to the matrix.

It would have been nice to move the coverage builds onto 7.3 at this time as that should raise the coverage a little as the PHP 7.3 specific code in the `NewFlexibleHeredocNowdoc` sniff should then show as covered.
However, that is not yet possible at this time as there is _no code coverage driver available_ for PHP 7.3 at this time. See https://travis-ci.org/PHPCompatibility/PHPCompatibility/jobs/441316823

---

Now, once I'd pushed the branch for this PR, the PHP 7.3 / PHPCS 3.0.2 build turned out to be failing. To fix this I've added a second commit with a small, but significant change.
I've also annotated in the `Readme` Requirements section that PHP 7.3 is only fully supported in combination with PHPCS 3.3.1 or higher.

As it took quite some figuring out and for future reference, this is the reasoning behind the additional changes (as written in the commit message):

`Sniff:getTestVersion()`: throw Exception instead of PHP native Warning

Ok, so this one will need some explaining and is actually about allowing the unit tests to pass on PHP 7.3.

First off, the underlying problem is that PHPCS isn't fully compliant with PHP 7.3 until version 3.3.1 - see upstream PR squizlabs/PHP_CodeSniffer#2086.
PHPCS prior to version 3.3.1, has a couple of `continue` statements within `switch` control structures causing PHP 7.3 to throw a warning. One of these is in the code for the `Tokenizer` class which is used to enhance the token array for every file being analysed and therefore unavoidable.

In PHPCS 2.x, this doesn't cause too much of a problem as PHPCS handled warnings encountered during the tokenizer runs differently.
In PHPCS 3.x, however, it becomes a problem as when such a warning will get thrown during the unit test run, PHPUnit will mark the first test which throws a warning as `Error` and fail the build.
Skipping select tests for the PHP 7.3 / PHPCS 3.0 < 3.3.1 combi will not help as that just moves the error to the next unit test with the same net effect.

Now, PHPUnit has a `convertWarningsToExceptions` setting which defaults to `true`. Changing that setting to `false` will allow the unit test run to pass as in that case, the first test which sees the warning will be marked as `Risky` for having output, but will not fail the build.

The next problem we then run into, is that PHPCompatibility itself throws a warning in the `getTestVersion()` method.
With the `convertWarningsToExceptions` setting set to `false`, those warnings will be thrown and the unit tests for that method which relied on the warnings being converted to exceptions will now fail.

That, however, is fixable.

So, I've added a new `PHPCompatibility\Util\TestVersionException` class and turned the warnings which were being thrown from the `getTestVersion()` method into Exceptions.

This Exception unfortunately can't extend the PHPCS native `RuntimeException` as PHPCS native exceptions weren't added until PHPCS 3.

Having said that, the current implementation allows the `convertWarningsToExceptions` setting to be set to `false` and our unit tests to still pass.
For PHP 7.3 in combination with PHPCS 3.0 < 3.3.1, this means that the very first test **will** be marked as risky, but other than that, the builds should pass.

**Note**: there is one additional caveat. PHPCS 2.x has a bug in the error handling and will throw an `Undefined offset: 0` error now whenever we throw the new Exception in PHPCS 2.x.
That warning will _only_ be thrown when someone sets an invalid `testVersion` though, so I'm not too concerned about that.

N.B.: The new `PHPCompatibility\Util\TestVersionException` class uses the new-style file and class docblock documentation as proposed in #734.
For that reason, some additional CS exceptions have been set in the `phpcs.xml.dist` file. Those can and will be removed when the big PR to fix #734 for all files is pulled.
