### PR TITLE
Internal/NewInterfaces: bug fix - recognize implemented interfaces prefixed with \

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -74,6 +74,7 @@ class InternalInterfacesSniff extends Sniff
         }
 
         foreach ($interfaces as $interface) {
+            $interface   = ltrim($interface, '\\');
             $interfaceLc = strtolower($interface);
             if (isset($this->internalInterfaces[$interfaceLc]) === true) {
                 $error     = 'The interface %s %s';

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -210,6 +210,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
         }
 
         foreach ($interfaces as $interface) {
+            $interface   = ltrim($interface, '\\');
             $interfaceLc = strtolower($interface);
 
             if (isset($this->newInterfaces[$interfaceLc]) === true) {

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.inc
@@ -4,7 +4,7 @@ class MyTraversable implements Traversable {}
 class MyDateTimeInterface implements DateTimeInterface {}
 class MyThrowable implements Throwable {}
 
-class MyMultiple implements SomeInterface, Throwable, AnotherInterface, Traversable {} // Test multiple interfaces.
+class MyMultiple implements SomeInterface, Throwable, AnotherInterface, \Traversable {} // Test multiple interfaces.
 
 class MyUppercase implements DATETIMEINTERFACE {} // Test case-insensitivity.
 class MyLowercase implements datetimeinterface {} // Test case-insensitivity.
@@ -16,5 +16,5 @@ class MyTraversable implements myNameSpace\Traversable {}
 // Internal interfaces with anonymous classes.
 $a = new class implements Traversable {}
 $b = new class implements DateTimeInterface {}
-$c = new class implements Throwable {}
+$c = new class implements \Throwable {}
 $d = new class implements SomeInterface, Throwable, AnotherInterface, Traversable {} // Test multiple interfaces.

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -3,7 +3,7 @@
 class MyCountable implements Countable {}
 class MyOuterIterator implements OuterIterator {}
 class MyRecursiveIterator implements RecursiveIterator {}
-class MySeekableIterator implements SeekableIterator {}
+class MySeekableIterator implements \SeekableIterator {}
 class MySerializable implements Serializable {
     public function __sleep() {}
     public function __wakeup() {}
@@ -26,7 +26,7 @@ class MyJsonSerializable implements myNameSpace\JsonSerializable {}
 
 // Test anonymous class support.
 $a = new class implements SeekableIterator {}
-$b = new class implements Serializable {
+$b = new class implements \Serializable {
     public function __sleep() {}
     public function __wakeup() {}
 }


### PR DESCRIPTION
Recognize classes implementing PHP native interfaces prefixed with a `\` (to indicate global namespace).

Includes (adjusted) unit tests.