### PR TITLE
PHP 7.4: NewFunctionParameters: account for new PCRE function parameters

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -709,6 +709,18 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.0'  => false,
                 '5.1'  => true,
             ),
+            5 => array(
+                'name' => 'flags',
+                '7.3'  => false,
+                '7.4'  => true,
+            ),
+        ),
+        'preg_replace_callback_array' => array(
+            4 => array(
+                'name' => 'flags',
+                '7.3'  => false,
+                '7.4'  => true,
+            ),
         ),
         'round' => array(
             2 => array(

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
@@ -66,7 +66,7 @@ parse_url($url, PHP_URL_PATH);
 pg_lo_create($database, $id);
 pg_lo_import($database, '/tmp/lob.dat', $id);
 preg_replace( '`[A-Z]([a-z]+)`', '$1', $subject , -1 , $count );
-preg_replace_callback( '`[A-Z]([a-z]+)`' , $callback , $subject , -1 , $count );
+preg_replace_callback( '`[A-Z]([a-z]+)`' , $callback , $subject , -1 , $count, $flags );
 round(1.55, 1, PHP_ROUND_HALF_EVEN);
 sem_acquire( $sem_identifier, true );
 session_regenerate_id (true);
@@ -115,3 +115,4 @@ ldap_parse_result( $link, $result, &$errcode, &$matcheddn, &$errmsg, &$referrals
 ldap_read( $link_identifier, $base_dn, $filter, $attributes, $attrsonly, $sizelimit, $timelimit, $deref, $serverctrls );
 ldap_rename( $link_identifier, $dn, $newrdn, $newparent, $deleteoldrdn, $serverctrls );
 ldap_search( $link_identifier, $base_dn, $filter, $attributes, $attrsonly, $sizelimit, $timelimit, $deref, $serverctrls );
+preg_replace_callback_array($patterns_and_callbacks, $subject, $limit, $count, $flags);

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -164,7 +164,9 @@ class NewFunctionParametersUnitTest extends BaseSniffTest
             array('pg_select', 'result_type', '7.0', array(101), '7.1'),
             array('php_uname', 'mode', '4.2', array(104), '4.3'),
             array('preg_replace', 'count', '5.0', array(68), '5.1'),
-            array('preg_replace_callback', 'count', '5.0', array(69), '5.1'),
+            array('preg_replace_callback', 'count', '5.0', array(69), '7.4'), // OK version > version in which last parameter was added to the function.
+            array('preg_replace_callback', 'flags', '7.3', array(69), '7.4'),
+            array('preg_replace_callback_array', 'flags', '7.3', array(118), '7.4'),
             array('round', 'mode', '5.2', array(70), '5.3'),
             array('sem_acquire', 'nowait', '5.6', array(71), '7.0'),
             array('session_regenerate_id', 'delete_old_session', '5.0', array(72), '5.1'),


### PR DESCRIPTION
> - PCRE:
>   The preg_replace_callback() and preg_replace_callback_array() functions now
>   accept an additional $flags argument, with support for the
>   PREG_OFFSET_CAPTURE and PREG_UNMATCHED_AS_NULL flags. This influences the
>   format of the matches array passed to to the callback function.

Refs:
* https://github.com/php/php-src/blob/42cc58ff7b2fee1c17a00dc77a4873552ffb577f/UPGRADING#L244
* https://bugs.php.net/bug.php?id=77094
* https://github.com/php/php-src/pull/3958
* https://github.com/php/php-src/commit/12bcdd68b421a9da50f7f56ea361003997819675

Loosely related to #808