### PR TITLE
Performance: use FQN for global constants

### DIFF
--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -53,12 +53,12 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      * @var array
      */
     private $ignoreTokens = array(
-        T_DOUBLE_COLON    => true,
-        T_OBJECT_OPERATOR => true,
-        T_FUNCTION        => true,
-        T_NEW             => true,
-        T_CONST           => true,
-        T_USE             => true,
+        \T_DOUBLE_COLON    => true,
+        \T_OBJECT_OPERATOR => true,
+        \T_FUNCTION        => true,
+        \T_NEW             => true,
+        \T_CONST           => true,
+        \T_USE             => true,
     );
 
 
@@ -72,7 +72,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
         // Handle case-insensitivity of function names.
         $this->targetFunctions = $this->arrayKeysToLowercase($this->targetFunctions);
 
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
 
@@ -102,8 +102,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($this->isMethod === true) {
-            if ($tokens[$prevNonEmpty]['code'] !== T_DOUBLE_COLON
-                && $tokens[$prevNonEmpty]['code'] !== T_OBJECT_OPERATOR
+            if ($tokens[$prevNonEmpty]['code'] !== \T_DOUBLE_COLON
+                && $tokens[$prevNonEmpty]['code'] !== \T_OBJECT_OPERATOR
             ) {
                 // Not a call to a PHP method.
                 return;
@@ -114,8 +114,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
                 return;
             }
 
-            if ($tokens[$prevNonEmpty]['code'] === T_NS_SEPARATOR
-                && $tokens[$prevNonEmpty - 1]['code'] === T_STRING
+            if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR
+                && $tokens[$prevNonEmpty - 1]['code'] === \T_STRING
             ) {
                 // Namespaced function.
                 return;

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -149,13 +149,13 @@ class PHPCSHelper
         $tokens    = $phpcsFile->getTokens();
         $endTokens = Tokens::$blockOpeners;
 
-        $endTokens[T_COLON]            = true;
-        $endTokens[T_COMMA]            = true;
-        $endTokens[T_DOUBLE_ARROW]     = true;
-        $endTokens[T_SEMICOLON]        = true;
-        $endTokens[T_OPEN_TAG]         = true;
-        $endTokens[T_CLOSE_TAG]        = true;
-        $endTokens[T_OPEN_SHORT_ARRAY] = true;
+        $endTokens[\T_COLON]            = true;
+        $endTokens[\T_COMMA]            = true;
+        $endTokens[\T_DOUBLE_ARROW]     = true;
+        $endTokens[\T_SEMICOLON]        = true;
+        $endTokens[\T_OPEN_TAG]         = true;
+        $endTokens[\T_CLOSE_TAG]        = true;
+        $endTokens[\T_OPEN_SHORT_ARRAY] = true;
 
         if ($ignore !== null) {
             $ignore = (array) $ignore;
@@ -227,16 +227,16 @@ class PHPCSHelper
 
         $tokens    = $phpcsFile->getTokens();
         $endTokens = array(
-            T_COLON                => true,
-            T_COMMA                => true,
-            T_DOUBLE_ARROW         => true,
-            T_SEMICOLON            => true,
-            T_CLOSE_PARENTHESIS    => true,
-            T_CLOSE_SQUARE_BRACKET => true,
-            T_CLOSE_CURLY_BRACKET  => true,
-            T_CLOSE_SHORT_ARRAY    => true,
-            T_OPEN_TAG             => true,
-            T_CLOSE_TAG            => true,
+            \T_COLON                => true,
+            \T_COMMA                => true,
+            \T_DOUBLE_ARROW         => true,
+            \T_SEMICOLON            => true,
+            \T_CLOSE_PARENTHESIS    => true,
+            \T_CLOSE_SQUARE_BRACKET => true,
+            \T_CLOSE_CURLY_BRACKET  => true,
+            \T_CLOSE_SHORT_ARRAY    => true,
+            \T_OPEN_TAG             => true,
+            \T_CLOSE_TAG            => true,
         );
 
         if ($ignore !== null) {
@@ -253,12 +253,12 @@ class PHPCSHelper
         for ($i = $start; $i < $phpcsFile->numTokens; $i++) {
             if ($i !== $start && isset($endTokens[$tokens[$i]['code']]) === true) {
                 // Found the end of the statement.
-                if ($tokens[$i]['code'] === T_CLOSE_PARENTHESIS
-                    || $tokens[$i]['code'] === T_CLOSE_SQUARE_BRACKET
-                    || $tokens[$i]['code'] === T_CLOSE_CURLY_BRACKET
-                    || $tokens[$i]['code'] === T_CLOSE_SHORT_ARRAY
-                    || $tokens[$i]['code'] === T_OPEN_TAG
-                    || $tokens[$i]['code'] === T_CLOSE_TAG
+                if ($tokens[$i]['code'] === \T_CLOSE_PARENTHESIS
+                    || $tokens[$i]['code'] === \T_CLOSE_SQUARE_BRACKET
+                    || $tokens[$i]['code'] === \T_CLOSE_CURLY_BRACKET
+                    || $tokens[$i]['code'] === \T_CLOSE_SHORT_ARRAY
+                    || $tokens[$i]['code'] === \T_OPEN_TAG
+                    || $tokens[$i]['code'] === \T_CLOSE_TAG
                 ) {
                     return $lastNotEmpty;
                 }
@@ -330,7 +330,7 @@ class PHPCSHelper
             return false;
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_CLASS
+        if ($tokens[$stackPtr]['code'] !== \T_CLASS
             && $tokens[$stackPtr]['type'] !== 'T_ANON_CLASS'
             && $tokens[$stackPtr]['type'] !== 'T_INTERFACE'
         ) {
@@ -342,15 +342,15 @@ class PHPCSHelper
         }
 
         $classCloserIndex = $tokens[$stackPtr]['scope_closer'];
-        $extendsIndex     = $phpcsFile->findNext(T_EXTENDS, $stackPtr, $classCloserIndex);
+        $extendsIndex     = $phpcsFile->findNext(\T_EXTENDS, $stackPtr, $classCloserIndex);
         if ($extendsIndex === false) {
             return false;
         }
 
         $find = array(
-            T_NS_SEPARATOR,
-            T_STRING,
-            T_WHITESPACE,
+            \T_NS_SEPARATOR,
+            \T_STRING,
+            \T_WHITESPACE,
         );
 
         $end  = $phpcsFile->findNext($find, ($extendsIndex + 1), $classCloserIndex, true);
@@ -395,7 +395,7 @@ class PHPCSHelper
             return false;
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_CLASS
+        if ($tokens[$stackPtr]['code'] !== \T_CLASS
             && $tokens[$stackPtr]['type'] !== 'T_ANON_CLASS'
         ) {
             return false;
@@ -406,16 +406,16 @@ class PHPCSHelper
         }
 
         $classOpenerIndex = $tokens[$stackPtr]['scope_opener'];
-        $implementsIndex  = $phpcsFile->findNext(T_IMPLEMENTS, $stackPtr, $classOpenerIndex);
+        $implementsIndex  = $phpcsFile->findNext(\T_IMPLEMENTS, $stackPtr, $classOpenerIndex);
         if ($implementsIndex === false) {
             return false;
         }
 
         $find = array(
-            T_NS_SEPARATOR,
-            T_STRING,
-            T_WHITESPACE,
-            T_COMMA,
+            \T_NS_SEPARATOR,
+            \T_STRING,
+            \T_WHITESPACE,
+            \T_COMMA,
         );
 
         $end  = $phpcsFile->findNext($find, ($implementsIndex + 1), ($classOpenerIndex + 1), true);
@@ -481,8 +481,8 @@ class PHPCSHelper
             return false;
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_FUNCTION
-            && $tokens[$stackPtr]['code'] !== T_CLOSURE
+        if ($tokens[$stackPtr]['code'] !== \T_FUNCTION
+            && $tokens[$stackPtr]['code'] !== \T_CLOSURE
         ) {
             throw new PHPCS_Exception('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
         }
@@ -557,7 +557,7 @@ class PHPCSHelper
                     // also be a constant used as a default value.
                     $prevComma = false;
                     for ($t = $i; $t >= $opener; $t--) {
-                        if ($tokens[$t]['code'] === T_COMMA) {
+                        if ($tokens[$t]['code'] === \T_COMMA) {
                             $prevComma = $t;
                             break;
                         }
@@ -566,7 +566,7 @@ class PHPCSHelper
                     if ($prevComma !== false) {
                         $nextEquals = false;
                         for ($t = $prevComma; $t < $i; $t++) {
-                            if ($tokens[$t]['code'] === T_EQUAL) {
+                            if ($tokens[$t]['code'] === \T_EQUAL) {
                                 $nextEquals = $t;
                                 break;
                             }

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -136,7 +136,7 @@ abstract class Sniff implements PHPCS_Sniff
                     if (version_compare($min, $max, '>')) {
                         trigger_error(
                             "Invalid range in testVersion setting: '" . $testVersion . "'",
-                            E_USER_WARNING
+                            \E_USER_WARNING
                         );
                         return $default;
                     } else {
@@ -148,7 +148,7 @@ abstract class Sniff implements PHPCS_Sniff
 
             trigger_error(
                 "Invalid testVersion setting: '" . $testVersion . "'",
-                E_USER_WARNING
+                \E_USER_WARNING
             );
             return $default;
         }
@@ -332,14 +332,14 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         // Is this one of the tokens this function handles ?
-        if (in_array($tokens[$stackPtr]['code'], array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY, T_VARIABLE), true) === false) {
+        if (in_array($tokens[$stackPtr]['code'], array(\T_STRING, \T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_VARIABLE), true) === false) {
             return false;
         }
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
 
         // Deal with short array syntax.
-        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
+        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY) {
             if (isset($tokens[$stackPtr]['bracket_closer']) === false) {
                 return false;
             }
@@ -354,7 +354,7 @@ abstract class Sniff implements PHPCS_Sniff
 
         // Deal with function calls & long arrays.
         // Next non-empty token should be the open parenthesis.
-        if ($nextNonEmpty === false && $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
+        if ($nextNonEmpty === false && $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
             return false;
         }
 
@@ -431,7 +431,7 @@ abstract class Sniff implements PHPCS_Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Mark the beginning and end tokens.
-        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
+        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY) {
             $opener = $stackPtr;
             $closer = $tokens[$stackPtr]['bracket_closer'];
 
@@ -453,7 +453,7 @@ abstract class Sniff implements PHPCS_Sniff
         $nextComma  = $opener;
         $paramStart = $opener + 1;
         $cnt        = 1;
-        while (($nextComma = $phpcsFile->findNext(array(T_COMMA, $tokens[$closer]['code'], T_OPEN_SHORT_ARRAY, T_CLOSURE), $nextComma + 1, $closer + 1)) !== false) {
+        while (($nextComma = $phpcsFile->findNext(array(\T_COMMA, $tokens[$closer]['code'], \T_OPEN_SHORT_ARRAY, \T_CLOSURE), $nextComma + 1, $closer + 1)) !== false) {
             // Ignore anything within short array definition brackets.
             if ($tokens[$nextComma]['type'] === 'T_OPEN_SHORT_ARRAY'
                 && (isset($tokens[$nextComma]['bracket_opener'])
@@ -593,14 +593,14 @@ abstract class Sniff implements PHPCS_Sniff
      */
     public function inClassScope(File $phpcsFile, $stackPtr, $strict = true)
     {
-        $validScopes = array(T_CLASS);
+        $validScopes = array(\T_CLASS);
         if (defined('T_ANON_CLASS') === true) {
-            $validScopes[] = T_ANON_CLASS;
+            $validScopes[] = \T_ANON_CLASS;
         }
 
         if ($strict === false) {
-            $validScopes[] = T_INTERFACE;
-            $validScopes[] = T_TRAIT;
+            $validScopes[] = \T_INTERFACE;
+            $validScopes[] = \T_TRAIT;
         }
 
         return $phpcsFile->hasCondition($stackPtr, $validScopes);
@@ -626,7 +626,7 @@ abstract class Sniff implements PHPCS_Sniff
             return '';
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_NEW) {
+        if ($tokens[$stackPtr]['code'] !== \T_NEW) {
             return '';
         }
 
@@ -636,20 +636,20 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         // Bow out if the next token is a variable as we don't know where it was defined.
-        if ($tokens[$start]['code'] === T_VARIABLE) {
+        if ($tokens[$start]['code'] === \T_VARIABLE) {
             return '';
         }
 
         // Bow out if the next token is the class keyword.
-        if ($tokens[$start]['type'] === 'T_ANON_CLASS' || $tokens[$start]['code'] === T_CLASS) {
+        if ($tokens[$start]['type'] === 'T_ANON_CLASS' || $tokens[$start]['code'] === \T_CLASS) {
             return '';
         }
 
         $find = array(
-            T_NS_SEPARATOR,
-            T_STRING,
-            T_NAMESPACE,
-            T_WHITESPACE,
+            \T_NS_SEPARATOR,
+            \T_STRING,
+            \T_NAMESPACE,
+            \T_WHITESPACE,
         );
 
         $end       = $phpcsFile->findNext($find, ($start + 1), null, true, null, true);
@@ -680,7 +680,7 @@ abstract class Sniff implements PHPCS_Sniff
             return '';
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_CLASS
+        if ($tokens[$stackPtr]['code'] !== \T_CLASS
             && $tokens[$stackPtr]['type'] !== 'T_ANON_CLASS'
             && $tokens[$stackPtr]['type'] !== 'T_INTERFACE'
         ) {
@@ -716,23 +716,23 @@ abstract class Sniff implements PHPCS_Sniff
             return '';
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_DOUBLE_COLON) {
+        if ($tokens[$stackPtr]['code'] !== \T_DOUBLE_COLON) {
             return '';
         }
 
         // Nothing to do if previous token is a variable as we don't know where it was defined.
-        if ($tokens[$stackPtr - 1]['code'] === T_VARIABLE) {
+        if ($tokens[$stackPtr - 1]['code'] === \T_VARIABLE) {
             return '';
         }
 
         // Nothing to do if 'parent' or 'static' as we don't know how far the class tree extends.
-        if (in_array($tokens[$stackPtr - 1]['code'], array(T_PARENT, T_STATIC), true)) {
+        if (in_array($tokens[$stackPtr - 1]['code'], array(\T_PARENT, \T_STATIC), true)) {
             return '';
         }
 
         // Get the classname from the class declaration if self is used.
-        if ($tokens[$stackPtr - 1]['code'] === T_SELF) {
-            $classDeclarationPtr = $phpcsFile->findPrevious(T_CLASS, $stackPtr - 1);
+        if ($tokens[$stackPtr - 1]['code'] === \T_SELF) {
+            $classDeclarationPtr = $phpcsFile->findPrevious(\T_CLASS, $stackPtr - 1);
             if ($classDeclarationPtr === false) {
                 return '';
             }
@@ -741,10 +741,10 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         $find = array(
-            T_NS_SEPARATOR,
-            T_STRING,
-            T_NAMESPACE,
-            T_WHITESPACE,
+            \T_NS_SEPARATOR,
+            \T_STRING,
+            \T_NAMESPACE,
+            \T_WHITESPACE,
         );
 
         $start = $phpcsFile->findPrevious($find, $stackPtr - 1, null, true, null, true);
@@ -831,7 +831,7 @@ abstract class Sniff implements PHPCS_Sniff
 
         // Check for scoped namespace {}.
         if (empty($tokens[$stackPtr]['conditions']) === false) {
-            $namespacePtr = $phpcsFile->getCondition($stackPtr, T_NAMESPACE);
+            $namespacePtr = $phpcsFile->getCondition($stackPtr, \T_NAMESPACE);
             if ($namespacePtr !== false) {
                 $namespace = $this->getDeclaredNamespaceName($phpcsFile, $namespacePtr);
                 if ($namespace !== false) {
@@ -853,7 +853,7 @@ abstract class Sniff implements PHPCS_Sniff
         $previousNSToken = $stackPtr;
         $namespace       = false;
         do {
-            $previousNSToken = $phpcsFile->findPrevious(T_NAMESPACE, ($previousNSToken - 1));
+            $previousNSToken = $phpcsFile->findPrevious(\T_NAMESPACE, ($previousNSToken - 1));
 
             // Stop if we encounter a scoped namespace declaration as we already know we're not in one.
             if (empty($tokens[$previousNSToken]['scope_condition']) === false && $tokens[$previousNSToken]['scope_condition'] === $previousNSToken) {
@@ -893,17 +893,17 @@ abstract class Sniff implements PHPCS_Sniff
             return false;
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_NAMESPACE) {
+        if ($tokens[$stackPtr]['code'] !== \T_NAMESPACE) {
             return false;
         }
 
-        if ($tokens[($stackPtr + 1)]['code'] === T_NS_SEPARATOR) {
+        if ($tokens[($stackPtr + 1)]['code'] === \T_NS_SEPARATOR) {
             // Not a namespace declaration, but use of, i.e. namespace\someFunction();
             return false;
         }
 
         $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
-        if ($tokens[$nextToken]['code'] === T_OPEN_CURLY_BRACKET) {
+        if ($tokens[$nextToken]['code'] === \T_OPEN_CURLY_BRACKET) {
             // Declaration for global namespace when using multiple namespaces in a file.
             // I.e.: namespace {}
             return '';
@@ -911,9 +911,9 @@ abstract class Sniff implements PHPCS_Sniff
 
         // Ok, this should be a namespace declaration, so get all the parts together.
         $validTokens = array(
-            T_STRING       => true,
-            T_NS_SEPARATOR => true,
-            T_WHITESPACE   => true,
+            \T_STRING       => true,
+            \T_NS_SEPARATOR => true,
+            \T_WHITESPACE   => true,
         );
 
         $namespaceName = '';
@@ -945,11 +945,11 @@ abstract class Sniff implements PHPCS_Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (defined('T_RETURN_TYPE') && $tokens[$stackPtr]['code'] === T_RETURN_TYPE) {
+        if (defined('T_RETURN_TYPE') && $tokens[$stackPtr]['code'] === \T_RETURN_TYPE) {
             return $stackPtr;
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_FUNCTION && $tokens[$stackPtr]['code'] !== T_CLOSURE) {
+        if ($tokens[$stackPtr]['code'] !== \T_FUNCTION && $tokens[$stackPtr]['code'] !== \T_CLOSURE) {
             return false;
         }
 
@@ -962,7 +962,7 @@ abstract class Sniff implements PHPCS_Sniff
         if (isset($tokens[$stackPtr]['scope_opener'])) {
             $endOfFunctionDeclaration = $tokens[$stackPtr]['scope_opener'];
         } else {
-            $nextSemiColon = $phpcsFile->findNext(T_SEMICOLON, ($tokens[$stackPtr]['parenthesis_closer'] + 1), null, false, null, true);
+            $nextSemiColon = $phpcsFile->findNext(\T_SEMICOLON, ($tokens[$stackPtr]['parenthesis_closer'] + 1), null, false, null, true);
             if ($nextSemiColon !== false) {
                 $endOfFunctionDeclaration = $nextSemiColon;
             }
@@ -973,7 +973,7 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         $hasColon = $phpcsFile->findNext(
-            array(T_COLON, T_INLINE_ELSE),
+            array(\T_COLON, \T_INLINE_ELSE),
             ($tokens[$stackPtr]['parenthesis_closer'] + 1),
             $endOfFunctionDeclaration
         );
@@ -991,11 +991,11 @@ abstract class Sniff implements PHPCS_Sniff
          *   As of PHPCS 3.3.0 `array` as a type declaration will be tokenized as `T_STRING`.
          */
         $unrecognizedTypes = array(
-            T_CALLABLE,
-            T_SELF,
-            T_PARENT,
-            T_ARRAY, // PHPCS < 2.4.0.
-            T_STRING,
+            \T_CALLABLE,
+            \T_SELF,
+            \T_PARENT,
+            \T_ARRAY, // PHPCS < 2.4.0.
+            \T_STRING,
         );
 
         return $phpcsFile->findPrevious($unrecognizedTypes, ($endOfFunctionDeclaration - 1), $hasColon);
@@ -1025,9 +1025,9 @@ abstract class Sniff implements PHPCS_Sniff
         $tokens = $phpcsFile->getTokens();
 
         // In older PHPCS versions, the nullable indicator will turn a return type colon into a T_INLINE_ELSE.
-        $colon = $phpcsFile->findPrevious(array(T_COLON, T_INLINE_ELSE, T_FUNCTION, T_CLOSE_PARENTHESIS), ($stackPtr - 1));
+        $colon = $phpcsFile->findPrevious(array(\T_COLON, \T_INLINE_ELSE, \T_FUNCTION, \T_CLOSE_PARENTHESIS), ($stackPtr - 1));
         if ($colon === false
-            || ($tokens[$colon]['code'] !== T_COLON && $tokens[$colon]['code'] !== T_INLINE_ELSE)
+            || ($tokens[$colon]['code'] !== \T_COLON && $tokens[$colon]['code'] !== \T_INLINE_ELSE)
         ) {
             // Shouldn't happen, just in case.
             return;
@@ -1045,7 +1045,7 @@ abstract class Sniff implements PHPCS_Sniff
                 continue;
             }
 
-            if (defined('T_NULLABLE') === false && $tokens[$i]['code'] === T_INLINE_THEN) {
+            if (defined('T_NULLABLE') === false && $tokens[$i]['code'] === \T_INLINE_THEN) {
                 // Old PHPCS.
                 continue;
             }
@@ -1075,7 +1075,7 @@ abstract class Sniff implements PHPCS_Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== T_VARIABLE) {
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_VARIABLE) {
             return false;
         }
 
@@ -1096,7 +1096,7 @@ abstract class Sniff implements PHPCS_Sniff
                 $deepestOpen = array_pop($parenthesis);
                 if ($deepestOpen < $scopePtr
                     || isset($tokens[$deepestOpen]['parenthesis_owner']) === false
-                    || $tokens[$tokens[$deepestOpen]['parenthesis_owner']]['code'] !== T_FUNCTION
+                    || $tokens[$tokens[$deepestOpen]['parenthesis_owner']]['code'] !== \T_FUNCTION
                 ) {
                     return true;
                 }
@@ -1120,7 +1120,7 @@ abstract class Sniff implements PHPCS_Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== T_CONST) {
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_CONST) {
             return false;
         }
 
@@ -1200,7 +1200,7 @@ abstract class Sniff implements PHPCS_Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] !== T_FUNCTION && $tokens[$stackPtr]['code'] !== T_CLOSURE) {
+        if ($tokens[$stackPtr]['code'] !== \T_FUNCTION && $tokens[$stackPtr]['code'] !== \T_CLOSURE) {
             return array();
         }
 
@@ -1249,7 +1249,7 @@ abstract class Sniff implements PHPCS_Sniff
             return false;
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_STRING) {
+        if ($tokens[$stackPtr]['code'] !== \T_STRING) {
             return false;
         }
 
@@ -1295,7 +1295,7 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         // Is this one of the tokens this function handles ?
-        if ($tokens[$stackPtr]['code'] !== T_STRING) {
+        if ($tokens[$stackPtr]['code'] !== \T_STRING) {
             return false;
         }
 
@@ -1303,7 +1303,7 @@ abstract class Sniff implements PHPCS_Sniff
         if (isset($isLowPHPCS, $isLowPHP) === false) {
             $isLowPHP   = false;
             $isLowPHPCS = false;
-            if (version_compare(PHP_VERSION_ID, '50400', '<')) {
+            if (version_compare(\PHP_VERSION_ID, '50400', '<')) {
                 $isLowPHP   = true;
                 $isLowPHPCS = version_compare(PHPCSHelper::getVersion(), '2.4.0', '<');
             }
@@ -1311,8 +1311,8 @@ abstract class Sniff implements PHPCS_Sniff
 
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($next !== false
-            && ($tokens[$next]['code'] === T_OPEN_PARENTHESIS
-                || $tokens[$next]['code'] === T_DOUBLE_COLON)
+            && ($tokens[$next]['code'] === \T_OPEN_PARENTHESIS
+                || $tokens[$next]['code'] === \T_DOUBLE_COLON)
         ) {
             // Function call or declaration.
             return false;
@@ -1343,7 +1343,7 @@ abstract class Sniff implements PHPCS_Sniff
         $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prev !== false
             && (isset($tokensToIgnore[$tokens[$prev]['type']]) === true
-                || ($tokens[$prev]['code'] === T_STRING
+                || ($tokens[$prev]['code'] === \T_STRING
                     && (($isLowPHPCS === true
                         && $tokens[$prev]['content'] === 'trait')
                     || ($isLowPHP === true
@@ -1354,15 +1354,15 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         if ($prev !== false
-            && $tokens[$prev]['code'] === T_NS_SEPARATOR
-            && $tokens[($prev - 1)]['code'] === T_STRING
+            && $tokens[$prev]['code'] === \T_NS_SEPARATOR
+            && $tokens[($prev - 1)]['code'] === \T_STRING
         ) {
             // Namespaced constant of the same name.
             return false;
         }
 
         if ($prev !== false
-            && $tokens[$prev]['code'] === T_CONST
+            && $tokens[$prev]['code'] === \T_CONST
             && $this->isClassConstant($phpcsFile, $prev) === true
         ) {
             // Class constant declaration of the same name.
@@ -1379,13 +1379,13 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         $firstOnLine = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
-        if ($firstOnLine !== false && $tokens[$firstOnLine]['code'] === T_USE) {
+        if ($firstOnLine !== false && $tokens[$firstOnLine]['code'] === \T_USE) {
             $nextOnLine = $phpcsFile->findNext(Tokens::$emptyTokens, ($firstOnLine + 1), null, true);
             if ($nextOnLine !== false) {
-                if (($tokens[$nextOnLine]['code'] === T_STRING && $tokens[$nextOnLine]['content'] === 'const')
-                    || $tokens[$nextOnLine]['code'] === T_CONST // Happens in some PHPCS versions.
+                if (($tokens[$nextOnLine]['code'] === \T_STRING && $tokens[$nextOnLine]['content'] === 'const')
+                    || $tokens[$nextOnLine]['code'] === \T_CONST // Happens in some PHPCS versions.
                 ) {
-                    $hasNsSep = $phpcsFile->findNext(T_NS_SEPARATOR, ($nextOnLine + 1), $stackPtr);
+                    $hasNsSep = $phpcsFile->findNext(\T_NS_SEPARATOR, ($nextOnLine + 1), $stackPtr);
                     if ($hasNsSep !== false) {
                         // Namespaced const (group) use statement.
                         return false;
@@ -1494,14 +1494,14 @@ abstract class Sniff implements PHPCS_Sniff
     {
         $stringTokens  = Tokens::$heredocTokens + Tokens::$stringTokens;
 
-        $validTokens            = array();
-        $validTokens[T_LNUMBER] = true;
-        $validTokens[T_TRUE]    = true; // Evaluates to int 1.
-        $validTokens[T_FALSE]   = true; // Evaluates to int 0.
-        $validTokens[T_NULL]    = true; // Evaluates to int 0.
+        $validTokens             = array();
+        $validTokens[\T_LNUMBER] = true;
+        $validTokens[\T_TRUE]    = true; // Evaluates to int 1.
+        $validTokens[\T_FALSE]   = true; // Evaluates to int 0.
+        $validTokens[\T_NULL]    = true; // Evaluates to int 0.
 
         if ($allowFloats === true) {
-            $validTokens[T_DNUMBER] = true;
+            $validTokens[\T_DNUMBER] = true;
         }
 
         $maybeValidTokens = $stringTokens + $validTokens;
@@ -1516,11 +1516,11 @@ abstract class Sniff implements PHPCS_Sniff
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $start, $searchEnd, true);
         while ($nextNonEmpty !== false
-            && ($tokens[$nextNonEmpty]['code'] === T_PLUS
-            || $tokens[$nextNonEmpty]['code'] === T_MINUS)
+            && ($tokens[$nextNonEmpty]['code'] === \T_PLUS
+            || $tokens[$nextNonEmpty]['code'] === \T_MINUS)
         ) {
 
-            if ($tokens[$nextNonEmpty]['code'] === T_MINUS) {
+            if ($tokens[$nextNonEmpty]['code'] === \T_MINUS) {
                 $negativeNumber = ($negativeNumber === false) ? true : false;
             }
 
@@ -1532,23 +1532,23 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         $content = false;
-        if ($tokens[$nextNonEmpty]['code'] === T_LNUMBER
-            || $tokens[$nextNonEmpty]['code'] === T_DNUMBER
+        if ($tokens[$nextNonEmpty]['code'] === \T_LNUMBER
+            || $tokens[$nextNonEmpty]['code'] === \T_DNUMBER
         ) {
             $content = (float) $tokens[$nextNonEmpty]['content'];
-        } elseif ($tokens[$nextNonEmpty]['code'] === T_TRUE) {
+        } elseif ($tokens[$nextNonEmpty]['code'] === \T_TRUE) {
             $content = 1.0;
-        } elseif ($tokens[$nextNonEmpty]['code'] === T_FALSE
-            || $tokens[$nextNonEmpty]['code'] === T_NULL
+        } elseif ($tokens[$nextNonEmpty]['code'] === \T_FALSE
+            || $tokens[$nextNonEmpty]['code'] === \T_NULL
         ) {
             $content = 0.0;
         } elseif (isset($stringTokens[$tokens[$nextNonEmpty]['code']]) === true) {
 
-            if ($tokens[$nextNonEmpty]['code'] === T_START_HEREDOC
-                || $tokens[$nextNonEmpty]['code'] === T_START_NOWDOC
+            if ($tokens[$nextNonEmpty]['code'] === \T_START_HEREDOC
+                || $tokens[$nextNonEmpty]['code'] === \T_START_NOWDOC
             ) {
                 // Skip past heredoc/nowdoc opener to the first content.
-                $firstDocToken = $phpcsFile->findNext(array(T_HEREDOC, T_NOWDOC), ($nextNonEmpty + 1), $searchEnd);
+                $firstDocToken = $phpcsFile->findNext(array(\T_HEREDOC, \T_NOWDOC), ($nextNonEmpty + 1), $searchEnd);
                 if ($firstDocToken === false) {
                     // Live coding or parse error.
                     return false;
@@ -1557,7 +1557,7 @@ abstract class Sniff implements PHPCS_Sniff
                 $stringContent = $content = $tokens[$firstDocToken]['content'];
 
                 // Skip forward to the end in preparation for the next part of the examination.
-                $nextNonEmpty = $phpcsFile->findNext(array(T_END_HEREDOC, T_END_NOWDOC), ($nextNonEmpty + 1), $searchEnd);
+                $nextNonEmpty = $phpcsFile->findNext(array(\T_END_HEREDOC, \T_END_NOWDOC), ($nextNonEmpty + 1), $searchEnd);
                 if ($nextNonEmpty === false) {
                     // Live coding or parse error.
                     return false;
@@ -1615,7 +1615,7 @@ abstract class Sniff implements PHPCS_Sniff
                 // use that to get the numeric value if possible.
                 // If the filter extension is not available, the value will be zero, but so be it.
                 if (function_exists('filter_var')) {
-                    $filtered = filter_var($hexNumberString[1], FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX);
+                    $filtered = filter_var($hexNumberString[1], \FILTER_VALIDATE_INT, \FILTER_FLAG_ALLOW_HEX);
                     if ($filtered !== false) {
                         $content = $filtered;
                     }
@@ -1663,15 +1663,15 @@ abstract class Sniff implements PHPCS_Sniff
         $arithmeticTokens = Tokens::$arithmeticTokens;
 
         // phpcs:disable PHPCompatibility.Constants.NewConstants.t_powFound
-        if (defined('T_POW') && isset($arithmeticTokens[T_POW]) === false) {
+        if (defined('T_POW') && isset($arithmeticTokens[\T_POW]) === false) {
             // T_POW was not added to the arithmetic array until PHPCS 2.9.0.
-            $arithmeticTokens[T_POW] = T_POW;
+            $arithmeticTokens[\T_POW] = \T_POW;
         }
         // phpcs:enable
 
         $skipTokens   = Tokens::$emptyTokens;
-        $skipTokens[] = T_MINUS;
-        $skipTokens[] = T_PLUS;
+        $skipTokens[] = \T_MINUS;
+        $skipTokens[] = \T_PLUS;
 
         // Find the first arithmetic operator, but skip past +/- signs before numbers.
         $nextNonEmpty = ($start - 1);
@@ -1693,8 +1693,8 @@ abstract class Sniff implements PHPCS_Sniff
         ) {
             // Recognize T_POW for PHPCS < 2.4.0 on low PHP versions.
             if (defined('T_POW') === false
-                && $tokens[$arithmeticOperator]['code'] === T_MULTIPLY
-                && $tokens[($arithmeticOperator + 1)]['code'] === T_MULTIPLY
+                && $tokens[$arithmeticOperator]['code'] === \T_MULTIPLY
+                && $tokens[($arithmeticOperator + 1)]['code'] === \T_MULTIPLY
                 && isset($tokens[$arithmeticOperator + 2]) === true
             ) {
                 // Move operator one forward to the second * in T_POW.
@@ -1745,21 +1745,21 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         // Is this one of the tokens this function handles ?
-        if ($tokens[$stackPtr]['code'] !== T_OPEN_SHORT_ARRAY
-            && $tokens[$stackPtr]['code'] !== T_CLOSE_SHORT_ARRAY
+        if ($tokens[$stackPtr]['code'] !== \T_OPEN_SHORT_ARRAY
+            && $tokens[$stackPtr]['code'] !== \T_CLOSE_SHORT_ARRAY
         ) {
             return false;
         }
 
         switch ($tokens[$stackPtr]['code']) {
-            case T_OPEN_SHORT_ARRAY:
+            case \T_OPEN_SHORT_ARRAY:
                 if (isset($tokens[$stackPtr]['bracket_closer']) === true) {
                     $opener = $stackPtr;
                     $closer = $tokens[$stackPtr]['bracket_closer'];
                 }
                 break;
 
-            case T_CLOSE_SHORT_ARRAY:
+            case \T_CLOSE_SHORT_ARRAY:
                 if (isset($tokens[$stackPtr]['bracket_opener']) === true) {
                     $opener = $tokens[$stackPtr]['bracket_opener'];
                     $closer = $stackPtr;
@@ -1779,7 +1779,7 @@ abstract class Sniff implements PHPCS_Sniff
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true, null, true);
 
         if ($prevNonEmpty !== false
-            && $tokens[$prevNonEmpty]['code'] === T_CLOSE_CURLY_BRACKET
+            && $tokens[$prevNonEmpty]['code'] === \T_CLOSE_CURLY_BRACKET
             && isset($tokens[$prevNonEmpty]['bracket_opener']) === true
         ) {
             $maybeVariableVariable = $phpcsFile->findPrevious(
@@ -1791,8 +1791,8 @@ abstract class Sniff implements PHPCS_Sniff
                 true
             );
 
-            if ($tokens[$maybeVariableVariable]['code'] === T_VARIABLE
-                || $tokens[$maybeVariableVariable]['code'] === T_DOLLAR
+            if ($tokens[$maybeVariableVariable]['code'] === \T_VARIABLE
+                || $tokens[$maybeVariableVariable]['code'] === \T_DOLLAR
             ) {
                 return false;
             }
@@ -1800,18 +1800,18 @@ abstract class Sniff implements PHPCS_Sniff
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($closer + 1), null, true, null, true);
 
-        if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === T_EQUAL) {
+        if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_EQUAL) {
             return true;
         }
 
         if ($prevNonEmpty !== false
-            && $tokens[$prevNonEmpty]['code'] === T_AS
+            && $tokens[$prevNonEmpty]['code'] === \T_AS
             && isset($tokens[$prevNonEmpty]['nested_parenthesis']) === true
         ) {
             $parentheses = array_reverse($tokens[$prevNonEmpty]['nested_parenthesis'], true);
             foreach ($parentheses as $open => $close) {
                 if (isset($tokens[$open]['parenthesis_owner'])
-                    && $tokens[$tokens[$open]['parenthesis_owner']]['code'] === T_FOREACH
+                    && $tokens[$tokens[$open]['parenthesis_owner']]['code'] === \T_FOREACH
                 ) {
                     return true;
                 }
@@ -1822,7 +1822,7 @@ abstract class Sniff implements PHPCS_Sniff
         $parentOpener = $opener;
         do {
             $parentOpener = $phpcsFile->findPrevious(
-                array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET),
+                array(\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET),
                 ($parentOpener - 1),
                 null,
                 false,
@@ -1845,7 +1845,7 @@ abstract class Sniff implements PHPCS_Sniff
             $phpcsVersion = PHPCSHelper::getVersion();
             if ((version_compare($phpcsVersion, '2.0', '>') === true
                 && version_compare($phpcsVersion, '2.8', '<') === true)
-                && $tokens[$parentOpener]['code'] === T_OPEN_SQUARE_BRACKET
+                && $tokens[$parentOpener]['code'] === \T_OPEN_SQUARE_BRACKET
             ) {
                 $nextNonEmpty = $phpcsFile->findNext(
                     Tokens::$emptyTokens,
@@ -1856,7 +1856,7 @@ abstract class Sniff implements PHPCS_Sniff
                     true
                 );
 
-                if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === T_EQUAL) {
+                if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_EQUAL) {
                     return true;
                 }
 
@@ -1890,8 +1890,8 @@ abstract class Sniff implements PHPCS_Sniff
         if (isset($tokenBlackList, $bracketTokens) === false) {
 
             $tokenBlackList  = array(
-                T_OPEN_PARENTHESIS => T_OPEN_PARENTHESIS,
-                T_STRING_CONCAT    => T_STRING_CONCAT,
+                \T_OPEN_PARENTHESIS => \T_OPEN_PARENTHESIS,
+                \T_STRING_CONCAT    => \T_STRING_CONCAT,
             );
             $tokenBlackList += Tokens::$assignmentTokens;
             $tokenBlackList += Tokens::$equalityTokens;
@@ -1906,15 +1906,15 @@ abstract class Sniff implements PHPCS_Sniff
              * Key is the open bracket token, value the close bracket token.
              */
             $bracketTokens = array(
-                T_OPEN_CURLY_BRACKET  => T_CLOSE_CURLY_BRACKET,
-                T_OPEN_SQUARE_BRACKET => T_CLOSE_SQUARE_BRACKET,
+                \T_OPEN_CURLY_BRACKET  => \T_CLOSE_CURLY_BRACKET,
+                \T_OPEN_SQUARE_BRACKET => \T_CLOSE_SQUARE_BRACKET,
             );
         }
 
         $tokens = $phpcsFile->getTokens();
 
         // If no variable at all was found, then it's definitely a no-no.
-        $hasVariable = $phpcsFile->findNext(T_VARIABLE, $start, $end);
+        $hasVariable = $phpcsFile->findNext(\T_VARIABLE, $start, $end);
         if ($hasVariable === false) {
             return false;
         }

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -38,7 +38,7 @@ class NewAnonymousClassesSniff extends Sniff
      * @var array
      */
     private $indicators = array(
-        T_CLASS => T_CLASS,
+        \T_CLASS => \T_CLASS,
     );
 
     /**
@@ -49,10 +49,10 @@ class NewAnonymousClassesSniff extends Sniff
     public function register()
     {
         if (defined('T_ANON_CLASS')) {
-            $this->indicators[T_ANON_CLASS] = T_ANON_CLASS;
+            $this->indicators[\T_ANON_CLASS] = \T_ANON_CLASS;
         }
 
-        return array(T_NEW);
+        return array(\T_NEW);
     }
 
 

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -583,20 +583,20 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         $this->newClasses = array_merge($this->newClasses, $this->newExceptions);
 
         $targets = array(
-            T_NEW,
-            T_CLASS,
-            T_DOUBLE_COLON,
-            T_FUNCTION,
-            T_CLOSURE,
-            T_CATCH,
+            \T_NEW,
+            \T_CLASS,
+            \T_DOUBLE_COLON,
+            \T_FUNCTION,
+            \T_CLOSURE,
+            \T_CATCH,
         );
 
         if (defined('T_ANON_CLASS')) {
-            $targets[] = T_ANON_CLASS;
+            $targets[] = \T_ANON_CLASS;
         }
 
         if (defined('T_RETURN_TYPE')) {
-            $targets[] = T_RETURN_TYPE;
+            $targets[] = \T_RETURN_TYPE;
         }
 
         return $targets;
@@ -746,12 +746,12 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         $name   = '';
         $listen = array(
             // Parts of a (namespaced) class name.
-            T_STRING              => true,
-            T_NS_SEPARATOR        => true,
+            \T_STRING              => true,
+            \T_NS_SEPARATOR        => true,
             // End/split tokens.
-            T_VARIABLE            => false,
-            T_BITWISE_OR          => false,
-            T_CLOSE_CURLY_BRACKET => false, // Shouldn't be needed as we expect a var before this.
+            \T_VARIABLE            => false,
+            \T_BITWISE_OR          => false,
+            \T_CLOSE_CURLY_BRACKET => false, // Shouldn't be needed as we expect a var before this.
         );
 
         for ($i = ($opener + 1); $i < $closer; $i++) {

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -35,7 +35,7 @@ class NewConstVisibilitySniff extends Sniff
      */
     public function register()
     {
-        return array(T_CONST);
+        return array(\T_CONST);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -33,7 +33,7 @@ class NewLateStaticBindingSniff extends Sniff
      */
     public function register()
     {
-        return array(T_STATIC);
+        return array(\T_STATIC);
     }
 
 
@@ -54,7 +54,7 @@ class NewLateStaticBindingSniff extends Sniff
         }
 
         $tokens = $phpcsFile->getTokens();
-        if ($tokens[$nextNonEmpty]['code'] !== T_DOUBLE_COLON) {
+        if ($tokens[$nextNonEmpty]['code'] !== \T_DOUBLE_COLON) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -3454,7 +3454,7 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -37,7 +37,7 @@ class NewMagicClassConstantSniff extends Sniff
      */
     public function register()
     {
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**
@@ -62,7 +62,7 @@ class NewMagicClassConstantSniff extends Sniff
         }
 
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-        if ($prevToken === false || $tokens[$prevToken]['code'] !== T_DOUBLE_COLON) {
+        if ($prevToken === false || $tokens[$prevToken]['code'] !== \T_DOUBLE_COLON) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -302,7 +302,7 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
      */
     public function register()
     {
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
 

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -34,11 +34,11 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
      * @var array
      */
     protected $validLoopStructures = array(
-        T_FOR     => true,
-        T_FOREACH => true,
-        T_WHILE   => true,
-        T_DO      => true,
-        T_SWITCH  => true,
+        \T_FOR     => true,
+        \T_FOREACH => true,
+        \T_WHILE   => true,
+        \T_DO      => true,
+        \T_SWITCH  => true,
     );
 
     /**
@@ -47,8 +47,8 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
      * @var array
      */
     protected $backCompat = array(
-        T_CASE    => true,
-        T_DEFAULT => true,
+        \T_CASE    => true,
+        \T_DEFAULT => true,
     );
 
     /**
@@ -59,8 +59,8 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
     public function register()
     {
         return array(
-            T_BREAK,
-            T_CONTINUE,
+            \T_BREAK,
+            \T_CONTINUE,
         );
     }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -49,7 +49,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
      */
     public function register()
     {
-        return array(T_BREAK, T_CONTINUE);
+        return array(\T_BREAK, \T_CONTINUE);
     }
 
     /**
@@ -68,14 +68,14 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
         }
 
         $tokens             = $phpcsFile->getTokens();
-        $nextSemicolonToken = $phpcsFile->findNext(array(T_SEMICOLON, T_CLOSE_TAG), ($stackPtr), null, false);
+        $nextSemicolonToken = $phpcsFile->findNext(array(\T_SEMICOLON, \T_CLOSE_TAG), ($stackPtr), null, false);
         $errorType          = '';
         for ($curToken = $stackPtr + 1; $curToken < $nextSemicolonToken; $curToken++) {
             if ($tokens[$curToken]['type'] === 'T_STRING') {
                 // If the next non-whitespace token after the string
                 // is an opening parenthesis then it's a function call.
                 $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, $curToken + 1, null, true);
-                if ($tokens[$openBracket]['code'] === T_OPEN_PARENTHESIS) {
+                if ($tokens[$openBracket]['code'] === \T_OPEN_PARENTHESIS) {
                     $errorType = 'variableArgument';
                     break;
                 }

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -35,7 +35,7 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
      */
     public function register()
     {
-        return array(T_SWITCH);
+        return array(\T_SWITCH);
     }
 
     /**
@@ -61,7 +61,7 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
         $defaultToken = $stackPtr;
         $defaultCount = 0;
         $targetLevel  = $tokens[$stackPtr]['level'] + 1;
-        while ($defaultCount < 2 && ($defaultToken = $phpcsFile->findNext(array(T_DEFAULT), $defaultToken + 1, $tokens[$stackPtr]['scope_closer'])) !== false) {
+        while ($defaultCount < 2 && ($defaultToken = $phpcsFile->findNext(array(\T_DEFAULT), $defaultToken + 1, $tokens[$stackPtr]['scope_closer'])) !== false) {
             // Same level or one below (= two default cases after each other).
             if ($tokens[$defaultToken]['level'] === $targetLevel || $tokens[$defaultToken]['level'] === ($targetLevel + 1)) {
                 $defaultCount++;

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -68,10 +68,10 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        $this->ignoreTokens          = Tokens::$emptyTokens;
-        $this->ignoreTokens[T_EQUAL] = T_EQUAL;
+        $this->ignoreTokens           = Tokens::$emptyTokens;
+        $this->ignoreTokens[\T_EQUAL] = \T_EQUAL;
 
-        return array(T_DECLARE);
+        return array(\T_DECLARE);
     }
 
 
@@ -97,14 +97,14 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
             }
 
             // Deal with PHPCS 2.3.0-2.3.3 which do not yet set the parenthesis properly for declare statements.
-            $openParenthesis = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($stackPtr + 1), null, false, null, true);
+            $openParenthesis = $phpcsFile->findNext(\T_OPEN_PARENTHESIS, ($stackPtr + 1), null, false, null, true);
             if ($openParenthesis === false || isset($tokens[$openParenthesis]['parenthesis_closer']) === false) {
                 return;
             }
             $closeParenthesis = $tokens[$openParenthesis]['parenthesis_closer'];
         }
 
-        $directivePtr = $phpcsFile->findNext(T_STRING, ($openParenthesis + 1), $closeParenthesis, false);
+        $directivePtr = $phpcsFile->findNext(\T_STRING, ($openParenthesis + 1), $closeParenthesis, false);
         if ($directivePtr === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -36,7 +36,7 @@ class NewForeachExpressionReferencingSniff extends Sniff
      */
     public function register()
     {
-        return array(T_FOREACH);
+        return array(\T_FOREACH);
     }
 
     /**
@@ -63,7 +63,7 @@ class NewForeachExpressionReferencingSniff extends Sniff
         $opener = $tokens[$stackPtr]['parenthesis_opener'];
         $closer = $tokens[$stackPtr]['parenthesis_closer'];
 
-        $asToken = $phpcsFile->findNext(T_AS, ($opener + 1), $closer);
+        $asToken = $phpcsFile->findNext(\T_AS, ($opener + 1), $closer);
         if ($asToken === false) {
             return;
         }
@@ -72,7 +72,7 @@ class NewForeachExpressionReferencingSniff extends Sniff
          * Note: referencing $key is not allowed in any version, so this should only find referenced $values.
          * If it does find a referenced key, it would be a parse error anyway.
          */
-        $hasReference = $phpcsFile->findNext(T_BITWISE_AND, ($asToken + 1), $closer);
+        $hasReference = $phpcsFile->findNext(\T_BITWISE_AND, ($asToken + 1), $closer);
         if ($hasReference === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -33,7 +33,7 @@ class NewListInForeachSniff extends Sniff
      */
     public function register()
     {
-        return array(T_FOREACH);
+        return array(\T_FOREACH);
     }
 
     /**
@@ -60,12 +60,12 @@ class NewListInForeachSniff extends Sniff
         $opener = $tokens[$stackPtr]['parenthesis_opener'];
         $closer = $tokens[$stackPtr]['parenthesis_closer'];
 
-        $asToken = $phpcsFile->findNext(T_AS, ($opener + 1), $closer);
+        $asToken = $phpcsFile->findNext(\T_AS, ($opener + 1), $closer);
         if ($asToken === false) {
             return;
         }
 
-        $hasList = $phpcsFile->findNext(array(T_LIST, T_OPEN_SHORT_ARRAY), ($asToken + 1), $closer);
+        $hasList = $phpcsFile->findNext(array(\T_LIST, \T_OPEN_SHORT_ARRAY), ($asToken + 1), $closer);
         if ($hasList === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -34,7 +34,7 @@ class NewMultiCatchSniff extends Sniff
      */
     public function register()
     {
-        return array(T_CATCH);
+        return array(\T_CATCH);
     }
 
     /**
@@ -60,7 +60,7 @@ class NewMultiCatchSniff extends Sniff
             return;
         }
 
-        $hasBitwiseOr = $phpcsFile->findNext(T_BITWISE_OR, $token['parenthesis_opener'], $token['parenthesis_closer']);
+        $hasBitwiseOr = $phpcsFile->findNext(\T_BITWISE_OR, $token['parenthesis_opener'], $token['parenthesis_closer']);
 
         if ($hasBitwiseOr === false) {
             return;

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -184,7 +184,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
         // Handle case-insensitivity of function names.
         $this->removedExtensions = $this->arrayKeysToLowercase($this->removedExtensions);
 
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**
@@ -203,7 +203,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
         // Find the next non-empty token.
         $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
-        if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
+        if ($tokens[$openBracket]['code'] !== \T_OPEN_PARENTHESIS) {
             // Not a function call.
             return;
         }
@@ -215,19 +215,19 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
 
         // Find the previous non-empty token.
         $search   = Tokens::$emptyTokens;
-        $search[] = T_BITWISE_AND;
+        $search[] = \T_BITWISE_AND;
         $previous = $phpcsFile->findPrevious($search, ($stackPtr - 1), null, true);
-        if ($tokens[$previous]['code'] === T_FUNCTION) {
+        if ($tokens[$previous]['code'] === \T_FUNCTION) {
             // It's a function definition, not a function call.
             return;
         }
 
-        if ($tokens[$previous]['code'] === T_NEW) {
+        if ($tokens[$previous]['code'] === \T_NEW) {
             // We are creating an object, not calling a function.
             return;
         }
 
-        if ($tokens[$previous]['code'] === T_OBJECT_OPERATOR) {
+        if ($tokens[$previous]['code'] === \T_OBJECT_OPERATOR) {
             // We are calling a method of an object.
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -41,8 +41,8 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
     public function register()
     {
         return array(
-            T_FUNCTION,
-            T_CLOSURE,
+            \T_FUNCTION,
+            \T_CLOSURE,
         );
     }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -37,8 +37,8 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
     public function register()
     {
         return array(
-            T_FUNCTION,
-            T_CLOSURE,
+            \T_FUNCTION,
+            \T_CLOSURE,
         );
     }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -38,7 +38,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
      */
     public function register()
     {
-        return array(T_USE);
+        return array(\T_USE);
     }
 
     /**
@@ -60,7 +60,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
 
         // Verify this use statement is used with a closure - if so, it has to have parenthesis before it.
         $previousNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-        if ($previousNonEmpty === false || $tokens[$previousNonEmpty]['code'] !== T_CLOSE_PARENTHESIS
+        if ($previousNonEmpty === false || $tokens[$previousNonEmpty]['code'] !== \T_CLOSE_PARENTHESIS
             || isset($tokens[$previousNonEmpty]['parenthesis_opener']) === false
         ) {
             return;
@@ -68,7 +68,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
 
         // ... and (a variable within) parenthesis after it.
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
-        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
+        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
             return;
         }
 
@@ -78,7 +78,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
         }
 
         $closurePtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($tokens[$previousNonEmpty]['parenthesis_opener'] - 1), null, true);
-        if ($closurePtr === false || $tokens[$closurePtr]['code'] !== T_CLOSURE) {
+        if ($closurePtr === false || $tokens[$closurePtr]['code'] !== \T_CLOSURE) {
             return;
         }
 
@@ -88,7 +88,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
         $errorMsg = 'Variables bound to a closure via the use construct cannot use the same name as superglobals, $this, or a declared parameter since PHP 7.1. Found: %s';
 
         for ($i = ($nextNonEmpty + 1); $i < $tokens[$nextNonEmpty]['parenthesis_closer']; $i++) {
-            if ($tokens[$i]['code'] !== T_VARIABLE) {
+            if ($tokens[$i]['code'] !== \T_VARIABLE) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -35,7 +35,7 @@ class NewClosureSniff extends Sniff
      */
     public function register()
     {
-        return array(T_CLOSURE);
+        return array(\T_CLOSURE);
     }
 
     /**
@@ -172,7 +172,7 @@ class NewClosureSniff extends Sniff
         $tokens    = $phpcsFile->getTokens();
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
 
-        return ($prevToken !== false && $tokens[$prevToken]['code'] === T_STATIC);
+        return ($prevToken !== false && $tokens[$prevToken]['code'] === \T_STATIC);
     }
 
 
@@ -194,7 +194,7 @@ class NewClosureSniff extends Sniff
         }
 
         return $phpcsFile->findNext(
-            T_VARIABLE,
+            \T_VARIABLE,
             $startToken,
             $endToken,
             false,
@@ -220,15 +220,15 @@ class NewClosureSniff extends Sniff
         }
 
         $tokens   = $phpcsFile->getTokens();
-        $classRef = $phpcsFile->findNext(array(T_SELF, T_PARENT, T_STATIC), $startToken, $endToken);
+        $classRef = $phpcsFile->findNext(array(\T_SELF, \T_PARENT, \T_STATIC), $startToken, $endToken);
 
-        if ($classRef === false || $tokens[$classRef]['code'] !== T_STATIC) {
+        if ($classRef === false || $tokens[$classRef]['code'] !== \T_STATIC) {
             return $classRef;
         }
 
         // T_STATIC, make sure it is used as a class reference.
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($classRef + 1), $endToken, true);
-        if ($next === false || $tokens[$next]['code'] !== T_DOUBLE_COLON) {
+        if ($next === false || $tokens[$next]['code'] !== \T_DOUBLE_COLON) {
             return false;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -41,12 +41,12 @@ class NewNullableTypesSniff extends Sniff
     public function register()
     {
         $tokens = array(
-            T_FUNCTION,
-            T_CLOSURE,
+            \T_FUNCTION,
+            \T_CLOSURE,
         );
 
         if (defined('T_RETURN_TYPE')) {
-            $tokens[] = T_RETURN_TYPE;
+            $tokens[] = \T_RETURN_TYPE;
         }
 
         return $tokens;
@@ -71,7 +71,7 @@ class NewNullableTypesSniff extends Sniff
         $tokens    = $phpcsFile->getTokens();
         $tokenCode = $tokens[$stackPtr]['code'];
 
-        if ($tokenCode === T_FUNCTION || $tokenCode === T_CLOSURE) {
+        if ($tokenCode === \T_FUNCTION || $tokenCode === \T_CLOSURE) {
             $this->processFunctionDeclaration($phpcsFile, $stackPtr);
 
             // Deal with older PHPCS version which don't recognize return type hints
@@ -134,10 +134,10 @@ class NewNullableTypesSniff extends Sniff
         $previous = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         // Deal with namespaced class names.
-        if ($tokens[$previous]['code'] === T_NS_SEPARATOR) {
-            $validTokens                 = Tokens::$emptyTokens;
-            $validTokens[T_STRING]       = true;
-            $validTokens[T_NS_SEPARATOR] = true;
+        if ($tokens[$previous]['code'] === \T_NS_SEPARATOR) {
+            $validTokens                  = Tokens::$emptyTokens;
+            $validTokens[\T_STRING]       = true;
+            $validTokens[\T_NS_SEPARATOR] = true;
 
             $stackPtr--;
 
@@ -150,7 +150,7 @@ class NewNullableTypesSniff extends Sniff
 
         // T_NULLABLE token was introduced in PHPCS 2.7.2. Before that it identified as T_INLINE_THEN.
         if ((defined('T_NULLABLE') === true && $tokens[$previous]['type'] === 'T_NULLABLE')
-            || (defined('T_NULLABLE') === false && $tokens[$previous]['code'] === T_INLINE_THEN)
+            || (defined('T_NULLABLE') === false && $tokens[$previous]['code'] === \T_INLINE_THEN)
         ) {
             $phpcsFile->addError(
                 'Nullable return types are not supported in PHP 7.0 or earlier.',

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -97,8 +97,8 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
     public function register()
     {
         return array(
-            T_FUNCTION,
-            T_CLOSURE,
+            \T_FUNCTION,
+            \T_CLOSURE,
         );
     }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -96,12 +96,12 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
     public function register()
     {
         $tokens = array(
-            T_FUNCTION,
-            T_CLOSURE,
+            \T_FUNCTION,
+            \T_CLOSURE,
         );
 
         if (defined('T_RETURN_TYPE')) {
-            $tokens[] = T_RETURN_TYPE;
+            $tokens[] = \T_RETURN_TYPE;
         }
 
         return $tokens;
@@ -123,7 +123,7 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
 
         // Deal with older PHPCS version which don't recognize return type hints
         // as well as newer PHPCS versions (3.3.0+) where the tokenization has changed.
-        if ($tokens[$stackPtr]['code'] === T_FUNCTION || $tokens[$stackPtr]['code'] === T_CLOSURE) {
+        if ($tokens[$stackPtr]['code'] === \T_FUNCTION || $tokens[$stackPtr]['code'] === \T_CLOSURE) {
             $returnTypeHint = $this->getReturnTypeHintToken($phpcsFile, $stackPtr);
             if ($returnTypeHint !== false) {
                 $stackPtr = $returnTypeHint;
@@ -137,8 +137,8 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
             $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
         }
         // Handle class name based return types.
-        elseif ($tokens[$stackPtr]['code'] === T_STRING
-            || (defined('T_RETURN_TYPE') && $tokens[$stackPtr]['code'] === T_RETURN_TYPE)
+        elseif ($tokens[$stackPtr]['code'] === \T_STRING
+            || (defined('T_RETURN_TYPE') && $tokens[$stackPtr]['code'] === \T_RETURN_TYPE)
         ) {
             $itemInfo = array(
                 'name'   => 'Class name',

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -84,13 +84,13 @@ class NonStaticMagicMethodsSniff extends Sniff
     public function register()
     {
         $targets = array(
-            T_CLASS,
-            T_INTERFACE,
-            T_TRAIT,
+            \T_CLASS,
+            \T_INTERFACE,
+            \T_TRAIT,
         );
 
         if (defined('T_ANON_CLASS')) {
-            $targets[] = T_ANON_CLASS;
+            $targets[] = \T_ANON_CLASS;
         }
 
         return $targets;
@@ -123,7 +123,7 @@ class NonStaticMagicMethodsSniff extends Sniff
         $functionPtr      = $stackPtr;
 
         // Find all the functions in this class or interface.
-        while (($functionToken = $phpcsFile->findNext(T_FUNCTION, $functionPtr, $classScopeCloser)) !== false) {
+        while (($functionToken = $phpcsFile->findNext(\T_FUNCTION, $functionPtr, $classScopeCloser)) !== false) {
             /*
              * Get the scope closer for this function in order to know how
              * to advance to the next function.

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -83,7 +83,7 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        return array(T_FUNCTION);
+        return array(\T_FUNCTION);
     }
 
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -43,7 +43,7 @@ class RemovedMagicAutoloadSniff extends Sniff
      */
     public function register()
     {
-        return array(T_FUNCTION);
+        return array(\T_FUNCTION);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -36,10 +36,10 @@ class RemovedNamespacedAssertSniff extends Sniff
      * @var array
      */
     private $scopes = array(
-        T_CLASS,
-        T_INTERFACE,
-        T_TRAIT,
-        T_CLOSURE,
+        \T_CLASS,
+        \T_INTERFACE,
+        \T_TRAIT,
+        \T_CLOSURE,
     );
 
     /**
@@ -51,10 +51,10 @@ class RemovedNamespacedAssertSniff extends Sniff
     {
         // Enrich the scopes list.
         if (defined('T_ANON_CLASS')) {
-            $this->scopes[] = T_ANON_CLASS;
+            $this->scopes[] = \T_ANON_CLASS;
         }
 
-        return array(T_FUNCTION);
+        return array(\T_FUNCTION);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -35,8 +35,8 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
     public function register()
     {
         return array(
-            T_CLASS,
-            T_INTERFACE,
+            \T_CLASS,
+            \T_INTERFACE,
         );
     }
 
@@ -75,7 +75,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
         }
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_STRING) {
+        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_STRING) {
             // Anonymous class in combination with PHPCS 2.3.x.
             return;
         }
@@ -92,7 +92,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
         $newConstructorFound = false;
         $oldConstructorFound = false;
         $oldConstructorPos   = -1;
-        while (($nextFunc = $phpcsFile->findNext(T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
+        while (($nextFunc = $phpcsFile->findNext(\T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
             $functionScopeCloser = $nextFunc;
             if (isset($tokens[$nextFunc]['scope_closer'])) {
                 // Normal (non-interface, non-abstract) method.

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -42,13 +42,13 @@ class ReservedFunctionNamesSniff extends PHPCS_CamelCapsFunctionNameSniff
      */
     public function __construct()
     {
-        $scopeTokens = array(T_CLASS, T_INTERFACE, T_TRAIT);
+        $scopeTokens = array(\T_CLASS, \T_INTERFACE, \T_TRAIT);
         if (defined('T_ANON_CLASS')) {
-            $scopeTokens[] = T_ANON_CLASS;
+            $scopeTokens[] = \T_ANON_CLASS;
         }
 
         // Call the grand-parent constructor directly.
-        PHPCS_AbstractScopeSniff::__construct($scopeTokens, array(T_FUNCTION), true);
+        PHPCS_AbstractScopeSniff::__construct($scopeTokens, array(\T_FUNCTION), true);
 
         // Make sure debuginfo is included in the array. Upstream only includes it since 2.5.1.
         $this->magicMethods['debuginfo'] = true;
@@ -96,7 +96,7 @@ class ReservedFunctionNamesSniff extends PHPCS_CamelCapsFunctionNameSniff
             ) {
                 $className         = '[anonymous class]';
                 $scopeNextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($currScope + 1), null, true);
-                if ($scopeNextNonEmpty !== false && $tokens[$scopeNextNonEmpty]['code'] === T_STRING) {
+                if ($scopeNextNonEmpty !== false && $tokens[$scopeNextNonEmpty]['code'] === \T_STRING) {
                     $className = $tokens[$scopeNextNonEmpty]['content'];
                 }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -69,8 +69,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      * @var array
      */
     private $noneFunctionCallIndicators = array(
-        T_DOUBLE_COLON    => true,
-        T_OBJECT_OPERATOR => true,
+        \T_DOUBLE_COLON    => true,
+        \T_OBJECT_OPERATOR => true,
     );
 
     /**
@@ -79,8 +79,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      * @var array
      */
     private $plusPlusMinusMinus = array(
-        T_DEC => true,
-        T_INC => true,
+        \T_DEC => true,
+        \T_INC => true,
     );
 
     /**
@@ -89,10 +89,10 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      * @var array
      */
     private $ignoreForStartOfStatement = array(
-        T_COMMA,
-        T_DOUBLE_ARROW,
-        T_OPEN_SQUARE_BRACKET,
-        T_OPEN_PARENTHESIS,
+        \T_COMMA,
+        \T_DOUBLE_ARROW,
+        \T_OPEN_SQUARE_BRACKET,
+        \T_OPEN_PARENTHESIS,
     );
 
     /**
@@ -103,8 +103,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
     public function register()
     {
         return array(
-            T_FUNCTION,
-            T_CLOSURE,
+            \T_FUNCTION,
+            \T_CLOSURE,
         );
     }
 
@@ -152,7 +152,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 continue;
             }
 
-            if ($tokens[$i]['code'] !== T_STRING) {
+            if ($tokens[$i]['code'] !== \T_STRING) {
                 continue;
             }
 
@@ -167,7 +167,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
              * Ok, so is this really a function call to one of the PHP native functions ?
              */
             $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
-            if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
+            if ($next === false || $tokens[$next]['code'] !== \T_OPEN_PARENTHESIS) {
                 // Live coding, parse error or not a function call.
                 continue;
             }
@@ -179,9 +179,9 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 }
 
                 // Check for namespaced functions, ie: \foo\bar() not \bar().
-                if ($tokens[ $prev ]['code'] === T_NS_SEPARATOR) {
+                if ($tokens[ $prev ]['code'] === \T_NS_SEPARATOR) {
                     $pprev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
-                    if ($pprev !== false && $tokens[ $pprev ]['code'] === T_STRING) {
+                    if ($pprev !== false && $tokens[ $pprev ]['code'] === \T_STRING) {
                         continue;
                     }
                 }
@@ -201,7 +201,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                         case 'debug_backtrace':
                         case 'debug_print_backtrace':
                             $hasIgnoreArgs = $phpcsFile->findNext(
-                                T_STRING,
+                                \T_STRING,
                                 $paramOne['start'],
                                 ($paramOne['end'] + 1),
                                 false,
@@ -225,7 +225,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                          *  Should be exceptionally rare and can - if needs be - be addressed at a later stage.}}
                          */
                         case 'func_get_arg':
-                            $number = $phpcsFile->findNext(T_LNUMBER, $paramOne['start'], ($paramOne['end'] + 1));
+                            $number = $phpcsFile->findNext(\T_LNUMBER, $paramOne['start'], ($paramOne['end'] + 1));
                             if ($number !== false) {
                                 $argNumber = $tokens[$number]['content'];
 
@@ -246,17 +246,17 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                  * {@internal Note: This does not take offset calculations into account!
                  *  Should be exceptionally rare and can - if needs be - be addressed at a later stage.}}
                  */
-                if ($prev !== false && $tokens[$prev]['code'] === T_OPEN_PARENTHESIS) {
+                if ($prev !== false && $tokens[$prev]['code'] === \T_OPEN_PARENTHESIS) {
 
                     $maybeFunctionCall = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
                     if ($maybeFunctionCall !== false
-                        && $tokens[$maybeFunctionCall]['code'] === T_STRING
+                        && $tokens[$maybeFunctionCall]['code'] === \T_STRING
                         && ($tokens[$maybeFunctionCall]['content'] === 'array_slice'
                         || $tokens[$maybeFunctionCall]['content'] === 'array_splice')
                     ) {
                         $parentFuncParamTwo = $this->getFunctionCallParameter($phpcsFile, $maybeFunctionCall, 2);
                         $number             = $phpcsFile->findNext(
-                            T_LNUMBER,
+                            \T_LNUMBER,
                             $parentFuncParamTwo['start'],
                             ($parentFuncParamTwo['end'] + 1)
                         );
@@ -288,7 +288,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     true
                 );
 
-                if ($tokens[$afterParenthesis]['code'] === T_OPEN_SQUARE_BRACKET
+                if ($tokens[$afterParenthesis]['code'] === \T_OPEN_SQUARE_BRACKET
                     && isset($tokens[$afterParenthesis]['bracket_closer'])
                 ) {
                     $afterStackFrame = $phpcsFile->findNext(
@@ -298,11 +298,11 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                         true
                     );
 
-                    if ($tokens[$afterStackFrame]['code'] === T_OPEN_SQUARE_BRACKET
+                    if ($tokens[$afterStackFrame]['code'] === \T_OPEN_SQUARE_BRACKET
                         && isset($tokens[$afterStackFrame]['bracket_closer'])
                     ) {
                         $arrayIndex = $phpcsFile->findNext(
-                            T_CONSTANT_ENCAPSED_STRING,
+                            \T_CONSTANT_ENCAPSED_STRING,
                             ($afterStackFrame + 1),
                             $tokens[$afterStackFrame]['bracket_closer']
                         );
@@ -336,7 +336,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     continue;
                 }
 
-                if ($tokens[$j]['code'] !== T_VARIABLE) {
+                if ($tokens[$j]['code'] !== \T_VARIABLE) {
                     continue;
                 }
 
@@ -388,12 +388,12 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     break;
                 }
 
-                if ($tokens[$afterVar]['code'] === T_OPEN_SQUARE_BRACKET
+                if ($tokens[$afterVar]['code'] === \T_OPEN_SQUARE_BRACKET
                     && isset($tokens[$afterVar]['bracket_closer'])
                 ) {
                     // Skip past array access on the variable.
                     while (($afterVar = $phpcsFile->findNext(Tokens::$emptyTokens, ($tokens[$afterVar]['bracket_closer'] + 1), null, true)) !== false) {
-                        if ($tokens[$afterVar]['code'] !== T_OPEN_SQUARE_BRACKET
+                        if ($tokens[$afterVar]['code'] !== \T_OPEN_SQUARE_BRACKET
                             || isset($tokens[$afterVar]['bracket_closer']) === false
                         ) {
                             break;

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -54,7 +54,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
      */
     public function register()
     {
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
 
@@ -77,22 +77,22 @@ class ArgumentFunctionsUsageSniff extends Sniff
 
         // Next non-empty token should be the open parenthesis.
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
-        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
+        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
             return;
         }
 
         $ignore = array(
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_NEW             => true,
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_FUNCTION        => true,
+            \T_NEW             => true,
         );
 
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
             // Not a call to a PHP function.
             return;
-        } elseif ($tokens[$prevNonEmpty]['code'] === T_NS_SEPARATOR && $tokens[$prevNonEmpty - 1]['code'] === T_STRING) {
+        } elseif ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR && $tokens[$prevNonEmpty - 1]['code'] === \T_STRING) {
             // Namespaced function.
             return;
         }
@@ -105,7 +105,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
          * As PHPCS can not determine whether a file is included from within a function in
          * another file, so always throw a warning/error.
          */
-        if ($phpcsFile->hasCondition($stackPtr, array(T_FUNCTION, T_CLOSURE)) === false) {
+        if ($phpcsFile->hasCondition($stackPtr, array(\T_FUNCTION, \T_CLOSURE)) === false) {
             $isError = false;
             $message = 'Use of %s() outside of a user-defined function is only supported if the file is included from within a user-defined function in another file prior to PHP 5.3.';
 
@@ -138,12 +138,12 @@ class ArgumentFunctionsUsageSniff extends Sniff
         } else {
             $opener       = key($tokens[$stackPtr]['nested_parenthesis']);
             $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
-            if ($tokens[$prevNonEmpty]['code'] !== T_STRING) {
+            if ($tokens[$prevNonEmpty]['code'] !== \T_STRING) {
                 return;
             }
 
             $prevPrevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
-            if ($tokens[$prevPrevNonEmpty]['code'] === T_FUNCTION) {
+            if ($tokens[$prevPrevNonEmpty]['code'] === \T_FUNCTION) {
                 return;
             }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -932,7 +932,7 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         // Handle case-insensitivity of function names.
         $this->newFunctionParameters = $this->arrayKeysToLowercase($this->newFunctionParameters);
 
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**
@@ -949,13 +949,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_CONST           => true,
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_FUNCTION        => true,
+            \T_CONST           => true,
         );
 
-        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -1852,7 +1852,7 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
         // Handle case-insensitivity of function names.
         $this->newFunctions = $this->arrayKeysToLowercase($this->newFunctions);
 
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**
@@ -1869,18 +1869,18 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_CONST           => true,
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_FUNCTION        => true,
+            \T_CONST           => true,
         );
 
-        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
 
-        } elseif ($tokens[$prevToken]['code'] === T_NS_SEPARATOR && $tokens[$prevToken - 1]['code'] === T_STRING) {
+        } elseif ($tokens[$prevToken]['code'] === \T_NS_SEPARATOR && $tokens[$prevToken - 1]['code'] === \T_STRING) {
             // Namespaced function.
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -77,7 +77,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         // Handle case-insensitivity of function names.
         $this->removedFunctionParameters = $this->arrayKeysToLowercase($this->removedFunctionParameters);
 
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**
@@ -94,13 +94,13 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_CONST           => true,
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_FUNCTION        => true,
+            \T_CONST           => true,
         );
 
-        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -897,7 +897,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         // Handle case-insensitivity of function names.
         $this->removedFunctions = $this->arrayKeysToLowercase($this->removedFunctions);
 
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
 
@@ -915,16 +915,16 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_CLASS           => true,
-            T_CONST           => true,
-            T_USE             => true,
-            T_NS_SEPARATOR    => true,
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_FUNCTION        => true,
+            \T_CLASS           => true,
+            \T_CONST           => true,
+            \T_USE             => true,
+            \T_NS_SEPARATOR    => true,
         );
 
-        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -145,7 +145,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
         // Handle case-insensitivity of function names.
         $this->functionParameters = $this->arrayKeysToLowercase($this->functionParameters);
 
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**
@@ -162,13 +162,13 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_CONST           => true,
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_FUNCTION        => true,
+            \T_CONST           => true,
         );
 
-        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
@@ -185,7 +185,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
         $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
 
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        if ($parameterCount === 0 && $tokens[$openParenthesis]['code'] !== T_OPEN_PARENTHESIS) {
+        if ($parameterCount === 0 && $tokens[$openParenthesis]['code'] !== \T_OPEN_PARENTHESIS) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -34,8 +34,8 @@ class NewGeneratorReturnSniff extends Sniff
      * @var array
      */
     private $validConditions = array(
-        T_FUNCTION => T_FUNCTION,
-        T_CLOSURE  => T_CLOSURE,
+        \T_FUNCTION => \T_FUNCTION,
+        \T_CLOSURE  => \T_CLOSURE,
     );
 
 
@@ -47,7 +47,7 @@ class NewGeneratorReturnSniff extends Sniff
     public function register()
     {
         $targets = array(
-            T_YIELD,
+            \T_YIELD,
         );
 
         /*
@@ -63,14 +63,14 @@ class NewGeneratorReturnSniff extends Sniff
          * For PHP 5.5+ we need to look for T_YIELD.
          * For PHPCS 3.1.0+, we also need to look for T_YIELD_FROM.
          */
-        if (version_compare(PHP_VERSION_ID, '50500', '<') === true
+        if (version_compare(\PHP_VERSION_ID, '50500', '<') === true
             && version_compare(PHPCSHelper::getVersion(), '3.1.0', '<') === true
         ) {
-            $targets[] = T_STRING;
+            $targets[] = \T_STRING;
         }
 
         if (defined('T_YIELD_FROM')) {
-            $targets[] = T_YIELD_FROM;
+            $targets[] = \T_YIELD_FROM;
         }
 
         return $targets;
@@ -93,7 +93,7 @@ class NewGeneratorReturnSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] === T_STRING
+        if ($tokens[$stackPtr]['code'] === \T_STRING
             && $tokens[$stackPtr]['content'] !== 'yield'
         ) {
             return;
@@ -122,15 +122,15 @@ class NewGeneratorReturnSniff extends Sniff
             return;
         }
 
-        $targets = array(T_RETURN, T_CLOSURE, T_FUNCTION, T_CLASS);
+        $targets = array(\T_RETURN, \T_CLOSURE, \T_FUNCTION, \T_CLASS);
         if (defined('T_ANON_CLASS')) {
-            $targets[] = T_ANON_CLASS;
+            $targets[] = \T_ANON_CLASS;
         }
 
         $current = $tokens[$function]['scope_opener'];
 
         while (($current = $phpcsFile->findNext($targets, ($current + 1), $tokens[$function]['scope_closer'])) !== false) {
-            if ($tokens[$current]['code'] === T_RETURN) {
+            if ($tokens[$current]['code'] === \T_RETURN) {
                 $phpcsFile->addError(
                     'Returning a final expression from a generator was not supported in PHP 5.6 or earlier',
                     $current,

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -511,7 +511,7 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**
@@ -528,13 +528,13 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_CONST           => true,
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_FUNCTION        => true,
+            \T_CONST           => true,
         );
 
-        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -237,7 +237,7 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
      */
     public function register()
     {
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**
@@ -254,13 +254,13 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_CONST           => true,
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_FUNCTION        => true,
+            \T_CONST           => true,
         );
 
-        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -35,7 +35,7 @@ class NewConstantArraysUsingConstSniff extends Sniff
      */
     public function register()
     {
-        return array(T_CONST);
+        return array(\T_CONST);
     }
 
     /**
@@ -55,8 +55,8 @@ class NewConstantArraysUsingConstSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
         $find   = array(
-            T_ARRAY             => T_ARRAY,
-            T_OPEN_SHORT_ARRAY  => T_OPEN_SHORT_ARRAY,
+            \T_ARRAY            => \T_ARRAY,
+            \T_OPEN_SHORT_ARRAY => \T_OPEN_SHORT_ARRAY,
         );
 
         while (($hasArray = $phpcsFile->findNext($find, ($stackPtr + 1), null, false, null, true)) !== false) {
@@ -68,9 +68,9 @@ class NewConstantArraysUsingConstSniff extends Sniff
 
             // Skip past the content of the array.
             $stackPtr = $hasArray;
-            if ($tokens[$hasArray]['code'] === T_OPEN_SHORT_ARRAY && isset($tokens[$hasArray]['bracket_closer'])) {
+            if ($tokens[$hasArray]['code'] === \T_OPEN_SHORT_ARRAY && isset($tokens[$hasArray]['bracket_closer'])) {
                 $stackPtr = $tokens[$hasArray]['bracket_closer'];
-            } elseif ($tokens[$hasArray]['code'] === T_ARRAY && isset($tokens[$hasArray]['parenthesis_closer'])) {
+            } elseif ($tokens[$hasArray]['code'] === \T_ARRAY && isset($tokens[$hasArray]['parenthesis_closer'])) {
                 $stackPtr = $tokens[$hasArray]['parenthesis_closer'];
             }
         }

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -35,7 +35,7 @@ class NewConstantArraysUsingDefineSniff extends Sniff
      */
     public function register()
     {
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**
@@ -56,13 +56,13 @@ class NewConstantArraysUsingDefineSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
-            T_DOUBLE_COLON    => true,
-            T_OBJECT_OPERATOR => true,
-            T_FUNCTION        => true,
-            T_CONST           => true,
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_FUNCTION        => true,
+            \T_CONST           => true,
         );
 
-        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;
@@ -83,7 +83,7 @@ class NewConstantArraysUsingDefineSniff extends Sniff
             $targetNestingLevel = count($tokens[$secondParam['start']]['nested_parenthesis']);
         }
 
-        $array = $phpcsFile->findNext(array(T_ARRAY, T_OPEN_SHORT_ARRAY), $secondParam['start'], ($secondParam['end'] + 1));
+        $array = $phpcsFile->findNext(array(\T_ARRAY, \T_OPEN_SHORT_ARRAY), $secondParam['start'], ($secondParam['end'] + 1));
         if ($array !== false) {
             if ((isset($tokens[$array]['nested_parenthesis']) === false && $targetNestingLevel === 0) || count($tokens[$array]['nested_parenthesis']) === $targetNestingLevel) {
                 $phpcsFile->addError(

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -60,29 +60,29 @@ class NewConstantScalarExpressionsSniff extends Sniff
      * @var array
      */
     protected $safeOperands = array(
-        T_LNUMBER                  => T_LNUMBER,
-        T_DNUMBER                  => T_DNUMBER,
-        T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
-        T_TRUE                     => T_TRUE,
-        T_FALSE                    => T_FALSE,
-        T_NULL                     => T_NULL,
+        \T_LNUMBER                  => \T_LNUMBER,
+        \T_DNUMBER                  => \T_DNUMBER,
+        \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
+        \T_TRUE                     => \T_TRUE,
+        \T_FALSE                    => \T_FALSE,
+        \T_NULL                     => \T_NULL,
 
-        T_LINE                     => T_LINE,
-        T_FILE                     => T_FILE,
-        T_DIR                      => T_DIR,
-        T_FUNC_C                   => T_FUNC_C,
-        T_CLASS_C                  => T_CLASS_C,
-        T_TRAIT_C                  => T_TRAIT_C,
-        T_METHOD_C                 => T_METHOD_C,
-        T_NS_C                     => T_NS_C,
+        \T_LINE                     => \T_LINE,
+        \T_FILE                     => \T_FILE,
+        \T_DIR                      => \T_DIR,
+        \T_FUNC_C                   => \T_FUNC_C,
+        \T_CLASS_C                  => \T_CLASS_C,
+        \T_TRAIT_C                  => \T_TRAIT_C,
+        \T_METHOD_C                 => \T_METHOD_C,
+        \T_NS_C                     => \T_NS_C,
 
         // Special cases:
-        T_NS_SEPARATOR             => T_NS_SEPARATOR,
+        \T_NS_SEPARATOR             => \T_NS_SEPARATOR,
         /*
          * This can be neigh anything, but for any usage except constants,
          * the T_STRING will be combined with non-allowed tokens, so we should be good.
          */
-        T_STRING                   => T_STRING,
+        \T_STRING                   => \T_STRING,
     );
 
 
@@ -97,11 +97,11 @@ class NewConstantScalarExpressionsSniff extends Sniff
         $this->setProperties();
 
         return array(
-            T_CONST,
-            T_VARIABLE,
-            T_FUNCTION,
-            T_CLOSURE,
-            T_STATIC,
+            \T_CONST,
+            \T_VARIABLE,
+            \T_FUNCTION,
+            \T_CLOSURE,
+            \T_STATIC,
         );
     }
 
@@ -180,7 +180,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                     }
 
                     $end = $param['token'];
-                    while (($end = $phpcsFile->findNext(array(T_COMMA, T_CLOSE_PARENTHESIS), ($end + 1), ($closer + 1))) !== false) {
+                    while (($end = $phpcsFile->findNext(array(\T_COMMA, \T_CLOSE_PARENTHESIS), ($end + 1), ($closer + 1))) !== false) {
                         $maybeSkipTo = $this->isRealEndOfDeclaration($tokens, $end, $nestedParenthesisCount);
                         if ($maybeSkipTo !== true) {
                             $end = $maybeSkipTo;
@@ -188,7 +188,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                         }
 
                         // Ignore closing parenthesis/bracket if not 'ours'.
-                        if ($tokens[$end]['code'] === T_CLOSE_PARENTHESIS && $end !== $closer) {
+                        if ($tokens[$end]['code'] === \T_CLOSE_PARENTHESIS && $end !== $closer) {
                             continue;
                         }
 
@@ -213,7 +213,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                 $type = 'const';
 
                 // Filter out non-property declarations.
-                if ($tokens[$stackPtr]['code'] === T_VARIABLE) {
+                if ($tokens[$stackPtr]['code'] === \T_VARIABLE) {
                     if ($this->isClassProperty($phpcsFile, $stackPtr) === false) {
                         return;
                     }
@@ -225,9 +225,9 @@ class NewConstantScalarExpressionsSniff extends Sniff
                 }
 
                 // Filter out late static binding and class properties.
-                if ($tokens[$stackPtr]['code'] === T_STATIC) {
+                if ($tokens[$stackPtr]['code'] === \T_STATIC) {
                     $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
-                    if ($next === false || $tokens[$next]['code'] !== T_VARIABLE) {
+                    if ($next === false || $tokens[$next]['code'] !== \T_VARIABLE) {
                         // Late static binding.
                         return;
                     }
@@ -241,7 +241,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                     $type = 'staticvar';
                 }
 
-                $endOfStatement = $phpcsFile->findNext(array(T_SEMICOLON, T_CLOSE_TAG), ($stackPtr + 1));
+                $endOfStatement = $phpcsFile->findNext(array(\T_SEMICOLON, \T_CLOSE_TAG), ($stackPtr + 1));
                 if ($endOfStatement === false) {
                     // No semi-colon - live coding.
                     return;
@@ -255,7 +255,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                 // Examine each variable/constant in multi-declarations.
                 $start = $stackPtr;
                 $end   = $stackPtr;
-                while (($end = $phpcsFile->findNext(array(T_COMMA, T_SEMICOLON, T_OPEN_SHORT_ARRAY, T_CLOSE_TAG), ($end + 1), ($endOfStatement + 1))) !== false) {
+                while (($end = $phpcsFile->findNext(array(\T_COMMA, \T_SEMICOLON, \T_OPEN_SHORT_ARRAY, \T_CLOSE_TAG), ($end + 1), ($endOfStatement + 1))) !== false) {
 
                     $maybeSkipTo = $this->isRealEndOfDeclaration($tokens, $end, $targetNestingLevel);
                     if ($maybeSkipTo !== true) {
@@ -265,8 +265,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
 
                     $start = $phpcsFile->findNext(Tokens::$emptyTokens, ($start + 1), $end, true);
                     if ($start === false
-                        || ($tokens[$stackPtr]['code'] === T_CONST && $tokens[$start]['code'] !== T_STRING)
-                        || ($tokens[$stackPtr]['code'] !== T_CONST && $tokens[$start]['code'] !== T_VARIABLE)
+                        || ($tokens[$stackPtr]['code'] === \T_CONST && $tokens[$start]['code'] !== \T_STRING)
+                        || ($tokens[$stackPtr]['code'] !== \T_CONST && $tokens[$start]['code'] !== \T_VARIABLE)
                     ) {
                         // Shouldn't be possible.
                         continue;
@@ -308,7 +308,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
     {
         $tokens = $phpcsFile->getTokens();
         $next   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), $end, true);
-        if ($next === false || $tokens[$next]['code'] !== T_EQUAL) {
+        if ($next === false || $tokens[$next]['code'] !== \T_EQUAL) {
             // No value assigned.
             return true;
         }
@@ -342,8 +342,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
          * OK, so we have at least one token which needs extra examination.
          */
         switch ($tokens[$nextNonSimple]['code']) {
-            case T_MINUS:
-            case T_PLUS:
+            case \T_MINUS:
+            case \T_PLUS:
                 if ($this->isNumber($phpcsFile, $start, $end, true) !== false) {
                     // Int or float with sign.
                     return true;
@@ -351,34 +351,34 @@ class NewConstantScalarExpressionsSniff extends Sniff
 
                 return false;
 
-            case T_NAMESPACE:
-            case T_PARENT:
-            case T_SELF:
-            case T_DOUBLE_COLON:
+            case \T_NAMESPACE:
+            case \T_PARENT:
+            case \T_SELF:
+            case \T_DOUBLE_COLON:
                 $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonSimple + 1), ($end + 1), true);
 
-                if ($tokens[$nextNonSimple]['code'] === T_NAMESPACE) {
+                if ($tokens[$nextNonSimple]['code'] === \T_NAMESPACE) {
                     // Allow only `namespace\...`.
-                    if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_NS_SEPARATOR) {
+                    if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_NS_SEPARATOR) {
                         return false;
                     }
-                } elseif ($tokens[$nextNonSimple]['code'] === T_PARENT
-                    || $tokens[$nextNonSimple]['code'] === T_SELF
+                } elseif ($tokens[$nextNonSimple]['code'] === \T_PARENT
+                    || $tokens[$nextNonSimple]['code'] === \T_SELF
                 ) {
                     // Allow only `parent::` and `self::`.
-                    if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_DOUBLE_COLON) {
+                    if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_DOUBLE_COLON) {
                         return false;
                     }
-                } elseif ($tokens[$nextNonSimple]['code'] === T_DOUBLE_COLON) {
+                } elseif ($tokens[$nextNonSimple]['code'] === \T_DOUBLE_COLON) {
                     // Allow only `T_STRING::T_STRING`.
-                    if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_STRING) {
+                    if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_STRING) {
                         return false;
                     }
 
                     $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nextNonSimple - 1), null, true);
                     // No need to worry about parent/self, that's handled above and
                     // the double colon is skipped over in that case.
-                    if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== T_STRING) {
+                    if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== \T_STRING) {
                         return false;
                     }
                 }
@@ -386,8 +386,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
                 // Examine what comes after the namespace/parent/self/double colon, if anything.
                 return $this->isStaticValue($phpcsFile, $tokens, ($nextNonEmpty + 1), $end, $nestedArrays);
 
-            case T_ARRAY:
-            case T_OPEN_SHORT_ARRAY:
+            case \T_ARRAY:
+            case \T_OPEN_SHORT_ARRAY:
                 ++$nestedArrays;
 
                 $arrayItems = $this->getFunctionCallParameters($phpcsFile, $nextNonSimple);
@@ -397,11 +397,11 @@ class NewConstantScalarExpressionsSniff extends Sniff
                         $doubleArrow = false;
 
                         $maybeDoubleArrow = $phpcsFile->findNext(
-                            array(T_DOUBLE_ARROW, T_ARRAY, T_OPEN_SHORT_ARRAY),
+                            array(\T_DOUBLE_ARROW, \T_ARRAY, \T_OPEN_SHORT_ARRAY),
                             $item['start'],
                             ($item['end'] + 1)
                         );
-                        if ($maybeDoubleArrow !== false && $tokens[$maybeDoubleArrow]['code'] === T_DOUBLE_ARROW) {
+                        if ($maybeDoubleArrow !== false && $tokens[$maybeDoubleArrow]['code'] === \T_DOUBLE_ARROW) {
                             // Double arrow is for this nesting level.
                             $doubleArrow = $maybeDoubleArrow;
                         }
@@ -433,13 +433,13 @@ class NewConstantScalarExpressionsSniff extends Sniff
                  * able to get the array items.
                  */
                 $closer = ($nextNonSimple + 1);
-                if ($tokens[$nextNonSimple]['code'] === T_OPEN_SHORT_ARRAY
+                if ($tokens[$nextNonSimple]['code'] === \T_OPEN_SHORT_ARRAY
                     && isset($tokens[$nextNonSimple]['bracket_closer']) === true
                 ) {
                     $closer = $tokens[$nextNonSimple]['bracket_closer'];
                 } else {
                     $maybeOpener = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonSimple + 1), ($end + 1), true);
-                    if ($tokens[$maybeOpener]['code'] === T_OPEN_PARENTHESIS) {
+                    if ($tokens[$maybeOpener]['code'] === \T_OPEN_PARENTHESIS) {
                         $opener = $maybeOpener;
                         if (isset($tokens[$opener]['parenthesis_closer']) === true) {
                             $closer = $tokens[$opener]['parenthesis_closer'];
@@ -508,7 +508,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
     private function isRealEndOfDeclaration($tokens, $endPtr, $targetLevel)
     {
         // Ignore anything within short array definition brackets for now.
-        if ($tokens[$endPtr]['code'] === T_OPEN_SHORT_ARRAY
+        if ($tokens[$endPtr]['code'] === \T_OPEN_SHORT_ARRAY
             && (isset($tokens[$endPtr]['bracket_opener'])
                 && $tokens[$endPtr]['bracket_opener'] === $endPtr)
             && isset($tokens[$endPtr]['bracket_closer'])
@@ -518,7 +518,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
         }
 
         // Skip past comma's at a lower nesting level.
-        if ($tokens[$endPtr]['code'] === T_COMMA) {
+        if ($tokens[$endPtr]['code'] === \T_COMMA) {
             // Check if a comma is at the nesting level we're targetting.
             $nestingLevel = 0;
             if (isset($tokens[$endPtr]['nested_parenthesis']) === true) {

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -80,11 +80,11 @@ class NewHeredocSniff extends NewConstantScalarExpressionsSniff
     {
         $tokens = $phpcsFile->getTokens();
         $next   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), $end, true);
-        if ($next === false || $tokens[$next]['code'] !== T_EQUAL) {
+        if ($next === false || $tokens[$next]['code'] !== \T_EQUAL) {
             // No value assigned.
             return true;
         }
 
-        return ($phpcsFile->findNext(T_START_HEREDOC, ($next + 1), $end, false, null, true) === false);
+        return ($phpcsFile->findNext(\T_START_HEREDOC, ($next + 1), $end, false, null, true) === false);
     }
 }

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -47,10 +47,10 @@ class InternalInterfacesSniff extends Sniff
         // Handle case-insensitivity of interface names.
         $this->internalInterfaces = $this->arrayKeysToLowercase($this->internalInterfaces);
 
-        $targets = array(T_CLASS);
+        $targets = array(\T_CLASS);
 
         if (defined('T_ANON_CLASS')) {
-            $targets[] = T_ANON_CLASS;
+            $targets[] = \T_ANON_CLASS;
         }
 
         return $targets;

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -123,17 +123,17 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
         $this->unsupportedMethods = $this->arrayKeysToLowercase($this->unsupportedMethods);
 
         $targets = array(
-            T_CLASS,
-            T_FUNCTION,
-            T_CLOSURE,
+            \T_CLASS,
+            \T_FUNCTION,
+            \T_CLOSURE,
         );
 
         if (defined('T_ANON_CLASS')) {
-            $targets[] = T_ANON_CLASS;
+            $targets[] = \T_ANON_CLASS;
         }
 
         if (defined('T_RETURN_TYPE')) {
-            $targets[] = T_RETURN_TYPE;
+            $targets[] = \T_RETURN_TYPE;
         }
 
         return $targets;
@@ -224,7 +224,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
 
             if ($checkMethods === true && isset($this->unsupportedMethods[$interfaceLc]) === true) {
                 $nextFunc = $stackPtr;
-                while (($nextFunc = $phpcsFile->findNext(T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
+                while (($nextFunc = $phpcsFile->findNext(\T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
                     $funcName   = $phpcsFile->getDeclarationName($nextFunc);
                     $funcNameLc = strtolower($funcName);
                     if ($funcNameLc === '') {

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -37,9 +37,9 @@ class CaseSensitiveKeywordsSniff extends Sniff
     public function register()
     {
         return array(
-            T_SELF,
-            T_STATIC,
-            T_PARENT,
+            \T_SELF,
+            \T_STATIC,
+            \T_PARENT,
         );
     }
 

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -38,9 +38,9 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
      * @var array
      */
     protected $forbiddenTokens = array(
-        T_NULL  => '7.0',
-        T_TRUE  => '7.0',
-        T_FALSE => '7.0',
+        \T_NULL  => '7.0',
+        \T_TRUE  => '7.0',
+        \T_FALSE => '7.0',
     );
 
     /**
@@ -99,11 +99,11 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
         $this->allForbiddenNames = array_merge($this->forbiddenNames, $this->softReservedNames);
 
         $targets = array(
-            T_CLASS,
-            T_INTERFACE,
-            T_TRAIT,
-            T_NAMESPACE,
-            T_STRING, // Compat for PHPCS < 2.4.0 and PHP < 5.3.
+            \T_CLASS,
+            \T_INTERFACE,
+            \T_TRAIT,
+            \T_NAMESPACE,
+            \T_STRING, // Compat for PHPCS < 2.4.0 and PHP < 5.3.
         );
 
         return $targets;
@@ -133,7 +133,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
         // For string tokens we only care about 'trait' as that is the only one
         // which may not be correctly recognized as it's own token.
         // This only happens in older versions of PHP where the token doesn't exist yet as a keyword.
-        if ($tokenCode === T_STRING && $tokenContentLc !== 'trait') {
+        if ($tokenCode === \T_STRING && $tokenContentLc !== 'trait') {
             return;
         }
 
@@ -157,7 +157,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
                 return;
             }
 
-        } elseif ($tokenCode === T_NAMESPACE) {
+        } elseif ($tokenCode === \T_NAMESPACE) {
             $namespaceName = $this->getDeclaredNamespaceName($phpcsFile, $stackPtr);
 
             if ($namespaceName === false || $namespaceName === '') {
@@ -173,7 +173,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
                     break;
                 }
             }
-        } elseif ($tokenCode === T_STRING) {
+        } elseif ($tokenCode === \T_STRING) {
             // Traits which are not yet tokenized as T_TRAIT.
             $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($nextNonEmpty === false) {
@@ -182,11 +182,11 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
 
             $nextNonEmptyCode = $tokens[$nextNonEmpty]['code'];
 
-            if ($nextNonEmptyCode !== T_STRING && isset($this->forbiddenTokens[$nextNonEmptyCode]) === true) {
+            if ($nextNonEmptyCode !== \T_STRING && isset($this->forbiddenTokens[$nextNonEmptyCode]) === true) {
                 $name   = $tokens[$nextNonEmpty]['content'];
                 $nameLc = strtolower($tokens[$nextNonEmpty]['content']);
-            } elseif ($nextNonEmptyCode === T_STRING) {
-                $endOfStatement = $phpcsFile->findNext(array(T_SEMICOLON, T_OPEN_CURLY_BRACKET), ($stackPtr + 1));
+            } elseif ($nextNonEmptyCode === \T_STRING) {
+                $endOfStatement = $phpcsFile->findNext(array(\T_SEMICOLON, \T_OPEN_CURLY_BRACKET), ($stackPtr + 1));
                 if ($endOfStatement === false) {
                     return;
                 }

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -33,22 +33,23 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
      * @var array
      */
     protected $targetedTokens = array(
-        T_ABSTRACT   => '5.0',
-        T_CALLABLE   => '5.4',
-        T_CATCH      => '5.0',
-        T_FINAL      => '5.0',
-        T_FINALLY    => '5.5',
-        T_GOTO       => '5.3',
-        T_IMPLEMENTS => '5.0',
-        T_INTERFACE  => '5.0',
-        T_INSTANCEOF => '5.0',
-        T_INSTEADOF  => '5.4',
-        T_NAMESPACE  => '5.3',
-        T_PRIVATE    => '5.0',
-        T_PROTECTED  => '5.0',
-        T_PUBLIC     => '5.0',
-        T_TRAIT      => '5.4',
-        T_TRY        => '5.0',
+        \T_ABSTRACT   => '5.0',
+        \T_CALLABLE   => '5.4',
+        \T_CATCH      => '5.0',
+        \T_FINAL      => '5.0',
+        \T_FINALLY    => '5.5',
+        \T_GOTO       => '5.3',
+        \T_IMPLEMENTS => '5.0',
+        \T_INTERFACE  => '5.0',
+        \T_INSTANCEOF => '5.0',
+        \T_INSTEADOF  => '5.4',
+        \T_NAMESPACE  => '5.3',
+        \T_PRIVATE    => '5.0',
+        \T_PROTECTED  => '5.0',
+        \T_PUBLIC     => '5.0',
+        \T_TRAIT      => '5.4',
+        \T_TRY        => '5.0',
+
     );
 
     /**
@@ -87,7 +88,7 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
     public function register()
     {
         $tokens   = array_keys($this->targetedTokens);
-        $tokens[] = T_STRING;
+        $tokens[] = \T_STRING;
 
         return $tokens;
     }
@@ -114,26 +115,26 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
          * token doesn't exist yet for that keyword or in later versions when the
          * token is used in a method invocation.
          */
-        if ($tokenCode === T_STRING
+        if ($tokenCode === \T_STRING
             && (isset($this->targetedStringTokens[$tokenContentLc]) === false)
         ) {
             return;
         }
 
-        if ($tokenCode === T_STRING) {
+        if ($tokenCode === \T_STRING) {
             $isString = true;
         }
 
         // Make sure this is a function call.
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
+        if ($next === false || $tokens[$next]['code'] !== \T_OPEN_PARENTHESIS) {
             // Not a function call.
             return;
         }
 
         // This sniff isn't concerned about function declarations.
         $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($prev !== false && $tokens[$prev]['code'] === T_FUNCTION) {
+        if ($prev !== false && $tokens[$prev]['code'] === \T_FUNCTION) {
             return;
         }
 
@@ -144,7 +145,7 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
          *
          * Only needed for those keywords which we sniff out via T_STRING.
          */
-        if (($tokens[$prev]['code'] === T_OBJECT_OPERATOR || $tokens[$prev]['code'] === T_DOUBLE_COLON)
+        if (($tokens[$prev]['code'] === \T_OBJECT_OPERATOR || $tokens[$prev]['code'] === \T_DOUBLE_COLON)
             && $this->supportsBelow('5.6') === false
         ) {
             return;
@@ -152,8 +153,8 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
 
         // For the word catch, it is valid to have an open parenthesis
         // after it, but only if it is preceded by a right curly brace.
-        if ($tokenCode === T_CATCH) {
-            if ($prev !== false && $tokens[$prev]['code'] === T_CLOSE_CURLY_BRACKET) {
+        if ($tokenCode === \T_CATCH) {
+            if ($prev !== false && $tokens[$prev]['code'] === \T_CLOSE_CURLY_BRACKET) {
                 // Ok, it's fine.
                 return;
             }

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -116,16 +116,16 @@ class ForbiddenNamesSniff extends Sniff
      * @var array
      */
     protected $targetedTokens = array(
-        T_CLASS,
-        T_FUNCTION,
-        T_NAMESPACE,
-        T_STRING,
-        T_CONST,
-        T_USE,
-        T_AS,
-        T_EXTENDS,
-        T_INTERFACE,
-        T_TRAIT,
+        \T_CLASS,
+        \T_FUNCTION,
+        \T_NAMESPACE,
+        \T_STRING,
+        \T_CONST,
+        \T_USE,
+        \T_AS,
+        \T_EXTENDS,
+        \T_INTERFACE,
+        \T_TRAIT,
     );
 
     /**
@@ -135,13 +135,13 @@ class ForbiddenNamesSniff extends Sniff
      */
     public function register()
     {
-        $this->allowedModifiers          = Tokens::$scopeModifiers;
-        $this->allowedModifiers[T_FINAL] = T_FINAL;
+        $this->allowedModifiers           = Tokens::$scopeModifiers;
+        $this->allowedModifiers[\T_FINAL] = \T_FINAL;
 
         $tokens = $this->targetedTokens;
 
         if (defined('T_ANON_CLASS')) {
-            $tokens[] = T_ANON_CLASS;
+            $tokens[] = \T_ANON_CLASS;
         }
 
         return $tokens;
@@ -221,7 +221,7 @@ class ForbiddenNamesSniff extends Sniff
          */
         elseif ($tokens[$stackPtr]['type'] === 'T_AS'
             && isset($this->allowedModifiers[$tokens[$nextNonEmpty]['code']]) === true
-            && $phpcsFile->hasCondition($stackPtr, T_USE) === true
+            && $phpcsFile->hasCondition($stackPtr, \T_USE) === true
         ) {
             $maybeUseNext = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext === false || $this->isEndOfUseStatement($tokens[$maybeUseNext]) === true) {
@@ -250,12 +250,12 @@ class ForbiddenNamesSniff extends Sniff
          * Deal with nested namespaces.
          */
         elseif ($tokens[$stackPtr]['type'] === 'T_NAMESPACE') {
-            if ($tokens[$stackPtr + 1]['code'] === T_NS_SEPARATOR) {
+            if ($tokens[$stackPtr + 1]['code'] === \T_NS_SEPARATOR) {
                 // Not a namespace declaration, but use of, i.e. namespace\someFunction();
                 return;
             }
 
-            $endToken      = $phpcsFile->findNext(array(T_SEMICOLON, T_OPEN_CURLY_BRACKET), ($stackPtr + 1), null, false, null, true);
+            $endToken      = $phpcsFile->findNext(array(\T_SEMICOLON, \T_OPEN_CURLY_BRACKET), ($stackPtr + 1), null, false, null, true);
             $namespaceName = trim($phpcsFile->getTokensAsString(($stackPtr + 1), ($endToken - $stackPtr - 1)));
             if (empty($namespaceName) === true) {
                 return;
@@ -328,7 +328,7 @@ class ForbiddenNamesSniff extends Sniff
          * its own token, but presents as T_STRING.
          * - trait keyword in PHP < 5.4
          */
-        if (version_compare(PHP_VERSION_ID, '50400', '<') && $tokenContentLc === 'trait') {
+        if (version_compare(\PHP_VERSION_ID, '50400', '<') && $tokenContentLc === 'trait') {
             $this->processNonString($phpcsFile, $stackPtr, $tokens);
             return;
         }
@@ -386,6 +386,6 @@ class ForbiddenNamesSniff extends Sniff
      */
     protected function isEndOfUseStatement($token)
     {
-        return in_array($token['code'], array(T_CLOSE_CURLY_BRACKET, T_SEMICOLON, T_COMMA), true);
+        return in_array($token['code'], array(\T_CLOSE_CURLY_BRACKET, \T_SEMICOLON, \T_COMMA), true);
     }
 }

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -178,7 +178,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
          */
         if (empty($translate) === false) {
             $this->translateContentToToken = $translate;
-            $tokens[] = T_STRING;
+            $tokens[] = \T_STRING;
         }
 
         return $tokens;
@@ -228,8 +228,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
          * a multi-line "yield from" is tokenized as two tokens.
          */
         if ($tokenType === 'T_YIELD') {
-            $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($end + 1), null, true);
-            if ($tokens[$nextToken]['code'] === T_STRING
+            $nextToken = $phpcsFile->findNext(\T_WHITESPACE, ($end + 1), null, true);
+            if ($tokens[$nextToken]['code'] === \T_STRING
                 && $tokens[$nextToken]['content'] === 'from'
             ) {
                 $tokenType = 'T_YIELD_FROM';
@@ -251,8 +251,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($prevToken !== false
-            && ($tokens[$prevToken]['code'] === T_DOUBLE_COLON
-            || $tokens[$prevToken]['code'] === T_OBJECT_OPERATOR)
+            && ($tokens[$prevToken]['code'] === \T_DOUBLE_COLON
+            || $tokens[$prevToken]['code'] === \T_OBJECT_OPERATOR)
         ) {
             // Class property of the same name as one of the keywords. Ignore.
             return;

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -36,7 +36,7 @@ class NewEmptyNonVariableSniff extends Sniff
      */
     public function register()
     {
-        return array(T_EMPTY);
+        return array(\T_EMPTY);
     }
 
     /**
@@ -58,7 +58,7 @@ class NewEmptyNonVariableSniff extends Sniff
 
         $open = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
         if ($open === false
-            || $tokens[$open]['code'] !== T_OPEN_PARENTHESIS
+            || $tokens[$open]['code'] !== \T_OPEN_PARENTHESIS
             || isset($tokens[$open]['parenthesis_closer']) === false
         ) {
             return;

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -38,8 +38,8 @@ class AssignmentOrderSniff extends Sniff
     public function register()
     {
         return array(
-            T_LIST,
-            T_OPEN_SHORT_ARRAY,
+            \T_LIST,
+            \T_OPEN_SHORT_ARRAY,
         );
     }
 
@@ -63,17 +63,17 @@ class AssignmentOrderSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY
+        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY
             && $this->isShortList($phpcsFile, $stackPtr) === false
         ) {
             // Short array, not short list.
             return;
         }
 
-        if ($tokens[$stackPtr]['code'] === T_LIST) {
+        if ($tokens[$stackPtr]['code'] === \T_LIST) {
             $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($nextNonEmpty === false
-                || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS
+                || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
                 || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
             ) {
                 // Parse error or live coding.
@@ -99,18 +99,18 @@ class AssignmentOrderSniff extends Sniff
          * OK, so we have the opener & closer, now we need to check all the variables in the
          * list() to see if there are duplicates as that's the problem.
          */
-        $hasVars = $phpcsFile->findNext(array(T_VARIABLE, T_DOLLAR), ($opener + 1), $closer);
+        $hasVars = $phpcsFile->findNext(array(\T_VARIABLE, \T_DOLLAR), ($opener + 1), $closer);
         if ($hasVars === false) {
             // Empty list, not our concern.
             return ($closer + 1);
         }
 
         // Set the variable delimiters based on the list type being examined.
-        $stopPoints = array(T_COMMA);
-        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
-            $stopPoints[] = T_CLOSE_SHORT_ARRAY;
+        $stopPoints = array(\T_COMMA);
+        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY) {
+            $stopPoints[] = \T_CLOSE_SHORT_ARRAY;
         } else {
-            $stopPoints[] = T_CLOSE_PARENTHESIS;
+            $stopPoints[] = \T_CLOSE_PARENTHESIS;
         }
 
         $listVars      = array();
@@ -128,13 +128,13 @@ class AssignmentOrderSniff extends Sniff
             }
 
             // Also detect this in PHP 7.1 keyed lists.
-            $hasDoubleArrow = $phpcsFile->findNext(T_DOUBLE_ARROW, ($lastStopPoint + 1), $nextStopPoint);
+            $hasDoubleArrow = $phpcsFile->findNext(\T_DOUBLE_ARROW, ($lastStopPoint + 1), $nextStopPoint);
             if ($hasDoubleArrow !== false) {
                 $lastStopPoint = $hasDoubleArrow;
             }
 
             // Find the start of the variable, allowing for variable variables.
-            $nextStartPoint = $phpcsFile->findNext(array(T_VARIABLE, T_DOLLAR), ($lastStopPoint + 1), $nextStopPoint);
+            $nextStartPoint = $phpcsFile->findNext(array(\T_VARIABLE, \T_DOLLAR), ($lastStopPoint + 1), $nextStopPoint);
             if ($nextStartPoint === false) {
                 // Skip past empty bits in the list, i.e. `list( $a, , ,)`.
                 $lastStopPoint = $nextStopPoint;

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -45,14 +45,14 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
     {
         // Set up a list of tokens to disregard when determining whether the list() is empty.
         // Only needs to be set up once.
-        $this->ignoreTokens                      = Tokens::$emptyTokens;
-        $this->ignoreTokens[T_COMMA]             = T_COMMA;
-        $this->ignoreTokens[T_OPEN_PARENTHESIS]  = T_OPEN_PARENTHESIS;
-        $this->ignoreTokens[T_CLOSE_PARENTHESIS] = T_CLOSE_PARENTHESIS;
+        $this->ignoreTokens                       = Tokens::$emptyTokens;
+        $this->ignoreTokens[\T_COMMA]             = \T_COMMA;
+        $this->ignoreTokens[\T_OPEN_PARENTHESIS]  = \T_OPEN_PARENTHESIS;
+        $this->ignoreTokens[\T_CLOSE_PARENTHESIS] = \T_CLOSE_PARENTHESIS;
 
         return array(
-            T_LIST,
-            T_OPEN_SHORT_ARRAY,
+            \T_LIST,
+            \T_OPEN_SHORT_ARRAY,
         );
     }
 
@@ -73,7 +73,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
+        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY) {
             if ($this->isShortList($phpcsFile, $stackPtr) === false) {
                 return;
             }
@@ -82,7 +82,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
             $close = $tokens[$stackPtr]['bracket_closer'];
         } else {
             // T_LIST.
-            $open = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, null, false, null, true);
+            $open = $phpcsFile->findNext(\T_OPEN_PARENTHESIS, $stackPtr, null, false, null, true);
             if ($open === false || isset($tokens[$open]['parenthesis_closer']) === false) {
                 return;
             }

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -34,8 +34,8 @@ class NewKeyedListSniff extends Sniff
      * @var array
      */
     protected $sniffTargets =  array(
-        T_LIST             => T_LIST,
-        T_OPEN_SHORT_ARRAY => T_OPEN_SHORT_ARRAY,
+        \T_LIST             => \T_LIST,
+        \T_OPEN_SHORT_ARRAY => \T_OPEN_SHORT_ARRAY,
     );
 
     /**
@@ -44,7 +44,7 @@ class NewKeyedListSniff extends Sniff
      * @var array
      */
     protected $targetsInList = array(
-        T_DOUBLE_ARROW => T_DOUBLE_ARROW,
+        \T_DOUBLE_ARROW => \T_DOUBLE_ARROW,
     );
 
     /**
@@ -107,17 +107,17 @@ class NewKeyedListSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY
+        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY
             && $this->isShortList($phpcsFile, $stackPtr) === false
         ) {
             // Short array, not short list.
             return;
         }
 
-        if ($tokens[$stackPtr]['code'] === T_LIST) {
+        if ($tokens[$stackPtr]['code'] === \T_LIST) {
             $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($nextNonEmpty === false
-                || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS
+                || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
                 || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
             ) {
                 // Parse error or live coding.
@@ -191,15 +191,15 @@ class NewKeyedListSniff extends Sniff
             }
 
             // Skip past nested list constructs.
-            if ($tokens[$i]['code'] === T_LIST) {
+            if ($tokens[$i]['code'] === \T_LIST) {
                 $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
                 if ($nextNonEmpty !== false
-                    && $tokens[$nextNonEmpty]['code'] === T_OPEN_PARENTHESIS
+                    && $tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS
                     && isset($tokens[$nextNonEmpty]['parenthesis_closer']) === true
                 ) {
                     $i = $tokens[$nextNonEmpty]['parenthesis_closer'];
                 }
-            } elseif ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY
+            } elseif ($tokens[$i]['code'] === \T_OPEN_SHORT_ARRAY
                 && isset($tokens[$i]['bracket_closer'])
             ) {
                 $i = $tokens[$i]['bracket_closer'];

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -31,7 +31,7 @@ class NewListReferenceAssignmentSniff extends NewKeyedListSniff
      * @var array
      */
     protected $targetsInList = array(
-        T_BITWISE_AND => T_BITWISE_AND,
+        \T_BITWISE_AND => \T_BITWISE_AND,
     );
 
     /**

--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -37,7 +37,7 @@ class NewShortListSniff extends Sniff
      */
     public function register()
     {
-        return array(T_OPEN_SHORT_ARRAY);
+        return array(\T_OPEN_SHORT_ARRAY);
     }
 
     /**
@@ -62,7 +62,7 @@ class NewShortListSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
         $closer = $tokens[$stackPtr]['bracket_closer'];
 
-        $hasVariable = $phpcsFile->findNext(T_VARIABLE, ($stackPtr + 1), $closer);
+        $hasVariable = $phpcsFile->findNext(\T_VARIABLE, ($stackPtr + 1), $closer);
         if ($hasVariable === false) {
             // List syntax is only valid if there are variables in it.
             return;

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -40,8 +40,8 @@ class NewDirectCallsToCloneSniff extends Sniff
     public function register()
     {
         return array(
-            T_DOUBLE_COLON,
-            T_OBJECT_OPERATOR,
+            \T_DOUBLE_COLON,
+            \T_OBJECT_OPERATOR,
         );
     }
 
@@ -65,7 +65,7 @@ class NewDirectCallsToCloneSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_STRING) {
+        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_STRING) {
             /*
              * Not a method call.
              *
@@ -83,7 +83,7 @@ class NewDirectCallsToCloneSniff extends Sniff
         }
 
         $nextNextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
-        if ($nextNextNonEmpty === false || $tokens[$nextNextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
+        if ($nextNextNonEmpty === false || $tokens[$nextNextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
             // Not a method call.
             return;
         }

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -45,15 +45,15 @@ class RemovedAlternativePHPTagsSniff extends Sniff
      */
     public function register()
     {
-        if (version_compare(PHP_VERSION_ID, '70000', '<') === true) {
+        if (version_compare(\PHP_VERSION_ID, '70000', '<') === true) {
             // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.asp_tagsRemoved
             $this->aspTags = (bool) ini_get('asp_tags');
         }
 
         return array(
-            T_OPEN_TAG,
-            T_OPEN_TAG_WITH_ECHO,
-            T_INLINE_HTML,
+            \T_OPEN_TAG,
+            \T_OPEN_TAG_WITH_ECHO,
+            \T_INLINE_HTML,
         );
     }
 
@@ -81,7 +81,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
             return;
         }
 
-        if ($openTag['code'] === T_OPEN_TAG || $openTag['code'] === T_OPEN_TAG_WITH_ECHO) {
+        if ($openTag['code'] === \T_OPEN_TAG || $openTag['code'] === \T_OPEN_TAG_WITH_ECHO) {
 
             if ($content === '<%' || $content === '<%=') {
                 $data      = array(
@@ -102,7 +102,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
         }
         // Account for incorrect script open tags.
         // The "(?:<s)?" in the regex is to work-around a bug in the tokenizer in PHP 5.2.
-        elseif ($openTag['code'] === T_INLINE_HTML
+        elseif ($openTag['code'] === \T_INLINE_HTML
             && preg_match('`((?:<s)?cript (?:[^>]+)?language=[\'"]?php[\'"]?(?:[^>]+)?>)`i', $content, $match) === 1
         ) {
             $found     = $match[1];
@@ -124,7 +124,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
         }
 
         // If we're still here, we can't be sure if what we find was really intended as ASP open tags.
-        if ($openTag['code'] === T_INLINE_HTML && $this->aspTags === false) {
+        if ($openTag['code'] === \T_INLINE_HTML && $this->aspTags === false) {
             if (strpos($content, '<%') !== false) {
                 $error   = 'Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: %s';
                 $snippet = $this->getSnippet($content, '<%');

--- a/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
@@ -36,11 +36,11 @@ class ValidIntegersSniff extends Sniff
      */
     public function register()
     {
-        $this->isLowPHPVersion = version_compare(PHP_VERSION_ID, '50400', '<');
+        $this->isLowPHPVersion = version_compare(\PHP_VERSION_ID, '50400', '<');
 
         return array(
-            T_LNUMBER, // Binary, octal integers.
-            T_CONSTANT_ENCAPSED_STRING, // Hex numeric string.
+            \T_LNUMBER, // Binary, octal integers.
+            \T_CONSTANT_ENCAPSED_STRING, // Hex numeric string.
         );
     }
 
@@ -119,7 +119,7 @@ class ValidIntegersSniff extends Sniff
     {
         $token = $tokens[$stackPtr];
 
-        if ($token['code'] !== T_LNUMBER) {
+        if ($token['code'] !== \T_LNUMBER) {
             return false;
         }
 
@@ -129,7 +129,7 @@ class ValidIntegersSniff extends Sniff
         // Pre-5.4, binary strings are tokenized as T_LNUMBER (0) + T_STRING ("b01010101").
         // At this point, we don't yet care whether it's a valid binary int, that's a separate check.
         else {
-            return($token['content'] === '0' && $tokens[$stackPtr + 1]['code'] === T_STRING && preg_match('`^b[0-9]+$`D', $tokens[$stackPtr + 1]['content']) === 1);
+            return($token['content'] === '0' && $tokens[$stackPtr + 1]['code'] === \T_STRING && preg_match('`^b[0-9]+$`D', $tokens[$stackPtr + 1]['content']) === 1);
         }
     }
 
@@ -149,7 +149,7 @@ class ValidIntegersSniff extends Sniff
 
         if ($this->isLowPHPVersion === false) {
             // If it's an invalid binary int, the token will be split into two T_LNUMBER tokens.
-            return ($tokens[$stackPtr + 1]['code'] === T_LNUMBER);
+            return ($tokens[$stackPtr + 1]['code'] === \T_LNUMBER);
         } else {
             return (preg_match('`^b[0-1]+$`D', $tokens[$stackPtr + 1]['content']) === 0);
         }
@@ -171,7 +171,7 @@ class ValidIntegersSniff extends Sniff
 
         if ($this->isLowPHPVersion === false) {
             $i = $stackPtr;
-            while ($tokens[$i]['code'] === T_LNUMBER) {
+            while ($tokens[$i]['code'] === \T_LNUMBER) {
                 $i++;
             }
             $length = ($i - $stackPtr);
@@ -192,7 +192,7 @@ class ValidIntegersSniff extends Sniff
     {
         $token = $tokens[$stackPtr];
 
-        if ($token['code'] === T_LNUMBER && preg_match('`^0[0-7]*[8-9]+[0-9]*$`D', $token['content']) === 1) {
+        if ($token['code'] === \T_LNUMBER && preg_match('`^0[0-7]*[8-9]+[0-9]*$`D', $token['content']) === 1) {
             return true;
         }
 
@@ -211,7 +211,7 @@ class ValidIntegersSniff extends Sniff
     {
         $token = $tokens[$stackPtr];
 
-        if ($token['code'] === T_CONSTANT_ENCAPSED_STRING && preg_match('`^0x[a-f0-9]+$`iD', $this->stripQuotes($token['content'])) === 1) {
+        if ($token['code'] === \T_CONSTANT_ENCAPSED_STRING && preg_match('`^0x[a-f0-9]+$`iD', $this->stripQuotes($token['content'])) === 1) {
             return true;
         }
 

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -39,10 +39,10 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
      * @var array
      */
     private $inclusiveStopPoints = array(
-        T_COLON        => true,
-        T_COMMA        => true,
-        T_DOUBLE_ARROW => true,
-        T_SEMICOLON    => true,
+        \T_COLON        => true,
+        \T_COMMA        => true,
+        \T_DOUBLE_ARROW => true,
+        \T_SEMICOLON    => true,
     );
 
     /**
@@ -53,10 +53,10 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
     public function register()
     {
         return array(
-            T_SL,
-            T_SL_EQUAL,
-            T_SR,
-            T_SR_EQUAL,
+            \T_SL,
+            \T_SL_EQUAL,
+            \T_SR,
+            \T_SR_EQUAL,
         );
     }
 
@@ -80,7 +80,7 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
         // Determine the start and end of the part of the statement we need to examine.
         $start = ($stackPtr + 1);
         $next  = $phpcsFile->findNext(Tokens::$emptyTokens, $start, null, true);
-        if ($next !== false && $tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
+        if ($next !== false && $tokens[$next]['code'] === \T_OPEN_PARENTHESIS) {
             $start = ($next + 1);
         }
 

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -73,11 +73,11 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
      * @var array(string => int)
      */
     protected $newOperatorsPHPCSCompat = array(
-        'T_POW'            => T_MULTIPLY,
-        'T_POW_EQUAL'      => T_MUL_EQUAL,
-        'T_SPACESHIP'      => T_GREATER_THAN,
-        'T_COALESCE'       => T_INLINE_THEN,
-        'T_COALESCE_EQUAL' => T_EQUAL,
+        'T_POW'            => \T_MULTIPLY,
+        'T_POW_EQUAL'      => \T_MUL_EQUAL,
+        'T_SPACESHIP'      => \T_GREATER_THAN,
+        'T_COALESCE'       => \T_INLINE_THEN,
+        'T_COALESCE_EQUAL' => \T_EQUAL,
     );
 
     /**
@@ -165,7 +165,7 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
             }
         } elseif ($tokenType === 'T_COALESCE') {
             // Make sure that T_COALESCE is not confused with T_COALESCE_EQUAL.
-            if (isset($tokens[($stackPtr + 1)]) !== false && $tokens[($stackPtr + 1)]['code'] === T_EQUAL) {
+            if (isset($tokens[($stackPtr + 1)]) !== false && $tokens[($stackPtr + 1)]['code'] === \T_EQUAL) {
                 // Ignore as will be dealt with via the T_EQUAL token.
                 return;
             }
@@ -250,7 +250,7 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
      */
     private function isTCoalesceEqual($tokens, $stackPtr)
     {
-        if ($tokens[$stackPtr]['code'] !== T_EQUAL || isset($tokens[($stackPtr - 1)]) === false) {
+        if ($tokens[$stackPtr]['code'] !== \T_EQUAL || isset($tokens[($stackPtr - 1)]) === false) {
             // Function called for wrong token or token has no predecesor.
             return false;
         }
@@ -277,14 +277,14 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
      */
     private function isTCoalesce($tokens, $stackPtr)
     {
-        if ($tokens[$stackPtr]['code'] !== T_INLINE_THEN || isset($tokens[($stackPtr - 1)]) === false) {
+        if ($tokens[$stackPtr]['code'] !== \T_INLINE_THEN || isset($tokens[($stackPtr - 1)]) === false) {
             // Function called for wrong token or token has no predecesor.
             return false;
         }
 
-        if ($tokens[($stackPtr - 1)]['code'] === T_INLINE_THEN) {
+        if ($tokens[($stackPtr - 1)]['code'] === \T_INLINE_THEN) {
             // Make sure not to confuse it with the T_COALESCE_EQUAL token.
-            if (isset($tokens[($stackPtr + 1)]) === false || $tokens[($stackPtr + 1)]['code'] !== T_EQUAL) {
+            if (isset($tokens[($stackPtr + 1)]) === false || $tokens[($stackPtr + 1)]['code'] !== \T_EQUAL) {
                 return true;
             }
         }

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -39,7 +39,7 @@ class NewShortTernarySniff extends Sniff
      */
     public function register()
     {
-        return array(T_INLINE_THEN);
+        return array(\T_INLINE_THEN);
     }
 
     /**
@@ -63,7 +63,7 @@ class NewShortTernarySniff extends Sniff
         // symbol, which is not allowed prior to PHP 5.3.
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
-        if ($next !== false && $tokens[$next]['code'] === T_INLINE_ELSE) {
+        if ($next !== false && $tokens[$next]['code'] === \T_INLINE_ELSE) {
             $phpcsFile->addError(
                 'Middle may not be omitted from ternary operators in PHP < 5.3',
                 $stackPtr,

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -40,12 +40,12 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
      * @var array
      */
     private $variableValueTokens = array(
-        T_VARIABLE,
-        T_STRING,
-        T_SELF,
-        T_PARENT,
-        T_STATIC,
-        T_DOUBLE_QUOTED_STRING,
+        \T_VARIABLE,
+        \T_STRING,
+        \T_SELF,
+        \T_PARENT,
+        \T_STATIC,
+        \T_DOUBLE_QUOTED_STRING,
     );
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -69,7 +69,7 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
         $errors      = array();
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if ($tokens[$i]['code'] !== T_CONSTANT_ENCAPSED_STRING) {
+            if ($tokens[$i]['code'] !== \T_CONSTANT_ENCAPSED_STRING) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -109,7 +109,7 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -86,14 +86,14 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
         $targetParam = $parameters[1];
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if ($tokens[$i]['code'] !== T_CONSTANT_ENCAPSED_STRING
-                && $tokens[$i]['code'] !== T_DOUBLE_QUOTED_STRING
+            if ($tokens[$i]['code'] !== \T_CONSTANT_ENCAPSED_STRING
+                && $tokens[$i]['code'] !== \T_DOUBLE_QUOTED_STRING
             ) {
                 continue;
             }
 
             $content = $tokens[$i]['content'];
-            if ($tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
+            if ($tokens[$i]['code'] === \T_DOUBLE_QUOTED_STRING) {
                 $content = $this->stripVariables($content);
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -54,7 +54,7 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
      */
     public function register()
     {
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -98,7 +98,7 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
             }
 
             $content = $this->stripQuotes($tokens[$i]['content']);
-            if ($tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
+            if ($tokens[$i]['code'] === \T_DOUBLE_QUOTED_STRING) {
                 $content = $this->stripVariables($content);
             }
             $content = trim($content);

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -95,7 +95,7 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
         if (strtolower($functionName) === 'hash_init'
             && (isset($parameters[2]) === false
             || ($parameters[2]['raw'] !== 'HASH_HMAC'
-                && $parameters[2]['raw'] !== (string) HASH_HMAC))
+                && $parameters[2]['raw'] !== (string) \HASH_HMAC))
         ) {
             // For hash_init(), these hashes are only disabled with HASH_HMAC set.
             return;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -79,12 +79,12 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 
         // Differentiate between an array of patterns passed and a single pattern.
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $firstParam['start'], ($firstParam['end'] + 1), true);
-        if ($nextNonEmpty !== false && ($tokens[$nextNonEmpty]['code'] === T_ARRAY || $tokens[$nextNonEmpty]['code'] === T_OPEN_SHORT_ARRAY)) {
+        if ($nextNonEmpty !== false && ($tokens[$nextNonEmpty]['code'] === \T_ARRAY || $tokens[$nextNonEmpty]['code'] === \T_OPEN_SHORT_ARRAY)) {
             $arrayValues = $this->getFunctionCallParameters($phpcsFile, $nextNonEmpty);
             if ($functionNameLc === 'preg_replace_callback_array') {
                 // For preg_replace_callback_array(), the patterns will be in the array keys.
                 foreach ($arrayValues as $value) {
-                    $hasKey = $phpcsFile->findNext(T_DOUBLE_ARROW, $value['start'], ($value['end'] + 1));
+                    $hasKey = $phpcsFile->findNext(\T_DOUBLE_ARROW, $value['start'], ($value['end'] + 1));
                     if ($hasKey === false) {
                         continue;
                     }
@@ -97,7 +97,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
             } else {
                 // Otherwise, the patterns will be in the array values.
                 foreach ($arrayValues as $value) {
-                    $hasKey = $phpcsFile->findNext(T_DOUBLE_ARROW, $value['start'], ($value['end'] + 1));
+                    $hasKey = $phpcsFile->findNext(\T_DOUBLE_ARROW, $value['start'], ($value['end'] + 1));
                     if ($hasKey !== false) {
                         $value['start'] = ($hasKey + 1);
                         $value['raw']   = trim($phpcsFile->getTokensAsString($value['start'], (($value['end'] + 1) - $value['start'])));
@@ -149,7 +149,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
         for ($i = $pattern['start']; $i <= $pattern['end']; $i++) {
             if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === true) {
                 $content = $this->stripQuotes($tokens[$i]['content']);
-                if ($tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
+                if ($tokens[$i]['code'] === \T_DOUBLE_QUOTED_STRING) {
                     $content = $this->stripVariables($content);
                 }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -73,8 +73,8 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
         $targetParam = $parameters[1];
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if ($tokens[$i]['code'] !== T_CONSTANT_ENCAPSED_STRING
-                && $tokens[$i]['code'] !== T_DOUBLE_QUOTED_STRING
+            if ($tokens[$i]['code'] !== \T_CONSTANT_ENCAPSED_STRING
+                && $tokens[$i]['code'] !== \T_DOUBLE_QUOTED_STRING
             ) {
                 continue;
             }

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -77,8 +77,8 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
     public function register()
     {
         return array(
-            T_STRING,
-            T_VARIABLE,
+            \T_STRING,
+            \T_VARIABLE,
         );
     }
 
@@ -104,7 +104,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
         // "myFunction" is T_STRING but we should skip because it is not a
         // function or method *call*.
         $findTokens   = Tokens::$emptyTokens;
-        $findTokens[] = T_BITWISE_AND;
+        $findTokens[] = \T_BITWISE_AND;
 
         $prevNonEmpty = $phpcsFile->findPrevious(
             $findTokens,
@@ -121,7 +121,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
         // is not an opening parenthesis then it can't really be a *call*.
         $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
-        if ($openBracket === false || $tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS
+        if ($openBracket === false || $tokens[$openBracket]['code'] !== \T_OPEN_PARENTHESIS
             || isset($tokens[$openBracket]['parenthesis_closer']) === false
         ) {
             return;
@@ -176,7 +176,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
         $searchEndToken   = $parameter['end'] + 1;
         $nextVariable     = $searchStartToken;
         do {
-            $nextVariable = $phpcsFile->findNext(array(T_VARIABLE, T_OPEN_SHORT_ARRAY, T_CLOSURE), ($nextVariable + 1), $searchEndToken);
+            $nextVariable = $phpcsFile->findNext(array(\T_VARIABLE, \T_OPEN_SHORT_ARRAY, \T_CLOSURE), ($nextVariable + 1), $searchEndToken);
             if ($nextVariable === false) {
                 return false;
             }
@@ -219,7 +219,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
                 true
             );
 
-            if ($tokenBefore === false || $tokens[$tokenBefore]['code'] !== T_BITWISE_AND) {
+            if ($tokenBefore === false || $tokens[$tokenBefore]['code'] !== \T_BITWISE_AND) {
                 // Nothing before the token or no &.
                 continue;
             }

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -36,9 +36,9 @@ class NewArrayStringDereferencingSniff extends Sniff
     public function register()
     {
         return array(
-            T_ARRAY,
-            T_OPEN_SHORT_ARRAY,
-            T_CONSTANT_ENCAPSED_STRING,
+            \T_ARRAY,
+            \T_OPEN_SHORT_ARRAY,
+            \T_CONSTANT_ENCAPSED_STRING,
         );
     }
 
@@ -60,12 +60,12 @@ class NewArrayStringDereferencingSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         switch ($tokens[$stackPtr]['code']) {
-            case T_CONSTANT_ENCAPSED_STRING:
+            case \T_CONSTANT_ENCAPSED_STRING:
                 $type = 'string literals';
                 $end  = $stackPtr;
                 break;
 
-            case T_ARRAY:
+            case \T_ARRAY:
                 if (isset($tokens[$stackPtr]['parenthesis_closer']) === false) {
                     // Live coding.
                     return;
@@ -75,7 +75,7 @@ class NewArrayStringDereferencingSniff extends Sniff
                 }
                 break;
 
-            case T_OPEN_SHORT_ARRAY:
+            case \T_OPEN_SHORT_ARRAY:
                 if (isset($tokens[$stackPtr]['bracket_closer']) === false) {
                     // Live coding.
                     return;

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -40,8 +40,8 @@ class NewClassMemberAccessSniff extends Sniff
     public function register()
     {
         return array(
-            T_NEW,
-            T_CLONE,
+            \T_NEW,
+            \T_CLONE,
         );
     }
 
@@ -58,9 +58,9 @@ class NewClassMemberAccessSniff extends Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] === T_NEW && $this->supportsBelow('5.3') !== true) {
+        if ($tokens[$stackPtr]['code'] === \T_NEW && $this->supportsBelow('5.3') !== true) {
             return;
-        } elseif ($tokens[$stackPtr]['code'] === T_CLONE && $this->supportsBelow('5.6') !== true) {
+        } elseif ($tokens[$stackPtr]['code'] === \T_CLONE && $this->supportsBelow('5.6') !== true) {
             return;
         }
 
@@ -78,7 +78,7 @@ class NewClassMemberAccessSniff extends Sniff
         }
 
         $prevBeforeParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($parenthesisOpener - 1), null, true);
-        if ($prevBeforeParenthesis !== false && $tokens[$prevBeforeParenthesis]['code'] === T_STRING) {
+        if ($prevBeforeParenthesis !== false && $tokens[$prevBeforeParenthesis]['code'] === \T_STRING) {
             // This is most likely a function call with the new/cloned object as a parameter.
             return;
         }
@@ -89,8 +89,8 @@ class NewClassMemberAccessSniff extends Sniff
             return;
         }
 
-        if ($tokens[$nextAfterParenthesis]['code'] !== T_OBJECT_OPERATOR
-            && $tokens[$nextAfterParenthesis]['code'] !== T_OPEN_SQUARE_BRACKET
+        if ($tokens[$nextAfterParenthesis]['code'] !== \T_OBJECT_OPERATOR
+            && $tokens[$nextAfterParenthesis]['code'] !== \T_OPEN_SQUARE_BRACKET
         ) {
             return;
         }
@@ -98,7 +98,7 @@ class NewClassMemberAccessSniff extends Sniff
         $data      = array('instantiation', '5.3');
         $errorCode = 'OnNewFound';
 
-        if ($tokens[$stackPtr]['code'] === T_CLONE) {
+        if ($tokens[$stackPtr]['code'] === \T_CLONE) {
             $data      = array('cloning', '5.6');
             $errorCode = 'OnCloneFound';
         }

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -38,7 +38,7 @@ class NewDynamicAccessToStaticSniff extends Sniff
     public function register()
     {
         return array(
-            T_DOUBLE_COLON,
+            \T_DOUBLE_COLON,
         );
     }
 
@@ -61,17 +61,17 @@ class NewDynamicAccessToStaticSniff extends Sniff
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         // Disregard `static::` as well. Late static binding is reported by another sniff.
-        if ($tokens[$prevNonEmpty]['code'] === T_SELF
-            || $tokens[$prevNonEmpty]['code'] === T_PARENT
-            || $tokens[$prevNonEmpty]['code'] === T_STATIC
+        if ($tokens[$prevNonEmpty]['code'] === \T_SELF
+            || $tokens[$prevNonEmpty]['code'] === \T_PARENT
+            || $tokens[$prevNonEmpty]['code'] === \T_STATIC
         ) {
             return;
         }
 
-        if ($tokens[$prevNonEmpty]['code'] === T_STRING) {
+        if ($tokens[$prevNonEmpty]['code'] === \T_STRING) {
             $prevPrevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
 
-            if ($tokens[$prevPrevNonEmpty]['code'] !== T_OBJECT_OPERATOR) {
+            if ($tokens[$prevPrevNonEmpty]['code'] !== \T_OBJECT_OPERATOR) {
                 return;
             }
         }

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -41,13 +41,13 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
     public function register()
     {
         $targets = array(
-            T_END_HEREDOC,
-            T_END_NOWDOC,
+            \T_END_HEREDOC,
+            \T_END_NOWDOC,
         );
 
-        if (version_compare(PHP_VERSION_ID, '70299', '>') === false) {
+        if (version_compare(\PHP_VERSION_ID, '70299', '>') === false) {
             // Start identifier of a PHP 7.3 flexible heredoc/nowdoc.
-            $targets[] = T_STRING;
+            $targets[] = \T_STRING;
         }
 
         return $targets;
@@ -75,7 +75,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
         }
 
         $tokens = $phpcsFile->getTokens();
-        if ($this->supportsAbove('7.3') === true && $tokens[$stackPtr]['code'] !== T_STRING) {
+        if ($this->supportsAbove('7.3') === true && $tokens[$stackPtr]['code'] !== \T_STRING) {
             $this->detectClosingMarkerInBody($phpcsFile, $stackPtr);
         }
     }
@@ -98,7 +98,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
         $trailingError     = 'Having code - other than a semi-colon or new line - after the closing marker of a heredoc/nowdoc is not supported in PHP 7.2 or earlier.';
         $trailingErrorCode = 'ClosingMarkerNoNewLine';
 
-        if (version_compare(PHP_VERSION_ID, '70299', '>') === true) {
+        if (version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
 
             /*
              * Check for indented closing marker.
@@ -110,13 +110,13 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
             /*
              * Check for tokens after the closing marker.
              */
-            $nextNonWhitespace = $phpcsFile->findNext(array(T_WHITESPACE, T_SEMICOLON), ($stackPtr + 1), null, true);
+            $nextNonWhitespace = $phpcsFile->findNext(array(\T_WHITESPACE, \T_SEMICOLON), ($stackPtr + 1), null, true);
             if ($tokens[$stackPtr]['line'] === $tokens[$nextNonWhitespace]['line']) {
                 $phpcsFile->addError($trailingError, $stackPtr, $trailingErrorCode);
             }
         } else {
             // For PHP < 7.3, we're only interested in T_STRING tokens.
-            if ($tokens[$stackPtr]['code'] !== T_STRING) {
+            if ($tokens[$stackPtr]['code'] !== \T_STRING) {
                 return;
             }
 
@@ -128,7 +128,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
             $identifier = $matches[2];
 
             for ($i = ($stackPtr + 1); $i <= $phpcsFile->numTokens; $i++) {
-                if ($tokens[$i]['code'] !== T_ENCAPSED_AND_WHITESPACE) {
+                if ($tokens[$i]['code'] !== \T_ENCAPSED_AND_WHITESPACE) {
                     continue;
                 }
 
@@ -183,12 +183,12 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
         $error     = 'The body of a heredoc/nowdoc can not contain the heredoc/nowdoc closing marker as text at the start of a line since PHP 7.3.';
         $errorCode = 'ClosingMarkerNoNewLine';
 
-        if (version_compare(PHP_VERSION_ID, '70299', '>') === true) {
-            $nextNonWhitespace = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true, null, true);
+        if (version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
+            $nextNonWhitespace = $phpcsFile->findNext(\T_WHITESPACE, ($stackPtr + 1), null, true, null, true);
             if ($nextNonWhitespace === false
-                || $tokens[$nextNonWhitespace]['code'] === T_SEMICOLON
-                || (($tokens[$nextNonWhitespace]['code'] === T_COMMA
-                    || $tokens[$nextNonWhitespace]['code'] === T_STRING_CONCAT)
+                || $tokens[$nextNonWhitespace]['code'] === \T_SEMICOLON
+                || (($tokens[$nextNonWhitespace]['code'] === \T_COMMA
+                    || $tokens[$nextNonWhitespace]['code'] === \T_STRING_CONCAT)
                     && $tokens[$nextNonWhitespace]['line'] !== $tokens[$stackPtr]['line'])
             ) {
                 // This is most likely a correctly identified closing marker.
@@ -196,7 +196,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
             }
 
             // The real closing tag has to be before the next heredoc/nowdoc.
-            $nextHereNowDoc = $phpcsFile->findNext(array(T_START_HEREDOC, T_START_NOWDOC), ($stackPtr + 1));
+            $nextHereNowDoc = $phpcsFile->findNext(array(\T_START_HEREDOC, \T_START_NOWDOC), ($stackPtr + 1));
             if ($nextHereNowDoc === false) {
                 $nextHereNowDoc = null;
             }
@@ -204,9 +204,9 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
             $identifier        = trim($tokens[$stackPtr]['content']);
             $realClosingMarker = $stackPtr;
 
-            while (($realClosingMarker = $phpcsFile->findNext(T_STRING, ($realClosingMarker + 1), $nextHereNowDoc, false, $identifier)) !== false) {
+            while (($realClosingMarker = $phpcsFile->findNext(\T_STRING, ($realClosingMarker + 1), $nextHereNowDoc, false, $identifier)) !== false) {
 
-                $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($realClosingMarker - 1), null, true);
+                $prevNonWhitespace = $phpcsFile->findPrevious(\T_WHITESPACE, ($realClosingMarker - 1), null, true);
                 if ($prevNonWhitespace === false
                     || $tokens[$prevNonWhitespace]['line'] === $tokens[$realClosingMarker]['line']
                 ) {
@@ -228,7 +228,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
                 $opener = $tokens[$stackPtr]['scope_opener'];
             } else {
                 // PHPCS < 3.0.2 did not add scope_* values for Nowdocs.
-                $opener = $phpcsFile->findPrevious(T_START_NOWDOC, ($stackPtr - 1));
+                $opener = $phpcsFile->findPrevious(\T_START_NOWDOC, ($stackPtr - 1));
                 if ($opener === false) {
                     return;
                 }

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -33,7 +33,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
      */
     public function register()
     {
-        return array(T_STRING);
+        return array(\T_STRING);
     }
 
     /**
@@ -55,7 +55,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
 
         // Next non-empty token should be the open parenthesis.
         $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
-        if ($openParenthesis === false || $tokens[$openParenthesis]['code'] !== T_OPEN_PARENTHESIS) {
+        if ($openParenthesis === false || $tokens[$openParenthesis]['code'] !== \T_OPEN_PARENTHESIS) {
             return;
         }
 
@@ -66,14 +66,14 @@ class NewFunctionArrayDereferencingSniff extends Sniff
 
         // Is this T_STRING really a function or method call ?
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($prevToken !== false && in_array($tokens[$prevToken]['code'], array(T_DOUBLE_COLON, T_OBJECT_OPERATOR), true) === false) {
+        if ($prevToken !== false && in_array($tokens[$prevToken]['code'], array(\T_DOUBLE_COLON, \T_OBJECT_OPERATOR), true) === false) {
             $ignore = array(
-                T_FUNCTION  => true,
-                T_CONST     => true,
-                T_USE       => true,
-                T_NEW       => true,
-                T_CLASS     => true,
-                T_INTERFACE => true,
+                \T_FUNCTION  => true,
+                \T_CONST     => true,
+                \T_USE       => true,
+                \T_NEW       => true,
+                \T_CLASS     => true,
+                \T_INTERFACE => true,
             );
 
             if (isset($ignore[$tokens[$prevToken]['code']]) === true) {

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -34,10 +34,10 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
     public function register()
     {
         return array(
-            T_STRING,
-            T_VARIABLE,
-            T_ISSET,
-            T_UNSET,
+            \T_STRING,
+            \T_VARIABLE,
+            \T_ISSET,
+            \T_UNSET,
         );
     }
 
@@ -60,17 +60,17 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS
+        if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
             || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
         ) {
             return;
         }
 
-        if ($tokens[$stackPtr]['code'] === T_STRING) {
+        if ($tokens[$stackPtr]['code'] === \T_STRING) {
             $ignore = array(
-                T_FUNCTION        => true,
-                T_CONST           => true,
-                T_USE             => true,
+                \T_FUNCTION        => true,
+                \T_CONST           => true,
+                \T_USE             => true,
             );
 
             $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
@@ -83,18 +83,18 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
         $closer            = $tokens[$nextNonEmpty]['parenthesis_closer'];
         $lastInParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), $nextNonEmpty, true);
 
-        if ($tokens[$lastInParenthesis]['code'] !== T_COMMA) {
+        if ($tokens[$lastInParenthesis]['code'] !== \T_COMMA) {
             return;
         }
 
         $data = array();
         switch ($tokens[$stackPtr]['code']) {
-            case T_ISSET:
+            case \T_ISSET:
                 $data[]    = 'calls to isset()';
                 $errorCode = 'FoundInIsset';
                 break;
 
-            case T_UNSET:
+            case \T_UNSET:
                 $data[]    = 'calls to unset()';
                 $errorCode = 'FoundInUnset';
                 break;

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -36,8 +36,8 @@ class NewShortArraySniff extends Sniff
     public function register()
     {
         return array(
-            T_OPEN_SHORT_ARRAY,
-            T_CLOSE_SHORT_ARRAY,
+            \T_OPEN_SHORT_ARRAY,
+            \T_CLOSE_SHORT_ARRAY,
         );
     }
 

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -38,7 +38,7 @@ class RemovedNewReferenceSniff extends Sniff
      */
     public function register()
     {
-        return array(T_NEW);
+        return array(\T_NEW);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -69,8 +69,8 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
          * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/1574
          */
         if (version_compare(PHPCSHelper::getVersion(), '3.4.0', '<') === true) {
-            $tokens[] = T_STRING_CAST;
-            $tokens[] = T_CONSTANT_ENCAPSED_STRING;
+            $tokens[] = \T_STRING_CAST;
+            $tokens[] = \T_CONSTANT_ENCAPSED_STRING;
         }
 
         return $tokens;

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -72,7 +72,7 @@ class LowPHPCSSniff extends Sniff
     public function register()
     {
         return array(
-            T_OPEN_TAG,
+            \T_OPEN_TAG,
         );
     }
 

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -34,9 +34,9 @@ class NewGroupUseDeclarationsSniff extends Sniff
     public function register()
     {
         if (defined('T_OPEN_USE_GROUP')) {
-            return array(T_OPEN_USE_GROUP);
+            return array(\T_OPEN_USE_GROUP);
         } else {
-            return array(T_USE);
+            return array(\T_USE);
         }
     }
 
@@ -60,14 +60,14 @@ class NewGroupUseDeclarationsSniff extends Sniff
         $token  = $tokens[$stackPtr];
 
         // Deal with PHPCS pre-2.6.0.
-        if ($token['code'] === T_USE) {
-            $hasCurlyBrace = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($stackPtr + 1), null, false, null, true);
+        if ($token['code'] === \T_USE) {
+            $hasCurlyBrace = $phpcsFile->findNext(\T_OPEN_CURLY_BRACKET, ($stackPtr + 1), null, false, null, true);
             if ($hasCurlyBrace === false) {
                 return;
             }
 
             $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($hasCurlyBrace - 1), null, true);
-            if ($prevToken === false || $tokens[$prevToken]['code'] !== T_NS_SEPARATOR) {
+            if ($prevToken === false || $tokens[$prevToken]['code'] !== \T_NS_SEPARATOR) {
                 return;
             }
 
@@ -83,9 +83,9 @@ class NewGroupUseDeclarationsSniff extends Sniff
             );
         }
 
-        $closers = array(T_CLOSE_CURLY_BRACKET);
+        $closers = array(\T_CLOSE_CURLY_BRACKET);
         if (defined('T_CLOSE_USE_GROUP')) {
-            $closers[] = T_CLOSE_USE_GROUP;
+            $closers[] = \T_CLOSE_USE_GROUP;
         }
 
         $closeCurly = $phpcsFile->findNext($closers, ($stackPtr + 1), null, false, null, true);
@@ -94,7 +94,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
         }
 
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closeCurly - 1), null, true);
-        if ($tokens[$prevToken]['code'] === T_COMMA) {
+        if ($tokens[$prevToken]['code'] === \T_COMMA) {
             $phpcsFile->addError(
                 'Trailing comma\'s are not allowed in group use statements in PHP 7.1 or earlier',
                 $prevToken,

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -48,7 +48,7 @@ class NewUseConstFunctionSniff extends Sniff
      */
     public function register()
     {
-        return array(T_USE);
+        return array(\T_USE);
     }
 
 
@@ -85,7 +85,7 @@ class NewUseConstFunctionSniff extends Sniff
         if ($functionOrConstName === false
             // Identifies as T_AS or T_STRING, this covers both.
             || ($tokens[$functionOrConstName]['content'] === 'as'
-            || $tokens[$functionOrConstName]['code'] === T_COMMA)
+            || $tokens[$functionOrConstName]['code'] === \T_COMMA)
         ) {
             // Live coding or incorrect use of reserved keyword, but that is
             // covered by the ForbiddenNames sniff.

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -36,7 +36,7 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
      */
     public function register()
     {
-        return array(T_GLOBAL);
+        return array(\T_GLOBAL);
     }
 
     /**
@@ -55,7 +55,7 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
         }
 
         $tokens         = $phpcsFile->getTokens();
-        $endOfStatement = $phpcsFile->findNext(array(T_SEMICOLON, T_CLOSE_TAG), ($stackPtr + 1));
+        $endOfStatement = $phpcsFile->findNext(array(\T_SEMICOLON, \T_CLOSE_TAG), ($stackPtr + 1));
         if ($endOfStatement === false) {
             // No semi-colon - live coding.
             return;
@@ -63,9 +63,9 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
 
         for ($ptr = ($stackPtr + 1); $ptr <= $endOfStatement; $ptr++) {
             $errorThrown = false;
-            $nextComma   = $phpcsFile->findNext(T_COMMA, $ptr, $endOfStatement, false, null, true);
+            $nextComma   = $phpcsFile->findNext(\T_COMMA, $ptr, $endOfStatement, false, null, true);
             $varEnd      = ($nextComma === false) ? $endOfStatement : $nextComma;
-            $variable    = $phpcsFile->findNext(T_VARIABLE, $ptr, $varEnd);
+            $variable    = $phpcsFile->findNext(\T_VARIABLE, $ptr, $varEnd);
             $varString   = trim($phpcsFile->getTokensAsString($ptr, ($varEnd - $ptr)));
             $data        = array($varString);
 
@@ -78,7 +78,7 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
                     $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($variable + 1), $varEnd, true);
 
                     if ($next !== false
-                        && in_array($tokens[$next]['code'], array(T_OPEN_SQUARE_BRACKET, T_OBJECT_OPERATOR, T_DOUBLE_COLON), true) === true
+                        && in_array($tokens[$next]['code'], array(\T_OPEN_SQUARE_BRACKET, \T_OBJECT_OPERATOR, \T_DOUBLE_COLON), true) === true
                     ) {
                         $phpcsFile->addError(
                             'Global with variable variables is not allowed since PHP 7.0. Found %s',
@@ -100,10 +100,10 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
             }
 
             if ($errorThrown === false) {
-                $dollar = $phpcsFile->findNext(T_DOLLAR, $ptr, $varEnd);
+                $dollar = $phpcsFile->findNext(\T_DOLLAR, $ptr, $varEnd);
                 if ($dollar !== false) {
                     $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($dollar + 1), $varEnd, true);
-                    if ($tokens[$next]['code'] === T_OPEN_CURLY_BRACKET) {
+                    if ($tokens[$next]['code'] === \T_OPEN_CURLY_BRACKET) {
                         $phpcsFile->addWarning(
                             'Global with anything other than bare variables is discouraged since PHP 7.0. Found %s',
                             $dollar,

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -60,9 +60,9 @@ class ForbiddenThisUseContextsSniff extends Sniff
      * @var array
      */
     private $ooScopeTokens = array(
-        'T_CLASS'     => T_CLASS,
-        'T_INTERFACE' => T_INTERFACE,
-        'T_TRAIT'     => T_TRAIT,
+        'T_CLASS'     => \T_CLASS,
+        'T_INTERFACE' => \T_INTERFACE,
+        'T_TRAIT'     => \T_TRAIT,
     );
 
     /**
@@ -85,8 +85,8 @@ class ForbiddenThisUseContextsSniff extends Sniff
      * @var array
      */
     private $validUseOutsideObject = array(
-        T_ISSET => true,
-        T_EMPTY => true,
+        \T_ISSET => true,
+        \T_EMPTY => true,
     );
 
     /**
@@ -99,18 +99,18 @@ class ForbiddenThisUseContextsSniff extends Sniff
     public function register()
     {
         if (defined('T_ANON_CLASS')) {
-            $this->ooScopeTokens['T_ANON_CLASS'] = T_ANON_CLASS;
+            $this->ooScopeTokens['T_ANON_CLASS'] = \T_ANON_CLASS;
         }
 
         $this->skipOverScopes += $this->ooScopeTokens;
 
         return array(
-            T_FUNCTION,
-            T_CLOSURE,
-            T_GLOBAL,
-            T_CATCH,
-            T_FOREACH,
-            T_UNSET,
+            \T_FUNCTION,
+            \T_CLOSURE,
+            \T_GLOBAL,
+            \T_CATCH,
+            \T_FOREACH,
+            \T_UNSET,
         );
     }
 
@@ -134,29 +134,29 @@ class ForbiddenThisUseContextsSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         switch ($tokens[$stackPtr]['code']) {
-            case T_FUNCTION:
+            case \T_FUNCTION:
                 $this->isThisUsedAsParameter($phpcsFile, $stackPtr);
                 $this->isThisUsedOutsideObjectContext($phpcsFile, $stackPtr);
                 break;
 
-            case T_CLOSURE:
+            case \T_CLOSURE:
                 $this->isThisUsedAsParameter($phpcsFile, $stackPtr);
                 break;
 
-            case T_GLOBAL:
+            case \T_GLOBAL:
                 /*
                  * $this can no longer be imported using the `global` keyword.
                  * This worked in PHP 7.0, though in PHP 5.x, it would throw a
                  * fatal "Cannot re-assign $this" error.
                  */
-                $endOfStatement = $phpcsFile->findNext(array(T_SEMICOLON, T_CLOSE_TAG), ($stackPtr + 1));
+                $endOfStatement = $phpcsFile->findNext(array(\T_SEMICOLON, \T_CLOSE_TAG), ($stackPtr + 1));
                 if ($endOfStatement === false) {
                     // No semi-colon - live coding.
                     return;
                 }
 
                 for ($i = ($stackPtr + 1); $i < $endOfStatement; $i++) {
-                    if ($tokens[$i]['code'] !== T_VARIABLE || $tokens[$i]['content'] !== '$this') {
+                    if ($tokens[$i]['code'] !== \T_VARIABLE || $tokens[$i]['content'] !== '$this') {
                         continue;
                     }
 
@@ -169,7 +169,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
 
                 break;
 
-            case T_CATCH:
+            case \T_CATCH:
                 /*
                  * $this can no longer be used as a catch variable.
                  */
@@ -178,7 +178,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
                 }
 
                 $varPtr = $phpcsFile->findNext(
-                    T_VARIABLE,
+                    \T_VARIABLE,
                     ($tokens[$stackPtr]['parenthesis_opener'] + 1),
                     $tokens[$stackPtr]['parenthesis_closer']
                 );
@@ -195,7 +195,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
 
                 break;
 
-            case T_FOREACH:
+            case \T_FOREACH:
                 /*
                  * $this can no longer be used as a foreach *value* variable.
                  * This worked in PHP 7.0, though in PHP 5.x, it would throw a
@@ -206,7 +206,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
                 }
 
                 $stopPtr = $phpcsFile->findPrevious(
-                    array(T_AS, T_DOUBLE_ARROW),
+                    array(\T_AS, \T_DOUBLE_ARROW),
                     ($tokens[$stackPtr]['parenthesis_closer'] - 1),
                     $tokens[$stackPtr]['parenthesis_opener']
                 );
@@ -215,7 +215,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
                 }
 
                 $valueVarPtr = $phpcsFile->findNext(
-                    T_VARIABLE,
+                    \T_VARIABLE,
                     ($stopPtr + 1),
                     $tokens[$stackPtr]['parenthesis_closer']
                 );
@@ -231,8 +231,8 @@ class ForbiddenThisUseContextsSniff extends Sniff
                 );
 
                 if ($afterThis !== false
-                    && ($tokens[$afterThis]['code'] === T_OBJECT_OPERATOR
-                        || $tokens[$afterThis]['code'] === T_DOUBLE_COLON)
+                    && ($tokens[$afterThis]['code'] === \T_OBJECT_OPERATOR
+                        || $tokens[$afterThis]['code'] === \T_DOUBLE_COLON)
                 ) {
                     return;
                 }
@@ -245,20 +245,20 @@ class ForbiddenThisUseContextsSniff extends Sniff
 
                 break;
 
-            case T_UNSET:
+            case \T_UNSET:
                 /*
                  * $this can no longer be unset.
                  */
                 $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
                 if ($openParenthesis === false
-                    || $tokens[$openParenthesis]['code'] !== T_OPEN_PARENTHESIS
+                    || $tokens[$openParenthesis]['code'] !== \T_OPEN_PARENTHESIS
                     || isset($tokens[$openParenthesis]['parenthesis_closer']) === false
                 ) {
                     return;
                 }
 
                 for ($i = ($openParenthesis + 1); $i < $tokens[$openParenthesis]['parenthesis_closer']; $i++) {
-                    if ($tokens[$i]['code'] !== T_VARIABLE || $tokens[$i]['content'] !== '$this') {
+                    if ($tokens[$i]['code'] !== \T_VARIABLE || $tokens[$i]['content'] !== '$this') {
                         continue;
                     }
 
@@ -270,9 +270,9 @@ class ForbiddenThisUseContextsSniff extends Sniff
                     );
 
                     if ($afterThis !== false
-                        && ($tokens[$afterThis]['code'] === T_OBJECT_OPERATOR
-                            || $tokens[$afterThis]['code'] === T_DOUBLE_COLON
-                            || $tokens[$afterThis]['code'] === T_OPEN_SQUARE_BRACKET)
+                        && ($tokens[$afterThis]['code'] === \T_OBJECT_OPERATOR
+                            || $tokens[$afterThis]['code'] === \T_DOUBLE_COLON
+                            || $tokens[$afterThis]['code'] === \T_OPEN_SQUARE_BRACKET)
                     ) {
                         $i = $afterThis;
                         continue;
@@ -321,7 +321,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
                 continue;
             }
 
-            if ($tokens[$stackPtr]['code'] === T_FUNCTION) {
+            if ($tokens[$stackPtr]['code'] === \T_FUNCTION) {
                 $phpcsFile->addError(
                     '"$this" can no longer be used as a parameter since PHP 7.1.',
                     $param['token'],
@@ -391,7 +391,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
                 continue;
             }
 
-            if ($tokens[$i]['code'] !== T_VARIABLE || $tokens[$i]['content'] !== '$this') {
+            if ($tokens[$i]['code'] !== \T_VARIABLE || $tokens[$i]['content'] !== '$this') {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -35,7 +35,7 @@ class NewUniformVariableSyntaxSniff extends Sniff
      */
     public function register()
     {
-        return array(T_VARIABLE);
+        return array(\T_VARIABLE);
     }
 
     /**
@@ -58,21 +58,21 @@ class NewUniformVariableSyntaxSniff extends Sniff
         // Verify that the next token is a square open bracket. If not, bow out.
         $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
 
-        if ($nextToken === false || $tokens[$nextToken]['code'] !== T_OPEN_SQUARE_BRACKET || isset($tokens[$nextToken]['bracket_closer']) === false) {
+        if ($nextToken === false || $tokens[$nextToken]['code'] !== \T_OPEN_SQUARE_BRACKET || isset($tokens[$nextToken]['bracket_closer']) === false) {
             return;
         }
 
         // The previous non-empty token has to be a $, -> or ::.
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-        if ($prevToken === false || in_array($tokens[$prevToken]['code'], array(T_DOLLAR, T_OBJECT_OPERATOR, T_DOUBLE_COLON), true) === false) {
+        if ($prevToken === false || in_array($tokens[$prevToken]['code'], array(\T_DOLLAR, \T_OBJECT_OPERATOR, \T_DOUBLE_COLON), true) === false) {
             return;
         }
 
         // For static object calls, it only applies when this is a function call.
-        if ($tokens[$prevToken]['code'] === T_DOUBLE_COLON) {
+        if ($tokens[$prevToken]['code'] === \T_DOUBLE_COLON) {
             $hasBrackets = $tokens[$nextToken]['bracket_closer'];
             while (($hasBrackets = $phpcsFile->findNext(Tokens::$emptyTokens, ($hasBrackets + 1), null, true, null, true)) !== false) {
-                if ($tokens[$hasBrackets]['code'] === T_OPEN_SQUARE_BRACKET) {
+                if ($tokens[$hasBrackets]['code'] === \T_OPEN_SQUARE_BRACKET) {
                     if (isset($tokens[$hasBrackets]['bracket_closer'])) {
                         $hasBrackets = $tokens[$hasBrackets]['bracket_closer'];
                         continue;
@@ -81,7 +81,7 @@ class NewUniformVariableSyntaxSniff extends Sniff
                         return;
                     }
 
-                } elseif ($tokens[$hasBrackets]['code'] === T_OPEN_PARENTHESIS) {
+                } elseif ($tokens[$hasBrackets]['code'] === \T_OPEN_PARENTHESIS) {
                     // Caught!
                     break;
 
@@ -94,9 +94,9 @@ class NewUniformVariableSyntaxSniff extends Sniff
             // Now let's also prevent false positives when used with self and static which still work fine.
             $classToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true, null, true);
             if ($classToken !== false) {
-                if ($tokens[$classToken]['code'] === T_STATIC || $tokens[$classToken]['code'] === T_SELF) {
+                if ($tokens[$classToken]['code'] === \T_STATIC || $tokens[$classToken]['code'] === \T_SELF) {
                     return;
-                } elseif ($tokens[$classToken]['code'] === T_STRING && $tokens[$classToken]['content'] === 'self') {
+                } elseif ($tokens[$classToken]['code'] === \T_STRING && $tokens[$classToken]['content'] === 'self') {
                     return;
                 }
             }

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -91,7 +91,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
      */
     public function register()
     {
-        return array(T_VARIABLE);
+        return array(\T_VARIABLE);
     }
 
 
@@ -125,7 +125,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
         // Check for static usage of class properties shadowing the removed global variables.
         if ($this->inClassScope($phpcsFile, $stackPtr, false) === true) {
             $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-            if ($prevToken !== false && $tokens[$prevToken]['code'] === T_DOUBLE_COLON) {
+            if ($prevToken !== false && $tokens[$prevToken]['code'] === \T_DOUBLE_COLON) {
                 return;
             }
         }
@@ -203,9 +203,9 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
         /*
          * If the variable is detected within the scope of a function/closure, limit the checking.
          */
-        $function = $phpcsFile->getCondition($stackPtr, T_CLOSURE);
+        $function = $phpcsFile->getCondition($stackPtr, \T_CLOSURE);
         if ($function === false) {
-            $function = $phpcsFile->getCondition($stackPtr, T_FUNCTION);
+            $function = $phpcsFile->getCondition($stackPtr, \T_FUNCTION);
         }
 
         // It could also be a function param, which is not in the function scope.
@@ -213,8 +213,8 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
             $nestedParentheses = $tokens[$stackPtr]['nested_parenthesis'];
             $parenthesisCloser = end($nestedParentheses);
             if (isset($tokens[$parenthesisCloser]['parenthesis_owner'])
-                && ($tokens[$tokens[$parenthesisCloser]['parenthesis_owner']]['code'] === T_FUNCTION
-                    || $tokens[$tokens[$parenthesisCloser]['parenthesis_owner']]['code'] === T_CLOSURE)
+                && ($tokens[$tokens[$parenthesisCloser]['parenthesis_owner']]['code'] === \T_FUNCTION
+                    || $tokens[$tokens[$parenthesisCloser]['parenthesis_owner']]['code'] === \T_CLOSURE)
             ) {
                 $function = $tokens[$parenthesisCloser]['parenthesis_owner'];
             }
@@ -230,7 +230,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         // Is the variable being used as an array ?
-        if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === T_OPEN_SQUARE_BRACKET) {
+        if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_SQUARE_BRACKET) {
             // The PHP native variable is a string, so this is probably not it
             // (except for array access to string, but why would you in this case ?).
             return false;
@@ -266,7 +266,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
         // Walk back and see if there is an assignment to the variable within the same scope.
         for ($i = ($stackPtr - 1); $i >= $scopeStart; $i--) {
-            if ($tokens[$i]['code'] === T_CLOSE_CURLY_BRACKET
+            if ($tokens[$i]['code'] === \T_CLOSE_CURLY_BRACKET
                 && isset($tokens[$i]['scope_condition'])
                 && isset($skipPast[$tokens[$tokens[$i]['scope_condition']]['type']])
             ) {
@@ -275,7 +275,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
                 continue;
             }
 
-            if ($tokens[$i]['code'] !== T_VARIABLE || $tokens[$i]['content'] !== '$php_errormsg') {
+            if ($tokens[$i]['code'] !== \T_VARIABLE || $tokens[$i]['content'] !== '$php_errormsg') {
                 continue;
             }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -41,7 +41,7 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
             self::$recognizesTraits = false;
         }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -41,7 +41,7 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
             self::$recognizesTraits = false;
         }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -43,7 +43,7 @@ class RemovedMagicAutoloadUnitTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
             self::$recognizesTraitsOrInterfaces = false;
         }
         parent::setUpBeforeClass();

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -44,7 +44,7 @@ class RemovedNamespacedAssertUnitTest extends BaseSniffTest
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are
         // not recognized and the scope condition for interfaces will not be set.
-        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
             self::$recognizesTraitsAndInterfaces = false;
         }
         parent::setUpBeforeClass();

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -55,7 +55,7 @@ class NewConstantScalarExpressionsUnitTest extends BaseSniffTest
         $phpcsVersion = PHPCSHelper::getVersion();
 
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare($phpcsVersion, '2.4.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
+        if (version_compare($phpcsVersion, '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
             self::$recognizesTraits = false;
         }
 

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -47,7 +47,7 @@ class NewHeredocUnitTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
             self::$recognizesTraits = false;
         }
 

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -379,7 +379,7 @@ class NewKeywordsUnitTest extends BaseSniffTest
      */
     public function testHaltCompiler()
     {
-        if (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION === 3) {
+        if (\PHP_MAJOR_VERSION === 5 && \PHP_MINOR_VERSION === 3) {
             // PHP 5.3 actually shows the warning.
             $file = $this->sniffFile(__FILE__, '5.0');
             $this->assertError($file, 124, '"__halt_compiler" keyword is not present in PHP version 5.0 or earlier');

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -39,7 +39,7 @@ class RemovedAlternativePHPTagsUnitTest extends BaseSniffTest
      */
     public static function setUpBeforeClass()
     {
-        if (version_compare(PHP_VERSION_ID, '70000', '<')) {
+        if (version_compare(\PHP_VERSION_ID, '70000', '<')) {
             // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.asp_tagsRemoved
             self::$aspTags = (bool) ini_get('asp_tags');
         }

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -55,7 +55,7 @@ class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
             self::$php73plus = false;
             // When using PHP 7.3+, the closing marker will be misidentified if the
             // body contains the heredoc/nowdoc identifier.
-            if (version_compare(PHP_VERSION_ID, '70299', '>') === true) {
+            if (version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
                 self::$php73plus = true;
             }
         }

--- a/PHPCompatibility/Util/Tests/Core/DoesFunctionCallHaveParametersUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/DoesFunctionCallHaveParametersUnitTest.php
@@ -36,7 +36,7 @@ class DoesFunctionCallHaveParametersUnitTest extends CoreMethodTestFrame
      */
     public function testDoesFunctionCallHaveParameters($commentString, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY));
+        $stackPtr = $this->getTargetToken($commentString, array(\T_STRING, \T_ARRAY, \T_OPEN_SHORT_ARRAY));
         $result   = $this->helperClass->doesFunctionCallHaveParameters($this->phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }

--- a/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromDoubleColonTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromDoubleColonTokenUnitTest.php
@@ -36,7 +36,7 @@ class GetFQClassNameFromDoubleColonTokenUnitTest extends CoreMethodTestFrame
      */
     public function testGetFQClassNameFromDoubleColonToken($commentString, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, T_DOUBLE_COLON);
+        $stackPtr = $this->getTargetToken($commentString, \T_DOUBLE_COLON);
         $result   = $this->helperClass->getFQClassNameFromDoubleColonToken($this->phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }

--- a/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromNewTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromNewTokenUnitTest.php
@@ -36,7 +36,7 @@ class GetFQClassNameFromNewTokenUnitTest extends CoreMethodTestFrame
      */
     public function testGetFQClassNameFromNewToken($commentString, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, T_NEW);
+        $stackPtr = $this->getTargetToken($commentString, \T_NEW);
         $result   = $this->helperClass->getFQClassNameFromNewToken($this->phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }

--- a/PHPCompatibility/Util/Tests/Core/GetFQExtendedClassNameUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFQExtendedClassNameUnitTest.php
@@ -36,7 +36,7 @@ class GetFQExtendedClassNameUnitTest extends CoreMethodTestFrame
      */
     public function testGetFQExtendedClassName($commentString, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, array(T_CLASS, T_INTERFACE));
+        $stackPtr = $this->getTargetToken($commentString, array(\T_CLASS, \T_INTERFACE));
         $result   = $this->helperClass->getFQExtendedClassName($this->phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }

--- a/PHPCompatibility/Util/Tests/Core/GetFunctionParameterCountUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFunctionParameterCountUnitTest.php
@@ -36,7 +36,7 @@ class GetFunctionParameterCountUnitTest extends CoreMethodTestFrame
      */
     public function testGetFunctionCallParameterCount($commentString, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY));
+        $stackPtr = $this->getTargetToken($commentString, array(\T_STRING, \T_ARRAY, \T_OPEN_SHORT_ARRAY));
         $result   = $this->helperClass->getFunctionCallParameterCount($this->phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }

--- a/PHPCompatibility/Util/Tests/Core/GetFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFunctionParametersUnitTest.php
@@ -38,13 +38,13 @@ class GetFunctionParametersUnitTest extends CoreMethodTestFrame
     {
         switch ($commentString[8]) {
             case 'S':
-                $stackPtr = $this->getTargetToken($commentString, array(T_STRING));
+                $stackPtr = $this->getTargetToken($commentString, array(\T_STRING));
                 break;
             case 'A':
-                $stackPtr = $this->getTargetToken($commentString, array(T_ARRAY, T_OPEN_SHORT_ARRAY));
+                $stackPtr = $this->getTargetToken($commentString, array(\T_ARRAY, \T_OPEN_SHORT_ARRAY));
                 break;
             case 'V':
-                $stackPtr = $this->getTargetToken($commentString, array(T_VARIABLE));
+                $stackPtr = $this->getTargetToken($commentString, array(\T_VARIABLE));
                 break;
         }
 
@@ -353,7 +353,7 @@ class GetFunctionParametersUnitTest extends CoreMethodTestFrame
      */
     public function testGetFunctionCallParameter($commentString, $paramPosition, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY));
+        $stackPtr = $this->getTargetToken($commentString, array(\T_STRING, \T_ARRAY, \T_OPEN_SHORT_ARRAY));
         /*
          * Start/end token position values in the expected array are set as offsets
          * in relation to the target token.

--- a/PHPCompatibility/Util/Tests/Core/IsClassConstantUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsClassConstantUnitTest.php
@@ -37,7 +37,7 @@ class IsClassConstantUnitTest extends CoreMethodTestFrame
      */
     public function testIsClassConstant($commentString, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, T_CONST);
+        $stackPtr = $this->getTargetToken($commentString, \T_CONST);
         $result   = $this->helperClass->isClassConstant($this->phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }

--- a/PHPCompatibility/Util/Tests/Core/IsClassPropertyUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsClassPropertyUnitTest.php
@@ -39,7 +39,7 @@ class IsClassPropertyUnitTest extends CoreMethodTestFrame
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
             self::$recognizesTraits = false;
         }
 
@@ -68,7 +68,7 @@ class IsClassPropertyUnitTest extends CoreMethodTestFrame
             return;
         }
 
-        $stackPtr = $this->getTargetToken($commentString, T_VARIABLE);
+        $stackPtr = $this->getTargetToken($commentString, \T_VARIABLE);
         $result   = $this->helperClass->isClassProperty($this->phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }

--- a/PHPCompatibility/Util/Tests/Core/IsNumberUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsNumberUnitTest.php
@@ -41,8 +41,8 @@ class IsNumberUnitTest extends CoreMethodTestFrame
      */
     public function testIsNumber($commentString, $allowFloats, $isNumber, $isPositiveNumber, $isNegativeNumber)
     {
-        $start = ($this->getTargetToken($commentString, T_EQUAL) + 1);
-        $end   = ($this->getTargetToken($commentString, T_SEMICOLON) - 1);
+        $start = ($this->getTargetToken($commentString, \T_EQUAL) + 1);
+        $end   = ($this->getTargetToken($commentString, \T_SEMICOLON) - 1);
 
         $result = $this->helperClass->isNumber($this->phpcsFile, $start, $end, $allowFloats);
         $this->assertSame($isNumber, $result);

--- a/PHPCompatibility/Util/Tests/Core/IsNumericCalculationUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsNumericCalculationUnitTest.php
@@ -36,8 +36,8 @@ class IsNumericCalculationUnitTest extends CoreMethodTestFrame
      */
     public function testIsNumericCalculation($commentString, $isCalc)
     {
-        $start = ($this->getTargetToken($commentString, T_EQUAL) + 1);
-        $end   = ($this->getTargetToken($commentString, T_SEMICOLON) - 1);
+        $start = ($this->getTargetToken($commentString, \T_EQUAL) + 1);
+        $end   = ($this->getTargetToken($commentString, \T_SEMICOLON) - 1);
 
         $result = $this->helperClass->isNumericCalculation($this->phpcsFile, $start, $end);
         $this->assertSame($isCalc, $result);

--- a/PHPCompatibility/Util/Tests/Core/IsShortListUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsShortListUnitTest.php
@@ -35,7 +35,7 @@ class IsShortListUnitTest extends CoreMethodTestFrame
      *
      * @return void
      */
-    public function testIsShortList($commentString, $expected, $targetToken = T_OPEN_SHORT_ARRAY)
+    public function testIsShortList($commentString, $expected, $targetToken = \T_OPEN_SHORT_ARRAY)
     {
         $stackPtr = $this->getTargetToken($commentString, $targetToken);
         $result   = $this->helperClass->isShortList($this->phpcsFile, $stackPtr);
@@ -53,17 +53,17 @@ class IsShortListUnitTest extends CoreMethodTestFrame
     public function dataIsShortList()
     {
         return array(
-            array('/* Case 1 */', false, T_ARRAY),
-            array('/* Case 2 */', false, T_LIST),
-            array('/* Case 3 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 1 */', false, \T_ARRAY),
+            array('/* Case 2 */', false, \T_LIST),
+            array('/* Case 3 */', false, array(\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET)),
             array('/* Case 4 */', true),
-            array('/* Case 5 */', true, T_CLOSE_SHORT_ARRAY),
+            array('/* Case 5 */', true, \T_CLOSE_SHORT_ARRAY),
             array('/* Case 6 */', true),
             array('/* Case 7 */', true),
             array('/* Case 8 */', true),
             array('/* Case 9 */', true),
             array('/* Case 10 */', true),
-            array('/* Case 11 */', true, T_CLOSE_SHORT_ARRAY),
+            array('/* Case 11 */', true, \T_CLOSE_SHORT_ARRAY),
             array('/* Case 12 */', true),
             array('/* Case 13 */', true),
             array('/* Case 14 */', true),
@@ -74,12 +74,12 @@ class IsShortListUnitTest extends CoreMethodTestFrame
             array('/* Case 19 */', true),
             array('/* Case 20 */', true),
             array('/* Case 21 */', true),
-            array('/* Case 22 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
-            array('/* Case 23 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
-            array('/* Case 24 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
-            array('/* Case 25 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
-            array('/* Case 26 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
-            array('/* Case final */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 22 */', false, array(\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 23 */', false, array(\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 24 */', false, array(\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 25 */', false, array(\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 26 */', false, array(\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET)),
+            array('/* Case final */', false, array(\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET)),
         );
     }
 }

--- a/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.php
@@ -36,7 +36,7 @@ class IsUseOfGlobalConstantUnitTest extends CoreMethodTestFrame
      */
     public function testIsUseOfGlobalConstant($commentString, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, T_STRING, 'PHP_VERSION_ID');
+        $stackPtr = $this->getTargetToken($commentString, \T_STRING, 'PHP_VERSION_ID');
         $result   = $this->helperClass->isUseOfGlobalConstant($this->phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }

--- a/PHPCompatibility/Util/Tests/Core/TokenScopeUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/TokenScopeUnitTest.php
@@ -39,7 +39,7 @@ class TokenScopeUnitTest extends CoreMethodTestFrame
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
             self::$recognizesTraits = false;
         }
 
@@ -79,37 +79,37 @@ class TokenScopeUnitTest extends CoreMethodTestFrame
     {
         return array(
             // No scope.
-            array('/* Case 1 */', T_VARIABLE, false), // $var
+            array('/* Case 1 */', \T_VARIABLE, false), // $var
 
             // Various scopes.
-            array('/* Case 2 */', T_ECHO, true), // echo within if
-            array('/* Case 2 */', T_ECHO, true, T_IF), // echo within if
-            array('/* Case 2 */', T_ECHO, false, array(T_SWITCH) ), // echo within if
+            array('/* Case 2 */', \T_ECHO, true), // echo within if
+            array('/* Case 2 */', \T_ECHO, true, \T_IF), // echo within if
+            array('/* Case 2 */', \T_ECHO, false, array(\T_SWITCH) ), // echo within if
 
-            array('/* Case 3 */', T_ECHO, true), // echo within else-if
-            array('/* Case 3 */', T_ECHO, true, array(T_ELSEIF)), // echo within else-if
-            array('/* Case 3 */', T_ECHO, false, array(T_IF)), // echo within else-if
+            array('/* Case 3 */', \T_ECHO, true), // echo within else-if
+            array('/* Case 3 */', \T_ECHO, true, array(\T_ELSEIF)), // echo within else-if
+            array('/* Case 3 */', \T_ECHO, false, array(\T_IF)), // echo within else-if
 
-            array('/* Case 4 */', T_ECHO, true), // echo within else
-            array('/* Case 5 */', T_ECHO, true), // echo within for
-            array('/* Case 6 */', T_ECHO, true), // echo within foreach
+            array('/* Case 4 */', \T_ECHO, true), // echo within else
+            array('/* Case 5 */', \T_ECHO, true), // echo within for
+            array('/* Case 6 */', \T_ECHO, true), // echo within foreach
 
-            array('/* Case 7 */', T_CASE, true), // case within switch
-            array('/* Case 7 */', T_CASE, true, array(T_SWITCH)), // case within switch
-            array('/* Case 7 */', T_CASE, false, array(T_CASE)), // case within switch
+            array('/* Case 7 */', \T_CASE, true), // case within switch
+            array('/* Case 7 */', \T_CASE, true, array(\T_SWITCH)), // case within switch
+            array('/* Case 7 */', \T_CASE, false, array(\T_CASE)), // case within switch
 
-            array('/* Case 8 */', T_ECHO, true), // echo within case within switch
-            array('/* Case 8 */', T_ECHO, true, array(T_SWITCH)), // echo within case within switch
-            array('/* Case 8 */', T_ECHO, true, T_CASE), // echo within case within switch
-            array('/* Case 8 */', T_ECHO, true, array(T_SWITCH, T_CASE)), // echo within case within switch
-            array('/* Case 8 */', T_ECHO, true, array(T_SWITCH, T_IF)), // echo within case within switch
-            array('/* Case 8 */', T_ECHO, false, array(T_ELSEIF, T_IF)), // echo within case within switch
+            array('/* Case 8 */', \T_ECHO, true), // echo within case within switch
+            array('/* Case 8 */', \T_ECHO, true, array(\T_SWITCH)), // echo within case within switch
+            array('/* Case 8 */', \T_ECHO, true, \T_CASE), // echo within case within switch
+            array('/* Case 8 */', \T_ECHO, true, array(\T_SWITCH, \T_CASE)), // echo within case within switch
+            array('/* Case 8 */', \T_ECHO, true, array(\T_SWITCH, \T_IF)), // echo within case within switch
+            array('/* Case 8 */', \T_ECHO, false, array(\T_ELSEIF, \T_IF)), // echo within case within switch
 
-            array('/* Case 9 */', T_DEFAULT, true), // default within switch
-            array('/* Case 10 */', T_ECHO, true), // echo within default within switch
+            array('/* Case 9 */', \T_DEFAULT, true), // default within switch
+            array('/* Case 10 */', \T_ECHO, true), // echo within default within switch
 
-            array('/* Case 11 */', T_ECHO, true), // echo within function
-            array('/* Case 11 */', T_ECHO, true, array(T_FUNCTION)), // echo within function
+            array('/* Case 11 */', \T_ECHO, true), // echo within function
+            array('/* Case 11 */', \T_ECHO, true, array(\T_FUNCTION)), // echo within function
         );
     }
 
@@ -150,17 +150,17 @@ class TokenScopeUnitTest extends CoreMethodTestFrame
     public function dataInClassScope()
     {
         return array(
-            array('/* Case C1 */', T_VARIABLE, true), // $property
-            array('/* Case C2 */', T_FUNCTION, true), // Function in class.
-            array('/* Case C3 */', T_FUNCTION, false), // Global function.
-            array('/* Case C4 */', T_FUNCTION, true), // Function in namespaced class.
-            array('/* Case C5 */', T_FUNCTION, true), // Function in anon class.
-            array('/* Case I1 */', T_FUNCTION, false), // Function in interface / strict.
-            array('/* Case I1 */', T_FUNCTION, true, false, true), // Function in interface.
-            array('/* Case T1 */', T_VARIABLE, false, true, true), // Property in trait / strict.
-            array('/* Case T1 */', T_VARIABLE, true, false, true), // Property in trait.
-            array('/* Case T2 */', T_FUNCTION, false, true, true), // Function in trait / strict.
-            array('/* Case T2 */', T_FUNCTION, true, false, true), // Function in trait.
+            array('/* Case C1 */', \T_VARIABLE, true), // $property
+            array('/* Case C2 */', \T_FUNCTION, true), // Function in class.
+            array('/* Case C3 */', \T_FUNCTION, false), // Global function.
+            array('/* Case C4 */', \T_FUNCTION, true), // Function in namespaced class.
+            array('/* Case C5 */', \T_FUNCTION, true), // Function in anon class.
+            array('/* Case I1 */', \T_FUNCTION, false), // Function in interface / strict.
+            array('/* Case I1 */', \T_FUNCTION, true, false, true), // Function in interface.
+            array('/* Case T1 */', \T_VARIABLE, false, true, true), // Property in trait / strict.
+            array('/* Case T1 */', \T_VARIABLE, true, false, true), // Property in trait.
+            array('/* Case T2 */', \T_FUNCTION, false, true, true), // Function in trait / strict.
+            array('/* Case T2 */', \T_FUNCTION, true, false, true), // Function in trait.
         );
     }
 }

--- a/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
+++ b/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
@@ -52,7 +52,7 @@ abstract class CoreMethodTestFrame extends PHPUnit_TestCase
         $parts       = explode('\\', $FQClassName);
         $className   = array_pop($parts);
         $subDir      = array_pop($parts);
-        $filename    = realpath(__DIR__) . DIRECTORY_SEPARATOR . $subDir . DIRECTORY_SEPARATOR . $className . '.inc';
+        $filename    = realpath(__DIR__) . \DIRECTORY_SEPARATOR . $subDir . \DIRECTORY_SEPARATOR . $className . '.inc';
         $contents    = file_get_contents($filename);
 
         if (version_compare(PHPCSHelper::getVersion(), '2.99.99', '>')) {
@@ -103,7 +103,7 @@ abstract class CoreMethodTestFrame extends PHPUnit_TestCase
     {
         $start   = ($this->phpcsFile->numTokens - 1);
         $comment = $this->phpcsFile->findPrevious(
-            T_COMMENT,
+            \T_COMMENT,
             $start,
             null,
             false,
@@ -115,7 +115,7 @@ abstract class CoreMethodTestFrame extends PHPUnit_TestCase
 
         // Limit the token finding to between this and the next case comment.
         for ($i = ($comment + 1); $i < $end; $i++) {
-            if ($tokens[$i]['code'] !== T_COMMENT) {
+            if ($tokens[$i]['code'] !== \T_COMMENT) {
                 continue;
             }
 


### PR DESCRIPTION
_As there are no sniff PRs open at the moment, this felt like as good a time s any to make this change_ ;-)

Constants in PHP are namespaced as well, however, when PHP cannot find the constant in the namespace, it will fall through to the global namespace.

The step to first check within the namespace can be skipped by either using `use const ...` (PHP 5.6+) or by prefixing the constant with a `\`.

As PHPCompatibility uses a lot of global constants, some performance gain can be archived by using the FQN for constants.

This PR implements this throughout the codebase.

If we want to guard this for the future, we could add the SlevomatCodingStandard as a `dev` dependency and add the `SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants` sniff to the PHPCompatibility native ruleset.