### PR TITLE
NewLanguageConstructs: improve T_ELLIPSIS error message text

### DIFF
--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -41,7 +41,7 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
         'T_ELLIPSIS' => array(
             '5.5' => false,
             '5.6' => true,
-            'description' => 'variadic functions using ...',
+            'description' => 'the ... spread operator',
         ),
     );
 

--- a/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
@@ -46,7 +46,7 @@ class NewLanguageConstructsUnitTest extends BaseSniffTest
     public function testEllipsis()
     {
         $file = $this->sniffFile(__FILE__, '5.5');
-        $this->assertError($file, 5, 'variadic functions using ... is not present in PHP version 5.5 or earlier');
+        $this->assertError($file, 5, 'the ... spread operator is not present in PHP version 5.5 or earlier');
 
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file, 5);


### PR DESCRIPTION
The `T_ELLIPSIS` or spread operator can be used for both variadic functions as well as for argument unpacking. Support for both was added in PHP 5.6.

In PHP 7.4, a third use case is added: unpacking arrays at array declaration.

This minor change is intended to make the language of the error message clearer so it will be applicable to all use-cases.

Related #808