### PR TITLE
PHP 7.0: New sniff to detect direct calls to __clone()

### DIFF
--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2018 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\MethodUse;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Detect direct calls to the __clone() magic method which is allowed since PHP 7.0.
+ *
+ * "Doing calls like $obj->__clone() is now allowed. This was the only magic method
+ *  that had a compile-time check preventing some calls to it, which doesn't make sense.
+ *  If we allow all other magic methods to be called, there's no reason to forbid this one."
+ *
+ * PHP version 7.0
+ *
+ * @link https://wiki.php.net/rfc/abstract_syntax_tree#directly_calling_clone_is_allowed
+ *
+ * @since 9.1.0
+ */
+class NewDirectCallsToCloneSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.1.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            T_DOUBLE_COLON,
+            T_OBJECT_OPERATOR,
+        );
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.1.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.6') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_STRING) {
+            /*
+             * Not a method call.
+             *
+             * Note: This disregards method calls with the method name in a variable, like:
+             *   $method = '__clone';
+             *   $obj->$method();
+             * However, that would be very hard to examine reliably anyway.
+             */
+            return;
+        }
+
+        if (strtolower($tokens[$nextNonEmpty]['content']) !== '__clone') {
+            // Not a call to the __clone() method.
+            return;
+        }
+
+        $nextNextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
+        if ($nextNextNonEmpty === false || $tokens[$nextNextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
+            // Not a method call.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Direct calls to the __clone() magic method are not allowed in PHP 5.6 or earlier.',
+            $nextNonEmpty,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.inc
+++ b/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.inc
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * These are not calls to the __clone() magic method.
+ */
+$a = __clone();
+BadPracticeClassConstant::__CLONE;
+$propertyAccess = $obj->__clone;
+BadPracticeClassProp::$__CLONE;
+$notclone = $obj->_clone();
+$notclone = $obj->cloning();
+
+class ABC {
+    function __clone() {}
+}
+
+/*
+ * These should be flagged.
+ */
+class DEF {
+    function something()
+    {
+		$clone = self::__clone();
+		$clone = static::__Clone();
+		$clone = parent::__CLONE();
+    }
+}
+
+$a = (new ABC()) ->  /* comment */ __clone();
+StaticClass::__clone();

--- a/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2018 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\MethodUse;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New direct calls to __clone() sniff tests.
+ *
+ * @group newDirectCallsToClone
+ * @group methodUse
+ *
+ * @covers \PHPCompatibility\Sniffs\MethodUse\NewDirectCallsToCloneSniff
+ *
+ * @since 9.1.0
+ */
+class NewDirectCallsToCloneUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test detecting direct calls to clone.
+     *
+     * @dataProvider dataDirectCallToClone
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testDirectCallToClone($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertError($file, $line, 'Direct calls to the __clone() magic method are not allowed in PHP 5.6 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDirectCallToClone()
+     *
+     * @return array
+     */
+    public function dataDirectCallToClone()
+    {
+        return array(
+            array(23),
+            array(24),
+            array(25),
+            array(29),
+            array(30),
+        );
+    }
+
+
+    /**
+     * Test against false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(6),
+            array(7),
+            array(8),
+            array(9),
+            array(10),
+            array(11),
+            array(14),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -130,30 +130,18 @@
     <rule ref="PEAR.Commenting">
         <!-- Exclude PEAR specific tag requirements. -->
         <exclude name="PEAR.Commenting.FileComment.MissingVersion" />
-        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag" />
+        <exclude name="PEAR.Commenting.FileComment.MissingAuthorTag" />
+        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag" />
         <exclude name="PEAR.Commenting.FileComment.MissingLicenseTag" />
+        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag" />
+        <exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag" />
+        <exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag" />
         <exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag" />
         <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag" />
+        <exclude name="PEAR.Commenting.ClassComment.MissingPackageTag" />
 
         <!-- Having a @see or @internal tag before the @category tag is fine. -->
         <exclude name="PEAR.Commenting.ClassComment.CategoryTagOrder"/>
-    </rule>
-
-    <!-- No need to be as strict about file and class comment tags for the unit tests. -->
-    <rule ref="PEAR.Commenting.FileComment.MissingCategoryTag">
-        <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Tests/*\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment.MissingAuthorTag">
-        <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Tests/*\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
-    </rule>
-    <rule ref="PEAR.Commenting.ClassComment.MissingCategoryTag">
-        <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Tests/*\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
> Directly calling __clone is allowed
>
> Doing calls like $obj->__clone() is now allowed. This was the only magic method that had a compile-time check preventing some calls to it, which doesn't make sense. If we allow all other magic methods to be called, there's no reason to forbid this one.

Ref: https://wiki.php.net/rfc/abstract_syntax_tree#directly_calling_clone_is_allowed

Includes unit tests.

Fixes #629

Note: PR includes minor adjustments to the PHPCompatibility native PHPCS ruleset to allow for the new docblock format as per #734. This will be further addressed in a separate PR dedicated to that issue.