### PR TITLE
pfpro sniff is conflicting with some custom code

### DIFF
--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -147,7 +147,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
             '5.1' => true,
             'alternative' => null,
         ),
-        'pfpro' => array(
+        'pfpro_' => array(
             '5.3' => true,
             'alternative' => null,
         ),

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.inc
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.inc
@@ -43,7 +43,7 @@ oracle();
 
 ovrimos();
 
-pfpro();
+pfpro_init();
 
 sqlite();
 

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -74,7 +74,7 @@ class RemovedExtensionsUnitTest extends BaseSniffTest
             array('msql', '5.3', array(36), '5.2'),
             array('mssql', '7.0', array(63), '5.6'),
             array('ovrimos', '5.1', array(44), '5.0'),
-            array('pfpro', '5.3', array(46), '5.2'),
+            array('pfpro_', '5.3', array(46), '5.2'),
             array('sqlite', '5.4', array(48), '5.3'),
             // array('sybase', '7.0', array(xx), '5.6'), sybase_ct ???
             array('yp', '5.1', array(54), '5.0'),


### PR DESCRIPTION
We have a function in our code, for example `pfproduct_update()` which is being caught by the `pfpro` sniff. Adding the `_` should fix this, as it did for mysql in https://github.com/PHPCompatibility/PHPCompatibility/issues/7