### PR TITLE
NewTypeCasts: updated for compatibility with PHPCS 3.4.0

### DIFF
--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\TypeCasts;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * \PHPCompatibility\Sniffs\TypeCasts\NewTypeCastsSniff.
@@ -62,11 +63,14 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
          *
          * - (binary) cast is incorrectly tokenized as T_STRING_CAST by PHP and PHPCS.
          * - b"something" binary cast is incorrectly tokenized as T_CONSTANT_ENCAPSED_STRING by PHP and PHPCS.
+         * - Since PHPCS 3.4.0, PHPCS *will* tokenize these correctly.
          *
          * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/1574
          */
-        $tokens[] = T_STRING_CAST;
-        $tokens[] = T_CONSTANT_ENCAPSED_STRING;
+        if (version_compare(PHPCSHelper::getVersion(), '3.4.0', '<') === true) {
+            $tokens[] = T_STRING_CAST;
+            $tokens[] = T_CONSTANT_ENCAPSED_STRING;
+        }
 
         return $tokens;
     }
@@ -99,7 +103,9 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
                     break;
 
                 case 'T_CONSTANT_ENCAPSED_STRING':
-                    if (strpos($tokenContent, 'b"') === 0 && substr($tokenContent, -1) === '"') {
+                    if ((strpos($tokenContent, 'b"') === 0 && substr($tokenContent, -1) === '"')
+                        || (strpos($tokenContent, "b'") === 0 && substr($tokenContent, -1) === "'")
+                    ) {
                         $tokenType = 'T_BINARY_CAST';
                     } else {
                         return;

--- a/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.inc
+++ b/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.inc
@@ -8,6 +8,8 @@
 (unset) $a;
 (binary) 1234;
 $binary = b"binary string";
+$binary = b"binary $string";
+$also_binary = b'124';
 
 // Verify space & case independency.
 (	unset	) $a;
@@ -16,5 +18,4 @@ $binary = b"binary string";
 ( BINARY ) 1234;
 
 // Just making sure / no false positives.
-$not_binary = b'124';
 $ordinary = 'b"something"';

--- a/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
@@ -27,7 +27,7 @@ class NewTypeCastsUnitTest extends BaseSniffTest
     /**
      * testNewTypeCasts
      *
-     * @dataProvider dataNewFunction
+     * @dataProvider dataNewTypeCasts
      *
      * @param string $castDescription   The type of type cast.
      * @param string $lastVersionBefore The PHP version just *before* the type cast was introduced.
@@ -56,15 +56,15 @@ class NewTypeCastsUnitTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNewFunction()
+     * @see testNewTypeCasts()
      *
      * @return array
      */
-    public function dataNewFunction()
+    public function dataNewTypeCasts()
     {
         return array(
-            array('The unset cast', '4.4', array(8, 13, 15), '5.0'),
-            array('The binary cast', '5.2.0', array(9, 10, 14, 16), '5.3', '5.2'), // Test (global) namespaced function.
+            array('The unset cast', '4.4', array(8, 15, 17), '5.0'),
+            array('The binary cast', '5.2.0', array(9, 10, 11, 12, 16, 18), '5.3', '5.2'), // Test (global) namespaced function.
         );
     }
 
@@ -96,8 +96,7 @@ class NewTypeCastsUnitTest extends BaseSniffTest
         return array(
             array(4),
             array(5),
-            array(19),
-            array(20),
+            array(21),
         );
     }
 


### PR DESCRIPTION
A fix for upstream issue #1574 has been committed to PHPCS and will be included in the PHPCS 3.4.0 release.

This PR:
* Makes a work-around used for the issue so far conditional on the PHPCS version detected.
* Recognize `b'singlequoted'` also as binary string casts.
* Adjusts the unit tests to match (for the single quoted fix) and add a test with a double quotes interpolated string.
* Includes fixing test file copy/paste error.

**Note**: This PR fixes the current Travis build failure against the `dev-master` branch.