### PR TITLE
PHP 7.4: RequiredToOptionalFunctionParameters: account for new optional array_merge() parameters

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -34,6 +34,20 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
      * @var array
      */
     protected $functionParameters = array(
+        'array_merge' => array(
+            0 => array(
+                'name' => 'array(s) to merge',
+                '7.3'  => true,
+                '7.4'  => false,
+            ),
+        ),
+        'array_merge_recursive' => array(
+            0 => array(
+                'name' => 'array(s) to merge',
+                '7.3'  => true,
+                '7.4'  => false,
+            ),
+        ),
         'array_push' => array(
             1 => array(
                 'name' => 'element to push',

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
@@ -30,3 +30,7 @@ ftp_nb_get( $ftp_stream, $local_file, $remote_file); // PHP 7.3+
 ftp_nb_put( $ftp_stream, $remote_file,$local_file); // PHP 7.3+
 ftp_put( $ftp_stream, $remote_file, $local_file); // PHP 7.3+
 ftp_put ( $ftp_stream, $remote_file, $local_file,$mode,$startpos); // OK.
+
+array_merge($arrays); // OK.
+array_merge(); // PHP 7.4+
+array_merge_recursive(); // PHP 7.4+

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -75,6 +75,8 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
             array('ftp_nb_get', 'mode', '7.2', array(29), '7.3'),
             array('ftp_nb_put', 'mode', '7.2', array(30), '7.3'),
             array('ftp_put', 'mode', '7.2', array(31), '7.3'),
+            array('array_merge', 'array(s) to merge', '7.3', array(35), '7.4'),
+            array('array_merge_recursive', 'array(s) to merge', '7.3', array(36), '7.4'),
         );
     }
 
@@ -112,6 +114,7 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
             array(20),
             array(23),
             array(32),
+            array(34),
         );
     }
 


### PR DESCRIPTION
> array_merge() and array_merge_recursive() may now be called without any
> arguments, in which case they will return an empty array. This is useful
> in conjunction with the spread operator, e.g. array_merge(...$arrays).

Refs:
* https://github.com/php/php-src/blob/42cc58ff7b2fee1c17a00dc77a4873552ffb577f/UPGRADING#L276
* https://www.php.net/manual/en/function.array-merge.php
* https://www.php.net/manual/en/function.array-merge-recursive.php
* https://github.com/php/php-src/pull/4175
* https://github.com/php/php-src/commit/77cf3d7b1100dbb2b441b2a75f21b4e8ee0cb9b1

Loosely related to #808