### PR TITLE
PHP 7.1: New "NewThisUsageLimitations" sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Variables/NewThisUsageLimitationsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewThisUsageLimitationsSniff.php
@@ -1,0 +1,423 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2018 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Variables;
+
+use PHPCompatibility\Sniff;
+use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Detect using $this in incompatible contexts.
+ *
+ * "Whilst $this is considered a special variable in PHP, it lacked proper checks
+ *  to ensure it wasn't used as a variable name or reassigned. This has now been
+ *  rectified to ensure that $this cannot be a user-defined variable, reassigned
+ *  to a different value, or be globalised."
+ *
+ * This sniff only addresses those situations which did *not* throw an error prior
+ * to PHP 7.1, either at all or only in PHP 7.0.
+ * In other words, the following situation, while mentioned in the RFC, will NOT
+ * be sniffed for:
+ * - Using $this as static variable. (error _message_ change only).
+ *
+ * Also, the changes with relation to assigning $this dynamically can not be
+ * sniffed for reliably, so are not covered by this sniff.
+ * - Disable ability to re-assign $this indirectly through $$.
+ * - Disable ability to re-assign $this indirectly through reference.
+ * - Disable ability to re-assign $this indirectly through extract() and parse_str().
+ *
+ * Other changes not (yet) covered:
+ * - get_defined_vars() always doesn't show value of variable $this.
+ * - Always show true $this value in magic method __call().
+ *   {@internal This could possibly be covered. Similar logic as "outside object context",
+ *   but with function name check and supportsBelow('7.0').}}
+ *
+ * PHP version 7.1
+ *
+ * @link https://wiki.php.net/rfc/this_var
+ *
+ * @since 9.1.0
+ */
+class NewThisUsageLimitationsSniff extends Sniff
+{
+
+    /**
+     * OO scope tokens.
+     *
+     * Duplicate of Tokens::$ooScopeTokens array in PHPCS which was added in 3.1.0.
+     *
+     * @since 9.1.0
+     *
+     * @var array
+     */
+    private $ooScopeTokens = array(
+        'T_CLASS'     => T_CLASS,
+        'T_INTERFACE' => T_INTERFACE,
+        'T_TRAIT'     => T_TRAIT,
+    );
+
+    /**
+     * Scopes to skip over when examining the contents of functions.
+     *
+     * @since 9.1.0
+     *
+     * @var array
+     */
+    private $skipOverScopes = array(
+        'T_FUNCTION' => true,
+        'T_CLOSURE'  => true,
+    );
+
+    /**
+     * Valid uses of $this in plain functions or methods outside object context.
+     *
+     * @since 9.1.0
+     *
+     * @var array
+     */
+    private $validUseOutsideObject = array(
+        T_ISSET => true,
+        T_EMPTY => true,
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.1.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        if (defined('T_ANON_CLASS')) {
+            $this->ooScopeTokens['T_ANON_CLASS'] = T_ANON_CLASS;
+        }
+
+        $this->skipOverScopes += $this->ooScopeTokens;
+
+        return array(
+            T_FUNCTION,
+            T_CLOSURE,
+            T_GLOBAL,
+            T_CATCH,
+            T_FOREACH,
+            T_UNSET,
+        );
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.1.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.1') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        switch ($tokens[$stackPtr]['code']) {
+            case T_FUNCTION:
+                $this->isThisUsedAsParameter($phpcsFile, $stackPtr);
+                $this->isThisUsedOutsideObjectContext($phpcsFile, $stackPtr);
+                break;
+
+            case T_CLOSURE:
+                $this->isThisUsedAsParameter($phpcsFile, $stackPtr);
+                break;
+
+            case T_GLOBAL:
+                /*
+                 * $this can no longer be imported using the `global` keyword.
+                 * This worked in PHP 7.0, though in PHP 5.x, it would throw a
+                 * fatal "Cannot re-assign $this" error.
+                 */
+                $endOfStatement = $phpcsFile->findNext(array(T_SEMICOLON, T_CLOSE_TAG), ($stackPtr + 1));
+                if ($endOfStatement === false) {
+                    // No semi-colon - live coding.
+                    return;
+                }
+
+                for ($i = ($stackPtr + 1); $i < $endOfStatement; $i++) {
+                    if ($tokens[$i]['code'] !== T_VARIABLE || $tokens[$i]['content'] !== '$this') {
+                        continue;
+                    }
+
+                    $phpcsFile->addError(
+                        '"$this" can no longer be used with the "global" keyword since PHP 7.1.',
+                        $i,
+                        'Global'
+                    );
+                }
+
+                break;
+
+            case T_CATCH:
+                /*
+                 * $this can no longer be used as a catch variable.
+                 */
+                if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {
+                    return;
+                }
+
+                $varPtr = $phpcsFile->findNext(
+                    T_VARIABLE,
+                    ($tokens[$stackPtr]['parenthesis_opener'] + 1),
+                    $tokens[$stackPtr]['parenthesis_closer']
+                );
+
+                if ($varPtr === false || $tokens[$varPtr]['content'] !== '$this') {
+                    return;
+                }
+
+                $phpcsFile->addError(
+                    '"$this" can no longer be used as a catch variable since PHP 7.1.',
+                    $varPtr,
+                    'Catch'
+                );
+
+                break;
+
+            case T_FOREACH:
+                /*
+                 * $this can no longer be used as a foreach *value* variable.
+                 * This worked in PHP 7.0, though in PHP 5.x, it would throw a
+                 * fatal "Cannot re-assign $this" error.
+                 */
+                if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {
+                    return;
+                }
+
+                $stopPtr = $phpcsFile->findPrevious(
+                    array(T_AS, T_DOUBLE_ARROW),
+                    ($tokens[$stackPtr]['parenthesis_closer'] - 1),
+                    $tokens[$stackPtr]['parenthesis_opener']
+                );
+                if ($stopPtr === false) {
+                    return;
+                }
+
+                $valueVarPtr = $phpcsFile->findNext(
+                    T_VARIABLE,
+                    ($stopPtr + 1),
+                    $tokens[$stackPtr]['parenthesis_closer']
+                );
+                if ($valueVarPtr === false || $tokens[$valueVarPtr]['content'] !== '$this') {
+                    return;
+                }
+
+                $afterThis = $phpcsFile->findNext(
+                    Tokens::$emptyTokens,
+                    ($valueVarPtr + 1),
+                    $tokens[$stackPtr]['parenthesis_closer'],
+                    true
+                );
+
+                if ($afterThis !== false
+                    && ($tokens[$afterThis]['code'] === T_OBJECT_OPERATOR
+                        || $tokens[$afterThis]['code'] === T_DOUBLE_COLON)
+                ) {
+                    return;
+                }
+
+                $phpcsFile->addError(
+                    '"$this" can no longer be used as value variable in a foreach control structure since PHP 7.1.',
+                    $valueVarPtr,
+                    'ForeachValueVar'
+                );
+
+                break;
+
+            case T_UNSET:
+                /*
+                 * $this can no longer be unset.
+                 */
+                $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+                if ($openParenthesis === false
+                    || $tokens[$openParenthesis]['code'] !== T_OPEN_PARENTHESIS
+                    || isset($tokens[$openParenthesis]['parenthesis_closer']) === false
+                ) {
+                    return;
+                }
+
+                for ($i = ($openParenthesis + 1); $i < $tokens[$openParenthesis]['parenthesis_closer']; $i++) {
+                    if ($tokens[$i]['code'] !== T_VARIABLE || $tokens[$i]['content'] !== '$this') {
+                        continue;
+                    }
+
+                    $afterThis = $phpcsFile->findNext(
+                        Tokens::$emptyTokens,
+                        ($i + 1),
+                        $tokens[$openParenthesis]['parenthesis_closer'],
+                        true
+                    );
+
+                    if ($afterThis !== false
+                        && ($tokens[$afterThis]['code'] === T_OBJECT_OPERATOR
+                            || $tokens[$afterThis]['code'] === T_DOUBLE_COLON)
+                    ) {
+                        $i = $afterThis;
+                        continue;
+                    }
+
+                    $phpcsFile->addError(
+                        '"$this" can no longer be unset since PHP 7.1.',
+                        $i,
+                        'Unset'
+                    );
+                }
+
+                break;
+        }
+    }
+
+    /**
+     * Check if $this is used as a parameter in a function declaration.
+     *
+     * $this can no longer be used as a parameter in a *global* function.
+     * Use as a parameter in a method was already an error prior to PHP 7.1.
+     *
+     * @since 9.1.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function isThisUsedAsParameter(File $phpcsFile, $stackPtr)
+    {
+        if ($this->validDirectScope($phpcsFile, $stackPtr, $this->ooScopeTokens) === true) {
+            return;
+        }
+
+        $params = PHPCSHelper::getMethodParameters($phpcsFile, $stackPtr);
+        if (empty($params)) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        foreach ($params as $param) {
+            if ($param['name'] !== '$this') {
+                continue;
+            }
+
+            if ($tokens[$stackPtr]['code'] === T_FUNCTION) {
+                $phpcsFile->addError(
+                    '"$this" can no longer be used as a parameter since PHP 7.1.',
+                    $param['token'],
+                    'FunctionParam'
+                );
+            } else {
+                $phpcsFile->addError(
+                    '"$this" can no longer be used as a closure parameter since PHP 7.0.7.',
+                    $param['token'],
+                    'ClosureParam'
+                );
+            }
+        }
+    }
+
+    /**
+     * Check if $this is used in a plain function or method.
+     *
+     * Prior to PHP 7.1, this would result in an "undefined variable" notice
+     * and execution would continue with $this regarded as `null`.
+     * As of PHP 7.1, this throws an exception.
+     *
+     * Note: use within isset() and empty() to check object context is still allowed.
+     * Note: $this can still be used within a closure.
+     *
+     * @since 9.1.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function isThisUsedOutsideObjectContext(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
+            return;
+        }
+
+        if ($this->validDirectScope($phpcsFile, $stackPtr, $this->ooScopeTokens) === true) {
+            $methodProps = $phpcsFile->getMethodProperties($stackPtr);
+            if ($methodProps['is_static'] === false) {
+                return;
+            } else {
+                $methodName = $phpcsFile->getDeclarationName($stackPtr);
+                if ($methodName === '__call') {
+                    /*
+                     * This is an exception.
+                     * @link https://wiki.php.net/rfc/this_var#always_show_true_this_value_in_magic_method_call
+                     */
+                    return;
+                }
+            }
+        }
+
+        for ($i = ($tokens[$stackPtr]['scope_opener'] + 1); $i < $tokens[$stackPtr]['scope_closer']; $i++) {
+            if (isset($this->skipOverScopes[$tokens[$i]['type']])) {
+                if (isset($tokens[$i]['scope_closer']) === false) {
+                    // Live coding or parse error, will only lead to inaccurate results.
+                    return;
+                }
+
+                // Skip over nested structures.
+                $i = $tokens[$i]['scope_closer'];
+                continue;
+            }
+
+            if ($tokens[$i]['code'] !== T_VARIABLE || $tokens[$i]['content'] !== '$this') {
+                continue;
+            }
+
+            if (isset($tokens[$i]['nested_parenthesis']) === true) {
+                $nestedParenthesis     = $tokens[$i]['nested_parenthesis'];
+                $nestedOpenParenthesis = array_keys($nestedParenthesis);
+                $lastOpenParenthesis   = array_pop($nestedOpenParenthesis);
+
+                $previousNonEmpty = $phpcsFile->findPrevious(
+                    Tokens::$emptyTokens,
+                    ($lastOpenParenthesis - 1),
+                    null,
+                    true,
+                    null,
+                    true
+                );
+
+                if (isset($this->validUseOutsideObject[$tokens[$previousNonEmpty]['code']])) {
+                    continue;
+                }
+            }
+
+            $phpcsFile->addError(
+                '"$this" can no longer be used in a plain function or method since PHP 7.1.',
+                $i,
+                'OutsideObjectContext'
+            );
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Variables/NewThisUsageLimitationsUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/NewThisUsageLimitationsUnitTest.inc
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * Disable using $this as parameter.
+ */
+function noParams() {}
+function paramNotThis($that) {}
+
+// This was already an error prior to PHP 7.1, so not our concern.
+class ThisAsMethodParam {
+    function methodParam($this) {
+    }
+}
+
+// These should be flagged. New fatal error: Cannot use $this as parameter.
+function thisAsGlobalFunctionParam($this) {}
+$a = function($paramA, $paramB, $this, $paramC, $this) {}; // Error x 2, throws error as of PHP 7.0.7.
+
+class NestedClosures {
+    function thisInNestedClosure() {
+		$a = function($this) {};
+    }
+}
+
+/*
+ * Disable using $this as global variable.
+ *
+ * New fatal error: Cannot use $this as global variable.
+ */
+global $this;
+
+function thisInGlobalStatement() {
+    global $that, $theOther, $this, $somethingElse;
+}
+
+class GlobalInMethod {
+    function thisInGlobalStatement() {
+        global $that,
+	        $theOther,
+			$this,
+			$somethingElse;
+    }
+}
+
+/*
+ * Disable using $this as catch variable.
+ *
+ * New fatal error: Cannot re-assign $this.
+ */
+try {
+   // Some code...
+} catch (ExceptionTypeA | ExceptionTypeB $that) { // OK.
+   // Code
+} catch (ExceptionType1 | ExceptionType2 $this) {
+   // Code to handle the exception.
+} catch (\Exception $this) {
+   // ...
+}
+
+/*
+ * Disable using $this as foreach value variable.
+ */
+foreach ($a as $something) {}
+
+class ForeachInMethod {
+    public function testThis($a) {
+        foreach($a as $k => $this->item) {}
+    }
+}
+
+// This was already an error prior to PHP 7.1, so not our concern.
+foreach ($a as $this => $that) {}
+
+// These should be flagged. New fatal error: Cannot re-assign $this.
+foreach ($a as $this) {}
+foreach ($a as $that => $this) {}
+
+/*
+ * Disable ability to unset() $this.
+ */
+class UnsetInMethod {
+	public function foo() {
+		unset($this->property); // OK.
+		
+		// This throws an "Attempt to unset static property" error across all versions, so not our concern.
+		unset($this::$property);
+	}
+}
+
+// These should be flagged. New fatal error: Cannot unset $this.
+unset($this);
+unset($that, $theOther, $this, $somethingElse, $this); // Error x 2.
+unset(
+	$that,
+	$this->something,
+	$this,
+);
+
+/*
+ * Using $this when not in object context now throws a fatal error.
+ */
+abstract class AbstractClass {
+	abstract function bar();
+
+    function foo() {
+        var_dump($this);
+    }
+}
+
+$a = function () {
+    var_dump($this);
+};
+
+function thisInGlobalFunction() {
+    if (isset($this)) {}
+}
+
+class ThisInStaticMethod {
+    static function foo() {
+        if (empty($this)) {};
+    }
+}
+
+class Nested {
+    public function getAnonymousClass() {
+		$a = function() {
+			var_dump($this);
+		};
+
+        return new class() {
+            public function nestedFunction() {
+                var_dump($this);
+            }
+        };
+    }
+}
+
+// These should be flagged.  New fatal error: using $this when not in object context.
+function usingThisNotInObjectContext() {
+    var_dump($this);
+}
+
+class StaticMethodsClass {
+    static function usingThisNotInObjectContext() {
+        var_dump($this);
+    }
+}
+
+
+/*
+ * ====================================================================
+ * THE BELOW CHANGES ARE NOT COVERED BY THE SNIFF.
+ * Just here in case someone does decide to work on them and to protect against false positives.
+ */
+
+/*
+ * Disable ability to re-assign $this indirectly through $$.
+ */
+$a = "this";
+$$a = 42; // throw new Error("Cannot re-assign $this")
+
+function_call( $$a );  // This is (still) fine.
+$b = $$a; // This is (still) fine.
+
+/*
+ * Disable ability to re-assign $this indirectly through reference.
+ */
+class ReassignThisThroughReference {
+  function foo(){
+    $a =& $this;
+    $a = 42;
+    var_dump($this); // prints object(C)#1 (0) {}, php-7.0 printed int(42)
+  }
+}
+$x = new ReassignThisThroughReference;
+$x->foo();
+
+/*
+ * Disable ability to re-assign $this indirectly through extract() and parse_str().
+ */
+class ReassignThisIndirectly {
+  function foo(){
+    extract(["this"=>42]);  // throw new Error("Cannot re-assign $this")
+    var_dump($this);
+  }
+}
+$x = new ReassignThisIndirectly;
+$x->foo();
+
+/*
+ * Always show true $this value in magic method __call().
+ * In PHP 7.0 and below $this in static magic method __call() had value NULL. However it was possible to access properties and call object methods.
+ */
+class MagicMethodCall {
+  static function __call($name, $args) {
+    var_dump($this); // prints object(C)#1 (0) {}, php-7.0 printed NULL
+    $this->test();   // prints "ops"
+  }
+  function test() {
+    echo "ops\n";
+  }
+}
+$x = new MagicMethodCall;
+$x->foo();

--- a/PHPCompatibility/Tests/Variables/NewThisUsageLimitationsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewThisUsageLimitationsUnitTest.php
@@ -1,0 +1,468 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2018 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Variables;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New $this usage limitations sniff tests.
+ *
+ * @group newThisUsageLimitations
+ * @group variables
+ *
+ * @covers \PHPCompatibility\Sniffs\Variables\newThisUsageLimitationsSniff
+ *
+ * @since 9.1.0
+ */
+class NewThisUsageLimitationsUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test $this being used as a parameter.
+     *
+     * @dataProvider dataIncompatibleThisUsageParam
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testIncompatibleThisUsageParam($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertError($file, $line, '"$this" can no longer be used as a parameter since PHP 7.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIncompatibleThisUsageParam()
+     *
+     * @return array
+     */
+    public function dataIncompatibleThisUsageParam()
+    {
+        return array(
+            array(16),
+        );
+    }
+
+
+    /**
+     * Test $this being used as a closure parameter.
+     *
+     * @dataProvider dataIncompatibleThisUsageClosureParam
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testIncompatibleThisUsageClosureParam($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertError($file, $line, '"$this" can no longer be used as a closure parameter since PHP 7.0.7.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIncompatibleThisUsageClosureParam()
+     *
+     * @return array
+     */
+    public function dataIncompatibleThisUsageClosureParam()
+    {
+        return array(
+            array(17), // x2.
+            array(21),
+        );
+    }
+
+
+    /**
+     * Test against false positives: $this as param.
+     *
+     * @dataProvider dataNoFalsePositivesParam
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesParam($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesParam()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesParam()
+    {
+        return array(
+            array(6),
+            array(7),
+            array(11),
+        );
+    }
+
+
+    /**
+     * Test $this being used as global variable.
+     *
+     * @dataProvider dataIncompatibleThisUsageGlobal
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testIncompatibleThisUsageGlobal($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertError($file, $line, '"$this" can no longer be used with the "global" keyword since PHP 7.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIncompatibleThisUsageGlobal()
+     *
+     * @return array
+     */
+    public function dataIncompatibleThisUsageGlobal()
+    {
+        return array(
+            array(30),
+            array(33),
+            array(40),
+        );
+    }
+
+
+    /**
+     * Test against false positives: $this as global.
+     *
+     * @dataProvider dataNoFalsePositivesGlobal
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesGlobal($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesGlobal()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesGlobal()
+    {
+        return array(
+            array(38),
+            array(39),
+            array(41),
+        );
+    }
+
+
+    /**
+     * Test $this being used as catch variable.
+     *
+     * @dataProvider dataIncompatibleThisUsageCatch
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testIncompatibleThisUsageCatch($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertError($file, $line, '"$this" can no longer be used as a catch variable since PHP 7.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIncompatibleThisUsageCatch()
+     *
+     * @return array
+     */
+    public function dataIncompatibleThisUsageCatch()
+    {
+        return array(
+            array(54),
+            array(56),
+        );
+    }
+
+
+    /**
+     * Test against false positives: $this as catch var.
+     *
+     * @dataProvider dataNoFalsePositivesCatch
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesCatch($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesCatch()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesCatch()
+    {
+        return array(
+            array(52),
+        );
+    }
+
+
+    /**
+     * Test $this being used as foreach value var.
+     *
+     * @dataProvider dataIncompatibleThisUsageForeach
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testIncompatibleThisUsageForeach($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertError($file, $line, '"$this" can no longer be used as value variable in a foreach control structure since PHP 7.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIncompatibleThisUsage()
+     *
+     * @return array
+     */
+    public function dataIncompatibleThisUsageForeach()
+    {
+        return array(
+            array(75),
+            array(76),
+        );
+    }
+
+
+    /**
+     * Test against false positives: $this as foreach value var.
+     *
+     * @dataProvider dataNoFalsePositivesForeach
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesForeach($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesForeach()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesForeach()
+    {
+        return array(
+            array(63),
+            array(67),
+            array(72),
+        );
+    }
+
+
+    /**
+     * Test $this being unset.
+     *
+     * @dataProvider dataIncompatibleThisUsageUnset
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testIncompatibleThisUsageUnset($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertError($file, $line, '"$this" can no longer be unset since PHP 7.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIncompatibleThisUsageUnset()
+     *
+     * @return array
+     */
+    public function dataIncompatibleThisUsageUnset()
+    {
+        return array(
+            array(91),
+            array(92), // x2.
+            array(96),
+        );
+    }
+
+
+    /**
+     * Test against false positives: $this in unset.
+     *
+     * @dataProvider dataNoFalsePositivesUnset
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesUnset($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesUnset()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesUnset()
+    {
+        return array(
+            array(83),
+            array(86),
+            array(94),
+            array(95),
+        );
+    }
+
+
+    /**
+     * Test $this being used in plain functions.
+     *
+     * @dataProvider dataIncompatibleThisUsageOutsideObjectContext
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testIncompatibleThisUsageOutsideObjectContext($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertError($file, $line, '"$this" can no longer be used in a plain function or method since PHP 7.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIncompatibleThisUsage()
+     *
+     * @return array
+     */
+    public function dataIncompatibleThisUsageOutsideObjectContext()
+    {
+        return array(
+            array(140),
+            array(145),
+        );
+    }
+
+
+    /**
+     * Test against false positives: $this in plain functions.
+     *
+     * @dataProvider dataNoFalsePositivesOutsideObjectContext
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesOutsideObjectContext($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesOutsideObjectContext()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesOutsideObjectContext()
+    {
+        return array(
+            array(103),
+            array(106),
+            array(111),
+            array(115),
+            array(120),
+            array(127),
+            array(132),
+            array(196), // Exception to the rule / static __call() magic method.
+        );
+    }
+
+
+    /**
+     * Test against false positives: uncovered cases.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesUncovered()
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+
+        // No errors expected on the first 14 lines.
+        for ($line = 150; $line <= 205; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -130,30 +130,18 @@
     <rule ref="PEAR.Commenting">
         <!-- Exclude PEAR specific tag requirements. -->
         <exclude name="PEAR.Commenting.FileComment.MissingVersion" />
-        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag" />
+        <exclude name="PEAR.Commenting.FileComment.MissingAuthorTag" />
+        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag" />
         <exclude name="PEAR.Commenting.FileComment.MissingLicenseTag" />
+        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag" />
+        <exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag" />
+        <exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag" />
         <exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag" />
         <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag" />
+        <exclude name="PEAR.Commenting.ClassComment.MissingPackageTag" />
 
         <!-- Having a @see or @internal tag before the @category tag is fine. -->
         <exclude name="PEAR.Commenting.ClassComment.CategoryTagOrder"/>
-    </rule>
-
-    <!-- No need to be as strict about file and class comment tags for the unit tests. -->
-    <rule ref="PEAR.Commenting.FileComment.MissingCategoryTag">
-        <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Tests/*\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment.MissingAuthorTag">
-        <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Tests/*\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
-    </rule>
-    <rule ref="PEAR.Commenting.ClassComment.MissingCategoryTag">
-        <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Tests/*\.php</exclude-pattern>
-        <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
> Inconsistency fixes to $this
>
> Whilst $this is considered a special variable in PHP, it lacked proper checks to ensure it wasn't used as a variable name or reassigned. This has now been rectified to ensure that $this cannot be a user-defined variable, reassigned to a different value, or be globalised.

Refs:
* https://wiki.php.net/rfc/this_var
* http://php.net/manual/en/migration71.other-changes.php#migration71.other-changes.inconsistency-fixes-to-this

Notes:
* This sniff only addresses those situations which did *not* throw an error prior to PHP 7.1.
    In other words, "_Using $this as static variable._" is not sniffed for (error _message_ change only).
* There is one exception to that, which is using `$this` as a closure parameter, which doesn't throw an error in PHP 7.0 until 7.0.7, so that will be covered by this sniff too.
* Also, the changes with relation to assigning `$this` dynamically can not be sniffed for reliably, so are not covered by this sniff.
    This includes:
    - "_Disable ability to re-assign $this indirectly through $$._"
    - "_Disable ability to re-assign $this indirectly through reference._"
    - "_Disable ability to re-assign $this indirectly through extract() and parse_str()._"
* Other changes not (yet) covered:
    - "_get_defined_vars() always doesn't show value of variable $this._"
    - "_Always show true $this value in magic method __call()._"
        This last one could possibly be covered. Similar logic as "outside object context", but with function name check and supportsBelow('7.0').

Includes unit tests.

Test cases based on extensive testing on 3v4l and running the sniff over a number of big PHP projects.

I'm not sure if this is the best name for this sniff. Alternative sniff name suggestion: `ForbiddenThisUse`.

Fixes #262
Fixes #740