### PR TITLE
Sniff::isClassProperty: bug fix

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -66,7 +66,7 @@ class RemovedMagicAutoloadSniff extends Sniff
             return;
         }
 
-        if ($this->validDirectScope($phpcsFile, $stackPtr, $this->checkForScopes) === true) {
+        if ($this->validDirectScope($phpcsFile, $stackPtr, $this->checkForScopes) !== false) {
             return;
         }
 

--- a/PHPCompatibility/Util/Tests/Core/IsClassPropertyUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Core/IsClassPropertyUnitTest.inc
@@ -95,3 +95,21 @@ class MyClass {
 		/* Case 32 */
 		$varF = 'string';
 }
+
+$a = ( $foo == $bar ? new stdClass() :
+	new class() {
+		/* Case 33 */
+		public $var = true;
+
+		/* Case 34 */
+		public function something($var = false) {}
+	}
+);
+
+function_call( 'param', new class {
+	/* Case 35 */
+	public $year = 2017;
+
+	/* Case 36 */
+	public function __construct( $open, $post_id ) {}
+}, 10, 2 );

--- a/PHPCompatibility/Util/Tests/Core/IsClassPropertyUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsClassPropertyUnitTest.php
@@ -114,6 +114,10 @@ class IsClassPropertyUnitTest extends CoreMethodTestFrame
             array('/* Case 30 */', true),
             array('/* Case 31 */', true),
             array('/* Case 32 */', true),
+            array('/* Case 33 */', true),
+            array('/* Case 34 */', false),
+            array('/* Case 35 */', true),
+            array('/* Case 36 */', false),
         );
     }
 }


### PR DESCRIPTION
When a class would be nested in parenthesis, the method did not recognize class properties properly.

To check for this without code duplication, the return of the `Sniff::validDirectScope()` method has changed. It used to always return a boolean. Now it will return `false` if not in a valid direct scope and the `$stackPtr` to the scope if it is.

Includes unit test.