### PR TITLE
PHP 7.3: NewIniDirectives: account for (more) new ini directives

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -479,6 +479,12 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '7.1' => true,
         ),
 
+        // Introduced in PHP 7.1.25, 7.2.13, 7.3.0.
+        'imap.enable_insecure_rsh' => array(
+            '7.1.24' => false,
+            '7.1.25' => true,
+        ),
+
         'syslog.facility' => array(
             '7.2' => false,
             '7.3' => true,

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -331,3 +331,6 @@ $test = ini_get('url_rewriter.hosts');
 
 ini_set('session.cookie_samesite', 1);
 $test = ini_get('session.cookie_samesite');
+
+ini_set('imap.enable_insecure_rsh', 1);
+$test = ini_get('imap.enable_insecure_rsh');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -185,6 +185,8 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('session.trans_sid_tags', '7.1', array(326, 327), '7.0'),
             array('url_rewriter.hosts', '7.1', array(329, 330), '7.0'),
 
+            array('imap.enable_insecure_rsh', '7.2', array(335, 336), '7.1.24', '7.1'),
+
             array('syslog.facility', '7.3', array(311, 312), '7.2'),
             array('syslog.ident', '7.3', array(314, 315), '7.2'),
             array('syslog.filter', '7.3', array(317, 318), '7.2'),


### PR DESCRIPTION
The `imap.enable_insecure_rsh` ini directive was introduced in PHP 7.1.25, 7.2.13, 7.3.0 simultaneously.

Refs:
* http://php.net/manual/en/migration73.incompatible.php#migration73.incompatible.imap