### PR TITLE
ReservedFunctionNames: bugfix for PHPCS 2.3.x

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -9,6 +9,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
+use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * \PHPCompatibility\Sniffs\FunctionNameRestrictions\ReservedFunctionNamesSniff.
  *
@@ -64,6 +65,19 @@ class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_Camel
     {
         $tokens = $phpcsFile->getTokens();
 
+        /*
+         * Determine if this is a function which needs to be examined.
+         * The `processTokenWithinScope()` is called for each valid scope a method is in,
+         * so for nested classes, we need to make sure we only examine the token for
+         * the lowest level valid scope.
+         */
+        $conditions = $tokens[$stackPtr]['conditions'];
+        end($conditions);
+        $deepestScope = key($conditions);
+        if ($deepestScope !== $currScope) {
+            return;
+        }
+
         $methodName = $phpcsFile->getDeclarationName($stackPtr);
         if ($methodName === null) {
             // Ignore closures.
@@ -76,9 +90,10 @@ class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_Camel
             if (isset($this->magicMethods[$magicPart]) === false
                 && isset($this->methodsDoubleUnderscore[$magicPart]) === false
             ) {
-                $className = '[anonymous class]';
-                if (defined('T_ANON_CLASS') === false || $tokens[$currScope]['type'] !== 'T_ANON_CLASS') {
-                    $className = $phpcsFile->getDeclarationName($currScope);
+                $className         = '[anonymous class]';
+                $scopeNextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($currScope + 1), null, true);
+                if ($scopeNextNonEmpty !== false && $tokens[$scopeNextNonEmpty]['code'] === T_STRING) {
+                    $className = $tokens[$scopeNextNonEmpty]['content'];
                 }
 
                 $phpcsFile->addWarning(

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -102,3 +102,13 @@ class ClassContainingClosure {
 		$a = function($c) {};
 	}
 }
+
+class Nested {
+    public function __getAnonymousClass() {
+        return new class() {
+            public function __nested() {
+                echo 'In method nested!';
+            }
+        };
+    }
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -73,6 +73,9 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
             array(92),
             array(93),
             array(94),
+
+            array(107),
+            array(109),
         );
     }
 


### PR DESCRIPTION
Loosely related to #751.

When this sniff would run on PHPCS 2.3.x and the function being examined would be in an anonymous class, the class name used in the error message would be incorrect as the `getDeclarationName()` method would use the first `T_STRING` found, which in the case of an anonymous class would be the name of the first constant or function within the anonymous class.

Additionally, the upstream `processTokenWithinScope()` method is called for each valid scope a function is in, so for a function in a nested anonymous class, the method would be called twice and the error would also be thrown twice, though with two different class names - both wrong.

This PR fixes both these issues.

Includes additional unit test for this issue, though as the class/method names being passed to the error message are not covered by the unit tests and the unit tests only test that the error is found on a line, not how _often_ the same error is found on a line, the issue can only be seen when testing this manually (for now).