### PR TITLE
PHP 7.4: new NewExceptionsFromToString sniff

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * As of PHP 7.4, throwing exceptions from a __toString() method is allowed.
+ *
+ * @link https://wiki.php.net/rfc/tostring_exceptions
+ *
+ * PHP version 7.4
+ *
+ * @since 9.2.0
+ */
+class NewExceptionsFromToStringSniff extends Sniff
+{
+
+    /**
+     * Valid scopes for the __toString() method to live in.
+     *
+     * @since 9.2.0
+     *
+     * @var array
+     */
+    public $ooScopeTokens = array(
+        'T_CLASS'      => true,
+        'T_TRAIT'      => true,
+        'T_ANON_CLASS' => true,
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.2.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(\T_FUNCTION);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.2.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.3') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
+            // Abstract function, interface function, live coding or parse error.
+            return;
+        }
+
+        $functionName = $phpcsFile->getDeclarationName($stackPtr);
+        if (strtolower($functionName) !== '__tostring') {
+            // Not the right function.
+            return;
+        }
+
+        if ($this->validDirectScope($phpcsFile, $stackPtr, $this->ooScopeTokens) === false) {
+            // Function, not method.
+            return;
+        }
+
+        $hasThrow = $phpcsFile->findNext(\T_THROW, ($tokens[$stackPtr]['scope_opener'] + 1), $tokens[$stackPtr]['scope_closer']);
+
+        if ($hasThrow === false) {
+            // No exception is being thrown.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Throwing exceptions from __toString() was not allowed prior to PHP 7.4',
+            $hasThrow,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.inc
@@ -1,0 +1,61 @@
+<?php
+
+class CrossVersionValid
+{
+    public function __toString() {
+        return $this->foo;
+    }
+
+    public function someOtherFunction() {
+        if ( is_int($this->foo) ) {
+            throw new Exception('Foo is int');
+        }
+        return $this->foo;
+    }
+}
+
+// Irrelevant, not the magic method.
+function __toString() {
+    if ( is_int($this->foo) ) {
+        throw new Exception('Foo is int');
+    }
+    return $this->foo;
+}
+
+// Irrelevant, methods in interfaces don't have a body.
+interface MyInterface {
+    public function __toString();
+}
+
+// Irrelevant, abstract method doesn't have a body.
+abstract class AbstractClass {
+    abstract public function __toString();
+}
+
+// PHP 7.4: throwing exceptions from __toString().
+class PHP74ValidClass {
+    public function __toString() {
+        if ( is_int($this->foo) ) {
+            throw new Exception('Foo is int');
+        }
+        return $this->foo;
+    }
+}
+
+trait PHP74ValidTrait {
+    public function __toString() {
+        if ( is_int($this->foo) ) {
+            throw new Exception('Foo is int');
+        }
+        return $this->foo;
+    }
+}
+
+$anon = new class() {
+    public function __toString() {
+        if ( is_int($this->foo) ) {
+            throw new Exception('Foo is int');
+        }
+        return $this->foo;
+    }
+};

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
 use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * Exceptions from __toString() sniff tests.
@@ -26,16 +27,46 @@ class NewExceptionsFromToStringUnitTest extends BaseSniffTest
 {
 
     /**
+     * Whether or not traits will be recognized in PHPCS.
+     *
+     * @var bool
+     */
+    protected static $recognizesTraits = true;
+
+
+    /**
+     * Set up skip condition.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
+            self::$recognizesTraits = false;
+        }
+
+        parent::setUpBeforeClass();
+    }
+
+
+    /**
      * testNewExceptionsFromToString.
      *
      * @dataProvider dataNewExceptionsFromToString
      *
-     * @param int $line The line number where a warning is expected.
+     * @param int  $line    The line number where a warning is expected.
+     * @param bool $isTrait Whether the test relates to a method in a trait.
      *
      * @return void
      */
-    public function testNewExceptionsFromToString($line)
+    public function testNewExceptionsFromToString($line, $isTrait = false)
     {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
+            return;
+        }
+
         $file = $this->sniffFile(__FILE__, '7.3');
         $this->assertError($file, $line, 'Throwing exceptions from __toString() was not allowed prior to PHP 7.4');
     }
@@ -51,7 +82,7 @@ class NewExceptionsFromToStringUnitTest extends BaseSniffTest
     {
         return array(
             array(39),
-            array(48),
+            array(48, true),
             array(57),
         );
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Exceptions from __toString() sniff tests.
+ *
+ * @group newExceptionsFromToString
+ * @group functionDeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewExceptionsFromToStringSniff
+ *
+ * @since 9.2.0
+ */
+class NewExceptionsFromToStringUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewExceptionsFromToString.
+     *
+     * @dataProvider dataNewExceptionsFromToString
+     *
+     * @param int $line The line number where a warning is expected.
+     *
+     * @return void
+     */
+    public function testNewExceptionsFromToString($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertError($file, $line, 'Throwing exceptions from __toString() was not allowed prior to PHP 7.4');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewExceptionsFromToString()
+     *
+     * @return array
+     */
+    public function dataNewExceptionsFromToString()
+    {
+        return array(
+            array(39),
+            array(48),
+            array(57),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = array();
+        // No errors expected on the first 34 lines.
+        for ($line = 1; $line <= 34; $line++) {
+            $cases[] = array($line);
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> As of PHP 7.4, throwing exceptions from __toString() is now permitted. Previously this resulted in a fatal error. Existing recoverable fatals in string conversions have been converted to Error exceptions.

Refs:
* https://wiki.php.net/rfc/tostring_exceptions
* https://github.com/php/php-src/blob/374f7699821eb723a3a82a9854d18c0530b9d4e9/UPGRADING#L190
* https://github.com/php/php-src/commit/a31f46421d7bf6f55dd9ac5876b8e2eacf7e0708

Related #808