### PR TITLE
PHP 7.4: new NewTypedProperties sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Typed properties are available since PHP 7.4.
+ *
+ * PHP version 7.4
+ *
+ * @link https://wiki.php.net/rfc/typed_properties_v2
+ *
+ * @since 9.2.0
+ */
+class NewTypedPropertiesSniff extends Sniff
+{
+
+    /**
+     * Valid property modifier keywords.
+     *
+     * @var array
+     */
+    private $modifierKeywords = array(
+        \T_PRIVATE   => \T_PRIVATE,
+        \T_PROTECTED => \T_PROTECTED,
+        \T_PUBLIC    => \T_PUBLIC,
+        \T_STATIC    => \T_STATIC,
+        \T_VAR       => \T_VAR,
+    );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(\T_VARIABLE);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->isClassProperty($phpcsFile, $stackPtr) === false) {
+            return;
+        }
+
+        $find  = $this->modifierKeywords;
+        $find += array(
+            \T_SEMICOLON          => \T_SEMICOLON,
+            \T_OPEN_CURLY_BRACKET => \T_OPEN_CURLY_BRACKET,
+        );
+
+        $tokens   = $phpcsFile->getTokens();
+        $modifier = $phpcsFile->findPrevious($find, ($stackPtr - 1));
+        if ($modifier === false
+            || $tokens[$modifier]['code'] === \T_SEMICOLON
+            || $tokens[$modifier]['code'] === \T_OPEN_CURLY_BRACKET
+        ) {
+            // Parse error. Ignore.
+            return;
+        }
+
+        $type = $phpcsFile->findNext(Tokens::$emptyTokens, ($modifier + 1), null, true);
+        if ($tokens[$type]['code'] === \T_VARIABLE) {
+            return;
+        }
+
+        // Still here ? In that case, this will be a typed property.
+        if ($this->supportsBelow('7.3') === true) {
+            $phpcsFile->addError(
+                'Typed properties are not supported in PHP 7.3 or earlier',
+                $type,
+                'Found'
+            );
+        }
+
+        if ($this->supportsAbove('7.4') === true) {
+            // Examine the type to verify it's valid.
+            if ($tokens[$type]['type'] === 'T_NULLABLE'
+                // Needed to support PHPCS < 3.5.0 which doesn't correct to the nullable token type yet.
+                || $tokens[$type]['code'] === \T_INLINE_THEN
+            ) {
+                $type = $phpcsFile->findNext(Tokens::$emptyTokens, ($type + 1), null, true);
+            }
+
+            $content = $tokens[$type]['content'];
+            if ($content === 'void' || $content === 'callable') {
+                $phpcsFile->addError(
+                    '%s is not supported as a type declaration for properties',
+                    $type,
+                    'InvalidType',
+                    array($content)
+                );
+            }
+        }
+
+        $endOfStatement = $phpcsFile->findNext(\T_SEMICOLON, ($stackPtr + 1));
+        if ($endOfStatement !== false) {
+            // Don't throw the same error multiple times for multi-property declarations.
+            return ($endOfStatement + 1);
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -1,0 +1,62 @@
+<?php
+
+// OK: Non-typed properties.
+class PHP73Example {
+    public $public;
+    protected /* comment */ $protected;
+    private static $private;
+    static public $publicStatic;
+    var $oldStyle;
+
+    // Intentional parse error.
+    $invalidProperty;
+
+    public function method($param) {
+        $localVar = 'abc';
+    }
+}
+
+// PHP 7.4 typed properies.
+class PHP74Example {
+    // All types with the exception of "void" and "callable" are supported
+    public int $scalarType;
+    protected ClassName $classType;
+    private ?ClassName $nullableClassType;
+
+    // Types are also legal on static properties
+    public static iterable $staticProp;
+
+    // Types can also be used with the "var" notation
+    var bool $flag;
+
+    // Typed properties may have default values (more below)
+    public string $str = "foo";
+    public ?string $nullableStr = null;
+
+    // The type applies to all properties in one declaration
+    public float $x, $y;
+
+    // Additional tests not from the RFC.
+    public int $x = 10,
+        /**
+         * Docblock
+         */
+        $y = 5,
+        // comment.
+        $z = 15;
+
+    protected \MyNamespace\InterfaceName $namespacedInterfaceType;
+
+    private static self $instance;
+
+    // Note: The RFC does not explicitely mention this syntax.
+    // @tod This needs verification once the alpha is out.
+    static bool $bool = true;
+}
+
+// Invalid property types.
+class InvalidExample {
+    public void $invalidType;
+    protected callable $callable = 'strlen';
+    private ?callable $nullableCallable = null;
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New Typed Properties Sniff tests
+ *
+ * @group newTypedProperties
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewTypedPropertiesSniff
+ *
+ * @since 9.2.0
+ */
+class NewTypedPropertiesUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewTypedProperties
+     *
+     * @dataProvider dataNewTypedProperties
+     *
+     * @param array $line The line number on which the error should occur.
+     *
+     * @return void
+     */
+    public function testNewTypedProperties($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertError($file, $line, 'Typed properties are not supported in PHP 7.3 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewTypedProperties()
+     *
+     * @return array
+     */
+    public function dataNewTypedProperties()
+    {
+        return array(
+            array(22),
+            array(23),
+            array(24),
+            array(27),
+            array(30),
+            array(33),
+            array(34),
+            array(37),
+            array(40),
+            array(48),
+            array(50),
+            array(54),
+            array(59),
+            array(60),
+            array(61),
+        );
+    }
+
+
+    /**
+     * Verify the sniff doesn't throw false positives for non-typed properties.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesNewTypedProperties()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+
+        for ($line = 1; $line < 18; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * testInvalidPropertyType
+     *
+     * @dataProvider dataInvalidPropertyType
+     *
+     * @param array  $line The line number on which the error should occur.
+     * @param string $type The invalid type which should be detected.
+     *
+     * @return void
+     */
+    public function testInvalidPropertyType($line, $type)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, "$type is not supported as a type declaration for properties");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidPropertyType()
+     *
+     * @return array
+     */
+    public function dataInvalidPropertyType()
+    {
+        return array(
+            array(59, 'void'),
+            array(60, 'callable'),
+            array(61, 'callable'),
+        );
+    }
+
+
+    /**
+     * Verify the sniff doesn't throw false positives.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesInvalidPropertyType()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+
+        for ($line = 1; $line < 57; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /*
+     * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will also throw warnings/errors
+     * about invalid typed properties.
+     */
+}


### PR DESCRIPTION
PHP 7.4 will be introducing support for runtime-enforced first-class property type declarations.

Refs:
* https://wiki.php.net/rfc/typed_properties_v2
* https://github.com/php/php-src/commit/e219ec144ef6682b71e135fd18654ee1bb4676b4

This PR introduces a new sniff to detect the use of these and report an error if PHP < 7.4 is intended to still be supported.

The PHP 7.4 implementation does not allow for properties with the `void` or `callable` type.
If these are detected and PHP 7.4 is supposed to be supported, an error will be thrown as well.

Related #808