### PR TITLE
Travis: test against PHP 7.4, not 8.0 and fix PHPUnit failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 7.3
-  - nightly
 
 env:
   global:
@@ -39,13 +37,13 @@ matrix:
     # N.B.: Coverage is only checked on the lowest and highest stable PHP versions for all PHPCS versions.
 
     - php: 7.2
-      env: PHPCS_VERSION="dev-master" LINT=1 SNIFF=1 COVERALLS_VERSION="^2.0"
+      env: PHPCS_VERSION="dev-master" LINT=1 SNIFF=1 COVERALLS_VERSION="^2.0" PHPUNIT_VERSION="^7.0"
       addons:
         apt:
           packages:
             - libxml2-utils
     - php: 7.2
-      env: PHPCS_VERSION="2.3.0" COVERALLS_VERSION="^2.0"
+      env: PHPCS_VERSION="2.3.0" COVERALLS_VERSION="^2.0" PHPUNIT_VERSION="^7.0"
 
     # PHPCS 3.x cannot be run on PHP 5.3.
     - php: 5.3
@@ -61,6 +59,16 @@ matrix:
     - php: 5.4
       env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="^1.0"
 
+    # The Travis image for PHP >= 7.2 comes with PHPUnit 8.x which PHPCompatibility doesn't support.
+    - php: 7.3
+      env: PHPCS_VERSION="2.3.0" PHPUNIT_VERSION="^7.0"
+    - php: 7.3
+      env: PHPCS_VERSION="dev-master" LINT=1 PHPUNIT_VERSION="^7.0"
+    - php: nightly
+      env: PHPCS_VERSION="2.3.0" PHPUNIT_VERSION="^7.0"
+    - php: nightly
+      env: PHPCS_VERSION="dev-master" LINT=1 PHPUNIT_VERSION="^7.0"
+
     # Test against a variation of PHPCS 2.x and 3.x versions.
     - php: 5.5
       env: PHPCS_VERSION="2.4.*"
@@ -73,13 +81,13 @@ matrix:
     - php: 7.1
       env: PHPCS_VERSION="2.7.*"
     - php: 7.2
-      env: PHPCS_VERSION="3.0.2" COVERALLS_VERSION="^2.0"
+      env: PHPCS_VERSION="3.0.2" COVERALLS_VERSION="^2.0" PHPUNIT_VERSION="^7.0"
     # Note: PHP 7.3+ is only fully supported icw PHPCS 2.9.2 and 3.3.1+.
     # While on PHPCS 2.x, the tests won't fail, on PHPCS 3.x < 3.3.1, they will.
     - php: 7.3
-      env: PHPCS_VERSION="3.3.*"
+      env: PHPCS_VERSION="3.3.*" PHPUNIT_VERSION="^7.0"
     - php: nightly
-      env: PHPCS_VERSION=">=2.0,<3.0"
+      env: PHPCS_VERSION=">=2.0,<3.0" PHPUNIT_VERSION="^7.0"
 
   allow_failures:
     # Allow failures for unstable builds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,10 +68,6 @@ matrix:
       env: PHPCS_VERSION="2.3.0" PHPUNIT_VERSION="^7.0"
     - php: "7.4snapshot"
       env: PHPCS_VERSION="dev-master" LINT=1 PHPUNIT_VERSION="^7.0"
-    - php: nightly
-      env: PHPCS_VERSION="2.3.0" PHPUNIT_VERSION="^7.0"
-    - php: nightly
-      env: PHPCS_VERSION="dev-master" LINT=1 PHPUNIT_VERSION="^7.0"
 
     # Test against a variation of PHPCS 2.x and 3.x versions.
     - php: 5.5
@@ -91,14 +87,11 @@ matrix:
     - php: 7.3
       env: PHPCS_VERSION="3.3.*" PHPUNIT_VERSION="^7.0"
     - php: "7.4snapshot"
-      env: PHPCS_VERSION="3.4.*" PHPUNIT_VERSION="^7.0"
-    - php: nightly
       env: PHPCS_VERSION=">=2.0,<3.0" PHPUNIT_VERSION="^7.0"
 
   allow_failures:
     # Allow failures for unstable builds.
     - php: "7.4snapshot"
-    - php: nightly
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,13 @@ matrix:
   include:
     # N.B.: Coverage is only checked on the lowest and highest stable PHP versions for all PHPCS versions.
 
-    - php: 7.2
+    - php: 7.3
       env: PHPCS_VERSION="dev-master" LINT=1 SNIFF=1 COVERALLS_VERSION="^2.0" PHPUNIT_VERSION="^7.0"
       addons:
         apt:
           packages:
             - libxml2-utils
-    - php: 7.2
+    - php: 7.3
       env: PHPCS_VERSION="2.3.0" COVERALLS_VERSION="^2.0" PHPUNIT_VERSION="^7.0"
 
     # PHPCS 3.x cannot be run on PHP 5.3.
@@ -60,9 +60,9 @@ matrix:
       env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="^1.0"
 
     # The Travis image for PHP >= 7.2 comes with PHPUnit 8.x which PHPCompatibility doesn't support.
-    - php: 7.3
+    - php: 7.2
       env: PHPCS_VERSION="2.3.0" PHPUNIT_VERSION="^7.0"
-    - php: 7.3
+    - php: 7.2
       env: PHPCS_VERSION="dev-master" LINT=1 PHPUNIT_VERSION="^7.0"
     - php: nightly
       env: PHPCS_VERSION="2.3.0" PHPUNIT_VERSION="^7.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,10 @@ matrix:
       env: PHPCS_VERSION="2.3.0" PHPUNIT_VERSION="^7.0"
     - php: 7.2
       env: PHPCS_VERSION="dev-master" LINT=1 PHPUNIT_VERSION="^7.0"
+    - php: "7.4snapshot"
+      env: PHPCS_VERSION="2.3.0" PHPUNIT_VERSION="^7.0"
+    - php: "7.4snapshot"
+      env: PHPCS_VERSION="dev-master" LINT=1 PHPUNIT_VERSION="^7.0"
     - php: nightly
       env: PHPCS_VERSION="2.3.0" PHPUNIT_VERSION="^7.0"
     - php: nightly
@@ -86,11 +90,14 @@ matrix:
     # While on PHPCS 2.x, the tests won't fail, on PHPCS 3.x < 3.3.1, they will.
     - php: 7.3
       env: PHPCS_VERSION="3.3.*" PHPUNIT_VERSION="^7.0"
+    - php: "7.4snapshot"
+      env: PHPCS_VERSION="3.4.*" PHPUNIT_VERSION="^7.0"
     - php: nightly
       env: PHPCS_VERSION=">=2.0,<3.0" PHPUNIT_VERSION="^7.0"
 
   allow_failures:
     # Allow failures for unstable builds.
+    - php: "7.4snapshot"
     - php: nightly
 
 before_install:


### PR DESCRIPTION
### Travis: use PHPUnit 7.x for PHP >= 7.2

PHPUnit 8 adds `void` return type declarations to the PHPUnit methods used by PHPCS, making it neigh impossible to make the unit test suite cross-version compatible for the PHP versions supported by PHPCompatibility.

As of the recent update to the Travis images, the images for PHP 7.2+ now ship with PHPUnit 8 which causes the unit tests to fail.

Officially, PHPUnit 7 is compatible with PHP 7.1, 7.2 and 7.3.
Ref: https://phpunit.de/supported-versions.html

So, for Travis images which come natively with PHPUnit 8 (PHP >= 7.2), PHPUnit 7 needs to be installed via Composer.

### Travis: test code coverage on the highest supported PHP version

As PHP 7.3 has been released, the build to test code coverage should be run on PHP 7.3.

This should raise the code coverage as for, for instance, the `FlexibleHeredocNowdoc` sniff, code coverage for a significant part of the sniff will only show up when run on PHP 7.3.

In contrast to when the PHP 7.3 build was added, there does appear to be a code coverage driver available for PHP 7.3 by now, so we should be safe to make this change now.

Ref: #764

Fixes #773

### Travis: test builds against PHP 7.4

Nightly has become PHP 8.0 since PHP 7.4 has been branched, so to continue to also test against PHP 7.4, it needs to be added separately.

Refs:
* https://twitter.com/nikita_ppv/status/1089839541828112384
* https://twitter.com/nikita_ppv/status/1094897743594770433

### Travis: remove testing against nightly / PHP 8

There is no PHPUnit version which is currently compatible with PHP 8.
As that either means that the builds for nightly would always fail or - if the unit tests would be skipped -, the only check executed on nightly would be linting the files, I've elected to remove build testing against nightly for the time being.

For more details about PHPUnit vs PHPCS vs PHP 8, see squizlabs/PHP_CodeSniffer#2416