### PR TITLE
PHP 5.3: new ForbiddenToStringParameters sniff

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHPCompatibility\Sniff;
+use PHPCompatibility\PHPCSHelper;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * As of PHP 5.3, the __toString() magic method can no longer accept arguments.
+ *
+ * @link https://www.php.net/manual/en/migration53.incompatible.php
+ *
+ * PHP version 5.3
+ *
+ * @since 9.2.0
+ */
+class ForbiddenToStringParametersSniff extends Sniff
+{
+
+    /**
+     * Valid scopes for the __toString() method to live in.
+     *
+     * @since 9.2.0
+     *
+     * @var array
+     */
+    public $ooScopeTokens = array(
+        'T_CLASS'      => true,
+        'T_INTERFACE'  => true,
+        'T_TRAIT'      => true,
+        'T_ANON_CLASS' => true,
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.2.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(\T_FUNCTION);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.2.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('5.3') === false) {
+            return;
+        }
+
+        $functionName = $phpcsFile->getDeclarationName($stackPtr);
+        if (strtolower($functionName) !== '__tostring') {
+            // Not the right function.
+            return;
+        }
+
+        if ($this->validDirectScope($phpcsFile, $stackPtr, $this->ooScopeTokens) === false) {
+            // Function, not method.
+            return;
+        }
+
+        $params = PHPCSHelper::getMethodParameters($phpcsFile, $stackPtr);
+        if (empty($params)) {
+            // Function declared without parameters.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'The __toString() magic method can no longer accept arguments since PHP 5.3',
+            $stackPtr,
+            'Declared'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenToStringParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenToStringParametersUnitTest.inc
@@ -1,0 +1,40 @@
+<?php
+
+class CrossVersionValid
+{
+    public function __toString() {
+        return $this->foo;
+    }
+}
+
+// Irrelevant, not the magic method.
+function __toString($param) {
+    return $foo;
+}
+
+// PHP 5.3: The __toString() magic method can no longer accept arguments.
+interface MyInterface {
+    public function __toString($param);
+}
+
+abstract class AbstractClass {
+    abstract public function __toString($param);
+}
+
+class MyClass {
+    public function __toString($param) {
+        return $this->foo;
+    }
+}
+
+trait MyTrait {
+    public function __toString($param) {
+        return $this->foo;
+    }
+}
+
+$anon = new class() {
+    public function __toString($param) {
+        return $this->foo;
+    }
+};

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenToStringParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenToStringParametersUnitTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
+
+/**
+ * Forbidden parameters passed to __toString() sniff tests.
+ *
+ * @group newForbiddenToStringParameters
+ * @group functionDeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenToStringParametersSniff
+ *
+ * @since 9.2.0
+ */
+class ForbiddenToStringParametersUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Whether or not traits will be recognized in PHPCS.
+     *
+     * @var bool
+     */
+    protected static $recognizesTraits = true;
+
+
+    /**
+     * Set up skip condition.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
+            self::$recognizesTraits = false;
+        }
+
+        parent::setUpBeforeClass();
+    }
+
+
+    /**
+     * testForbiddenToStringParameters.
+     *
+     * @dataProvider dataForbiddenToStringParameters
+     *
+     * @param int  $line    The line number where a warning is expected.
+     * @param bool $isTrait Whether the test relates to a method in a trait.
+     *
+     * @return void
+     */
+    public function testForbiddenToStringParameters($line, $isTrait = false)
+    {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
+            return;
+        }
+
+        $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertError($file, $line, 'The __toString() magic method can no longer accept arguments since PHP 5.3');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenToStringParameters()
+     *
+     * @return array
+     */
+    public function dataForbiddenToStringParameters()
+    {
+        return array(
+            array(17),
+            array(21),
+            array(25),
+            array(31, true),
+            array(37),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = array();
+        // No errors expected on the first 15 lines.
+        for ($line = 1; $line <= 15; $line++) {
+            $cases[] = array($line);
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.2');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> The __toString() magic method can no longer accept arguments.

Ref: https://www.php.net/manual/en/migration53.incompatible.php

---

Potential additional enhancement which could be added (now or later):
* Check whether direct calls to `__toString()` methods pass arguments, i.e. `self::__toString($param)`, `$obj->__toString($param)`.