### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.3
   - nightly
 
 env:
@@ -73,6 +74,10 @@ matrix:
       env: PHPCS_VERSION="2.7.*"
     - php: 7.2
       env: PHPCS_VERSION="3.0.2" COVERALLS_VERSION="^2.0"
+    # Note: PHP 7.3+ is only fully supported icw PHPCS 2.9.2 and 3.3.1+.
+    # While on PHPCS 2.x, the tests won't fail, on PHPCS 3.x < 3.3.1, they will.
+    - php: 7.3
+      env: PHPCS_VERSION="3.3.*"
     - php: nightly
       env: PHPCS_VERSION=">=2.0,<3.0"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PHP Compatibility Coding Standard for PHP CodeSniffer
 [![Coverage Status](https://coveralls.io/repos/github/PHPCompatibility/PHPCompatibility/badge.svg?branch=master)](https://coveralls.io/github/PHPCompatibility/PHPCompatibility?branch=master)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcompatibility/php-compatibility.svg?maxAge=3600)](https://packagist.org/packages/phpcompatibility/php-compatibility)
-[![Tested on PHP 5.3 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.3%20|%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%20nightly-brightgreen.svg?maxAge=2419200)](https://travis-ci.org/PHPCompatibility/PHPCompatibility)
+[![Tested on PHP 5.3 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.3%20|%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%20nightly-brightgreen.svg?maxAge=2419200)](https://travis-ci.org/PHPCompatibility/PHPCompatibility)
 
 
 This is a set of sniffs for [PHP CodeSniffer](http://pear.php.net/PHP_CodeSniffer) that checks for PHP cross-version compatibility.
@@ -36,6 +36,10 @@ PHP CodeSniffer: 2.3.0+ or 3.0.2+.
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP CodeSniffer. You should get reasonably consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on PHP 5.4 or higher.
 
 PHP CodeSniffer 2.3.0 is required for 90% of the sniffs, PHP CodeSniffer 2.6.0 or later is required for full support, notices may be thrown on older versions.
+
+For running the sniffs on PHP 7.3, it is recommended to use PHP_CodeSniffer 3.3.1+, or, if needs be, PHP_CodeSniffer 2.9.2.
+PHP_CodeSniffer < 2.9.2/3.3.1 is not fully compatible with PHP 7.3, which effectively means that PHPCompatibility can't be either.
+While the sniffs will still work in _most_ cases, you can expect PHP warnings to be thrown.
 
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP CodeSniffer 3.x.
 


### PR DESCRIPTION
Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and the builds haven't been tested against PHP 7.3 for months now.

Luckily, Travis has, in the mean time, deemed it appropriate to set up a PHP 7.3 alias now RC3 is out, so I've added PHP 7.3 to the matrix.

**Important note**:
PHP 7.3+ is only fully supported in combination with PHPCS 2.9.2 and 3.3.1+.
When running PHPCompatibility against PHPCS < 2.9.2 or PHPCS 3.x < 3.3.1, PHP warnings about using `continue` within `switch` will be thrown, but will in most cases not affect the functioning of the sniffs.

While on PHPCS 2.x, the tests won't fail, on PHPCS 3.x < 3.3.1, they will, as the error handling during PHPCS runs has changed in PHPCS 3.x.
In other words, for PHP 7.3, we can safely run the unit tests on PHPCS 2.x and PHPCS >= 3.3.1, but PHPCS 3.0 - 3.3.0 can not be tested.
See: https://travis-ci.org/jrfnl/PHPCompatibility/builds/465553352

Includes updating the `README` with a note about PHP 7.3 support.

N.B.: It would have been nice to move the coverage builds onto 7.3 at this time as that should raise the coverage a little as the PHP 7.3 specific code in the `NewFlexibleHeredocNowdoc` sniff should then show as covered.
However, that is not yet possible at this time as there is _no code coverage driver available_ for PHP 7.3 in the PHPUnit version included on the PHP 7.3 Travis images at this time.
See https://travis-ci.org/jrfnl/PHPCompatibility/jobs/465544658#L808

This PR supersedes the earlier PR regarding this #754 