### PR TITLE
ForbiddenThisUseContexts: allow for array access

### DIFF
--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -271,7 +271,8 @@ class ForbiddenThisUseContextsSniff extends Sniff
 
                     if ($afterThis !== false
                         && ($tokens[$afterThis]['code'] === T_OBJECT_OPERATOR
-                            || $tokens[$afterThis]['code'] === T_DOUBLE_COLON)
+                            || $tokens[$afterThis]['code'] === T_DOUBLE_COLON
+                            || $tokens[$afterThis]['code'] === T_OPEN_SQUARE_BRACKET)
                     ) {
                         $i = $afterThis;
                         continue;

--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.inc
@@ -87,6 +87,12 @@ class UnsetInMethod {
 	}
 }
 
+class MyBar implements ArrayAccess {
+    public function remove($name) {
+        unset($this[$name]); // OK.
+    }
+}
+
 // These should be flagged. New fatal error: Cannot unset $this.
 unset($this);
 unset($that, $theOther, $this, $somethingElse, $this); // Error x 2.

--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
@@ -331,9 +331,9 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTest
     public function dataIncompatibleThisUsageUnset()
     {
         return array(
-            array(91),
-            array(92), // x2.
-            array(96),
+            array(97),
+            array(98), // x2.
+            array(102),
         );
     }
 
@@ -365,8 +365,9 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTest
         return array(
             array(83),
             array(86),
-            array(94),
-            array(95),
+            array(92),
+            array(100),
+            array(101),
         );
     }
 
@@ -396,8 +397,8 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTest
     public function dataIncompatibleThisUsageOutsideObjectContext()
     {
         return array(
-            array(140),
-            array(145),
+            array(146),
+            array(151),
         );
     }
 
@@ -427,14 +428,14 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTest
     public function dataNoFalsePositivesOutsideObjectContext()
     {
         return array(
-            array(103),
-            array(106),
-            array(111),
-            array(115),
-            array(120),
-            array(127),
-            array(132),
-            array(196), // Exception to the rule / static __call() magic method.
+            array(109),
+            array(112),
+            array(117),
+            array(121),
+            array(126),
+            array(133),
+            array(138),
+            array(202), // Exception to the rule / static __call() magic method.
         );
     }
 
@@ -449,7 +450,7 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.1');
 
         // No errors expected on the first 14 lines.
-        for ($line = 150; $line <= 205; $line++) {
+        for ($line = 156; $line <= 205; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }


### PR DESCRIPTION
For classes which implement the `ArrayAccess` interface, such as the `ArrayObject` class, using `$this['key']` is a perfectly fine, working syntax and unsetting an item in the object using that syntax will still work and is unaffected by the changes in PHP 7.1.

The sniff, however, would throw a false positive for this.

This PR fixes that.

Includes unit tests.

Fixes #780