### PR TITLE
QA: add `use` statements for the aliased PHPCS and PHPUnit classes

### DIFF
--- a/PHPCompatibility/AbstractComplexVersionSniff.php
+++ b/PHPCompatibility/AbstractComplexVersionSniff.php
@@ -9,6 +9,8 @@
 
 namespace PHPCompatibility;
 
+use PHP_CodeSniffer_File as File;
+
 /**
  * \PHPCompatibility\AbstractComplexVersionSniff.
  *
@@ -31,7 +33,7 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
      *
      * @return void
      */
-    public function handleFeature(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo)
+    public function handleFeature(File $phpcsFile, $stackPtr, array $itemInfo)
     {
         $itemArray = $this->getItemArray($itemInfo);
         $errorInfo = $this->getErrorInfo($itemArray, $itemInfo);

--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -10,6 +10,8 @@
 namespace PHPCompatibility;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\AbstractFunctionCallParameterSniff.
@@ -83,7 +85,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->bowOutEarly() === true) {
             return;
@@ -97,7 +99,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
             return;
         }
 
-        $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($this->isMethod === true) {
             if ($tokens[$prevNonEmpty]['code'] !== T_DOUBLE_COLON
@@ -154,7 +156,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    abstract public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters);
+    abstract public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters);
 
 
     /**
@@ -170,7 +172,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processNoParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName)
+    public function processNoParameters(File $phpcsFile, $stackPtr, $functionName)
     {
         return;
     }

--- a/PHPCompatibility/AbstractNewFeatureSniff.php
+++ b/PHPCompatibility/AbstractNewFeatureSniff.php
@@ -9,6 +9,8 @@
 
 namespace PHPCompatibility;
 
+use PHP_CodeSniffer_File as File;
+
 /**
  * \PHPCompatibility\AbstractNewFeatureSniff.
  *
@@ -87,7 +89,7 @@ abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
      *
      * @return void
      */
-    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    public function addError(File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
     {
         $itemName = $this->getItemName($itemInfo, $errorInfo);
         $error    = $this->getErrorMsgTemplate();

--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -9,6 +9,8 @@
 
 namespace PHPCompatibility;
 
+use PHP_CodeSniffer_File as File;
+
 /**
  * \PHPCompatibility\AbstractRemovedFeatureSniff.
  *
@@ -109,7 +111,7 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
      *
      * @return void
      */
-    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    public function addError(File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
     {
         $itemName = $this->getItemName($itemInfo, $errorInfo);
         $error    = $this->getErrorMsgTemplate();

--- a/PHPCompatibility/ComplexVersionInterface.php
+++ b/PHPCompatibility/ComplexVersionInterface.php
@@ -9,6 +9,8 @@
 
 namespace PHPCompatibility;
 
+use PHP_CodeSniffer_File as File;
+
 /**
  * \PHPCompatibility\ComplexVersionInterface.
  *
@@ -35,7 +37,7 @@ interface ComplexVersionInterface
      *
      * @return void
      */
-    public function handleFeature(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo);
+    public function handleFeature(File $phpcsFile, $stackPtr, array $itemInfo);
 
 
     /**
@@ -71,5 +73,5 @@ interface ComplexVersionInterface
      *
      * @return void
      */
-    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo);
+    public function addError(File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo);
 }

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -9,6 +9,7 @@
 
 namespace PHPCompatibility;
 
+use PHP_CodeSniffer_Exception as PHPCS_Exception;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
@@ -101,7 +102,7 @@ class PHPCSHelper
      *
      * @return string|null
      */
-    public static function getCommandLineData($phpcsFile, $key)
+    public static function getCommandLineData(File $phpcsFile, $key)
     {
         if (class_exists('\PHP_CodeSniffer\Config')) {
             // PHPCS 3.x.
@@ -218,7 +219,7 @@ class PHPCSHelper
      *
      * @return int
      */
-    public static function findEndOfStatement(\PHP_CodeSniffer_File $phpcsFile, $start, $ignore = null)
+    public static function findEndOfStatement(File $phpcsFile, $start, $ignore = null)
     {
         if (version_compare(self::getVersion(), '3.3.0', '>=') === true) {
             return $phpcsFile->findEndOfStatement($start, $ignore);
@@ -285,7 +286,7 @@ class PHPCSHelper
                 $i = $tokens[$i]['parenthesis_closer'];
             }
 
-            if (isset(\PHP_CodeSniffer_Tokens::$emptyTokens[$tokens[$i]['code']]) === false) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false) {
                 $lastNotEmpty = $i;
             }
         }//end for
@@ -316,7 +317,7 @@ class PHPCSHelper
      *
      * @return string|false
      */
-    public static function findExtendedClassName(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public static function findExtendedClassName(File $phpcsFile, $stackPtr)
     {
         if (version_compare(self::getVersion(), '3.1.0', '>=') === true) {
             return $phpcsFile->findExtendedClassName($stackPtr);
@@ -381,7 +382,7 @@ class PHPCSHelper
      *
      * @return array|false
      */
-    public static function findImplementedInterfaceNames(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public static function findImplementedInterfaceNames(File $phpcsFile, $stackPtr)
     {
         if (version_compare(self::getVersion(), '2.7.1', '>') === true) {
             return $phpcsFile->findImplementedInterfaceNames($stackPtr);
@@ -467,7 +468,7 @@ class PHPCSHelper
      * @throws \PHP_CodeSniffer_Exception If the specified $stackPtr is not of
      *                                    type T_FUNCTION or T_CLOSURE.
      */
-    public static function getMethodParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public static function getMethodParameters(File $phpcsFile, $stackPtr)
     {
         if (version_compare(self::getVersion(), '3.3.0', '>=') === true) {
             return $phpcsFile->getMethodParameters($stackPtr);
@@ -483,7 +484,7 @@ class PHPCSHelper
         if ($tokens[$stackPtr]['code'] !== T_FUNCTION
             && $tokens[$stackPtr]['code'] !== T_CLOSURE
         ) {
-            throw new \PHP_CodeSniffer_Exception('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
+            throw new PHPCS_Exception('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
         }
 
         $opener = $tokens[$stackPtr]['parenthesis_opener'];

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Classes;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Classes\NewAnonymousClasses.
@@ -63,14 +65,14 @@ class NewAnonymousClassesSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.6') === false) {
             return;
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         if ($nextNonEmpty === false || isset($this->indicators[$tokens[$nextNonEmpty]['code']]) === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\Classes;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Classes\NewClassesSniff.
@@ -611,7 +612,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -652,7 +653,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    private function processSingularToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processSingularToken(File $phpcsFile, $stackPtr)
     {
         $tokens      = $phpcsFile->getTokens();
         $FQClassName = '';
@@ -697,7 +698,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    private function processFunctionToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processFunctionToken(File $phpcsFile, $stackPtr)
     {
         // Retrieve typehints stripped of global NS indicator and/or nullable indicator.
         $typeHints = $this->getTypeHintsFromFunctionDeclaration($phpcsFile, $stackPtr);
@@ -731,7 +732,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    private function processCatchToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processCatchToken(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -797,7 +798,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    private function processReturnTypeToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processReturnTypeToken(File $phpcsFile, $stackPtr)
     {
         $returnTypeHint   = $this->getReturnTypeHintName($phpcsFile, $stackPtr);
         $returnTypeHint   = ltrim($returnTypeHint, '\\');

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Classes;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Classes\NewConstVisibility.
@@ -45,17 +47,17 @@ class NewConstVisibilitySniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('7.0') === false) {
             return;
         }
 
         $tokens    = $phpcsFile->getTokens();
-        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
 
         // Is the previous token a visibility indicator ?
-        if ($prevToken === false || isset(\PHP_CodeSniffer_Tokens::$scopeModifiers[$tokens[$prevToken]['code']]) === false) {
+        if ($prevToken === false || isset(Tokens::$scopeModifiers[$tokens[$prevToken]['code']]) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Classes;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Classes\NewLateStaticBindingSniff.
@@ -44,9 +46,9 @@ class NewLateStaticBindingSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
-        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         if ($nextNonEmpty === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\Constants;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Constants\NewConstantsSniff.
@@ -3456,7 +3457,7 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens       = $phpcsFile->getTokens();
         $constantName = $tokens[$stackPtr]['content'];

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Constants;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Constants\NewMagicClassConstantSniff.
@@ -47,7 +49,7 @@ class NewMagicClassConstantSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.4') === false) {
             return;
@@ -59,7 +61,7 @@ class NewMagicClassConstantSniff extends Sniff
             return;
         }
 
-        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
         if ($prevToken === false || $tokens[$prevToken]['code'] !== T_DOUBLE_COLON) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\Constants;
 
 use PHPCompatibility\AbstractRemovedFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Constants\RemovedConstantsSniff.
@@ -314,7 +315,7 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens       = $phpcsFile->getTokens();
         $constantName = $tokens[$stackPtr]['content'];

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\ControlStructures\DiscouragedSwitchContinue.
@@ -71,8 +73,8 @@ class DiscouragedSwitchContinueSniff extends Sniff
      */
     public function register()
     {
-        $this->acceptedLevelTokens += \PHP_CodeSniffer_Tokens::$arithmeticTokens;
-        $this->acceptedLevelTokens += \PHP_CodeSniffer_Tokens::$emptyTokens;
+        $this->acceptedLevelTokens += Tokens::$arithmeticTokens;
+        $this->acceptedLevelTokens += Tokens::$emptyTokens;
 
         return array(\T_SWITCH);
     }
@@ -86,7 +88,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.3') === false) {
             return;
@@ -165,7 +167,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
                         continue 2;
                     }
 
-                    if (isset(\PHP_CodeSniffer_Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                    if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
                         continue;
                     }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ControlStructures\ForbiddenBreakContinueOutsideLoop.
@@ -72,7 +73,7 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $token  = $tokens[$stackPtr];

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -13,6 +13,8 @@
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\ControlStructures\ForbiddenBreakContinueVariableArguments.
@@ -59,7 +61,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.4') === false) {
             return;
@@ -72,7 +74,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
             if ($tokens[$curToken]['type'] === 'T_STRING') {
                 // If the next non-whitespace token after the string
                 // is an opening parenthesis then it's a function call.
-                $openBracket = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $curToken + 1, null, true);
+                $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, $curToken + 1, null, true);
                 if ($tokens[$openBracket]['code'] === T_OPEN_PARENTHESIS) {
                     $errorType = 'variableArgument';
                     break;

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ControlStructures\ForbiddenSwitchWithMultipleDefaultBlocksSniff.
@@ -46,7 +47,7 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -11,6 +11,8 @@ namespace PHPCompatibility\Sniffs\ControlStructures;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\ControlStructures\NewExecutionDirectivesSniff.
@@ -66,7 +68,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        $this->ignoreTokens          = \PHP_CodeSniffer_Tokens::$emptyTokens;
+        $this->ignoreTokens          = Tokens::$emptyTokens;
         $this->ignoreTokens[T_EQUAL] = T_EQUAL;
 
         return array(T_DECLARE);
@@ -82,7 +84,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -229,7 +231,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    public function addError(File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
     {
         if ($errorInfo['not_in_version'] !== '') {
             parent::addError($phpcsFile, $stackPtr, $itemInfo, $errorInfo);
@@ -257,12 +259,12 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    protected function addWarningOnInvalidValue(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $directive)
+    protected function addWarningOnInvalidValue(File $phpcsFile, $stackPtr, $directive)
     {
         $tokens = $phpcsFile->getTokens();
 
         $value = $tokens[$stackPtr]['content'];
-        if (isset(\PHP_CodeSniffer_Tokens::$stringTokens[$tokens[$stackPtr]['code']]) === true) {
+        if (isset(Tokens::$stringTokens[$tokens[$stackPtr]['code']]) === true) {
             $value = $this->stripQuotes($value);
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * New `foreach` Expression Referencing.
@@ -47,7 +48,7 @@ class NewForeachExpressionReferencingSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.4') === false) {
             return;

--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * Detect unpacking nested arrays with list() in a foreach().
@@ -44,7 +45,7 @@ class NewListInForeachSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.4') === false) {
             return;

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ControlStructures\NewMultiCatch.
@@ -45,7 +46,7 @@ class NewMultiCatchSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -11,6 +11,8 @@
 namespace PHPCompatibility\Sniffs\Extensions;
 
 use PHPCompatibility\AbstractRemovedFeatureSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Extensions\RemovedExtensionsSniff.
@@ -194,12 +196,12 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
         // Find the next non-empty token.
-        $openBracket = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
             // Not a function call.
@@ -212,7 +214,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
         }
 
         // Find the previous non-empty token.
-        $search   = \PHP_CodeSniffer_Tokens::$emptyTokens;
+        $search   = Tokens::$emptyTokens;
         $search[] = T_BITWISE_AND;
         $previous = $phpcsFile->findPrevious($search, ($stackPtr - 1), null, true);
         if ($tokens[$previous]['code'] === T_FUNCTION) {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -14,6 +14,7 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenParameterShadowSuperGlobalsSniff
@@ -53,7 +54,7 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.4') === false) {
             return;

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenParametersWithSameName.
@@ -50,7 +51,7 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -13,6 +13,8 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * PHP 7.1 Forbidden variable names in closure use statements.
@@ -48,7 +50,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.1') === false) {
             return;
@@ -57,7 +59,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Verify this use statement is used with a closure - if so, it has to have parenthesis before it.
-        $previousNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $previousNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
         if ($previousNonEmpty === false || $tokens[$previousNonEmpty]['code'] !== T_CLOSE_PARENTHESIS
             || isset($tokens[$previousNonEmpty]['parenthesis_opener']) === false
         ) {
@@ -65,7 +67,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
         }
 
         // ... and (a variable within) parenthesis after it.
-        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
         if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
             return;
         }
@@ -75,7 +77,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
             return;
         }
 
-        $closurePtr = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($tokens[$previousNonEmpty]['parenthesis_opener'] - 1), null, true);
+        $closurePtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($tokens[$previousNonEmpty]['parenthesis_opener'] - 1), null, true);
         if ($closurePtr === false || $tokens[$closurePtr]['code'] !== T_CLOSURE) {
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionDeclarations\NewClosure.
@@ -45,7 +47,7 @@ class NewClosureSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.2')) {
             $phpcsFile->addError(
@@ -165,10 +167,10 @@ class NewClosureSniff extends Sniff
      *
      * @return bool
      */
-    protected function isClosureStatic(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function isClosureStatic(File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
-        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
 
         return ($prevToken !== false && $tokens[$prevToken]['code'] === T_STATIC);
     }
@@ -184,7 +186,7 @@ class NewClosureSniff extends Sniff
      * @return int|false The stackPtr to the first $this usage if found or false if
      *                   $this is not used.
      */
-    protected function findThisUsageInClosure(\PHP_CodeSniffer_File $phpcsFile, $startToken, $endToken)
+    protected function findThisUsageInClosure(File $phpcsFile, $startToken, $endToken)
     {
         // Make sure the $startToken is valid.
         if ($startToken >= $endToken) {
@@ -210,7 +212,7 @@ class NewClosureSniff extends Sniff
      * @return int|false The stackPtr to the first classRef usage if found or false if
      *                   they are not used.
      */
-    protected function findClassRefUsageInClosure(\PHP_CodeSniffer_File $phpcsFile, $startToken, $endToken)
+    protected function findClassRefUsageInClosure(File $phpcsFile, $startToken, $endToken)
     {
         // Make sure the $startToken is valid.
         if ($startToken >= $endToken) {
@@ -225,7 +227,7 @@ class NewClosureSniff extends Sniff
         }
 
         // T_STATIC, make sure it is used as a class reference.
-        $next = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($classRef + 1), $endToken, true);
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($classRef + 1), $endToken, true);
         if ($next === false || $tokens[$next]['code'] !== T_DOUBLE_COLON) {
             return false;
         }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -13,6 +13,8 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionDeclarations\NewNullableTypes.
@@ -60,7 +62,7 @@ class NewNullableTypesSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('7.0') === false) {
             return;
@@ -93,7 +95,7 @@ class NewNullableTypesSniff extends Sniff
      *
      * @return void
      */
-    protected function processFunctionDeclaration(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processFunctionDeclaration(File $phpcsFile, $stackPtr)
     {
         $params = PHPCSHelper::getMethodParameters($phpcsFile, $stackPtr);
 
@@ -121,7 +123,7 @@ class NewNullableTypesSniff extends Sniff
      *
      * @return void
      */
-    protected function processReturnType(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processReturnType(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -129,11 +131,11 @@ class NewNullableTypesSniff extends Sniff
             return;
         }
 
-        $previous = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $previous = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         // Deal with namespaced class names.
         if ($tokens[$previous]['code'] === T_NS_SEPARATOR) {
-            $validTokens                 = \PHP_CodeSniffer_Tokens::$emptyTokens;
+            $validTokens                 = Tokens::$emptyTokens;
             $validTokens[T_STRING]       = true;
             $validTokens[T_NS_SEPARATOR] = true;
 
@@ -143,7 +145,7 @@ class NewNullableTypesSniff extends Sniff
                 $stackPtr--;
             }
 
-            $previous = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $previous = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         }
 
         // T_NULLABLE token was introduced in PHPCS 2.7.2. Before that it identified as T_INLINE_THEN.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -11,6 +11,7 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionDeclarations\NewParamTypeDeclarationsSniff.
@@ -111,7 +112,7 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         // Get all parameters from method signature.
         $paramNames = PHPCSHelper::getMethodParameters($phpcsFile, $stackPtr);

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionDeclarations\NewReturnTypeDeclarationsSniff.
@@ -116,7 +117,7 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -13,6 +13,7 @@
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionDeclarations\NonStaticMagicMethodsSniff.
@@ -105,7 +106,7 @@ class NonStaticMagicMethodsSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         // Should be removed, the requirement was previously also there, 5.3 just started throwing a warning about it.
         if ($this->supportsAbove('5.3') === false) {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionNameRestrictions\NewMagicMethodsSniff.
@@ -95,7 +96,7 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $functionName   = $phpcsFile->getDeclarationName($stackPtr);
         $functionNameLc = strtolower($functionName);

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedMagicAutoloadSniff.
@@ -54,7 +55,7 @@ class RemovedMagicAutoloadSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.2') === false) {
             return;

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * Removed Namespaced Assert.
@@ -65,7 +66,7 @@ class RemovedNamespacedAssertSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.3') === false) {
             return;

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
@@ -48,7 +49,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -9,6 +9,9 @@
 
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
+use Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff as PHPCS_CamelCapsFunctionNameSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Standards_AbstractScopeSniff as PHPCS_AbstractScopeSniff;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
@@ -31,7 +34,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff
+class ReservedFunctionNamesSniff extends PHPCS_CamelCapsFunctionNameSniff
 {
 
     /**
@@ -45,7 +48,7 @@ class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_Camel
         }
 
         // Call the grand-parent constructor directly.
-        \PHP_CodeSniffer_Standards_AbstractScopeSniff::__construct($scopeTokens, array(T_FUNCTION), true);
+        PHPCS_AbstractScopeSniff::__construct($scopeTokens, array(T_FUNCTION), true);
 
         // Make sure debuginfo is included in the array. Upstream only includes it since 2.5.1.
         $this->magicMethods['debuginfo'] = true;
@@ -62,7 +65,7 @@ class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_Camel
      *
      * @return void
      */
-    protected function processTokenWithinScope(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope)
+    protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -117,7 +120,7 @@ class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_Camel
      *
      * @return void
      */
-    protected function processTokenOutsideScope(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processTokenOutsideScope(File $phpcsFile, $stackPtr)
     {
         $functionName = $phpcsFile->getDeclarationName($stackPtr);
         if ($functionName === null) {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionUse\ArgumentFunctionsUsageSniff.
@@ -65,7 +67,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens     = $phpcsFile->getTokens();
         $functionLc = strtolower($tokens[$stackPtr]['content']);
@@ -74,7 +76,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
         }
 
         // Next non-empty token should be the open parenthesis.
-        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
         if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
             return;
         }
@@ -86,7 +88,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
             T_NEW             => true,
         );
 
-        $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
             // Not a call to a PHP function.
             return;
@@ -135,12 +137,12 @@ class ArgumentFunctionsUsageSniff extends Sniff
             $throwError = true;
         } else {
             $opener       = key($tokens[$stackPtr]['nested_parenthesis']);
-            $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($opener - 1), null, true);
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
             if ($tokens[$prevNonEmpty]['code'] !== T_STRING) {
                 return;
             }
 
-            $prevPrevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+            $prevPrevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
             if ($tokens[$prevPrevNonEmpty]['code'] === T_FUNCTION) {
                 return;
             }

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -10,6 +10,8 @@
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionUse\newFunctionParametersSniff.
@@ -942,7 +944,7 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -972,7 +974,7 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         }
 
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        $openParenthesis      = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $openParenthesis      = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $parameterOffsetFound = $parameterCount - 1;
 
         foreach ($this->newFunctionParameters[$functionLc] as $offset => $parameterDetails) {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionUse\newFunctionsSniff.
@@ -1863,7 +1864,7 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\Sniffs\FunctionUse\RequiredToOptionalFunctionParametersSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionUse\OptionalToRequiredFunctionParametersSniff.
@@ -117,7 +118,7 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
      *
      * @return void
      */
-    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    public function addError(File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
     {
         $error = 'The "%s" parameter for function %s() is missing. Passing this parameter is ';
         if ($errorInfo['optionalRecommended'] === '') {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -10,6 +10,8 @@
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractRemovedFeatureSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionParametersSniff.
@@ -87,7 +89,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -117,7 +119,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         }
 
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        $openParenthesis      = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $openParenthesis      = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $parameterOffsetFound = $parameterCount - 1;
 
         foreach ($this->removedFunctionParameters[$functionLc] as $offset => $parameterDetails) {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractRemovedFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionsSniff.
@@ -909,7 +910,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -10,6 +10,8 @@
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractComplexVersionSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\FunctionUse\RequiredToOptionalFunctionParametersSniff.
@@ -155,7 +157,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -180,7 +182,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
         }
 
         $parameterCount  = $this->getFunctionCallParameterCount($phpcsFile, $stackPtr);
-        $openParenthesis = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
 
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
         if ($parameterCount === 0 && $tokens[$openParenthesis]['code'] !== T_OPEN_PARENTHESIS) {
@@ -293,7 +295,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
      *
      * @return void
      */
-    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    public function addError(File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
     {
         $error     = $this->getErrorMsgTemplate();
         $errorCode = $this->stringToErrorCode($itemInfo['name'] . '_' . $errorInfo['paramName']) . 'Missing';

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Generators;
 
 use PHPCompatibility\Sniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Generators\NewGeneratorReturnSniff.
@@ -84,7 +85,7 @@ class NewGeneratorReturnSniff extends Sniff
      *
      * @return void|int Void or a stack pointer to skip forward.
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.6') !== true) {
             return;

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\IniDirectives;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\IniDirectives\NewIniDirectivesSniff.
@@ -522,7 +523,7 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\IniDirectives;
 
 use PHPCompatibility\AbstractRemovedFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\IniDirectives\RemovedIniDirectivesSniff.
@@ -248,7 +249,7 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\InitialValue;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\InitialValue\NewConstantArraysUsingConstSniff.
@@ -46,7 +47,7 @@ class NewConstantArraysUsingConstSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.5') !== true) {
             return;

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\InitialValue;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\InitialValue\NewConstantArraysUsingDefineSniff.
@@ -46,7 +47,7 @@ class NewConstantArraysUsingDefineSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.6') !== true) {
             return;

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -13,6 +13,8 @@ namespace PHPCompatibility\Sniffs\InitialValue;
 
 use PHPCompatibility\Sniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\InitialValue\NewConstantScalarExpressionsSniff.
@@ -111,8 +113,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
      */
     public function setProperties()
     {
-        $this->safeOperands += \PHP_CodeSniffer_Tokens::$heredocTokens;
-        $this->safeOperands += \PHP_CodeSniffer_Tokens::$emptyTokens;
+        $this->safeOperands += Tokens::$heredocTokens;
+        $this->safeOperands += Tokens::$emptyTokens;
     }
 
 
@@ -136,7 +138,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
      *
      * @return void|int Null or integer stack pointer to skip forward.
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->bowOutEarly() === true) {
             return;
@@ -224,14 +226,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
 
                 // Filter out late static binding and class properties.
                 if ($tokens[$stackPtr]['code'] === T_STATIC) {
-                    $next = $phpcsFile->findNext(
-                        \PHP_CodeSniffer_Tokens::$emptyTokens,
-                        ($stackPtr + 1),
-                        null,
-                        true,
-                        null,
-                        true
-                    );
+                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
                     if ($next === false || $tokens[$next]['code'] !== T_VARIABLE) {
                         // Late static binding.
                         return;
@@ -268,7 +263,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                         continue;
                     }
 
-                    $start = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($start + 1), $end, true);
+                    $start = $phpcsFile->findNext(Tokens::$emptyTokens, ($start + 1), $end, true);
                     if ($start === false
                         || ($tokens[$stackPtr]['code'] === T_CONST && $tokens[$start]['code'] !== T_STRING)
                         || ($tokens[$stackPtr]['code'] !== T_CONST && $tokens[$start]['code'] !== T_VARIABLE)
@@ -309,10 +304,10 @@ class NewConstantScalarExpressionsSniff extends Sniff
      *
      * @return bool
      */
-    protected function isValidAssignment(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $end)
+    protected function isValidAssignment(File $phpcsFile, $stackPtr, $end)
     {
         $tokens = $phpcsFile->getTokens();
-        $next   = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), $end, true);
+        $next   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), $end, true);
         if ($next === false || $tokens[$next]['code'] !== T_EQUAL) {
             // No value assigned.
             return true;
@@ -336,7 +331,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
      *
      * @return bool
      */
-    protected function isStaticValue(\PHP_CodeSniffer_File $phpcsFile, $tokens, $start, $end, $nestedArrays = 0)
+    protected function isStaticValue(File $phpcsFile, $tokens, $start, $end, $nestedArrays = 0)
     {
         $nextNonSimple = $phpcsFile->findNext($this->safeOperands, $start, ($end + 1), true);
         if ($nextNonSimple === false) {
@@ -360,12 +355,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
             case T_PARENT:
             case T_SELF:
             case T_DOUBLE_COLON:
-                $nextNonEmpty = $phpcsFile->findNext(
-                    \PHP_CodeSniffer_Tokens::$emptyTokens,
-                    ($nextNonSimple + 1),
-                    ($end + 1),
-                    true
-                );
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonSimple + 1), ($end + 1), true);
 
                 if ($tokens[$nextNonSimple]['code'] === T_NAMESPACE) {
                     // Allow only `namespace\...`.
@@ -385,7 +375,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                         return false;
                     }
 
-                    $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonSimple - 1), null, true);
+                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nextNonSimple - 1), null, true);
                     // No need to worry about parent/self, that's handled above and
                     // the double colon is skipped over in that case.
                     if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== T_STRING) {
@@ -448,12 +438,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                 ) {
                     $closer = $tokens[$nextNonSimple]['bracket_closer'];
                 } else {
-                    $maybeOpener = $phpcsFile->findNext(
-                        \PHP_CodeSniffer_Tokens::$emptyTokens,
-                        ($nextNonSimple + 1),
-                        ($end + 1),
-                        true
-                    );
+                    $maybeOpener = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonSimple + 1), ($end + 1), true);
                     if ($tokens[$maybeOpener]['code'] === T_OPEN_PARENTHESIS) {
                         $opener = $maybeOpener;
                         if (isset($tokens[$opener]['parenthesis_closer']) === true) {
@@ -486,7 +471,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
      *
      * @return void
      */
-    protected function throwError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $type, $content = '')
+    protected function throwError(File $phpcsFile, $stackPtr, $type, $content = '')
     {
         $error     = static::ERROR_PHRASE;
         $phrase    = '';

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\InitialValue;
 
 use PHPCompatibility\Sniffs\InitialValue\NewConstantScalarExpressionsSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\InitialValue\NewHeredocSniff.
@@ -74,10 +76,10 @@ class NewHeredocSniff extends NewConstantScalarExpressionsSniff
      *
      * @return bool True if no heredoc (or assignment) is found, false otherwise.
      */
-    protected function isValidAssignment(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $end)
+    protected function isValidAssignment(File $phpcsFile, $stackPtr, $end)
     {
         $tokens = $phpcsFile->getTokens();
-        $next   = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), $end, true);
+        $next   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), $end, true);
         if ($next === false || $tokens[$next]['code'] !== T_EQUAL) {
             // No value assigned.
             return true;

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -11,6 +11,7 @@ namespace PHPCompatibility\Sniffs\Interfaces;
 
 use PHPCompatibility\Sniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Interfaces\InternalInterfacesSniff.
@@ -65,7 +66,7 @@ class InternalInterfacesSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $interfaces = PHPCSHelper::findImplementedInterfaceNames($phpcsFile, $stackPtr);
 

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -11,6 +11,7 @@ namespace PHPCompatibility\Sniffs\Interfaces;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Interfaces\NewInterfacesSniff.
@@ -148,7 +149,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -193,7 +194,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    private function processClassToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processClassToken(File $phpcsFile, $stackPtr)
     {
         $interfaces = PHPCSHelper::findImplementedInterfaceNames($phpcsFile, $stackPtr);
 
@@ -257,7 +258,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    private function processFunctionToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processFunctionToken(File $phpcsFile, $stackPtr)
     {
         $typeHints = $this->getTypeHintsFromFunctionDeclaration($phpcsFile, $stackPtr);
         if (empty($typeHints) || is_array($typeHints) === false) {
@@ -290,7 +291,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    private function processReturnTypeToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processReturnTypeToken(File $phpcsFile, $stackPtr)
     {
         $returnTypeHint   = $this->getReturnTypeHintName($phpcsFile, $stackPtr);
         $returnTypeHint   = ltrim($returnTypeHint, '\\');

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\Keywords;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Keywords\CaseSensitiveKeywordsSniff.
@@ -51,7 +52,7 @@ class CaseSensitiveKeywordsSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.4') === false) {
             return;

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Keywords;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesAsDeclaredClassSniff.
@@ -117,7 +119,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;
@@ -137,7 +139,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
 
         if (in_array($tokenType, array('T_CLASS', 'T_INTERFACE', 'T_TRAIT'), true)) {
             // Check for the declared name being a name which is not tokenized as T_STRING.
-            $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($nextNonEmpty !== false && isset($this->forbiddenTokens[$tokens[$nextNonEmpty]['code']]) === true) {
                 $name = $tokens[$nextNonEmpty]['content'];
             } else {
@@ -173,7 +175,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
             }
         } elseif ($tokenCode === T_STRING) {
             // Traits which are not yet tokenized as T_TRAIT.
-            $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($nextNonEmpty === false) {
                 return;
             }
@@ -198,7 +200,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
                         break;
                     }
 
-                    $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), $endOfStatement, true);
+                    $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), $endOfStatement, true);
                 } while ($nextNonEmpty !== false);
             }
             unset($nextNonEmptyCode, $nextNonEmptyLc, $endOfStatement);

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -11,6 +11,8 @@
 namespace PHPCompatibility\Sniffs\Keywords;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesAsInvokedFunctionsSniff.
@@ -99,7 +101,7 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens         = $phpcsFile->getTokens();
         $tokenCode      = $tokens[$stackPtr]['code'];
@@ -123,14 +125,14 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
         }
 
         // Make sure this is a function call.
-        $next = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
             // Not a function call.
             return;
         }
 
         // This sniff isn't concerned about function declarations.
-        $prev = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prev !== false && $tokens[$prev]['code'] === T_FUNCTION) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -11,6 +11,8 @@
 namespace PHPCompatibility\Sniffs\Keywords;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesSniff.
@@ -133,7 +135,7 @@ class ForbiddenNamesSniff extends Sniff
      */
     public function register()
     {
-        $this->allowedModifiers          = \PHP_CodeSniffer_Tokens::$scopeModifiers;
+        $this->allowedModifiers          = Tokens::$scopeModifiers;
         $this->allowedModifiers[T_FINAL] = T_FINAL;
 
         $tokens = $this->targetedTokens;
@@ -154,7 +156,7 @@ class ForbiddenNamesSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -179,9 +181,9 @@ class ForbiddenNamesSniff extends Sniff
      *
      * @return void
      */
-    public function processNonString(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
+    public function processNonString(File $phpcsFile, $stackPtr, $tokens)
     {
-        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             return;
         }
@@ -192,7 +194,7 @@ class ForbiddenNamesSniff extends Sniff
          * In PHPCS < 2.3.4 these were tokenized as T_CLASS no matter what.
          */
         if ($tokens[$stackPtr]['type'] === 'T_ANON_CLASS' || $tokens[$stackPtr]['type'] === 'T_CLASS') {
-            $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
             if ($prevNonEmpty !== false && $tokens[$prevNonEmpty]['type'] === 'T_NEW') {
                 return;
             }
@@ -206,7 +208,7 @@ class ForbiddenNamesSniff extends Sniff
         elseif ($tokens[$stackPtr]['type'] === 'T_USE'
             && isset($this->validUseNames[strtolower($tokens[$nextNonEmpty]['content'])]) === true
         ) {
-            $maybeUseNext = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
+            $maybeUseNext = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext !== false && $this->isEndOfUseStatement($tokens[$maybeUseNext]) === false) {
                 $nextNonEmpty = $maybeUseNext;
             }
@@ -221,7 +223,7 @@ class ForbiddenNamesSniff extends Sniff
             && isset($this->allowedModifiers[$tokens[$nextNonEmpty]['code']]) === true
             && $phpcsFile->hasCondition($stackPtr, T_USE) === true
         ) {
-            $maybeUseNext = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
+            $maybeUseNext = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext === false || $this->isEndOfUseStatement($tokens[$maybeUseNext]) === true) {
                 return;
             }
@@ -235,7 +237,7 @@ class ForbiddenNamesSniff extends Sniff
         elseif ($tokens[$stackPtr]['type'] === 'T_FUNCTION'
             && $tokens[$nextNonEmpty]['type'] === 'T_BITWISE_AND'
         ) {
-            $maybeUseNext = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
+            $maybeUseNext = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext === false) {
                 // Live coding.
                 return;
@@ -317,7 +319,7 @@ class ForbiddenNamesSniff extends Sniff
      *
      * @return void
      */
-    public function processString(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
+    public function processString(File $phpcsFile, $stackPtr, $tokens)
     {
         $tokenContentLc = strtolower($tokens[$stackPtr]['content']);
 
@@ -366,7 +368,7 @@ class ForbiddenNamesSniff extends Sniff
      *
      * @return void
      */
-    protected function addError($phpcsFile, $stackPtr, $content, $data)
+    protected function addError(File $phpcsFile, $stackPtr, $content, $data)
     {
         $error     = "Function name, class name, namespace name or constant name can not be reserved keyword '%s' (since version %s)";
         $errorCode = $this->stringToErrorCode($content) . 'Found';

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -11,6 +11,8 @@
 namespace PHPCompatibility\Sniffs\Keywords;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Keywords\NewKeywordsSniff.
@@ -192,7 +194,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
         $tokenType = $tokens[$stackPtr]['type'];
@@ -245,8 +247,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
             return;
         }
 
-        $nextToken = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), null, true);
-        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($prevToken !== false
             && ($tokens[$prevToken]['code'] === T_DOUBLE_COLON
@@ -356,7 +358,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
      *
      * @return bool
      */
-    public function isNotQuoted(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function isNotQuoted(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         return ($tokens[$stackPtr]['content'][3] !== '"');

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\LanguageConstructs;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\LanguageConstructs\NewEmptyNonVariableSniff.
@@ -46,7 +48,7 @@ class NewEmptyNonVariableSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.4') === false) {
             return;
@@ -54,7 +56,7 @@ class NewEmptyNonVariableSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $open = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $open = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
         if ($open === false
             || $tokens[$open]['code'] !== T_OPEN_PARENTHESIS
             || isset($tokens[$open]['parenthesis_closer']) === false

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\LanguageConstructs;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\LanguageConstructs\NewLanguageConstructsSniff.
@@ -69,7 +70,7 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
         $tokenType = $tokens[$stackPtr]['type'];

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Lists;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * List assignment order.
@@ -53,7 +55,7 @@ class AssignmentOrderSniff extends Sniff
      *                  examined, the stack pointer to the list closer to skip
      *                  passed any nested lists which don't need to be examined again.
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;
@@ -69,7 +71,7 @@ class AssignmentOrderSniff extends Sniff
         }
 
         if ($tokens[$stackPtr]['code'] === T_LIST) {
-            $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($nextNonEmpty === false
                 || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS
                 || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
@@ -147,7 +149,7 @@ class AssignmentOrderSniff extends Sniff
             $varContent = '';
 
             for ($i = $nextStartPoint; $i < $nextStopPoint; $i++) {
-                if (isset(\PHP_CodeSniffer_Tokens::$emptyTokens[$tokens[$i]['code']])) {
+                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
                     continue;
                 }
 

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Lists;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Lists\ForbiddenEmptyListAssignmentSniff.
@@ -43,7 +45,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
     {
         // Set up a list of tokens to disregard when determining whether the list() is empty.
         // Only needs to be set up once.
-        $this->ignoreTokens                      = \PHP_CodeSniffer_Tokens::$emptyTokens;
+        $this->ignoreTokens                      = Tokens::$emptyTokens;
         $this->ignoreTokens[T_COMMA]             = T_COMMA;
         $this->ignoreTokens[T_OPEN_PARENTHESIS]  = T_OPEN_PARENTHESIS;
         $this->ignoreTokens[T_CLOSE_PARENTHESIS] = T_CLOSE_PARENTHESIS;
@@ -63,7 +65,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Lists;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Lists\NewKeyedListSniff.
@@ -97,7 +99,7 @@ class NewKeyedListSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->bowOutEarly() === true) {
             return;
@@ -113,7 +115,7 @@ class NewKeyedListSniff extends Sniff
         }
 
         if ($tokens[$stackPtr]['code'] === T_LIST) {
-            $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($nextNonEmpty === false
                 || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS
                 || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
@@ -150,7 +152,7 @@ class NewKeyedListSniff extends Sniff
      *
      * @return void
      */
-    protected function examineList(\PHP_CodeSniffer_File $phpcsFile, $opener, $closer)
+    protected function examineList(File $phpcsFile, $opener, $closer)
     {
         $start = $opener;
         while (($start = $this->hasTargetInList($phpcsFile, $start, $closer)) !== false) {
@@ -175,7 +177,7 @@ class NewKeyedListSniff extends Sniff
      *
      * @return int|bool Stack pointer to the target token if encountered. False otherwise.
      */
-    protected function hasTargetInList(\PHP_CodeSniffer_File $phpcsFile, $start, $closer)
+    protected function hasTargetInList(File $phpcsFile, $start, $closer)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -190,7 +192,7 @@ class NewKeyedListSniff extends Sniff
 
             // Skip past nested list constructs.
             if ($tokens[$i]['code'] === T_LIST) {
-                $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($i + 1), null, true);
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
                 if ($nextNonEmpty !== false
                     && $tokens[$nextNonEmpty]['code'] === T_OPEN_PARENTHESIS
                     && isset($tokens[$nextNonEmpty]['parenthesis_closer']) === true

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\Lists;
 
 use PHPCompatibility\Sniffs\Lists\NewKeyedListSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * Detect reference assignments in array destructuring using (short) list.
@@ -52,7 +53,7 @@ class NewListReferenceAssignmentSniff extends NewKeyedListSniff
      *
      * @return void
      */
-    protected function examineList(\PHP_CodeSniffer_File $phpcsFile, $opener, $closer)
+    protected function examineList(File $phpcsFile, $opener, $closer)
     {
         $start   = $opener;
         while (($start = $this->hasTargetInList($phpcsFile, $start, $closer)) !== false) {

--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\Lists;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Lists\NewShortListSniff.
@@ -48,7 +49,7 @@ class NewShortListSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\Miscellaneous;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Miscellaneous\RemovedAlternativePHPTags.
@@ -66,7 +67,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\Miscellaneous;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Miscellaneous\ValidIntegersSniff.
@@ -53,7 +54,7 @@ class ValidIntegersSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $token  = $tokens[$stackPtr];
@@ -164,7 +165,7 @@ class ValidIntegersSniff extends Sniff
      *
      * @return string
      */
-    private function getBinaryInteger(\PHP_CodeSniffer_File $phpcsFile, $tokens, $stackPtr)
+    private function getBinaryInteger(File $phpcsFile, $tokens, $stackPtr)
     {
         $length = 2; // PHP < 5.4 T_LNUMBER + T_STRING.
 

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -13,6 +13,8 @@ namespace PHPCompatibility\Sniffs\Operators;
 
 use PHPCompatibility\Sniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Operators\ForbiddenNegativeBitshift.
@@ -67,7 +69,7 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;
@@ -77,7 +79,7 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
 
         // Determine the start and end of the part of the statement we need to examine.
         $start = ($stackPtr + 1);
-        $next  = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $start, null, true);
+        $next  = $phpcsFile->findNext(Tokens::$emptyTokens, $start, null, true);
         if ($next !== false && $tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
             $start = ($next + 1);
         }

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\Operators;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Operators\NewOperatorsSniff.
@@ -147,7 +148,7 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
         $tokenType = $tokens[$stackPtr]['type'];

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -13,6 +13,8 @@
 namespace PHPCompatibility\Sniffs\Operators;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Operators\NewShortTernarySniff.
@@ -49,7 +51,7 @@ class NewShortTernarySniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.2') === false) {
             return;
@@ -59,7 +61,7 @@ class NewShortTernarySniff extends Sniff
 
         // Get next non-whitespace token, and check it isn't the related inline else
         // symbol, which is not allowed prior to PHP 5.3.
-        $next = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         if ($next !== false && $tokens[$next]['code'] === T_INLINE_ELSE) {
             $phpcsFile->addError(

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\ForbiddenGetClassNullSniff.
@@ -60,7 +61,7 @@ class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         if (isset($parameters[1]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\NewArrayReduceInitialTypeSniff.
@@ -70,7 +71,7 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         if (isset($parameters[3]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\NewFopenModesSniff.
@@ -57,7 +58,7 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         if (isset($parameters[2]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\NewHashAlgorithmsSniff.
@@ -121,7 +122,7 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $algo = $this->getHashAlgorithmParameter($phpcsFile, $stackPtr);
         if (empty($algo) || is_string($algo) === false) {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\NewNegativeStringOffsetSniff.
@@ -96,7 +97,7 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         $functionLC = strtolower($functionName);
         foreach ($this->targetFunctions[$functionLC] as $pos => $name) {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\Sniffs\ParameterValues\RemovedPCREModifiersSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\NewPCREModifiers.
@@ -80,7 +81,7 @@ class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
      *
      * @return void
      */
-    protected function examineModifiers(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $modifiers)
+    protected function examineModifiers(File $phpcsFile, $stackPtr, $functionName, $modifiers)
     {
         $error = 'The PCRE regex modifier "%s" is not present in PHP version %s or earlier';
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\NewPackFormatSniff.
@@ -75,7 +76,7 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         if (isset($parameters[1]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -13,6 +13,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractRemovedFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\RemovedHashAlgorithmsSniff.
@@ -66,7 +67,7 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $algo = $this->getHashAlgorithmParameter($phpcsFile, $stackPtr);
         if (empty($algo) || is_string($algo) === false) {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\RemovedIconvEncodingSniff.
@@ -63,7 +64,7 @@ class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         if (isset($parameters[1]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\RemovedMbstringModifiersSniff.
@@ -67,7 +69,7 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         $tokens         = $phpcsFile->getTokens();
         $functionNameLc = strtolower($functionName);
@@ -79,7 +81,7 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
 
         $optionsParam = $parameters[$this->targetFunctions[$functionNameLc]];
 
-        $stringToken = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$stringTokens, $optionsParam['start'], $optionsParam['end'] + 1);
+        $stringToken = $phpcsFile->findNext(Tokens::$stringTokens, $optionsParam['start'], $optionsParam['end'] + 1);
         if ($stringToken === false) {
             // No string token found in the options parameter, so skip it (e.g. variable passed in).
             return;
@@ -91,7 +93,7 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
          * Get the content of any string tokens in the options parameter and remove the quotes and variables.
          */
         for ($i = $stringToken; $i <= $optionsParam['end']; $i++) {
-            if (isset(\PHP_CodeSniffer_Tokens::$stringTokens[$tokens[$i]['code']]) === false) {
+            if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\RemovedNonCryptoHashSniff.
@@ -79,7 +80,7 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         if (isset($parameters[1]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -13,6 +13,8 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\RemovedPCREModifiersSniff.
@@ -64,7 +66,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         // Check the first parameter in the function call as that should contain the regex(es).
         if (isset($parameters[1]) === false) {
@@ -76,7 +78,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
         $firstParam     = $parameters[1];
 
         // Differentiate between an array of patterns passed and a single pattern.
-        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $firstParam['start'], ($firstParam['end'] + 1), true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $firstParam['start'], ($firstParam['end'] + 1), true);
         if ($nextNonEmpty !== false && ($tokens[$nextNonEmpty]['code'] === T_ARRAY || $tokens[$nextNonEmpty]['code'] === T_OPEN_SHORT_ARRAY)) {
             $arrayValues = $this->getFunctionCallParameters($phpcsFile, $nextNonEmpty);
             if ($functionNameLc === 'preg_replace_callback_array') {
@@ -135,7 +137,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
      *
      * @return void
      */
-    protected function processRegexPattern($pattern, \PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName)
+    protected function processRegexPattern($pattern, File $phpcsFile, $stackPtr, $functionName)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -145,7 +147,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
          */
         $regex = '';
         for ($i = $pattern['start']; $i <= $pattern['end']; $i++) {
-            if (isset(\PHP_CodeSniffer_Tokens::$stringTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === true) {
                 $content = $this->stripQuotes($tokens[$i]['content']);
                 if ($tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
                     $content = $this->stripVariables($content);
@@ -197,7 +199,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
      *
      * @return void
      */
-    protected function examineModifiers(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $modifiers)
+    protected function examineModifiers(File $phpcsFile, $stackPtr, $functionName, $modifiers)
     {
         if (strpos($modifiers, 'e') !== false) {
             $error     = '%s() - /e modifier is deprecated since PHP 5.5';

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -13,6 +13,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\ParameterValues\RemovedSetlocaleStringSniff.
@@ -62,7 +63,7 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
      * @return int|void Integer stack pointer to skip forward or void to continue
      *                  normal file processing.
      */
-    public function processParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $parameters)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         if (isset($parameters[1]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -14,6 +14,8 @@
 namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Syntax\ForbiddenCallTimePassByReference.
@@ -89,7 +91,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.3') === false) {
             return;
@@ -101,7 +103,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
         // within their definitions. For example: function myFunction...
         // "myFunction" is T_STRING but we should skip because it is not a
         // function or method *call*.
-        $findTokens   = \PHP_CodeSniffer_Tokens::$emptyTokens;
+        $findTokens   = Tokens::$emptyTokens;
         $findTokens[] = T_BITWISE_AND;
 
         $prevNonEmpty = $phpcsFile->findPrevious(
@@ -117,12 +119,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
         // If the next non-whitespace token after the function or method call
         // is not an opening parenthesis then it can't really be a *call*.
-        $openBracket = $phpcsFile->findNext(
-            \PHP_CodeSniffer_Tokens::$emptyTokens,
-            ($stackPtr + 1),
-            null,
-            true
-        );
+        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         if ($openBracket === false || $tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS
             || isset($tokens[$openBracket]['parenthesis_closer']) === false
@@ -171,7 +168,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
      *
      * @return bool
      */
-    protected function isCallTimePassByReferenceParam(\PHP_CodeSniffer_File $phpcsFile, $parameter, $nestingLevel)
+    protected function isCallTimePassByReferenceParam(File $phpcsFile, $parameter, $nestingLevel)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -216,7 +213,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
             // Checking this: $value = my_function(...[*]$arg...).
             $tokenBefore = $phpcsFile->findPrevious(
-                \PHP_CodeSniffer_Tokens::$emptyTokens,
+                Tokens::$emptyTokens,
                 ($nextVariable - 1),
                 $searchStartToken,
                 true
@@ -233,7 +230,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
             // Checking this: $value = my_function(...[*]&$arg...).
             $tokenBefore = $phpcsFile->findPrevious(
-                \PHP_CodeSniffer_Tokens::$emptyTokens,
+                Tokens::$emptyTokens,
                 ($tokenBefore - 1),
                 $searchStartToken,
                 true

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Syntax\NewArrayStringDereferencingSniff.
@@ -49,7 +51,7 @@ class NewArrayStringDereferencingSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.4') === false) {
             return;
@@ -89,7 +91,7 @@ class NewArrayStringDereferencingSniff extends Sniff
             return;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true, null, true);
 
         if ($nextNonEmpty !== false
             && ($tokens[$nextNonEmpty]['type'] === 'T_OPEN_SQUARE_BRACKET'

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -13,6 +13,8 @@
 namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff.
@@ -52,7 +54,7 @@ class NewClassMemberAccessSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -75,23 +77,13 @@ class NewClassMemberAccessSniff extends Sniff
             return;
         }
 
-        $prevBeforeParenthesis = $phpcsFile->findPrevious(
-            \PHP_CodeSniffer_Tokens::$emptyTokens,
-            ($parenthesisOpener - 1),
-            null,
-            true
-        );
+        $prevBeforeParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($parenthesisOpener - 1), null, true);
         if ($prevBeforeParenthesis !== false && $tokens[$prevBeforeParenthesis]['code'] === T_STRING) {
             // This is most likely a function call with the new/cloned object as a parameter.
             return;
         }
 
-        $nextAfterParenthesis = $phpcsFile->findNext(
-            \PHP_CodeSniffer_Tokens::$emptyTokens,
-            ($parenthesisCloser + 1),
-            null,
-            true
-        );
+        $nextAfterParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, ($parenthesisCloser + 1), null, true);
         if ($nextAfterParenthesis === false) {
             // Live coding.
             return;

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
@@ -50,7 +51,7 @@ class NewDynamicAccessToStaticSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.2') === false) {
             return;

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
 
 /**
  * New Flexible Heredoc Nowdoc.
@@ -62,7 +63,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         /*
          * Due to a tokenizer bug which gets hit when the PHP 7.3 heredoc/nowdoc syntax
@@ -89,7 +90,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
      *
      * @return void
      */
-    protected function detectIndentedNonStandAloneClosingMarker(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function detectIndentedNonStandAloneClosingMarker(File $phpcsFile, $stackPtr)
     {
         $tokens            = $phpcsFile->getTokens();
         $indentError       = 'Heredoc/nowdoc with an indented closing marker is not supported in PHP 7.2 or earlier.';
@@ -176,7 +177,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
      *
      * @return void
      */
-    protected function detectClosingMarkerInBody(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function detectClosingMarkerInBody(File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
         $error     = 'The body of a heredoc/nowdoc can not contain the heredoc/nowdoc closing marker as text at the start of a line since PHP 7.3.';

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff.
@@ -43,7 +45,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.3') === false) {
             return;
@@ -52,7 +54,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Next non-empty token should be the open parenthesis.
-        $openParenthesis = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
         if ($openParenthesis === false || $tokens[$openParenthesis]['code'] !== T_OPEN_PARENTHESIS) {
             return;
         }
@@ -63,7 +65,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
         }
 
         // Is this T_STRING really a function or method call ?
-        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevToken !== false && in_array($tokens[$prevToken]['code'], array(T_DOUBLE_COLON, T_OBJECT_OPERATOR), true) === false) {
             $ignore = array(
                 T_FUNCTION  => true,
@@ -81,7 +83,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
         }
 
         $closeParenthesis = $tokens[$openParenthesis]['parenthesis_closer'];
-        $nextNonEmpty     = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($closeParenthesis + 1), null, true, null, true);
+        $nextNonEmpty     = $phpcsFile->findNext(Tokens::$emptyTokens, ($closeParenthesis + 1), null, true, null, true);
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['type'] === 'T_OPEN_SQUARE_BRACKET') {
             $phpcsFile->addError(
                 'Function array dereferencing is not present in PHP version 5.3 or earlier',

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Syntax\NewFunctionCallTrailingCommaSniff.
@@ -49,7 +51,7 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('7.2') === false) {
             return;
@@ -57,7 +59,7 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS
             || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
         ) {
@@ -71,7 +73,7 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
                 T_USE             => true,
             );
 
-            $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
             if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
                 // Not a function call.
                 return;
@@ -79,12 +81,7 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
         }
 
         $closer            = $tokens[$nextNonEmpty]['parenthesis_closer'];
-        $lastInParenthesis = $phpcsFile->findPrevious(
-            \PHP_CodeSniffer_Tokens::$emptyTokens,
-            ($closer - 1),
-            $nextNonEmpty,
-            true
-        );
+        $lastInParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), $nextNonEmpty, true);
 
         if ($tokens[$lastInParenthesis]['code'] !== T_COMMA) {
             return;

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Syntax\NewShortArray.
@@ -50,7 +51,7 @@ class NewShortArraySniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.3') === false) {
             return;

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -13,6 +13,8 @@
 namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Syntax\RemovedNewReferenceSniff.
@@ -48,14 +50,14 @@ class RemovedNewReferenceSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.3') === false) {
             return;
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['type'] !== 'T_BITWISE_AND') {
             return;
         }

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -11,6 +11,7 @@ namespace PHPCompatibility\Sniffs\TypeCasts;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\TypeCasts\NewTypeCastsSniff.
@@ -85,7 +86,7 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
         $tokenType = $tokens[$stackPtr]['type'];

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\TypeCasts;
 
 use PHPCompatibility\AbstractRemovedFeatureSniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\TypeCasts\RemovedTypeCastsSniff.
@@ -62,7 +63,7 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
         $tokenType = $tokens[$stackPtr]['type'];

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -11,6 +11,7 @@ namespace PHPCompatibility\Sniffs\Upgrade;
 
 use PHPCompatibility\Sniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
 
 /**
  * \PHPCompatibility\Sniffs\Upgrade\LowPHPCSSniff.
@@ -84,7 +85,7 @@ class LowPHPCSSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         // Don't do anything if the warning has already been thrown or is not necessary.
         if ($this->examine === false) {

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\UseDeclarations;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\UseDeclarations\NewGroupUseDeclarationsSniff.
@@ -48,7 +50,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('7.1') === false) {
             return;
@@ -64,7 +66,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
                 return;
             }
 
-            $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($hasCurlyBrace - 1), null, true);
+            $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($hasCurlyBrace - 1), null, true);
             if ($prevToken === false || $tokens[$prevToken]['code'] !== T_NS_SEPARATOR) {
                 return;
             }
@@ -91,7 +93,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
             return;
         }
 
-        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($closeCurly - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closeCurly - 1), null, true);
         if ($tokens[$prevToken]['code'] === T_COMMA) {
             $phpcsFile->addError(
                 'Trailing comma\'s are not allowed in group use statements in PHP 7.1 or earlier',

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\UseDeclarations;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\UseDeclarations\NewUseConstFunctionSniff.
@@ -59,7 +61,7 @@ class NewUseConstFunctionSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.5') !== true) {
             return;
@@ -67,7 +69,7 @@ class NewUseConstFunctionSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             // Live coding.
             return;
@@ -79,7 +81,7 @@ class NewUseConstFunctionSniff extends Sniff
         }
 
         // `use const` and `use function` have to be followed by the function/constant name.
-        $functionOrConstName = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
+        $functionOrConstName = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
         if ($functionOrConstName === false
             // Identifies as T_AS or T_STRING, this covers both.
             || ($tokens[$functionOrConstName]['content'] === 'as'

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Variables;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Variables\ForbiddenGlobalVariableVariableSniff.
@@ -46,7 +48,7 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;
@@ -69,11 +71,11 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
 
             if ($variable !== false) {
 
-                $prev = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($variable - 1), $ptr, true);
+                $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($variable - 1), $ptr, true);
 
                 if ($prev !== false && $tokens[$prev]['type'] === 'T_DOLLAR') {
 
-                    $next = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($variable + 1), $varEnd, true);
+                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($variable + 1), $varEnd, true);
 
                     if ($next !== false
                         && in_array($tokens[$next]['code'], array(T_OPEN_SQUARE_BRACKET, T_OBJECT_OPERATOR, T_DOUBLE_COLON), true) === true
@@ -100,7 +102,7 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
             if ($errorThrown === false) {
                 $dollar = $phpcsFile->findNext(T_DOLLAR, $ptr, $varEnd);
                 if ($dollar !== false) {
-                    $next = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($dollar + 1), $varEnd, true);
+                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($dollar + 1), $varEnd, true);
                     if ($tokens[$next]['code'] === T_OPEN_CURLY_BRACKET) {
                         $phpcsFile->addWarning(
                             'Global with anything other than bare variables is discouraged since PHP 7.0. Found %s',

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -12,6 +12,8 @@
 namespace PHPCompatibility\Sniffs\Variables;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Variables\NewUniformVariableSyntax.
@@ -45,7 +47,7 @@ class NewUniformVariableSyntaxSniff extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;
@@ -54,14 +56,14 @@ class NewUniformVariableSyntaxSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Verify that the next token is a square open bracket. If not, bow out.
-        $nextToken = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
 
         if ($nextToken === false || $tokens[$nextToken]['code'] !== T_OPEN_SQUARE_BRACKET || isset($tokens[$nextToken]['bracket_closer']) === false) {
             return;
         }
 
         // The previous non-empty token has to be a $, -> or ::.
-        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
         if ($prevToken === false || in_array($tokens[$prevToken]['code'], array(T_DOLLAR, T_OBJECT_OPERATOR, T_DOUBLE_COLON), true) === false) {
             return;
         }
@@ -69,7 +71,7 @@ class NewUniformVariableSyntaxSniff extends Sniff
         // For static object calls, it only applies when this is a function call.
         if ($tokens[$prevToken]['code'] === T_DOUBLE_COLON) {
             $hasBrackets = $tokens[$nextToken]['bracket_closer'];
-            while (($hasBrackets = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($hasBrackets + 1), null, true, null, true)) !== false) {
+            while (($hasBrackets = $phpcsFile->findNext(Tokens::$emptyTokens, ($hasBrackets + 1), null, true, null, true)) !== false) {
                 if ($tokens[$hasBrackets]['code'] === T_OPEN_SQUARE_BRACKET) {
                     if (isset($tokens[$hasBrackets]['bracket_closer'])) {
                         $hasBrackets = $tokens[$hasBrackets]['bracket_closer'];
@@ -90,7 +92,7 @@ class NewUniformVariableSyntaxSniff extends Sniff
             }
 
             // Now let's also prevent false positives when used with self and static which still work fine.
-            $classToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($prevToken - 1), null, true, null, true);
+            $classToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true, null, true);
             if ($classToken !== false) {
                 if ($tokens[$classToken]['code'] === T_STATIC || $tokens[$classToken]['code'] === T_SELF) {
                     return;

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -11,6 +11,8 @@ namespace PHPCompatibility\Sniffs\Variables;
 
 use PHPCompatibility\AbstractRemovedFeatureSniff;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Variables\RemovedPredefinedGlobalVariablesSniff.
@@ -102,7 +104,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.3') === false) {
             return;
@@ -122,7 +124,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
         // Check for static usage of class properties shadowing the removed global variables.
         if ($this->inClassScope($phpcsFile, $stackPtr, false) === true) {
-            $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+            $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
             if ($prevToken !== false && $tokens[$prevToken]['code'] === T_DOUBLE_COLON) {
                 return;
             }
@@ -194,7 +196,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
      *
      * @return bool
      */
-    private function isTargetPHPErrormsgVar(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $tokens)
+    private function isTargetPHPErrormsgVar(File $phpcsFile, $stackPtr, array $tokens)
     {
         $scopeStart = 0;
 
@@ -225,12 +227,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
         /*
          * Now, let's do some additional checks.
          */
-        $nextNonEmpty = $phpcsFile->findNext(
-            \PHP_CodeSniffer_Tokens::$emptyTokens,
-            ($stackPtr + 1),
-            null,
-            true
-        );
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         // Is the variable being used as an array ?
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === T_OPEN_SQUARE_BRACKET) {
@@ -241,7 +238,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
         // Is this a variable assignment ?
         if ($nextNonEmpty !== false
-            && isset(\PHP_CodeSniffer_Tokens::$assignmentTokens[$tokens[$nextNonEmpty]['code']]) === true
+            && isset(Tokens::$assignmentTokens[$tokens[$nextNonEmpty]['code']]) === true
         ) {
             return false;
         }
@@ -282,15 +279,10 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
                 continue;
             }
 
-            $nextNonEmpty = $phpcsFile->findNext(
-                \PHP_CodeSniffer_Tokens::$emptyTokens,
-                ($i + 1),
-                null,
-                true
-            );
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
 
             if ($nextNonEmpty !== false
-                && isset(\PHP_CodeSniffer_Tokens::$assignmentTokens[$tokens[$nextNonEmpty]['code']]) === true
+                && isset(Tokens::$assignmentTokens[$tokens[$nextNonEmpty]['code']]) === true
             ) {
                 return false;
             }

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -7,7 +7,9 @@
 
 namespace PHPCompatibility\Tests;
 
+use PHPUnit_Framework_TestCase as PHPUnit_TestCase;
 use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
 
 /**
  * BaseSniffTest
@@ -19,7 +21,7 @@ use PHPCompatibility\PHPCSHelper;
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */
-class BaseSniffTest extends \PHPUnit_Framework_TestCase
+class BaseSniffTest extends PHPUnit_TestCase
 {
     const STANDARD_NAME = 'PHPCompatibility';
 
@@ -173,7 +175,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
      *
      * @return bool
      */
-    public function assertError(\PHP_CodeSniffer_File $file, $lineNumber, $expectedMessage)
+    public function assertError(File $file, $lineNumber, $expectedMessage)
     {
         $errors = $this->gatherErrors($file);
 
@@ -189,7 +191,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
      *
      * @return bool
      */
-    public function assertWarning(\PHP_CodeSniffer_File $file, $lineNumber, $expectedMessage)
+    public function assertWarning(File $file, $lineNumber, $expectedMessage)
     {
         $warnings = $this->gatherWarnings($file);
 
@@ -235,7 +237,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
      *
      * @return bool
      */
-    public function assertNoViolation(\PHP_CodeSniffer_File $file, $lineNumber = 0)
+    public function assertNoViolation(File $file, $lineNumber = 0)
     {
         $errors   = $this->gatherErrors($file);
         $warnings = $this->gatherWarnings($file);
@@ -279,7 +281,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public function showViolations(\PHP_CodeSniffer_File $file)
+    public function showViolations(File $file)
     {
         $violations = array(
             'errors'   => $this->gatherErrors($file),
@@ -296,7 +298,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public function gatherErrors(\PHP_CodeSniffer_File $file)
+    public function gatherErrors(File $file)
     {
         $foundErrors = $file->getErrors();
 
@@ -310,7 +312,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public function gatherWarnings(\PHP_CodeSniffer_File $file)
+    public function gatherWarnings(File $file)
     {
         $foundWarnings = $file->getWarnings();
 

--- a/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
@@ -7,6 +7,7 @@
 
 namespace PHPCompatibility\Util\Tests\Core;
 
+use PHPUnit_Framework_TestCase as PHPUnit_TestCase;
 use PHPCompatibility\PHPCSHelper;
 use PHPCompatibility\Util\Tests\TestHelperPHPCompatibility;
 
@@ -20,7 +21,7 @@ use PHPCompatibility\Util\Tests\TestHelperPHPCompatibility;
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class FunctionsUnitTest extends \PHPUnit_Framework_TestCase
+class FunctionsUnitTest extends PHPUnit_TestCase
 {
 
     /**

--- a/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
+++ b/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
@@ -7,8 +7,10 @@
 
 namespace PHPCompatibility\Util\Tests;
 
+use PHPUnit_Framework_TestCase as PHPUnit_TestCase;
 use PHPCompatibility\PHPCSHelper;
 use PHPCompatibility\Util\Tests\TestHelperPHPCompatibility;
+use PHP_CodeSniffer_File as File;
 
 /**
  * Set up and Tear down methods for testing methods in the Sniff.php file.
@@ -17,7 +19,7 @@ use PHPCompatibility\Util\Tests\TestHelperPHPCompatibility;
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class CoreMethodTestFrame extends \PHPUnit_Framework_TestCase
+abstract class CoreMethodTestFrame extends PHPUnit_TestCase
 {
 
     /**
@@ -66,7 +68,7 @@ abstract class CoreMethodTestFrame extends \PHPUnit_Framework_TestCase
         } else {
             // PHPCS 2.x.
             $phpcs           = new \PHP_CodeSniffer();
-            $this->phpcsFile = new \PHP_CodeSniffer_File(
+            $this->phpcsFile = new File(
                 $filename,
                 array(),
                 array(),

--- a/PHPCompatibility/Util/Tests/TestHelperPHPCompatibility.php
+++ b/PHPCompatibility/Util/Tests/TestHelperPHPCompatibility.php
@@ -8,6 +8,7 @@
 namespace PHPCompatibility\Util\Tests;
 
 use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
 
 /**
  * Helper class to facilitate testing of the methods within the abstract \PHPCompatibility\Sniff class.
@@ -36,7 +37,7 @@ class TestHelperPHPCompatibility extends Sniff
      *
      * @return void
      */
-    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
     }
 
@@ -52,7 +53,7 @@ class TestHelperPHPCompatibility extends Sniff
      *
      * @return int|float|bool
      */
-    public function isNumber(\PHP_CodeSniffer_File $phpcsFile, $start, $end, $allowFloats = false)
+    public function isNumber(File $phpcsFile, $start, $end, $allowFloats = false)
     {
         return parent::isNumber($phpcsFile, $start, $end, $allowFloats);
     }
@@ -68,7 +69,7 @@ class TestHelperPHPCompatibility extends Sniff
      *
      * @return bool
      */
-    public function isNumericCalculation(\PHP_CodeSniffer_File $phpcsFile, $start, $end)
+    public function isNumericCalculation(File $phpcsFile, $start, $end)
     {
         return parent::isNumericCalculation($phpcsFile, $start, $end);
     }


### PR DESCRIPTION
For those classes which have 1-on-1 aliases across PHPCS versions, we can use `use ... as ...` statements to import the aliased class and use a shorter reference inline.

This applies to:
* `PHP_CodeSniffer_File` - aliased as `File` which is the PHPCS 3.x class name.
* `PHP_CodeSniffer_Tokens` - aliased as `Tokens` which is the PHPCS 3.x class name.
* `PHP_CodeSniffer_Exception` - in PHPCS 3.x, this class is called `PHP_CodeSniffer\Exceptions\RuntimeException`, aliased to `PHPCS_Exception` to prevent confusion with the PHP native `RuntimeException` class.
* `Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff` - aliased as `PHPCS_CamelCapsFunctionNameSniff`.
* `PHP_CodeSniffer_Standards_AbstractScopeSniff` - aliased as `PHPCS_AbstractScopeSniff` to prevent confusion with the PHPCompatibility native abstract sniffs.

Note: this is not possible for those classes which don't have a direct counter-part between PHPCS 2 and PHPCS 3!

Additionally, the references to the PHPUnit class - which is aliased within the `phpunit-bootstrap.php` file - have also been changed to `use` statements.