### PR TITLE
PHP 7.4/8.0: new RemovedTernaryAssociativity sniff

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1722,6 +1722,48 @@ abstract class Sniff implements PHPCS_Sniff
     }
 
 
+
+    /**
+     * Determine whether a ternary is a short ternary, i.e. without "middle".
+     *
+     * N.B.: This is a back-fill for a new method which is expected to go into
+     * PHP_CodeSniffer 3.5.0.
+     * Once that method has been merged into PHPCS, this one should be moved
+     * to the PHPCSHelper.php file.
+     *
+     * @since 9.2.0
+     *
+     * @codeCoverageIgnore Method as pulled upstream is accompanied by unit tests.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the ternary operator
+     *                                         in the stack.
+     *
+     * @return bool True if short ternary, or false otherwise.
+     */
+    public function isShortTernary(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr]) === false
+            || $tokens[$stackPtr]['code'] !== \T_INLINE_THEN
+        ) {
+            return false;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
+            // Live coding or parse error.
+            return false;
+        }
+
+        if ($tokens[$nextNonEmpty]['code'] === \T_INLINE_ELSE) {
+            return true;
+        }
+
+        return false;
+    }
+
+
     /**
      * Determine whether a T_OPEN/CLOSE_SHORT_ARRAY token is a list() construct.
      *

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -14,7 +14,6 @@ namespace PHPCompatibility\Sniffs\Operators;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * \PHPCompatibility\Sniffs\Operators\NewShortTernarySniff.
@@ -57,18 +56,14 @@ class NewShortTernarySniff extends Sniff
             return;
         }
 
-        $tokens = $phpcsFile->getTokens();
-
-        // Get next non-whitespace token, and check it isn't the related inline else
-        // symbol, which is not allowed prior to PHP 5.3.
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-
-        if ($next !== false && $tokens[$next]['code'] === \T_INLINE_ELSE) {
-            $phpcsFile->addError(
-                'Middle may not be omitted from ternary operators in PHP < 5.3',
-                $stackPtr,
-                'MiddleMissing'
-            );
+        if ($this->isShortTernary($phpcsFile, $stackPtr) === false) {
+            return;
         }
+
+        $phpcsFile->addError(
+            'Middle may not be omitted from ternary operators in PHP < 5.3',
+            $stackPtr,
+            'MiddleMissing'
+        );
     }
 }

--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Operators;
+
+use PHPCompatibility\Sniff;
+use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * The left-associativity of the ternary operator is deprecated in PHP 7.4 and
+ * removed in PHP 8.0.
+ *
+ * @link https://wiki.php.net/rfc/ternary_associativity
+ * @link https://github.com/php/php-src/pull/4017
+ *
+ * PHP version 7.4
+ * PHP version 8.0
+ *
+ * @since 9.2.0
+ */
+class RemovedTernaryAssociativitySniff extends Sniff
+{
+
+    /**
+     * List of tokens with a lower operator precedence than ternary.
+     *
+     * @since 9.2.0
+     *
+     * @var array
+     */
+    private $tokensWithLowerPrecedence = array(
+        'T_YIELD_FROM'  => true,
+        'T_YIELD'       => true,
+        'T_LOGICAL_AND' => true,
+        'T_LOGICAL_OR'  => true,
+        'T_LOGICAL_XOR' => true,
+    );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.2.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(\T_INLINE_THEN);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.2.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.4') === false) {
+            return;
+        }
+
+        $tokens         = $phpcsFile->getTokens();
+        $endOfStatement = PHPCSHelper::findEndOfStatement($phpcsFile, $stackPtr);
+        if ($tokens[$endOfStatement]['code'] !== \T_SEMICOLON
+            && $tokens[$endOfStatement]['code'] !== \T_COLON
+            && $tokens[$endOfStatement]['code'] !== \T_COMMA
+            && $tokens[$endOfStatement]['code'] !== \T_DOUBLE_ARROW
+            && $tokens[$endOfStatement]['code'] !== \T_OPEN_TAG
+            && $tokens[$endOfStatement]['code'] !== \T_CLOSE_TAG
+        ) {
+            // End of statement is last non-empty before close brace, so make sure we examine that token too.
+            ++$endOfStatement;
+        }
+
+        $ternaryCount      = 0;
+        $elseCount         = 0;
+        $shortTernaryCount = 0;
+
+        // Start at $stackPtr so we don't need duplicate code for short ternary determination.
+        for ($i = $stackPtr; $i < $endOfStatement; $i++) {
+            if (($tokens[$i]['code'] === \T_OPEN_SHORT_ARRAY
+                || $tokens[$i]['code'] === \T_OPEN_SQUARE_BRACKET
+                || $tokens[$i]['code'] === \T_OPEN_CURLY_BRACKET)
+                && isset($tokens[$i]['bracket_closer'])
+            ) {
+                // Skip over short arrays, array access keys and curlies.
+                $i = $tokens[$i]['bracket_closer'];
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_OPEN_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_closer'])
+            ) {
+                // Skip over anything between parentheses.
+                $i = $tokens[$i]['parenthesis_closer'];
+                continue;
+            }
+
+            // Check for operators with lower operator precedence.
+            if (isset(Tokens::$assignmentTokens[$tokens[$i]['code']])
+                || isset($this->tokensWithLowerPrecedence[$tokens[$i]['code']])
+            ) {
+                break;
+            }
+
+            if ($tokens[$i]['code'] === \T_INLINE_THEN) {
+                ++$ternaryCount;
+
+                if ($this->isShortTernary($phpcsFile, $i) === true) {
+                    ++$shortTernaryCount;
+                }
+
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_INLINE_ELSE) {
+                if (($ternaryCount - $elseCount) >= 2) {
+                    // This is the `else` for a ternary in the middle part of a previous ternary.
+                    --$ternaryCount;
+                } else {
+                    ++$elseCount;
+                }
+                continue;
+            }
+        }
+
+        if ($ternaryCount > 1 && $ternaryCount === $elseCount && $ternaryCount > $shortTernaryCount) {
+            $message = 'The left-associativity of the ternary operator has been deprecated in PHP 7.4';
+            $isError = false;
+            if ($this->supportsAbove('8.0') === true) {
+                $message .= ' and removed in PHP 8.0';
+                $isError  = true;
+            }
+
+            $message .= '. Multiple consecutive ternaries detected. Use parenthesis to clarify the order in which the operations should be executed';
+
+            $this->addMessage($phpcsFile, $message, $stackPtr, $isError);
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.inc
+++ b/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.inc
@@ -1,0 +1,126 @@
+<?php
+
+return $a == 1 ? 'one'
+     : $a == 2 ? 'two'
+     : $a == 3 ? 'three'
+     : $a == 4 ? 'four'
+               : 'other'; // Deprecated.
+
+return $a == 1 ? 'one'
+     : ($a == 2 ? 'two'
+     : ($a == 3 ? 'three'
+     : ($a == 4 ? 'four'
+               : 'other'))); // OK.
+
+return ((($a == 1 ? 'one'
+     : $a == 2) ? 'two'
+     : $a == 3) ? 'three'
+     : $a == 4) ? 'four'
+               : 'other'; // OK.
+
+return $a == 1 ? 'one'
+     : ($a == 2 ? 'two'
+     : $a == 3 ? 'three'
+     : ($a == 4 ? 'four'
+               : 'other')); // Deprecated, not all ternaries in parentheses.
+
+return (($a == 1 ? 'one'
+     : $a == 2) ? 'two'
+     : $a == 3 ? 'three'
+     : $a == 4) ? 'four'
+               : 'other'; // Deprecated, not all ternaries in parentheses.
+
+// In PHP 7.4 using nested ternaries without explicit parentheses will throw a deprecation warning. In PHP 8.0 it will become a compile-time error instead.
+$d = 1 ? 2 : 3 ? 4 : 5;   // Deprecated.
+$d = (1 ? 2 : 3) ? 4 : 5; // OK.
+$d = 1 ? 2 : (3 ? 4 : 5); // OK.
+
+// PHP 7.4: This also applies when mixing short and long ternary syntax:
+
+$d = 1 ?: 2 ? 3 : 4;   // Deprecated.
+$d = (1 ?: 2) ? 3 : 4; // OK.
+$d = 1 ?: (2 ? 3 : 4); // OK.
+
+$d = 1 ? 2 : 3 ?: 4;   // Deprecated.
+$d = (1 ? 2 : 3) ?: 4; // OK.
+$d = 1 ? 2 : (3 ?: 4); // OK.
+
+// PHP 7.4: as an exception, explicit parenthesis are not required when combining two short ternaries:
+$d = 1 ?: 2 ?: 3;   // OK.
+$d = (1 ?: 2) ?: 3; // OK.
+$d = 1 ?: (2 ?: 3); // OK.
+
+// PHP 7.4: Parentheses are also not required when nesting into the middle operand, as this is always unambiguous and not affected by associativity:
+$d = 1 ? 2 ? 3 : 4 : 5; // OK.
+$d = 1 ? 2 ?: 3 : 4; // OK.
+
+// More test cases.
+$d = $a ? ( $x ? $y : $z ) : $b ? $c : $d; // Deprecated.
+?>
+<div class="<?php echo $a ? $b : $c ? $d : $e ? $f : $g ?>"></div><!-- Deprecated x2-->
+<?php
+
+$array = true ? array( $a ? $b : $c ) : array( $d ? $e : $f ); // OK.
+$array = true ? [ $a ? $b : $c ] : [ $d ? $e : $f ]; // OK.
+
+$closure = $a ? function() { return $a ? $b : $c; } : function() { return $d ? $e : $f; } ? function() { return $g ? $h : $i; } : function() { return $j ? $k : $l; } ; // Deprecated.
+
+$closure = ( $a ? function() { return $a ? $b : $c; } : function() { return $d ? $e : $f; } ) ? function() { return $g ? $h : $i; } : function() { return $j ? $k : $l; } ; // OK.
+
+// Logical operators have a lower precedence than ternary.
+$logical = true ? true : false and false ? true : false;
+
+/*
+ * Additional real-world test cases.
+ * Source ternary_top1000: https://gist.github.com/nikic/b6214f87b0e4a7c6fe26919ac849194f
+ */
+// (possibly okay) /home/nikic/package-analysis/sources/symfony/routing/Matcher/Dumper/CompiledUrlMatcherDumper.php:225
+$compiledRoutes[$url][] = $this->compileRoute($route, $name, !$route->compile()->getHostVariables() ? $route->getHost() : $route->compile()->getHostRegex() ?: null, $hasTrailingSlash, false, $conditions);
+
+// (BUG!) /home/nikic/package-analysis/sources/symfony/symfony/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php:113
+$messageLocation = isset($tag['handles']) ? 'declared in your tag attribute "handles"' : $r->implementsInterface(MessageSubscriberInterface::class) ? sprintf('returned by method "%s::getHandledMessages()"', $r->getName()) : sprintf('used as argument type in method "%s::%s()"', $r->getName(), $method);
+
+// (BUG!) /home/nikic/package-analysis/sources/symfony/symfony/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php:126
+$messageLocation = isset($tag['handles']) ? 'declared in your tag attribute "handles"' : $r->implementsInterface(MessageSubscriberInterface::class) ? sprintf('returned by method "%s::getHandledMessages()"', $r->getName()) : sprintf('used as argument type in method "%s::%s()"', $r->getName(), $method);
+
+// (possibly okay) /home/nikic/package-analysis/sources/ekino/newrelic-bundle/NewRelic/Config.php:32
+$this->name = !empty($name) ? $name : \ini_get('newrelic.appname') ?: '';
+
+// (possibly okay) /home/nikic/package-analysis/sources/ekino/newrelic-bundle/NewRelic/Config.php:34
+$this->licenseKey = !empty($licenseKey) ? $licenseKey : \ini_get('newrelic.license') ?: '';
+
+// (BUG!) /home/nikic/package-analysis/sources/kartik-v/yii2-grid/src/ColumnTrait.php:274
+$curr = is_array($this->format) && isset($this->format[1]) ? $this->format[1] :
+    isset($formatter->currencyCode) ? $formatter->currencyCode . ' ' : '';
+
+// (BUG!) /home/nikic/package-analysis/sources/zendframework/zendframework1/library/Zend/Service/Console/Command.php:223
+$handlerDescription = isset($handlerDescriptions[$hi]) ? $handlerDescriptions[$hi] : isset($handlerDescriptions[0]) ? $handlerDescriptions[0] : '';
+
+// (BUG!) /home/nikic/package-analysis/sources/hoa/compiler/Bin/Pp.php:232
+            printf(
+                $format,
+                $i,
+                $token['namespace'],
+                $token['token'],
+                30 < $token['length']
+                    ? mb_substr($token['value'], 0, 29) . '…'
+                    : 'EOF' === $token['token']
+                        ? str_repeat(' ', 30)
+                        : $token['value'] .
+                          str_repeat(' ', 30 - $token['length']),
+                $token['offset']
+            );
+
+// (BUG!) /home/nikic/package-analysis/sources/jms/serializer/src/SerializationContext.php:152
+return $this->initialType
+    ? $this->initialType
+    : $this->hasAttribute('initial_type') ? $this->getAttribute('initial_type') : null;
+
+// (BUG!) /home/nikic/package-analysis/sources/psy/psysh/src/Formatter/SignatureFormatter.php:290
+$value     = \is_array($value) ? 'array()' : \is_null($value) ? 'null' : \var_export($value, true);
+
+// (BUG!) /home/nikic/package-analysis/sources/nesbot/carbon/src/Carbon/Lang/ga.php:69
+return $number.($number === 1 ? 'd' : $number % 10 === 2 ? 'na' : 'mh');
+
+// (BUG!) /home/nikic/package-analysis/sources/respect/validation/library/Rules/Cnh.php:59
+$check = $dv2 < 0 ? $dv2 + 11 : $dv2 > 9 ? 0 : $dv2;

--- a/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Operators;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Removed Ternary Associativity sniff tests.
+ *
+ * @group removedTernaryAssociativity
+ * @group operators
+ *
+ * @covers \PHPCompatibility\Sniffs\Operators\RemovedTernaryAssociativitySniff
+ *
+ * @since 9.2.0
+ */
+class RemovedTernaryAssociativityUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Lines on which to expect errors.
+     *
+     * @var array
+     */
+    protected $problemLines = array(
+        3,
+        4,
+        5,
+        22,
+        28,
+        34,
+        40,
+        44,
+        58,
+        60, // x2.
+        66,
+        71,
+        78,
+        81,
+        84,
+        87,
+        90,
+        93,
+        97,
+        106,
+        116,
+        120,
+        123,
+        126,
+    );
+
+
+    /**
+     * testRemovedTernaryAssociativity.
+     *
+     * @dataProvider dataRemovedTernaryAssociativity
+     *
+     * @param int $line The line number where a warning/error is expected.
+     *
+     * @return void
+     */
+    public function testRemovedTernaryAssociativity($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertWarning($file, $line, 'The left-associativity of the ternary operator has been deprecated in PHP 7.4. Multiple consecutive ternaries detected. Use parenthesis to clarify the order in which the operations should be executed');
+
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'The left-associativity of the ternary operator has been deprecated in PHP 7.4 and removed in PHP 8.0. Multiple consecutive ternaries detected. Use parenthesis to clarify the order in which the operations should be executed');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedTernaryAssociativity()
+     *
+     * @return array
+     */
+    public function dataRemovedTernaryAssociativity()
+    {
+        $cases = array();
+        foreach ($this->problemLines as $line) {
+            $cases[] = array($line);
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify the sniff doesn't throw false positives.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file     = $this->sniffFile(__FILE__, '7.4');
+        $tokens   = $file->getTokens();
+        $lastLine = $tokens[($file->numTokens - 1)]['line'];
+        $exclude  = array_flip($this->problemLines);
+
+        for ($line = 1; $line <= $lastLine; $line++) {
+            if (isset($exclude[$line])) {
+                continue;
+            }
+
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
PHP 7.4 deprecates nesting of ternaries without explicit use of parentheses.
PHP 8.0 will remove the (left-)associativity of ternaries completely. This will become a compile-time error.

Refs:
* https://wiki.php.net/rfc/ternary_associativity
* php/php-src@09ea55c (PHP 7.4 deprecation)
* https://gist.github.com/nikic/b6214f87b0e4a7c6fe26919ac849194f

Includes unit tests.

To test this sniff, I have run it over some 200.000 files. While I can't say for sure whether there were any missed problem cases (false negatives), all the issues detected by the sniff were actual cases of nested ternaries which would become problematic in PHP 7.4/8.0 (and most, if not all, were bugs).

Related to #808

---
This PR includes adding a new `Sniff::isShortTernary()` method to determine whether a ternary is a short ternary, i.e. without the middle.

This method will :fingers_crossed: also be introduced into PHPCS itself in version 3.5.0.

Upstream, the method will be pulled with unit tests. As the intention is for this method to primarily be hosted within PHPCS, it seemed redundant to duplicate those here.

Refs:
* squizlabs/PHP_CodeSniffer#2456


This PR also implements the use of this new `Sniff::isShortTernary()` method in the existing `NewShortTernary` sniff.
