### PR TITLE
Clean up: use array_change_key_case()

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -299,9 +299,7 @@ abstract class Sniff implements PHPCS_Sniff
      */
     public function arrayKeysToLowercase($array)
     {
-        $keys = array_keys($array);
-        $keys = array_map('strtolower', $keys);
-        return array_combine($keys, $array);
+        return array_change_key_case($array, CASE_LOWER);
     }
 
 


### PR DESCRIPTION
You learn something new every day. Never came across this function before, but definitely simplifies the `Sniff::arrayKeysToLowercase()` method.

Ref: https://php.net/manual/en/function.array-change-key-case.php