### PR TITLE
PHP 7.3: NewFunctions: more updates

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -1786,7 +1786,35 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.2' => false,
             '7.3' => true,
         ),
+        'ldap_add_ext' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
+        'ldap_bind_ext' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
+        'ldap_delete_ext' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
         'ldap_exop_refresh' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
+        'ldap_mod_add_ext' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
+        'ldap_mod_replace_ext' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
+        'ldap_mod_del_ext' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
+        'ldap_rename_ext' => array(
             '7.2' => false,
             '7.3' => true,
         ),

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -1826,10 +1826,6 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.2' => false,
             '7.3' => true,
         ),
-        'sapi_add_request_header' => array(
-            '7.2' => false,
-            '7.3' => true,
-        ),
         'socket_wsaprotocol_info_export' => array(
             '7.2' => false,
             '7.3' => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -465,3 +465,11 @@ sapi_windows_cp_is_utf8();
 sapi_windows_cp_conv();
 hash_hkdf();
 pcntl_signal_get_handler();
+
+ldap_add_ext();
+ldap_bind_ext();
+ldap_delete_ext();
+ldap_mod_add_ext();
+ldap_mod_replace_ext();
+ldap_mod_del_ext();
+ldap_rename_ext();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -454,7 +454,7 @@ gmp_kronecker();
 ldap_exop_refresh();
 normalizer_get_raw_decomposition();
 openssl_pkey_derive();
-sapi_add_request_header();
+
 socket_wsaprotocol_info_export();
 socket_wsaprotocol_info_import();
 socket_wsaprotocol_info_release();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -515,7 +515,6 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('ldap_exop_refresh', '7.2', array(454), '7.3'),
             array('normalizer_get_raw_decomposition', '7.2', array(455), '7.3'),
             array('openssl_pkey_derive', '7.2', array(456), '7.3'),
-            array('sapi_add_request_header', '7.2', array(457), '7.3'),
             array('socket_wsaprotocol_info_export', '7.2', array(458), '7.3'),
             array('socket_wsaprotocol_info_import', '7.2', array(459), '7.3'),
             array('socket_wsaprotocol_info_release', '7.2', array(460), '7.3'),

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -519,6 +519,14 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('socket_wsaprotocol_info_export', '7.2', array(458), '7.3'),
             array('socket_wsaprotocol_info_import', '7.2', array(459), '7.3'),
             array('socket_wsaprotocol_info_release', '7.2', array(460), '7.3'),
+
+            array('ldap_add_ext', '7.2', array(469), '7.3'),
+            array('ldap_bind_ext', '7.2', array(470), '7.3'),
+            array('ldap_delete_ext', '7.2', array(471), '7.3'),
+            array('ldap_mod_add_ext', '7.2', array(472), '7.3'),
+            array('ldap_mod_replace_ext', '7.2', array(473), '7.3'),
+            array('ldap_mod_del_ext', '7.2', array(474), '7.3'),
+            array('ldap_rename_ext', '7.2', array(475), '7.3'),
         );
     }
 


### PR DESCRIPTION
### PHP 7.3: NewFunctions: account for (more) new global LDAP functions

Refs:
* https://github.com/php/php-src/blob/cb00ca7cfeea8af8083d28d7bc66957c61899732/UPGRADING#L456-L460
* php/php-src#2640

### PHP 7.3: NewFunctions: remove internal function

Looks like the `sapi_add_request_header()` function is an internal C function and not exposed.