### PR TITLE
PHP 7.4/8.0: new ChangedConcatOperatorPrecedence sniff

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1955,4 +1955,98 @@ abstract class Sniff implements PHPCS_Sniff
 
         return true;
     }
+
+    /**
+     * Determine whether a T_MINUS/T_PLUS token is a unary operator.
+     *
+     * N.B.: This is a back-fill for a new method which is expected to go into
+     * PHP_CodeSniffer 3.5.0.
+     * Once that method has been merged into PHPCS, this one should be moved
+     * to the PHPCSHelper.php file.
+     *
+     * @since 9.2.0
+     *
+     * @codeCoverageIgnore Method as pulled upstream is accompanied by unit tests.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the plus/minus token.
+     *
+     * @return bool True if the token passed is a unary operator.
+     *              False otherwise or if the token is not a T_PLUS/T_MINUS token.
+     */
+    public static function isUnaryPlusMinus(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false
+            || ($tokens[$stackPtr]['code'] !== \T_PLUS
+            && $tokens[$stackPtr]['code'] !== \T_MINUS)
+        ) {
+            return false;
+        }
+
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($next === false) {
+            // Live coding or parse error.
+            return false;
+        }
+
+        if (isset(Tokens::$operators[$tokens[$next]['code']]) === true) {
+            // Next token is an operator, so this is not a unary.
+            return false;
+        }
+
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+        if ($tokens[$prev]['code'] === \T_RETURN) {
+            // Just returning a positive/negative value; eg. (return -1).
+            return true;
+        }
+
+        if (isset(Tokens::$operators[$tokens[$prev]['code']]) === true) {
+            // Just trying to operate on a positive/negative value; eg. ($var * -1).
+            return true;
+        }
+
+        if (isset(Tokens::$comparisonTokens[$tokens[$prev]['code']]) === true) {
+            // Just trying to compare a positive/negative value; eg. ($var === -1).
+            return true;
+        }
+
+        if (isset(Tokens::$booleanOperators[$tokens[$prev]['code']]) === true) {
+            // Just trying to compare a positive/negative value; eg. ($var || -1 === $b).
+            return true;
+        }
+
+        if (isset(Tokens::$assignmentTokens[$tokens[$prev]['code']]) === true) {
+            // Just trying to assign a positive/negative value; eg. ($var = -1).
+            return true;
+        }
+
+        if (isset(Tokens::$castTokens[$tokens[$prev]['code']]) === true) {
+            // Just casting a positive/negative value; eg. (string) -$var.
+            return true;
+        }
+
+        // Other indicators that a plus/minus sign is a unary operator.
+        $invalidTokens = array(
+            \T_COMMA               => true,
+            \T_OPEN_PARENTHESIS    => true,
+            \T_OPEN_SQUARE_BRACKET => true,
+            \T_OPEN_SHORT_ARRAY    => true,
+            \T_COLON               => true,
+            \T_INLINE_THEN         => true,
+            \T_INLINE_ELSE         => true,
+            \T_CASE                => true,
+            \T_OPEN_CURLY_BRACKET  => true,
+            \T_STRING_CONCAT       => true,
+        );
+
+        if (isset($invalidTokens[$tokens[$prev]['code']]) === true) {
+            // Just trying to use a positive/negative value; eg. myFunction($var, -2).
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Operators;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * The operator precedence of concatenation will be lowered in PHP 8.0.
+ *
+ * In PHP < 8.0 the operator precedence of `.`, `+` and `-` are the same.
+ * As of PHP 8.0, the operator precedence of the concatenation operator will be
+ * lowered to be right below the '«' and '»' operators.
+ *
+ * As of PHP 7.4, a deprecation warning will be thrown upon encountering an
+ * unparenthesized expression containing an '.' before a '+' or '-'.
+ *
+ * PHP version 7.4
+ * PHP version 8.0
+ *
+ * @link https://wiki.php.net/rfc/concatenation_precedence
+ * @link https://www.php.net/manual/en/language.operators.precedence.php
+ *
+ * @since 9.2.0
+ */
+class ChangedConcatOperatorPrecedenceSniff extends Sniff
+{
+
+    /**
+     * List of tokens with a lower operator precedence than concatenation in PHP >= 8.0.
+     *
+     * @since 9.2.0
+     *
+     * @var array
+     */
+    private $tokensWithLowerPrecedence = array(
+        'T_BITWISE_AND' => true,
+        'T_BITWISE_XOR' => true,
+        'T_BITWISE_OR'  => true,
+        'T_COALESCE'    => true,
+        'T_INLINE_THEN' => true,
+        'T_INLINE_ELSE' => true,
+        'T_YIELD_FROM'  => true,
+        'T_YIELD'       => true,
+    );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.2.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            \T_PLUS,
+            \T_MINUS,
+        );
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.2.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.4') === false) {
+            return;
+        }
+
+        if ($this->isUnaryPlusMinus($phpcsFile, $stackPtr) === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        for ($i = ($stackPtr - 1); $stackPtr >= 0; $i--) {
+            if ($tokens[$i]['code'] === \T_STRING_CONCAT) {
+                // Found one.
+                break;
+            }
+
+            if ($tokens[$i]['code'] === \T_SEMICOLON
+                || $tokens[$i]['code'] === \T_OPEN_CURLY_BRACKET
+                || $tokens[$i]['code'] === \T_OPEN_TAG
+                || $tokens[$i]['code'] === \T_OPEN_TAG_WITH_ECHO
+                || $tokens[$i]['code'] === \T_COMMA
+                || $tokens[$i]['code'] === \T_COLON
+                || $tokens[$i]['code'] === \T_CASE
+            ) {
+                // If we reached any of the above tokens, we've reached the end of
+                // the statement without encountering a concatenation operator.
+                return;
+            }
+
+            if ($tokens[$i]['code'] === \T_OPEN_CURLY_BRACKET
+                && isset($tokens[$i]['bracket_closer'])
+                && $tokens[$i]['bracket_closer'] > $stackPtr
+            ) {
+                // No need to look any further, this is plus/minus within curly braces
+                // and we've reached the open curly.
+                return;
+            }
+
+            if ($tokens[$i]['code'] === \T_OPEN_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_closer'])
+                && $tokens[$i]['parenthesis_closer'] > $stackPtr
+            ) {
+                // No need to look any further, this is plus/minus within parenthesis
+                // and we've reached the open parenthesis.
+                return;
+            }
+
+            if (($tokens[$i]['code'] === \T_OPEN_SHORT_ARRAY
+                || $tokens[$i]['code'] === \T_OPEN_SQUARE_BRACKET)
+                && isset($tokens[$i]['bracket_closer'])
+                && $tokens[$i]['bracket_closer'] > $stackPtr
+            ) {
+                // No need to look any further, this is plus/minus within a short array
+                // or array key square brackets and we've reached the opener.
+                return;
+            }
+
+            if ($tokens[$i]['code'] === \T_CLOSE_CURLY_BRACKET) {
+                if (isset($tokens[$i]['scope_owner'])) {
+                    // Different scope, we've passed the start of the statement.
+                    return;
+                }
+
+                if (isset($tokens[$i]['bracket_opener'])) {
+                    $i = $tokens[$i]['bracket_opener'];
+                }
+
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_CLOSE_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_opener'])
+            ) {
+                // Skip over statements in parenthesis, including long arrays.
+                $i = $tokens[$i]['parenthesis_opener'];
+                continue;
+            }
+
+            if (($tokens[$i]['code'] === \T_CLOSE_SQUARE_BRACKET
+                || $tokens[$i]['code'] === \T_CLOSE_SHORT_ARRAY)
+                && isset($tokens[$i]['bracket_opener'])
+            ) {
+                // Skip over array keys and short arrays.
+                $i = $tokens[$i]['bracket_opener'];
+                continue;
+            }
+
+            // Check for chain being broken by a token with a lower precedence.
+            if (isset(Tokens::$booleanOperators[$tokens[$i]['code']]) === true
+                || isset(Tokens::$assignmentTokens[$tokens[$i]['code']]) === true
+            ) {
+                return;
+            }
+
+            if (isset($this->tokensWithLowerPrecedence[$tokens[$i]['type']]) === true) {
+                if ($tokens[$i]['code'] === \T_BITWISE_AND
+                    && $phpcsFile->isReference($i) === true
+                ) {
+                    continue;
+                }
+
+                return;
+            }
+        }
+
+        $message = 'Using an unparenthesized expression containing a "." before a "+" or "-" has been deprecated in PHP 7.4';
+        $isError = false;
+        if ($this->supportsAbove('8.0') === true) {
+            $message .= ' and removed in PHP 8.0';
+            $isError  = true;
+        }
+
+        $this->addMessage($phpcsFile, $message, $i, $isError);
+    }
+}

--- a/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.inc
+++ b/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.inc
@@ -1,0 +1,95 @@
+<?php
+
+// OK: Parentheses used, not an issue.
+echo ("sum: " . $a) + $b;
+echo "sum :" . ($a + $b);
+
+// OK: Not an issue as both are left-associative.
+echo $a + $b . 'text';
+
+// OK: Lower precedence operator preventing an issue.
+$b = 'test' . $a = 10 + 20;
+$b = 'test' . $a & 10 + 20;
+
+// OK: Not in the same statement.
+$a = 'text' . 10;
+echo $a + 20;
+?>
+<?= 'Text' . 'Text' ?><div><?= $a + 20 ?>
+<?php
+
+$array = array(
+    1 => 'text' . 'text',
+    2 => 1 + 2,
+);
+
+$short = [
+    'text' . 'text',
+    1 + 2,
+];
+
+echo 'text'.'text', 10 + 20;
+
+switch ( $a . 's' ) :
+    case 10 + 20:
+        break;
+    case 's' . 't':
+        echo 10 + 20;
+        break;
+endswitch;
+
+$b = $a . ${$b + 10};
+
+if () {$a . $b} // Intentional parse error, missing semi-colon.
+echo 10 + 10;
+
+// OK: unary plus/minus.
+echo $a . -10;
+echo $a . +$b;
+
+// OK: concat or plus/minus in various brackets.
+echo $a[ '_' . $b ] + 20;
+$a = array( 'a'.'b' ) + $anotherArray;
+return basename('X'.$splited[count($splited) - 1], $suffix);
+
+// OK: not the same nesting level.
+$a = 'Text' . implode( '', array( 'a'.'b' ) + $anotherArray );
+
+// Affected by PHP 7.4 changed concat precedence.
+echo "sum: " . $a + $b;
+$b = 'test' . $a * 10 + 20;
+$b = 'test' . ${$a} * 10 + 20;
+
+/*
+ * Additional real-world test cases.
+ * Source concat_results_top2000: https://gist.github.com/nikic/a4df3e8e18c7955c2c21cf6cdb4cbfaa
+ */
+// (BUG!) /home/nikic/package-analysis/sources/johnpbloch/wordpress-core/wp-admin/includes/class-wp-ajax-upgrader-skin.php:100
+$this->errors->add( 'unknown_upgrade_error_' . $errors_count + 1, $string );
+
+// (BUG!) /home/nikic/package-analysis/sources/microsoft/azure-storage/tests/Functional/File/FileServiceFunctionalTest.php:1005
+$this->assertTrue(
+    count($ret->getFiles()) + count($ret->getDirectories()) <= $options->getMaxResults(),
+    'when NextMarker (\'' . $ret->getNextMarker() .
+    '\')==\'\', Files length (' .
+    count($ret->getFiles()) + count($ret->getDirectories()) .
+        ') should be <= MaxResults (' .
+        $options->getMaxResults() . ')'
+);
+
+// (BUG!) /home/nikic/package-analysis/sources/microsoft/azure-storage/tests/Functional/File/FileServiceFunctionalTest.php:1015
+$this->assertEquals(
+    $options->getMaxResults(),
+    count($ret->getFiles()) + count($ret->getDirectories()),
+    'when NextMarker (' . $ret->getNextMarker() .
+        ')!=\'\', Files length (' .
+        count($ret->getFiles()) + count($ret->getDirectories()) .
+        ') should be == MaxResults (' .
+        $options->getMaxResults() .')'
+);
+
+// (BUG!) /home/nikic/package-analysis/sources/sabre/vobject/lib/Recur/RRuleIterator.php:344
+$this->currentDate = $this->currentDate->modify('+'.$this->interval - 1 .' days');
+
+// (BUG!) /home/nikic/package-analysis/sources/sabre/vobject/lib/Recur/RRuleIterator.php:404
+$this->currentDate = $this->currentDate->modify('+'.$this->interval - 1 .' weeks');

--- a/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Operators;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Changed Concat Operator Precendence Sniff tests
+ *
+ * @group changedConcatOperatorPrecedence
+ * @group operators
+ *
+ * @covers \PHPCompatibility\Sniffs\Operators\ChangedConcatOperatorPrecedenceSniff
+ *
+ * @since 9.2.0
+ */
+class ChangedConcatOperatorPrecedenceUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testChangedConcatOperatorPrecedence
+     *
+     * @dataProvider dataChangedConcatOperatorPrecedence
+     *
+     * @param array $line The line number on which the warning/error should occur.
+     *
+     * @return void
+     */
+    public function testChangedConcatOperatorPrecedence($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertWarning($file, $line, 'Using an unparenthesized expression containing a "." before a "+" or "-" has been deprecated in PHP 7.4');
+
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Using an unparenthesized expression containing a "." before a "+" or "-" has been deprecated in PHP 7.4 and removed in PHP 8.0');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testChangedConcatOperatorPrecedence()
+     *
+     * @return array
+     */
+    public function dataChangedConcatOperatorPrecedence()
+    {
+        return array(
+            array(59),
+            array(60),
+            array(61),
+            array(68),
+            array(74),
+            array(85),
+            array(92),
+            array(95),
+        );
+    }
+
+
+    /**
+     * Verify the sniff doesn't throw false positives.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+
+        for ($line = 1; $line < 57; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
As of PHP 8.0, the operator precedence of concatenation will be lowered, with deprecation notices being thrown as of PHP 7.4 for unparenthesized expressions containing an '.' before a '+' or '-'.

Refs:
* https://wiki.php.net/rfc/concatenation_precedence
* php/php-src@3b23694 (PHP 7.4 deprecation)
* php/php-src@61ee869 (PHP 8.0 precedence change)

Notes:
- I've not been able to come up with a valid unit test which would involve `&` as a reference, but I suspect this should be accounted for all the same, so the sniff does account for it.

**NOTE**: the name of the sniff does not comply with the "normal" naming pattern, but I'm not sure what would be a more appropriate name `ForbiddenConcatBeforePlusMinusWithoutParenthesis` seems a bit overly long, just as `RemovedConcatPrecedenceSameAsPlusMinus`.

Ideas welcome.

Related #808

--- 
This PR includes adding a new `Sniff::isUnaryPlusMinus()` method to determine whether a `+` or `-` is an operator or a unary, i.e. `-1`.

This method will :fingers_crossed: also be introduced into PHPCS itself in version 3.5.0.

Upstream, the method has been pulled with unit tests. As the intention is for this method to primarily be hosted within PHPCS, it seemed redundant to duplicate those here.

Refs:
* squizlabs/PHP_CodeSniffer#2456
* squizlabs/PHP_CodeSniffer@3167110