### PR TITLE
CS: remove end comments and superfluous blank lines

### DIFF
--- a/PHPCompatibility/AbstractComplexVersionSniff.php
+++ b/PHPCompatibility/AbstractComplexVersionSniff.php
@@ -127,6 +127,4 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
     {
         return $data;
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -174,4 +174,4 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
     {
         return;
     }
-}//end class
+}

--- a/PHPCompatibility/AbstractNewFeatureSniff.php
+++ b/PHPCompatibility/AbstractNewFeatureSniff.php
@@ -103,6 +103,4 @@ abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
 
         $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -141,8 +141,5 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
         $data  = $this->filterErrorData($data, $itemInfo, $errorInfo);
 
         $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
-
-    }//end addError()
-
-
-}//end class
+    }
+}

--- a/PHPCompatibility/ComplexVersionInterface.php
+++ b/PHPCompatibility/ComplexVersionInterface.php
@@ -72,6 +72,4 @@ interface ComplexVersionInterface
      * @return void
      */
     public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo);
-
-
-}//end interface
+}

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -209,8 +209,7 @@ class PHPCSHelper
         }//end for
 
         return ($phpcsFile->numTokens - 1);
-
-    }//end findEndOfStatement()
+    }
 
 
     /**
@@ -280,8 +279,7 @@ class PHPCSHelper
         }
 
         return $name;
-
-    }//end findExtendedClassName()
+    }
 
 
     /**
@@ -348,8 +346,7 @@ class PHPCSHelper
             $names = array_map('trim', $names);
             return $names;
         }
-
-    }//end findImplementedInterfaceNames()
+    }
 
 
     /**
@@ -568,6 +565,5 @@ class PHPCSHelper
         }//end for
 
         return $vars;
-
-    }//end getMethodParameters()
+    }
 }

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -181,7 +181,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         } else {
             return false;
         }
-    }//end supportsAbove()
+    }
 
 
     /**
@@ -208,7 +208,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         } else {
             return false;
         }
-    }//end supportsBelow()
+    }
 
 
     /**
@@ -1447,7 +1447,6 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         }
 
         return ($number < 0);
-
     }
 
     /**
@@ -1957,4 +1956,4 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
 
         return true;
     }
-}//end class
+}

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -51,7 +51,7 @@ class NewAnonymousClassesSniff extends Sniff
         }
 
         return array(T_NEW);
-    }//end register()
+    }
 
 
     /**
@@ -81,8 +81,5 @@ class NewAnonymousClassesSniff extends Sniff
             $stackPtr,
             'Found'
         );
-
-    }//end process()
-
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -579,8 +579,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         }
 
         return $targets;
-
-    }//end register()
+    }
 
 
     /**
@@ -621,8 +620,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
                 $this->processSingularToken($phpcsFile, $stackPtr);
                 break;
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -665,8 +663,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             'nameLc' => $classNameLc,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end processSingularToken()
+    }
 
 
     /**
@@ -821,6 +818,4 @@ class NewClassesSniff extends AbstractNewFeatureSniff
     {
         return 'The built-in class ' . parent::getErrorMsgTemplate();
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -34,8 +34,7 @@ class NewConstVisibilitySniff extends Sniff
     public function register()
     {
         return array(T_CONST);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -73,7 +72,5 @@ class NewConstVisibilitySniff extends Sniff
             'Found',
             array($tokens[$prevToken]['content'])
         );
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -32,8 +32,7 @@ class NewLateStaticBindingSniff extends Sniff
     public function register()
     {
         return array(T_STATIC);
-
-    }//end register()
+    }
 
 
     /**
@@ -74,8 +73,5 @@ class NewLateStaticBindingSniff extends Sniff
                 'OutsideClassScope'
             );
         }
-
-    }//end process()
-
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -3189,8 +3189,7 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
     public function register()
     {
         return array(T_STRING);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -3218,8 +3217,7 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
             'name' => $constantName,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -3244,6 +3242,4 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
     {
         return 'The constant "%s" is not present in PHP version %s or earlier';
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -302,8 +302,7 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
     public function register()
     {
         return array(T_STRING);
-
-    }//end register()
+    }
 
 
     /**
@@ -332,8 +331,7 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
             'name' => $constantName,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -358,5 +356,4 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
     {
         return 'The constant "%s" is ';
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -219,5 +219,4 @@ class DiscouragedSwitchContinueSniff extends Sniff
 
         } while ($caseDefault < $switchCloser);
     }
-
 }

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -61,8 +61,7 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
             T_BREAK,
             T_CONTINUE,
         );
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -105,7 +104,5 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
         }
 
         $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -48,8 +48,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
     public function register()
     {
         return array(T_BREAK, T_CONTINUE);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -96,7 +95,5 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
 
             $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
         }
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -35,8 +35,7 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
     public function register()
     {
         return array(T_SWITCH);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -75,6 +74,5 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
                 'Found'
             );
         }
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -70,7 +70,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
         $this->ignoreTokens[T_EQUAL] = T_EQUAL;
 
         return array(T_DECLARE);
-    }//end register()
+    }
 
 
     /**
@@ -133,8 +133,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
             $this->addWarningOnInvalidValue($phpcsFile, $valuePtr, $directiveContent);
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -245,8 +244,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
             $phpcsFile->addWarning($error, $stackPtr, $errorCode, $data);
         }
-
-    }//end addError()
+    }
 
 
     /**
@@ -290,7 +288,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
             $phpcsFile->addWarning($error, $stackPtr, $errorCode, $data);
         }
-    }//end addWarningOnInvalidValue()
+    }
 
 
     /**
@@ -331,6 +329,4 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
         return in_array($value, $encodings, true);
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -34,8 +34,7 @@ class NewMultiCatchSniff extends Sniff
     public function register()
     {
         return array(T_CATCH);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -71,7 +70,5 @@ class NewMultiCatchSniff extends Sniff
             $hasBitwiseOr,
             'Found'
         );
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -183,8 +183,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
         $this->removedExtensions = $this->arrayKeysToLowercase($this->removedExtensions);
 
         return array(T_STRING);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -248,8 +247,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
                 break;
             }
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -281,8 +279,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
         }
 
         return false;
-
-    }//end isWhiteListed()
+    }
 
 
     /**
@@ -307,6 +304,4 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
     {
         return "Extension '%s' is ";
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -39,8 +39,7 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
             T_FUNCTION,
             T_CLOSURE,
         );
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -82,7 +81,5 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
                 'Found'
             );
         }
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -37,8 +37,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
     public function register()
     {
         return array(T_USE);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -113,7 +112,5 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
                 }
             }
         }
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -34,8 +34,7 @@ class NewClosureSniff extends Sniff
     public function register()
     {
         return array(T_CLOSURE);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -154,8 +153,7 @@ class NewClosureSniff extends Sniff
 
         // Prevent double reporting for nested closures.
         return $scopeEnd;
-
-    }//end process()
+    }
 
 
     /**
@@ -234,5 +232,4 @@ class NewClosureSniff extends Sniff
 
         return $classRef;
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -48,8 +48,7 @@ class NewNullableTypesSniff extends Sniff
         }
 
         return $tokens;
-
-    }//end register()
+    }
 
 
     /**
@@ -82,8 +81,7 @@ class NewNullableTypesSniff extends Sniff
         } else {
             $this->processReturnType($phpcsFile, $stackPtr);
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -159,5 +157,4 @@ class NewNullableTypesSniff extends Sniff
             );
         }
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -99,7 +99,7 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
             T_FUNCTION,
             T_CLOSURE,
         );
-    }//end register()
+    }
 
 
     /**
@@ -166,7 +166,7 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
                 $phpcsFile->addError($error, $param['token'], 'InvalidTypeHintFound', $data);
             }
         }
-    }//end process()
+    }
 
 
     /**
@@ -191,6 +191,4 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
     {
         return "'%s' type declaration is not present in PHP version %s or earlier";
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -104,7 +104,7 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
         }
 
         return $tokens;
-    }//end register()
+    }
 
 
     /**
@@ -144,7 +144,7 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
             );
             $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
         }
-    }//end process()
+    }
 
 
     /**
@@ -169,6 +169,4 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
     {
         return '%s return type is not present in PHP version %s or earlier';
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -93,8 +93,7 @@ class NonStaticMagicMethodsSniff extends Sniff
         }
 
         return $targets;
-
-    }//end register()
+    }
 
 
     /**
@@ -174,8 +173,5 @@ class NonStaticMagicMethodsSniff extends Sniff
             // Advance to next function.
             $functionPtr = $scopeCloser;
         }
-
-    }//end process()
-
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -83,8 +83,7 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
     public function register()
     {
         return array(T_FUNCTION);
-
-    }//end register()
+    }
 
 
     /**
@@ -114,8 +113,7 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
             'nameLc' => $functionNameLc,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -192,6 +190,4 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
 
         return $error;
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -43,7 +43,7 @@ class RemovedMagicAutoloadSniff extends Sniff
     public function register()
     {
         return array(T_FUNCTION);
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -75,6 +75,5 @@ class RemovedMagicAutoloadSniff extends Sniff
         }
 
         $phpcsFile->addWarning('Use of __autoload() function is deprecated since PHP 7.2', $stackPtr, 'Found');
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -88,5 +88,4 @@ class RemovedNamespacedAssertSniff extends Sniff
 
         $phpcsFile->addWarning('Declaring a free-standing function called assert() is deprecated since PHP 7.3.', $stackPtr, 'Found');
     }
-
 }

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -33,7 +33,6 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
     public function register()
     {
         return array(T_CLASS);
-
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -124,5 +124,4 @@ class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_Camel
             }
         }
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -159,5 +159,4 @@ class ArgumentFunctionsUsageSniff extends Sniff
             $data
         );
     }
-
 }

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -847,7 +847,7 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         $this->newFunctionParameters = $this->arrayKeysToLowercase($this->newFunctionParameters);
 
         return array(T_STRING);
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -901,8 +901,7 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 $this->handleFeature($phpcsFile, $openParenthesis, $itemInfo);
             }
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -986,6 +985,4 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         array_unshift($data, $itemInfo['name'], $errorInfo['paramName']);
         return $data;
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -1828,8 +1828,7 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
         $this->newFunctions = $this->arrayKeysToLowercase($this->newFunctions);
 
         return array(T_STRING);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -1873,8 +1872,7 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             'nameLc' => $functionLc,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -1899,6 +1897,4 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
     {
         return 'The function %s() is not present in PHP version %s or earlier';
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -102,8 +102,7 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
         $errorInfo['paramName'] = $itemArray['name'];
 
         return $errorInfo;
-
-    }//end getErrorInfo()
+    }
 
 
     /**
@@ -155,8 +154,5 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
         }
 
         $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
-
-    }//end addError()
-
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -76,7 +76,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         $this->removedFunctionParameters = $this->arrayKeysToLowercase($this->removedFunctionParameters);
 
         return array(T_STRING);
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -130,8 +130,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
                 $this->handleFeature($phpcsFile, $openParenthesis, $itemInfo);
             }
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -215,6 +214,4 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         array_unshift($data, $errorInfo['paramName'], $itemInfo['name']);
         return $data;
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -897,8 +897,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         $this->removedFunctions = $this->arrayKeysToLowercase($this->removedFunctions);
 
         return array(T_STRING);
-
-    }//end register()
+    }
 
 
     /**
@@ -942,8 +941,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             'nameLc' => $functionLc,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -968,6 +966,4 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
     {
         return 'Function %s() is ';
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -144,7 +144,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
         $this->functionParameters = $this->arrayKeysToLowercase($this->functionParameters);
 
         return array(T_STRING);
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -199,8 +199,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
                 $this->handleFeature($phpcsFile, $openParenthesis, $itemInfo);
             }
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -268,8 +267,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
         $errorInfo['paramName'] = $itemArray['name'];
 
         return $errorInfo;
-
-    }//end getErrorInfo()
+    }
 
 
     /**
@@ -306,8 +304,5 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
         );
 
         $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-
-    }//end addError()
-
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -505,8 +505,7 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
     public function register()
     {
         return array(T_STRING);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -554,8 +553,7 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             'functionLc' => $functionLc,
         );
         $this->handleFeature($phpcsFile, $iniToken['end'], $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -655,6 +653,4 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
 
         return $data;
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -237,8 +237,7 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
     public function register()
     {
         return array(T_STRING);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -286,8 +285,7 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             'functionLc' => $functionLc,
         );
         $this->handleFeature($phpcsFile, $iniToken['end'], $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -344,6 +342,4 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
     {
         return str_replace("%s", "'%s'", parent::getAlternativeOptionTemplate());
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -53,8 +53,7 @@ class InternalInterfacesSniff extends Sniff
         }
 
         return $targets;
-
-    }//end register()
+    }
 
 
     /**
@@ -87,8 +86,5 @@ class InternalInterfacesSniff extends Sniff
                 $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
             }
         }
-
-    }//end process()
-
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -128,8 +128,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
         }
 
         return $targets;
-
-    }//end register()
+    }
 
 
     /**
@@ -171,8 +170,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
                 // Deliberately left empty.
                 break;
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -237,7 +235,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
                 }
             }
         }
-    }//end processClassToken()
+    }
 
 
     /**
@@ -325,6 +323,4 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
     {
         return 'The built-in interface ' . parent::getErrorMsgTemplate();
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -105,8 +105,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
         );
 
         return $targets;
-
-    }//end register()
+    }
 
 
     /**
@@ -243,7 +242,5 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
 
             $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
         }
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -88,7 +88,7 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
         $tokens[] = T_STRING;
 
         return $tokens;
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -174,6 +174,5 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
 
             $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
         }
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -144,7 +144,7 @@ class ForbiddenNamesSniff extends Sniff
         }
 
         return $tokens;
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -305,8 +305,7 @@ class ForbiddenNamesSniff extends Sniff
             );
             $this->addError($phpcsFile, $stackPtr, $tokens[$nextNonEmpty]['content'], $data);
         }
-
-    }//end processNonString()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -354,7 +353,7 @@ class ForbiddenNamesSniff extends Sniff
             );
             $this->addError($phpcsFile, $stackPtr, $defineNameLc, $data);
         }
-    }//end processString()
+    }
 
 
     /**
@@ -388,4 +387,4 @@ class ForbiddenNamesSniff extends Sniff
     {
         return in_array($token['code'], array(T_CLOSE_CURLY_BRACKET, T_SEMICOLON, T_COMMA), true);
     }
-}//end class
+}

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -180,8 +180,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
         }
 
         return $tokens;
-
-    }//end register()
+    }
 
 
     /**
@@ -281,8 +280,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
             );
             $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -327,7 +325,6 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
         $errorInfo['description'] = $itemArray['description'];
 
         return $errorInfo;
-
     }
 
 
@@ -364,6 +361,4 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
         $tokens = $phpcsFile->getTokens();
         return ($tokens[$stackPtr]['content'][3] !== '"');
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -57,7 +57,7 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
             $tokens[] = constant($token);
         }
         return $tokens;
-    }//end register()
+    }
 
 
     /**
@@ -78,8 +78,7 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
             'name' => $tokenType,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -120,7 +119,6 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
         $errorInfo['description'] = $itemArray['description'];
 
         return $errorInfo;
-
     }
 
 
@@ -138,5 +136,4 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
         $data[0] = $errorInfo['description'];
         return $data;
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -54,8 +54,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
             T_OPEN_TAG_WITH_ECHO,
             T_INLINE_HTML,
         );
-
-    }//end register()
+    }
 
 
     /**
@@ -133,8 +132,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
                 $phpcsFile->addWarning($error, $stackPtr, 'MaybeASPOpenTagFound', $data);
             }
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -163,7 +161,5 @@ class RemovedAlternativePHPTagsSniff extends Sniff
         }
 
         return $snippet;
-
-    }//end getSnippet()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
@@ -41,8 +41,7 @@ class ValidIntegersSniff extends Sniff
             T_LNUMBER, // Binary, octal integers.
             T_CONSTANT_ENCAPSED_STRING, // Hex numeric string.
         );
-
-    }//end register()
+    }
 
 
     /**
@@ -104,8 +103,7 @@ class ValidIntegersSniff extends Sniff
             );
             return;
         }
-
-    }//end process()
+    }
 
 
     /**
@@ -218,5 +216,4 @@ class ValidIntegersSniff extends Sniff
 
         return false;
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -56,8 +56,7 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
             T_SR,
             T_SR_EQUAL,
         );
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -99,7 +98,5 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
             'Found',
             array($phpcsFile->getTokensAsString($start, ($end - $start + 1)))
         );
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -135,7 +135,7 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
             }
         }
         return $tokens;
-    }//end register()
+    }
 
 
     /**
@@ -179,8 +179,7 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
             'name' => $tokenType,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -221,7 +220,6 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
         $errorInfo['description'] = $itemArray['description'];
 
         return $errorInfo;
-
     }
 
 
@@ -292,5 +290,4 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
 
         return false;
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -76,4 +76,4 @@ class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
             'Found'
         );
     }
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -108,4 +108,4 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
             );
         }
     }
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -109,8 +109,7 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
     public function register()
     {
         return array(T_STRING);
-
-    }//end register()
+    }
 
 
     /**
@@ -139,8 +138,7 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
             'name'   => $algo,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -165,6 +163,4 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
     {
         return 'The %s hash algorithm is not present in PHP version %s or earlier';
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -122,4 +122,4 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
             );
         }
     }
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -111,5 +111,4 @@ class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
             $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
         }
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -119,4 +119,4 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
             }
         }
     }
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -54,8 +54,7 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
     public function register()
     {
         return array(T_STRING);
-
-    }//end register()
+    }
 
 
     /**
@@ -83,8 +82,7 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
             'name' => $algo,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -109,6 +107,4 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
     {
         return 'The %s hash algorithm is ';
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -76,4 +76,4 @@ class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
             $parameters[1]['raw']
         );
     }
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -117,4 +117,4 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
             $phpcsFile->addWarning($error, $stackPtr, 'Deprecated');
         }
     }
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -110,4 +110,4 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
             )
         );
     }
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -183,7 +183,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
             $modifiers = substr($regex, $regexEndPos + 1);
             $this->examineModifiers($phpcsFile, $stackPtr, $functionName, $modifiers);
         }
-    }//end processRegexPattern()
+    }
 
 
     /**
@@ -214,5 +214,4 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
             $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
         }
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -95,4 +95,4 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
             break;
         }
     }
-}//end class
+}

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -158,7 +158,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
                 $this->addMessage($phpcsFile, $error, $parameter['start'], $isError, $errorCode);
             }
         }
-    }//end process()
+    }
 
 
     /**
@@ -253,5 +253,4 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
         // This code should never be reached, but here in case of weird bugs.
         return false;
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -38,7 +38,7 @@ class NewArrayStringDereferencingSniff extends Sniff
             T_OPEN_SHORT_ARRAY,
             T_CONSTANT_ENCAPSED_STRING,
         );
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -102,7 +102,5 @@ class NewArrayStringDereferencingSniff extends Sniff
                 array($type)
             );
         }
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -32,7 +32,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
     public function register()
     {
         return array(T_STRING);
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -89,6 +89,5 @@ class NewFunctionArrayDereferencingSniff extends Sniff
                 'Found'
             );
         }
-
-    }//end process()
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -114,7 +114,5 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
             $errorCode,
             $data
         );
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -38,7 +38,7 @@ class NewShortArraySniff extends Sniff
             T_OPEN_SHORT_ARRAY,
             T_CLOSE_SHORT_ARRAY,
         );
-    }//end register()
+    }
 
 
     /**
@@ -69,7 +69,5 @@ class NewShortArraySniff extends Sniff
         }
 
         $phpcsFile->addError($error, $stackPtr, 'Found', $data);
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -37,8 +37,7 @@ class RemovedNewReferenceSniff extends Sniff
     public function register()
     {
         return array(T_NEW);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -72,7 +71,5 @@ class RemovedNewReferenceSniff extends Sniff
         }
 
         $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode);
-
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -69,7 +69,7 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
         $tokens[] = T_CONSTANT_ENCAPSED_STRING;
 
         return $tokens;
-    }//end register()
+    }
 
 
     /**
@@ -119,8 +119,7 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
             'content' => $tokens[$stackPtr]['content'],
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -194,6 +193,4 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
         $data[]  = $itemInfo['content'];
         return $data;
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -50,8 +50,7 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
         }
 
         return $tokens;
-
-    }//end register()
+    }
 
 
     /**
@@ -73,8 +72,7 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
             'description' => $this->deprecatedTypeCasts[$tokenType]['description'],
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -125,5 +123,4 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
         $data[0] = $itemInfo['description'];
         return $data;
     }
-
-}//end class
+}

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -36,7 +36,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
         } else {
             return array(T_USE);
         }
-    }//end register()
+    }
 
 
     /**
@@ -99,6 +99,5 @@ class NewGroupUseDeclarationsSniff extends Sniff
                 'TrailingCommaFound'
             );
         }
-    }//end process()
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -97,5 +97,4 @@ class NewUseConstFunctionSniff extends Sniff
             'Found'
         );
     }
-
 }

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -34,8 +34,7 @@ class NewUniformVariableSyntaxSniff extends Sniff
     public function register()
     {
         return array(T_VARIABLE);
-
-    }//end register()
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -106,8 +105,5 @@ class NewUniformVariableSyntaxSniff extends Sniff
             $stackPtr,
             'Found'
         );
-
-    }//end process()
-
-
-}//end class
+    }
+}

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -90,8 +90,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
     public function register()
     {
         return array(T_VARIABLE);
-
-    }//end register()
+    }
 
 
     /**
@@ -141,8 +140,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
             'name' => $varName,
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
-
-    }//end process()
+    }
 
 
     /**
@@ -300,6 +298,4 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
         return true;
     }
-
-
-}//end class
+}

--- a/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
@@ -58,5 +58,4 @@ class NewAnonymousClassesUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.0');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -243,5 +243,4 @@ class NewClassesUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
@@ -109,5 +109,4 @@ class NewConstVisibilityUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.1');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
@@ -125,5 +125,4 @@ class NewLateStaticBindingUnitTest extends BaseSniffTest
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw an error
      * independently of PHP version when late static binding is used outside of class scope.
      */
-
 }

--- a/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
@@ -859,5 +859,4 @@ class NewConstantsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -98,5 +98,4 @@ class NewMagicClassConstantUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.5');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
@@ -273,5 +273,4 @@ class RemovedConstantsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.0'); // Low version below the first deprecation.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
@@ -143,5 +143,4 @@ class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.2');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
@@ -120,5 +120,4 @@ class ForbiddenBreakContinueOutsideLoopUnitTest extends BaseSniffTest
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw a warning
      * on invalid use of the construct in pre-PHP 7 versions.
      */
-
 }

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -127,5 +127,4 @@ class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.3');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
@@ -99,5 +99,4 @@ class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -190,5 +190,4 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
     /*
      * `testNoViolationsInFileOnValidVersion` test omitted as the directive value checks are version independent.
      */
-
 }

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
@@ -99,5 +99,4 @@ class NewMultiCatchUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.1');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -247,5 +247,4 @@ class RemovedExtensionsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.0'); // Low version below the first deprecation.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
@@ -109,5 +109,4 @@ class ForbiddenParameterShadowSuperGlobalsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.3');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
@@ -96,5 +96,4 @@ class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitfTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitfTest.php
@@ -153,5 +153,4 @@ class ForbiddenVariableNamesInClosureUseUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE, '7.0');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
@@ -308,5 +308,4 @@ class NewClosureUnitTest extends BaseSniffTest
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors
      * about the use of closures in PHP < 5.3 and about invalid usage of $this in closures for PHP 5.4+.
      */
-
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
@@ -168,5 +168,4 @@ class NewNullableTypesUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.1');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -248,5 +248,4 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw errors
      * for invalid type hints and incorrect usage.
      */
-
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -121,5 +121,4 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -448,5 +448,4 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
         $file = $this->getTestFile(true, '5.2');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -275,5 +275,4 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
         $file = $this->getTestFile(true, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
@@ -96,5 +96,4 @@ class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -157,5 +157,4 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff operates
      *  independently of the testVersion.
      */
-
 }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -170,5 +170,4 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTest
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors
      * about the use of these functions in the global scope independently of the PHP version.
      */
-
 }

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -228,5 +228,4 @@ class NewFunctionParametersUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -568,5 +568,4 @@ class NewFunctionsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -148,5 +148,4 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.5'); // Version before earliest required/optional change.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -205,5 +205,4 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.0'); // Low version below the first deprecation.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -466,5 +466,4 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.0'); // Low version below the first deprecation.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -126,5 +126,4 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond latest required/optional change.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -103,5 +103,4 @@ class NewGeneratorReturnUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.0');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -281,5 +281,4 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -318,5 +318,4 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.0'); // Low version below the first deprecation.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
@@ -107,5 +107,4 @@ class NewConstantArraysUsingConstUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -103,5 +103,4 @@ class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.0');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -228,5 +228,4 @@ class NewConstantScalarExpressionsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -145,5 +145,4 @@ class NewHeredocUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.3');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -139,5 +139,4 @@ class InternalInterfacesUnitTest extends BaseSniffTest
     /*
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff is version independent.
      */
-
 }

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -166,5 +166,4 @@ class NewInterfacesUnitTest extends BaseSniffTest
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw an error
      * on invalid use of some magic methods for the Serializable Interface.
      */
-
 }

--- a/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
@@ -105,5 +105,4 @@ class CaseSensitiveKeywordsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.5');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsDeclaredUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsDeclaredUnitTest.php
@@ -208,5 +208,4 @@ class ForbiddenNamesAsDeclaredUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6'); // Low version below the first introduced reserved word.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsInvokedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsInvokedFunctionsUnitTest.php
@@ -145,5 +145,4 @@ class ForbiddenNamesAsInvokedFunctionsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '4.4'); // Low version below the first introduced reserved word.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -53,7 +53,6 @@ class ForbiddenNamesUnitTest extends BaseSniffTest
         for ($i = 3; $i < $lineCount; $i++) {
             $this->assertError($file, $i, 'Function name, class name, namespace name or constant name can not be reserved keyword');
         }
-
     }
 
     /**

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -406,5 +406,4 @@ class NewKeywordsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
@@ -149,5 +149,4 @@ class NewEmptyNonVariableUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.5');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
@@ -63,5 +63,4 @@ class NewLanguageConstructsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
@@ -110,5 +110,4 @@ class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
@@ -121,5 +121,4 @@ class NewKeyedListUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.1');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
@@ -112,5 +112,4 @@ class NewListReferenceAssignmentUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.3');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
@@ -104,5 +104,4 @@ class NewShortListUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.1');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -172,5 +172,4 @@ class RemovedAlternativePHPTagsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.php
@@ -149,5 +149,4 @@ class ValidIntegersUnitTest extends BaseSniffTest
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors
      * about invalid integers independently of the testVersion.
      */
-
 }

--- a/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
@@ -103,5 +103,4 @@ class ForbiddenNegativeBitshiftUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
@@ -104,5 +104,4 @@ class NewOperatorsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
@@ -78,5 +78,4 @@ class NewShortTernaryUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.3');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -119,5 +119,4 @@ class NewHashAlgorithmsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0');  // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -109,5 +109,4 @@ class NewPCREModifiersUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
@@ -112,5 +112,4 @@ class RemovedHashAlgorithmsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.3'); // Low version below the first removal.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
@@ -113,5 +113,4 @@ class RemovedMbstringModifiersUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.0');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -188,5 +188,4 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.4');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
@@ -154,5 +154,4 @@ class ForbiddenCallTimePassByReferenceUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.2');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
@@ -104,5 +104,4 @@ class NewArrayStringDereferencingUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.5');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
@@ -132,5 +132,4 @@ class NewClassMemberAccessUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.0');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
@@ -114,5 +114,4 @@ class NewDynamicAccessToStaticUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.3');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
@@ -102,5 +102,4 @@ class NewFunctionArrayDereferencingUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.4');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -116,5 +116,4 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.3');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
@@ -101,5 +101,4 @@ class NewShortArrayUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.4');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
@@ -40,7 +40,6 @@ class RemovedNewReferenceUnitTest extends BaseSniffTest
 
         $file = $this->sniffFile(__FILE__, '7.0');
         $this->assertError($file, $line, 'Assigning the return value of new by reference is deprecated in PHP 5.3 and has been removed in PHP 7.0');
-
     }
 
     /**
@@ -83,5 +82,4 @@ class RemovedNewReferenceUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.2');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
@@ -112,5 +112,4 @@ class NewTypeCastsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
@@ -110,5 +110,4 @@ class RemovedTypeCastsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.1'); // Low version below the first deprecation.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
@@ -176,5 +176,4 @@ class NewGroupUseDeclarationsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.2');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
@@ -112,5 +112,4 @@ class NewUseConstFunctionUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
@@ -150,5 +150,4 @@ class ForbiddenGlobalVariableVariableUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
@@ -119,5 +119,4 @@ class NewUniformVariableSyntaxUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -223,5 +223,4 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '5.2'); // Low version below the first deprecation.
         $this->assertNoViolation($file);
     }
-
 }

--- a/PHPCompatibility/Util/Tests/Core/DoesFunctionCallHaveParametersUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/DoesFunctionCallHaveParametersUnitTest.php
@@ -77,5 +77,4 @@ class DoesFunctionCallHaveParametersUnitTest extends CoreMethodTestFrame
             array('/* Case A14 */', true),
         );
     }
-
 }

--- a/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
@@ -513,5 +513,4 @@ class FunctionsUnitTest extends \PHPUnit_Framework_TestCase
 
         return $method->invokeArgs($object, $parameters);
     }
-
 }

--- a/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromDoubleColonTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromDoubleColonTokenUnitTest.php
@@ -72,5 +72,4 @@ class GetFQClassNameFromDoubleColonTokenUnitTest extends CoreMethodTestFrame
             array('/* Case 19 */', ''),
         );
     }
-
 }

--- a/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromNewTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromNewTokenUnitTest.php
@@ -69,5 +69,4 @@ class GetFQClassNameFromNewTokenUnitTest extends CoreMethodTestFrame
             array('/* Case 16 */', ''),
         );
     }
-
 }

--- a/PHPCompatibility/Util/Tests/Core/GetFQExtendedClassNameUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFQExtendedClassNameUnitTest.php
@@ -70,5 +70,4 @@ class GetFQExtendedClassNameUnitTest extends CoreMethodTestFrame
             array('/* Case 17 */', '\Yet\More\Testing\SomeInterface'),
         );
     }
-
 }

--- a/PHPCompatibility/Util/Tests/Core/GetFunctionParameterCountUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFunctionParameterCountUnitTest.php
@@ -122,5 +122,4 @@ class GetFunctionParameterCountUnitTest extends CoreMethodTestFrame
             array('/* Case A16 */', 3),
         );
     }
-
 }

--- a/PHPCompatibility/Util/Tests/Core/GetFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFunctionParametersUnitTest.php
@@ -469,5 +469,4 @@ class GetFunctionParametersUnitTest extends CoreMethodTestFrame
             ),
         );
     }
-
 }

--- a/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
+++ b/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
@@ -85,8 +85,7 @@ abstract class CoreMethodTestFrame extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         unset($this->phpcsFile, $this->helperClass);
-
-    }//end tearDown()
+    }
 
 
     /**
@@ -138,5 +137,4 @@ abstract class CoreMethodTestFrame extends \PHPUnit_Framework_TestCase
 
         return $target;
     }
-
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -43,8 +43,6 @@
         <exclude name="Generic.Files.LineLength.TooLong"/>
 
         <!-- Ignoring a number of whitespace issues around blank lines. -->
-        <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
-        <exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose"/>
         <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
         <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
         <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>


### PR DESCRIPTION
* `//end ...` comments probably entered the code base originally based on PHPCS native code. They were applied inconsistently and can be considered superfluous with modern IDEs anyway, so I've removed them.
* Also removed superfluous blank lines at the end of function declarations and classes.
    These were often added to improve code readibility when the `//end` comments were used.
    This fixes the violations against the `PSR2.Classes.ClassDeclaration` and `PSR2.Methods.FunctionClosingBrace` sniffs which were up to now ignored.
* Includes removing the related exclusions from the PHPCompatibility native ruleset.