### PR TITLE
Performance: use FQN for functions which can use PHP7 compile time opcodes

### DIFF
--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -132,7 +132,7 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
         }
 
         // Remove the last 'and' from the message.
-        $error = substr($error, 0, (strlen($error) - 5));
+        $error = substr($error, 0, (\strlen($error) - 5));
 
         if ($errorInfo['alternative'] !== '') {
             $error .= $this->getAlternativeOptionTemplate();

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -37,7 +37,7 @@ class PHPCSHelper
      */
     public static function getVersion()
     {
-        if (defined('\PHP_CodeSniffer\Config::VERSION')) {
+        if (\defined('\PHP_CodeSniffer\Config::VERSION')) {
             // PHPCS 3.x.
             return \PHP_CodeSniffer\Config::VERSION;
         } else {

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -178,7 +178,7 @@ abstract class Sniff implements PHPCS_Sniff
         $testVersion = $this->getTestVersion();
         $testVersion = $testVersion[1];
 
-        if (is_null($testVersion)
+        if (\is_null($testVersion)
             || version_compare($testVersion, $phpVersion) >= 0
         ) {
             return true;
@@ -205,7 +205,7 @@ abstract class Sniff implements PHPCS_Sniff
         $testVersion = $this->getTestVersion();
         $testVersion = $testVersion[0];
 
-        if (is_null($testVersion) === false
+        if (\is_null($testVersion) === false
             && version_compare($testVersion, $phpVersion) <= 0
         ) {
             return true;
@@ -332,7 +332,7 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         // Is this one of the tokens this function handles ?
-        if (in_array($tokens[$stackPtr]['code'], array(\T_STRING, \T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_VARIABLE), true) === false) {
+        if (\in_array($tokens[$stackPtr]['code'], array(\T_STRING, \T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_VARIABLE), true) === false) {
             return false;
         }
 
@@ -398,7 +398,7 @@ abstract class Sniff implements PHPCS_Sniff
             return 0;
         }
 
-        return count($this->getFunctionCallParameters($phpcsFile, $stackPtr));
+        return \count($this->getFunctionCallParameters($phpcsFile, $stackPtr));
     }
 
 
@@ -446,7 +446,7 @@ abstract class Sniff implements PHPCS_Sniff
 
         // Which nesting level is the one we are interested in ?
         if (isset($tokens[$opener]['nested_parenthesis'])) {
-            $nestedParenthesisCount += count($tokens[$opener]['nested_parenthesis']);
+            $nestedParenthesisCount += \count($tokens[$opener]['nested_parenthesis']);
         }
 
         $parameters = array();
@@ -479,7 +479,7 @@ abstract class Sniff implements PHPCS_Sniff
             // Ignore comma's at a lower nesting level.
             if ($tokens[$nextComma]['type'] === 'T_COMMA'
                 && isset($tokens[$nextComma]['nested_parenthesis'])
-                && count($tokens[$nextComma]['nested_parenthesis']) !== $nestedParenthesisCount
+                && \count($tokens[$nextComma]['nested_parenthesis']) !== $nestedParenthesisCount
             ) {
                 continue;
             }
@@ -594,7 +594,7 @@ abstract class Sniff implements PHPCS_Sniff
     public function inClassScope(File $phpcsFile, $stackPtr, $strict = true)
     {
         $validScopes = array(\T_CLASS);
-        if (defined('T_ANON_CLASS') === true) {
+        if (\defined('T_ANON_CLASS') === true) {
             $validScopes[] = \T_ANON_CLASS;
         }
 
@@ -688,7 +688,7 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         $extends = PHPCSHelper::findExtendedClassName($phpcsFile, $stackPtr);
-        if (empty($extends) || is_string($extends) === false) {
+        if (empty($extends) || \is_string($extends) === false) {
             return '';
         }
 
@@ -726,7 +726,7 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         // Nothing to do if 'parent' or 'static' as we don't know how far the class tree extends.
-        if (in_array($tokens[$stackPtr - 1]['code'], array(\T_PARENT, \T_STATIC), true)) {
+        if (\in_array($tokens[$stackPtr - 1]['code'], array(\T_PARENT, \T_STATIC), true)) {
             return '';
         }
 
@@ -945,7 +945,7 @@ abstract class Sniff implements PHPCS_Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (defined('T_RETURN_TYPE') && $tokens[$stackPtr]['code'] === \T_RETURN_TYPE) {
+        if (\defined('T_RETURN_TYPE') && $tokens[$stackPtr]['code'] === \T_RETURN_TYPE) {
             return $stackPtr;
         }
 
@@ -1045,7 +1045,7 @@ abstract class Sniff implements PHPCS_Sniff
                 continue;
             }
 
-            if (defined('T_NULLABLE') === false && $tokens[$i]['code'] === \T_INLINE_THEN) {
+            if (\defined('T_NULLABLE') === false && $tokens[$i]['code'] === \T_INLINE_THEN) {
                 // Old PHPCS.
                 continue;
             }
@@ -1205,7 +1205,7 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         $parameters = PHPCSHelper::getMethodParameters($phpcsFile, $stackPtr);
-        if (empty($parameters) || is_array($parameters) === false) {
+        if (empty($parameters) || \is_array($parameters) === false) {
             return array();
         }
 
@@ -1663,7 +1663,7 @@ abstract class Sniff implements PHPCS_Sniff
         $arithmeticTokens = Tokens::$arithmeticTokens;
 
         // phpcs:disable PHPCompatibility.Constants.NewConstants.t_powFound
-        if (defined('T_POW') && isset($arithmeticTokens[\T_POW]) === false) {
+        if (\defined('T_POW') && isset($arithmeticTokens[\T_POW]) === false) {
             // T_POW was not added to the arithmetic array until PHPCS 2.9.0.
             $arithmeticTokens[\T_POW] = \T_POW;
         }
@@ -1692,7 +1692,7 @@ abstract class Sniff implements PHPCS_Sniff
             && isset($tokens[($arithmeticOperator + 1)]) === true
         ) {
             // Recognize T_POW for PHPCS < 2.4.0 on low PHP versions.
-            if (defined('T_POW') === false
+            if (\defined('T_POW') === false
                 && $tokens[$arithmeticOperator]['code'] === \T_MULTIPLY
                 && $tokens[($arithmeticOperator + 1)]['code'] === \T_MULTIPLY
                 && isset($tokens[$arithmeticOperator + 2]) === true
@@ -1921,7 +1921,7 @@ abstract class Sniff implements PHPCS_Sniff
 
         // Check if the variable found is at the right level. Deeper levels are always an error.
         if (isset($tokens[$hasVariable]['nested_parenthesis'])
-            && count($tokens[$hasVariable]['nested_parenthesis']) !== $targetNestingLevel
+            && \count($tokens[$hasVariable]['nested_parenthesis']) !== $targetNestingLevel
         ) {
                 return false;
         }

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -48,7 +48,7 @@ class NewAnonymousClassesSniff extends Sniff
      */
     public function register()
     {
-        if (defined('T_ANON_CLASS')) {
+        if (\defined('T_ANON_CLASS')) {
             $this->indicators[\T_ANON_CLASS] = \T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -591,11 +591,11 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             \T_CATCH,
         );
 
-        if (defined('T_ANON_CLASS')) {
+        if (\defined('T_ANON_CLASS')) {
             $targets[] = \T_ANON_CLASS;
         }
 
-        if (defined('T_RETURN_TYPE')) {
+        if (\defined('T_RETURN_TYPE')) {
             $targets[] = \T_RETURN_TYPE;
         }
 
@@ -702,7 +702,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
     {
         // Retrieve typehints stripped of global NS indicator and/or nullable indicator.
         $typeHints = $this->getTypeHintsFromFunctionDeclaration($phpcsFile, $stackPtr);
-        if (empty($typeHints) || is_array($typeHints) === false) {
+        if (empty($typeHints) || \is_array($typeHints) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -80,7 +80,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
                     break;
                 }
 
-            } elseif (in_array($tokens[$curToken]['type'], array('T_VARIABLE', 'T_FUNCTION', 'T_CLOSURE'), true)) {
+            } elseif (\in_array($tokens[$curToken]['type'], array('T_VARIABLE', 'T_FUNCTION', 'T_CLOSURE'), true)) {
                 $errorType = 'variableArgument';
                 break;
 

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -196,7 +196,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
         if (empty($versionArray) === false) {
             foreach ($versionArray as $version => $present) {
-                if (is_string($present) === true && $this->supportsBelow($version) === true) {
+                if (\is_string($present) === true && $this->supportsBelow($version) === true) {
                     // We cannot test for compilation option (ok, except by scraping the output of phpinfo...).
                     $errorInfo['conditional_version'] = $version;
                     $errorInfo['condition']           = $present;
@@ -270,11 +270,11 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
         $isError = false;
         if (isset($this->newDirectives[$directive]['valid_values'])) {
-            if (in_array($value, $this->newDirectives[$directive]['valid_values']) === false) {
+            if (\in_array($value, $this->newDirectives[$directive]['valid_values']) === false) {
                 $isError = true;
             }
         } elseif (isset($this->newDirectives[$directive]['valid_value_callback'])) {
-            $valid = call_user_func(array($this, $this->newDirectives[$directive]['valid_value_callback']), $value);
+            $valid = \call_user_func(array($this, $this->newDirectives[$directive]['valid_value_callback']), $value);
             if ($valid === false) {
                 $isError = true;
             }
@@ -324,11 +324,11 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
             $encodings = mb_list_encodings();
         }
 
-        if (empty($encodings) || is_array($encodings) === false) {
+        if (empty($encodings) || \is_array($encodings) === false) {
             // If we can't test the encoding, let it pass through.
             return true;
         }
 
-        return in_array($value, $encodings, true);
+        return \in_array($value, $encodings, true);
     }
 }

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -79,7 +79,7 @@ class NewForeachExpressionReferencingSniff extends Sniff
 
         $nestingLevel = 0;
         if ($asToken !== ($opener + 1) && isset($tokens[$opener + 1]['nested_parenthesis'])) {
-            $nestingLevel = count($tokens[$opener + 1]['nested_parenthesis']);
+            $nestingLevel = \count($tokens[$opener + 1]['nested_parenthesis']);
         }
 
         if ($this->isVariable($phpcsFile, ($opener + 1), $asToken, $nestingLevel) === true) {

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -267,7 +267,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
             return false;
         }
 
-        if (is_string($this->functionWhitelist) === true) {
+        if (\is_string($this->functionWhitelist) === true) {
             if (strpos($this->functionWhitelist, ',') !== false) {
                 $this->functionWhitelist = explode(',', $this->functionWhitelist);
             } else {
@@ -275,9 +275,9 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
             }
         }
 
-        if (is_array($this->functionWhitelist) === true) {
+        if (\is_array($this->functionWhitelist) === true) {
             $this->functionWhitelist = array_map('strtolower', $this->functionWhitelist);
-            return in_array($content, $this->functionWhitelist, true);
+            return \in_array($content, $this->functionWhitelist, true);
         }
 
         return false;

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -62,7 +62,7 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
 
         // Get all parameters from function signature.
         $parameters = PHPCSHelper::getMethodParameters($phpcsFile, $stackPtr);
-        if (empty($parameters) || is_array($parameters) === false) {
+        if (empty($parameters) || \is_array($parameters) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -66,7 +66,7 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
 
         // Get all parameters from method signature.
         $parameters = PHPCSHelper::getMethodParameters($phpcsFile, $stackPtr);
-        if (empty($parameters) || is_array($parameters) === false) {
+        if (empty($parameters) || \is_array($parameters) === false) {
             return;
         }
 
@@ -75,7 +75,7 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
             $paramNames[] = strtolower($param['name']);
         }
 
-        if (count($paramNames) !== count(array_unique($paramNames))) {
+        if (\count($paramNames) !== \count(array_unique($paramNames))) {
             $phpcsFile->addError(
                 'Functions can not have multiple parameters with the same name since PHP 7.0',
                 $stackPtr,

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -45,7 +45,7 @@ class NewNullableTypesSniff extends Sniff
             \T_CLOSURE,
         );
 
-        if (defined('T_RETURN_TYPE')) {
+        if (\defined('T_RETURN_TYPE')) {
             $tokens[] = \T_RETURN_TYPE;
         }
 
@@ -99,7 +99,7 @@ class NewNullableTypesSniff extends Sniff
     {
         $params = PHPCSHelper::getMethodParameters($phpcsFile, $stackPtr);
 
-        if (empty($params) === false && is_array($params)) {
+        if (empty($params) === false && \is_array($params)) {
             foreach ($params as $param) {
                 if ($param['nullable_type'] === true) {
                     $phpcsFile->addError(
@@ -149,8 +149,8 @@ class NewNullableTypesSniff extends Sniff
         }
 
         // T_NULLABLE token was introduced in PHPCS 2.7.2. Before that it identified as T_INLINE_THEN.
-        if ((defined('T_NULLABLE') === true && $tokens[$previous]['type'] === 'T_NULLABLE')
-            || (defined('T_NULLABLE') === false && $tokens[$previous]['code'] === \T_INLINE_THEN)
+        if ((\defined('T_NULLABLE') === true && $tokens[$previous]['type'] === 'T_NULLABLE')
+            || (\defined('T_NULLABLE') === false && $tokens[$previous]['code'] === \T_INLINE_THEN)
         ) {
             $phpcsFile->addError(
                 'Nullable return types are not supported in PHP 7.0 or earlier.',

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -100,7 +100,7 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
             \T_CLOSURE,
         );
 
-        if (defined('T_RETURN_TYPE')) {
+        if (\defined('T_RETURN_TYPE')) {
             $tokens[] = \T_RETURN_TYPE;
         }
 
@@ -138,7 +138,7 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
         }
         // Handle class name based return types.
         elseif ($tokens[$stackPtr]['code'] === \T_STRING
-            || (defined('T_RETURN_TYPE') && $tokens[$stackPtr]['code'] === \T_RETURN_TYPE)
+            || (\defined('T_RETURN_TYPE') && $tokens[$stackPtr]['code'] === \T_RETURN_TYPE)
         ) {
             $itemInfo = array(
                 'name'   => 'Class name',

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -89,7 +89,7 @@ class NonStaticMagicMethodsSniff extends Sniff
             \T_TRAIT,
         );
 
-        if (defined('T_ANON_CLASS')) {
+        if (\defined('T_ANON_CLASS')) {
             $targets[] = \T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -50,7 +50,7 @@ class RemovedNamespacedAssertSniff extends Sniff
     public function register()
     {
         // Enrich the scopes list.
-        if (defined('T_ANON_CLASS')) {
+        if (\defined('T_ANON_CLASS')) {
             $this->scopes[] = \T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -83,7 +83,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
         $scopeCloser = $class['scope_closer'];
         $className   = $tokens[$nextNonEmpty]['content'];
 
-        if (empty($className) || is_string($className) === false) {
+        if (empty($className) || \is_string($className) === false) {
             return;
         }
 
@@ -100,7 +100,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
             }
 
             $funcName = $phpcsFile->getDeclarationName($nextFunc);
-            if (empty($funcName) || is_string($funcName) === false) {
+            if (empty($funcName) || \is_string($funcName) === false) {
                 $nextFunc = $functionScopeCloser;
                 continue;
             }

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -43,7 +43,7 @@ class ReservedFunctionNamesSniff extends PHPCS_CamelCapsFunctionNameSniff
     public function __construct()
     {
         $scopeTokens = array(\T_CLASS, \T_INTERFACE, \T_TRAIT);
-        if (defined('T_ANON_CLASS')) {
+        if (\defined('T_ANON_CLASS')) {
             $scopeTokens[] = \T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -267,7 +267,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                         }
 
                         // Slice starts at a named argument, but we know which params are being accessed.
-                        $paramNamesSubset = array_slice($paramNames, $tokens[$number]['content']);
+                        $paramNamesSubset = \array_slice($paramNames, $tokens[$number]['content']);
                     }
                 }
             }
@@ -348,11 +348,11 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                         continue;
                     }
                 } elseif ($foundFunctionName === 'func_get_args' && isset($paramNamesSubset)) {
-                    if (in_array($tokens[$j]['content'], $paramNamesSubset, true) === false) {
+                    if (\in_array($tokens[$j]['content'], $paramNamesSubset, true) === false) {
                         // Different param than the ones requested by func_get_args().
                         continue;
                     }
-                } elseif (in_array($tokens[$j]['content'], $paramNames, true) === false) {
+                } elseif (\in_array($tokens[$j]['content'], $paramNames, true) === false) {
                     // Variable is not one of the function parameters.
                     continue;
                 }

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -151,7 +151,7 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
             }
 
             // Remove the last 'and' from the message.
-            $error = substr($error, 0, (strlen($error) - 5));
+            $error = substr($error, 0, (\strlen($error) - 5));
         }
 
         $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -69,7 +69,7 @@ class NewGeneratorReturnSniff extends Sniff
             $targets[] = \T_STRING;
         }
 
-        if (defined('T_YIELD_FROM')) {
+        if (\defined('T_YIELD_FROM')) {
             $targets[] = \T_YIELD_FROM;
         }
 
@@ -123,7 +123,7 @@ class NewGeneratorReturnSniff extends Sniff
         }
 
         $targets = array(\T_RETURN, \T_CLOSURE, \T_FUNCTION, \T_CLASS);
-        if (defined('T_ANON_CLASS')) {
+        if (\defined('T_ANON_CLASS')) {
             $targets[] = \T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -80,12 +80,12 @@ class NewConstantArraysUsingDefineSniff extends Sniff
 
         $targetNestingLevel = 0;
         if (isset($tokens[$secondParam['start']]['nested_parenthesis'])) {
-            $targetNestingLevel = count($tokens[$secondParam['start']]['nested_parenthesis']);
+            $targetNestingLevel = \count($tokens[$secondParam['start']]['nested_parenthesis']);
         }
 
         $array = $phpcsFile->findNext(array(\T_ARRAY, \T_OPEN_SHORT_ARRAY), $secondParam['start'], ($secondParam['end'] + 1));
         if ($array !== false) {
-            if ((isset($tokens[$array]['nested_parenthesis']) === false && $targetNestingLevel === 0) || count($tokens[$array]['nested_parenthesis']) === $targetNestingLevel) {
+            if ((isset($tokens[$array]['nested_parenthesis']) === false && $targetNestingLevel === 0) || \count($tokens[$array]['nested_parenthesis']) === $targetNestingLevel) {
                 $phpcsFile->addError(
                     'Constant arrays using define are not allowed in PHP 5.6 or earlier',
                     $array,

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -171,7 +171,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                 // Which nesting level is the one we are interested in ?
                 $nestedParenthesisCount = 1;
                 if (isset($tokens[$opener]['nested_parenthesis'])) {
-                    $nestedParenthesisCount += count($tokens[$opener]['nested_parenthesis']);
+                    $nestedParenthesisCount += \count($tokens[$opener]['nested_parenthesis']);
                 }
 
                 foreach ($params as $param) {
@@ -249,7 +249,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
 
                 $targetNestingLevel = 0;
                 if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
-                    $targetNestingLevel = count($tokens[$stackPtr]['nested_parenthesis']);
+                    $targetNestingLevel = \count($tokens[$stackPtr]['nested_parenthesis']);
                 }
 
                 // Examine each variable/constant in multi-declarations.
@@ -522,7 +522,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
             // Check if a comma is at the nesting level we're targetting.
             $nestingLevel = 0;
             if (isset($tokens[$endPtr]['nested_parenthesis']) === true) {
-                $nestingLevel = count($tokens[$endPtr]['nested_parenthesis']);
+                $nestingLevel = \count($tokens[$endPtr]['nested_parenthesis']);
             }
             if ($nestingLevel > $targetLevel) {
                 return $endPtr;

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -49,7 +49,7 @@ class InternalInterfacesSniff extends Sniff
 
         $targets = array(\T_CLASS);
 
-        if (defined('T_ANON_CLASS')) {
+        if (\defined('T_ANON_CLASS')) {
             $targets[] = \T_ANON_CLASS;
         }
 
@@ -70,7 +70,7 @@ class InternalInterfacesSniff extends Sniff
     {
         $interfaces = PHPCSHelper::findImplementedInterfaceNames($phpcsFile, $stackPtr);
 
-        if (is_array($interfaces) === false || $interfaces === array()) {
+        if (\is_array($interfaces) === false || $interfaces === array()) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -128,11 +128,11 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
             \T_CLOSURE,
         );
 
-        if (defined('T_ANON_CLASS')) {
+        if (\defined('T_ANON_CLASS')) {
             $targets[] = \T_ANON_CLASS;
         }
 
-        if (defined('T_RETURN_TYPE')) {
+        if (\defined('T_RETURN_TYPE')) {
             $targets[] = \T_RETURN_TYPE;
         }
 
@@ -198,7 +198,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
     {
         $interfaces = PHPCSHelper::findImplementedInterfaceNames($phpcsFile, $stackPtr);
 
-        if (is_array($interfaces) === false || $interfaces === array()) {
+        if (\is_array($interfaces) === false || $interfaces === array()) {
             return;
         }
 
@@ -262,7 +262,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
     private function processFunctionToken(File $phpcsFile, $stackPtr)
     {
         $typeHints = $this->getTypeHintsFromFunctionDeclaration($phpcsFile, $stackPtr);
-        if (empty($typeHints) || is_array($typeHints) === false) {
+        if (empty($typeHints) || \is_array($typeHints) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -137,7 +137,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
             return;
         }
 
-        if (in_array($tokenType, array('T_CLASS', 'T_INTERFACE', 'T_TRAIT'), true)) {
+        if (\in_array($tokenType, array('T_CLASS', 'T_INTERFACE', 'T_TRAIT'), true)) {
             // Check for the declared name being a name which is not tokenized as T_STRING.
             $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($nextNonEmpty !== false && isset($this->forbiddenTokens[$tokens[$nextNonEmpty]['code']]) === true) {
@@ -148,7 +148,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
             }
             unset($nextNonEmpty);
 
-            if (isset($name) === false || is_string($name) === false || $name === '') {
+            if (isset($name) === false || \is_string($name) === false || $name === '') {
                 return;
             }
 

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -140,7 +140,7 @@ class ForbiddenNamesSniff extends Sniff
 
         $tokens = $this->targetedTokens;
 
-        if (defined('T_ANON_CLASS')) {
+        if (\defined('T_ANON_CLASS')) {
             $tokens[] = \T_ANON_CLASS;
         }
 
@@ -386,6 +386,6 @@ class ForbiddenNamesSniff extends Sniff
      */
     protected function isEndOfUseStatement($token)
     {
-        return in_array($token['code'], array(\T_CLOSE_CURLY_BRACKET, \T_SEMICOLON, \T_COMMA), true);
+        return \in_array($token['code'], array(\T_CLOSE_CURLY_BRACKET, \T_SEMICOLON, \T_COMMA), true);
     }
 }

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -164,7 +164,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
         $tokens    = array();
         $translate = array();
         foreach ($this->newKeywords as $token => $versions) {
-            if (defined($token)) {
+            if (\defined($token)) {
                 $tokens[] = constant($token);
             }
             if (isset($versions['content'])) {
@@ -272,7 +272,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
         ) {
             // Skip based on token scope condition.
             if (isset($this->newKeywords[$tokenType]['condition'])
-                && call_user_func(array($this, $this->newKeywords[$tokenType]['condition']), $phpcsFile, $stackPtr) === true
+                && \call_user_func(array($this, $this->newKeywords[$tokenType]['condition']), $phpcsFile, $stackPtr) === true
             ) {
                 return;
             }

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -68,7 +68,7 @@ class NewEmptyNonVariableSniff extends Sniff
 
         $nestingLevel = 0;
         if ($close !== ($open + 1) && isset($tokens[$open + 1]['nested_parenthesis'])) {
-            $nestingLevel = count($tokens[$open + 1]['nested_parenthesis']);
+            $nestingLevel = \count($tokens[$open + 1]['nested_parenthesis']);
         }
 
         if ($this->isVariable($phpcsFile, ($open + 1), $close, $nestingLevel) === true) {

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -170,7 +170,7 @@ class AssignmentOrderSniff extends Sniff
         }
 
         // Verify that all variables used in the list() construct are unique.
-        if (count($listVars) !== count(array_unique($listVars))) {
+        if (\count($listVars) !== \count(array_unique($listVars))) {
             $phpcsFile->addError(
                 'list() will assign variable from left-to-right since PHP 7.0. Ensure all variables in list() are unique to prevent unexpected results.',
                 $stackPtr,

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -152,12 +152,12 @@ class RemovedAlternativePHPTagsSniff extends Sniff
         if ($startAt !== '') {
             $startPos = strpos($content, $startAt);
             if ($startPos !== false) {
-                $startPos += strlen($startAt);
+                $startPos += \strlen($startAt);
             }
         }
 
         $snippet = substr($content, $startPos, $length);
-        if ((strlen($content) - $startPos) > $length) {
+        if ((\strlen($content) - $startPos) > $length) {
             $snippet .= '...';
         }
 

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -129,7 +129,7 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
     {
         $tokens = array();
         foreach ($this->newOperators as $token => $versions) {
-            if (defined($token)) {
+            if (\defined($token)) {
                 $tokens[] = constant($token);
             } elseif (isset($this->newOperatorsPHPCSCompat[$token])) {
                 $tokens[] = $this->newOperatorsPHPCSCompat[$token];
@@ -159,7 +159,7 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
                 && ((isset($this->PHPCSCompatTranslate[$tokenType]['before'], $tokens[$stackPtr - 1]) === true
                     && $tokens[$stackPtr - 1]['type'] === $this->PHPCSCompatTranslate[$tokenType]['before'])
                 || (isset($this->PHPCSCompatTranslate[$tokenType]['callback']) === true
-                    && call_user_func(array($this, $this->PHPCSCompatTranslate[$tokenType]['callback']), $tokens, $stackPtr) === true))
+                    && \call_user_func(array($this, $this->PHPCSCompatTranslate[$tokenType]['callback']), $tokens, $stackPtr) === true))
             ) {
                 $tokenType = $this->PHPCSCompatTranslate[$tokenType]['real_token'];
             }

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -125,7 +125,7 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $algo = $this->getHashAlgorithmParameter($phpcsFile, $stackPtr);
-        if (empty($algo) || is_string($algo) === false) {
+        if (empty($algo) || \is_string($algo) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -70,7 +70,7 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $algo = $this->getHashAlgorithmParameter($phpcsFile, $stackPtr);
-        if (empty($algo) || is_string($algo) === false) {
+        if (empty($algo) || \is_string($algo) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -113,7 +113,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
             true
         );
 
-        if ($prevNonEmpty !== false && in_array($tokens[$prevNonEmpty]['type'], array('T_FUNCTION', 'T_CLASS', 'T_INTERFACE', 'T_TRAIT'), true)) {
+        if ($prevNonEmpty !== false && \in_array($tokens[$prevNonEmpty]['type'], array('T_FUNCTION', 'T_CLASS', 'T_INTERFACE', 'T_TRAIT'), true)) {
             return;
         }
 
@@ -129,14 +129,14 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
         // Get the function call parameters.
         $parameters = $this->getFunctionCallParameters($phpcsFile, $stackPtr);
-        if (count($parameters) === 0) {
+        if (\count($parameters) === 0) {
             return;
         }
 
         // Which nesting level is the one we are interested in ?
         $nestedParenthesisCount = 1;
         if (isset($tokens[$openBracket]['nested_parenthesis'])) {
-            $nestedParenthesisCount = count($tokens[$openBracket]['nested_parenthesis']) + 1;
+            $nestedParenthesisCount = \count($tokens[$openBracket]['nested_parenthesis']) + 1;
         }
 
         foreach ($parameters as $parameter) {
@@ -206,7 +206,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
             // Make sure the variable belongs directly to this function call
             // and is not inside a nested function call or array.
             if (isset($tokens[$nextVariable]['nested_parenthesis']) === false
-                || (count($tokens[$nextVariable]['nested_parenthesis']) !== $nestingLevel)
+                || (\count($tokens[$nextVariable]['nested_parenthesis']) !== $nestingLevel)
             ) {
                 continue;
             }

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -152,7 +152,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
                  * Check for tokens after the closing marker.
                  */
                 // Remove the identifier.
-                $afterMarker = substr($trimmed, strlen($identifier));
+                $afterMarker = substr($trimmed, \strlen($identifier));
                 // Remove a potential semi-colon at the beginning of what's left of the string.
                 $afterMarker = ltrim($afterMarker, ';');
                 // Remove new line characters at the end of the string.

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -66,7 +66,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
 
         // Is this T_STRING really a function or method call ?
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($prevToken !== false && in_array($tokens[$prevToken]['code'], array(\T_DOUBLE_COLON, \T_OBJECT_OPERATOR), true) === false) {
+        if ($prevToken !== false && \in_array($tokens[$prevToken]['code'], array(\T_DOUBLE_COLON, \T_OBJECT_OPERATOR), true) === false) {
             $ignore = array(
                 \T_FUNCTION  => true,
                 \T_CONST     => true,

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -54,7 +54,7 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
     {
         $tokens = array();
         foreach ($this->newTypeCasts as $token => $versions) {
-            if (defined($token)) {
+            if (\defined($token)) {
                 $tokens[] = constant($token);
             }
         }

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -33,7 +33,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
      */
     public function register()
     {
-        if (defined('T_OPEN_USE_GROUP')) {
+        if (\defined('T_OPEN_USE_GROUP')) {
             return array(\T_OPEN_USE_GROUP);
         } else {
             return array(\T_USE);
@@ -84,7 +84,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
         }
 
         $closers = array(\T_CLOSE_CURLY_BRACKET);
-        if (defined('T_CLOSE_USE_GROUP')) {
+        if (\defined('T_CLOSE_USE_GROUP')) {
             $closers[] = \T_CLOSE_USE_GROUP;
         }
 

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -78,7 +78,7 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
                     $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($variable + 1), $varEnd, true);
 
                     if ($next !== false
-                        && in_array($tokens[$next]['code'], array(\T_OPEN_SQUARE_BRACKET, \T_OBJECT_OPERATOR, \T_DOUBLE_COLON), true) === true
+                        && \in_array($tokens[$next]['code'], array(\T_OPEN_SQUARE_BRACKET, \T_OBJECT_OPERATOR, \T_DOUBLE_COLON), true) === true
                     ) {
                         $phpcsFile->addError(
                             'Global with variable variables is not allowed since PHP 7.0. Found %s',

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -98,7 +98,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
      */
     public function register()
     {
-        if (defined('T_ANON_CLASS')) {
+        if (\defined('T_ANON_CLASS')) {
             $this->ooScopeTokens['T_ANON_CLASS'] = \T_ANON_CLASS;
         }
 

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -64,7 +64,7 @@ class NewUniformVariableSyntaxSniff extends Sniff
 
         // The previous non-empty token has to be a $, -> or ::.
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-        if ($prevToken === false || in_array($tokens[$prevToken]['code'], array(\T_DOLLAR, \T_OBJECT_OPERATOR, \T_DOUBLE_COLON), true) === false) {
+        if ($prevToken === false || \in_array($tokens[$prevToken]['code'], array(\T_DOLLAR, \T_OBJECT_OPERATOR, \T_DOUBLE_COLON), true) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -246,7 +246,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
         // Is this a function param shadowing the PHP native one ?
         if ($function !== false) {
             $parameters = PHPCSHelper::getMethodParameters($phpcsFile, $function);
-            if (is_array($parameters) === true && empty($parameters) === false) {
+            if (\is_array($parameters) === true && empty($parameters) === false) {
                 foreach ($parameters as $param) {
                     if ($param['name'] === '$php_errormsg') {
                         return false;

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -106,7 +106,7 @@ class BaseSniffTest extends PHPUnit_TestCase
      */
     protected function getSniffCode()
     {
-        $class    = get_class($this);
+        $class    = \get_class($this);
         $parts    = explode('\\', $class);
         $sniff    = array_pop($parts);
         $sniff    = str_replace('UnitTest', '', $sniff);
@@ -247,7 +247,7 @@ class BaseSniffTest extends PHPUnit_TestCase
         }
 
         if ($lineNumber === 0) {
-            $failMessage = 'Failed asserting no violations in file. Found ' . count($errors) . ' errors and ' . count($warnings) . ' warnings.';
+            $failMessage = 'Failed asserting no violations in file. Found ' . \count($errors) . ' errors and ' . \count($warnings) . ' warnings.';
             $allMessages = $errors + $warnings;
             // TODO: Update the fail message to give the tester some
             // indication of what the errors or warnings were.

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -47,7 +47,7 @@ class ForbiddenNamesUnitTest extends BaseSniffTest
 
         $this->assertNoViolation($file, 2);
 
-        $lineCount = count(file($filename));
+        $lineCount = \count(file($filename));
         // Each line of the use case files (starting at line 3) exhibits an
         // error.
         for ($i = 3; $i < $lineCount; $i++) {

--- a/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
@@ -508,7 +508,7 @@ class FunctionsUnitTest extends PHPUnit_TestCase
      */
     private function invokeMethod(&$object, $methodName, array $parameters = array())
     {
-        $reflection = new \ReflectionClass(get_class($object));
+        $reflection = new \ReflectionClass(\get_class($object));
         $method     = $reflection->getMethod($methodName);
         $method->setAccessible(true);
 

--- a/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
+++ b/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
@@ -48,7 +48,7 @@ abstract class CoreMethodTestFrame extends PHPUnit_TestCase
 
         $this->helperClass = new TestHelperPHPCompatibility();
 
-        $FQClassName = get_class($this);
+        $FQClassName = \get_class($this);
         $parts       = explode('\\', $FQClassName);
         $className   = array_pop($parts);
         $subDir      = array_pop($parts);


### PR DESCRIPTION
_Performance optimization along the same lines as #783_

Functions in PHP are namespaced as well, however, when PHP cannot find the function in the namespace, it will fall through to the global namespace.

The step to first check within the namespace can be skipped by either using `use func ...` (PHP 5.6+) or by prefixing the function with a `\`.

While this offers a small performance gain as a general practice, using this for the special compiled functions should offer a noticeable performance gain when running PHPCompatibility on PHP 7+.
The special compiled function are replaced by opcodes at compile time, but only if it's clear at compile time that the global PHP native functions will be used.
For the list of functions, see: https://github.com/php/php-src/blob/f2db305fa4e9bd7d04d567822687ec714aedcdb5/Zend/zend_compile.c#L3872

This PR implements this throughout the codebase.