### PR TITLE
PHP 7.4: new NewArrayUnpacking sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Syntax;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Using the spread operator for unpacking arrays in array expressions is available since PHP 7.4.
+ *
+ * PHP version 7.4
+ *
+ * @link https://wiki.php.net/rfc/spread_operator_for_array
+ *
+ * @since 9.2.0
+ */
+class NewArrayUnpackingSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            \T_ARRAY,
+            \T_OPEN_SHORT_ARRAY,
+        );
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.3') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        /*
+         * Determine the array opener & closer.
+         */
+        $closer = $phpcsFile->numTokens;
+        if ($tokens[$stackPtr]['code'] === \T_ARRAY) {
+            if (isset($tokens[$stackPtr]['parenthesis_opener']) === false) {
+                return;
+            }
+
+            $opener = $tokens[$stackPtr]['parenthesis_opener'];
+
+            if (isset($tokens[$opener]['parenthesis_closer'])) {
+                $closer = $tokens[$opener]['parenthesis_closer'];
+            }
+        } else {
+            // Short array syntax.
+            $opener = $stackPtr;
+
+            if (isset($tokens[$stackPtr]['bracket_closer'])) {
+                $closer = $tokens[$stackPtr]['bracket_closer'];
+            }
+        }
+
+        $nestingLevel = 0;
+        if (isset($tokens[($opener + 1)]['nested_parenthesis'])) {
+            $nestingLevel = count($tokens[($opener + 1)]['nested_parenthesis']);
+        }
+
+        for ($i = $opener; $i < $closer;) {
+            $i = $phpcsFile->findNext(array(\T_ELLIPSIS, \T_OPEN_SHORT_ARRAY, \T_ARRAY), ($i + 1), $closer);
+            if ($i === false) {
+                return;
+            }
+
+            if ($tokens[$i]['code'] === \T_OPEN_SHORT_ARRAY) {
+                if (isset($tokens[$i]['bracket_closer']) === false) {
+                    // Live coding, unfinished nested array, handle this when the array opener
+                    // of the nested array is passed.
+                    return;
+                }
+
+                // Skip over nested short arrays. These will be handled when the array opener
+                // of the nested array is passed.
+                $i = $tokens[$i]['bracket_closer'];
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_ARRAY) {
+                if (isset($tokens[$i]['parenthesis_closer']) === false) {
+                    // Live coding, unfinished nested array, handle this when the array opener
+                    // of the nested array is passed.
+                    return;
+                }
+
+                // Skip over nested long arrays. These will be handled when the array opener
+                // of the nested array is passed.
+                $i = $tokens[$i]['parenthesis_closer'];
+                continue;
+            }
+
+            // Ensure this is not function call variable unpacking.
+            if (isset($tokens[$i]['nested_parenthesis'])
+                && count($tokens[$i]['nested_parenthesis']) > $nestingLevel
+            ) {
+                continue;
+            }
+
+            // Ok, found one.
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+            $snippet      = trim($phpcsFile->getTokensAsString($i, (($nextNonEmpty - $i) + 1)));
+            $phpcsFile->addError(
+                'Array unpacking within array declarations using the spread operator is not supported in PHP 7.3 or earlier. Found: %s',
+                $i,
+                'Found',
+                array($snippet)
+            );
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.inc
@@ -1,0 +1,43 @@
+<?php
+
+// Valid spread operator use prior to PHP 7.4.
+function myFunction(...$params) {}
+function_call(1, ...$values);
+$arr6 = array(getArr(1, 2, ...$passedToFunctionNotArray), 'c');
+
+/*
+ * PHP 7.4: New spread operator in array expressions.
+ */
+$fruits = ['a' => 'banana', 'b' => 'orange', ...$parts, 'watermelon'];
+
+$arr1 = [1, 2, 3];
+$arr2 = [...$arr1];
+$arr3 = array(0, ...$arr1);
+$arr4 = array(
+    ...$arr1,
+    ...$arr2,
+    111,
+);
+$arr5 = [
+    ...$arr1,
+    [...$arr1]
+    getArr(1, 2, ...$passedToFunctionNotArray),
+];
+$arr5 = array(
+    ...$arr1,
+    array(...$arr1),
+    getArr(1, 2, ...$passedToFunctionNotArray),
+);
+
+function getArr() { return ['a', 'b']; }
+$arr6 = array(...getArr(), 'c');
+$arr7 = [...new ArrayIterator(['a', 'b', 'c'])];
+$arr8 = [...arrGen()];
+
+// Unpacking array by reference is not supported in PHP 7.4, but not our concern, throw an error anyway.
+$arr2 = [...&$arr1];
+
+// Intentional parse error. This has to be the last test in the file.
+$arr5 = array(
+    ...$arr1,
+    array(...$arr1

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New Array Unpacking Sniff tests
+ *
+ * @group newArrayUnpacking
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewArrayUnpackingSniff
+ *
+ * @since 9.2.0
+ */
+class NewArrayUnpackingUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewArrayUnpacking
+     *
+     * @dataProvider dataNewArrayUnpacking
+     *
+     * @param array $line The line number on which the error should occur.
+     *
+     * @return void
+     */
+    public function testNewArrayUnpacking($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertError($file, $line, 'Array unpacking within array declarations using the spread operator is not supported in PHP 7.3 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewArrayUnpacking()
+     *
+     * @return array
+     */
+    public function dataNewArrayUnpacking()
+    {
+        return array(
+            array(11),
+            array(14),
+            array(15),
+            array(17),
+            array(18),
+            array(22),
+            array(23),
+            array(27),
+            array(28),
+            array(33),
+            array(34),
+            array(35),
+            array(38),
+            array(42),
+            array(43),
+        );
+    }
+
+
+    /**
+     * Verify the sniff doesn't throw false positives.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+
+        for ($line = 1; $line < 7; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
As of PHP 7.4, the spread operator can also be used to expand (unpack) arrays when declaring a new array.

Refs:
* https://wiki.php.net/rfc/spread_operator_for_array
* https://github.com/php/php-src/commit/e829d087299b59e638e91f18ea76f4dbe920c77b

**NOTE**: A critical look at the sniff category & sniff name are very welcome.
Ideas to improve these are welcome.

Related #808