### PR TITLE
Build: whitelist two minor issues and don't ignore warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
             - libxml2-utils
       script:
         # Check the code style of the code base.
-        - vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1
+        - vendor/bin/phpcs
 
         # Validate the xml file.
         # @link http://xmlsoft.org/xmllint.html

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -54,6 +54,11 @@
         <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
     </rule>
 
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
+        <exclude-pattern>*/PHPCSAliases\.php</exclude-pattern>
+    </rule>
+
     <!-- Check that variable names are in camelCaps. -->
     <rule ref="Squiz.NamingConventions.ValidVariableName">
         <exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>


### PR DESCRIPTION
As the code base as-is, is currently clean, except for two warnings which are typical acceptable situations, let's explicitly ignore those two and fail builds on new CS warnings being introduced to keep the codebase properly clean.