### PR TITLE
PHP 7.4/NewFunctions: detect new mb_str_split()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -1849,6 +1849,11 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.2' => false,
             '7.3' => true,
         ),
+
+        'mb_str_split' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -476,3 +476,5 @@ ldap_rename_ext();
 
 oci_set_call_timeout();
 oci_set_db_operation();
+
+mb_str_split();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -529,6 +529,8 @@ class NewFunctionsUnitTest extends BaseSniffTest
 
             array('oci_set_call_timeout', '7.2.13', array(477), '7.3', '7.2'),
             array('oci_set_db_operation', '7.2.13', array(478), '7.3', '7.2'),
+
+            array('mb_str_split', '7.3', array(480), '7.4'),
         );
     }
 


### PR DESCRIPTION
Refs:
* https://wiki.php.net/rfc/mb_str_split
* https://github.com/php/php-src/commit/d77ad27415a34e4f5908cb262567b7b6f0eca17f