### PR TITLE
PHP 7.4: new RemovedOrphanedParent sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * Using "parent" inside a class without parent is deprecated since PHP 7.4.
+ *
+ * This will throw a compile-time error in the future. Currently an error will only
+ * be generated if/when the parent is accessed at run-time.
+ *
+ * @link https://github.com/php/php-src/blob/42cc58ff7b2fee1c17a00dc77a4873552ffb577f/UPGRADING#L303
+ *
+ * PHP version 7.4
+ *
+ * @since 9.2.0
+ */
+class RemovedOrphanedParentSniff extends Sniff
+{
+
+    /**
+     * Class scopes to check the class declaration.
+     *
+     * @since 9.2.0
+     *
+     * @var array
+     */
+    public $classScopeTokens = array(
+        'T_CLASS'      => true,
+        'T_ANON_CLASS' => true,
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.2.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(\T_PARENT);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.2.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (empty($tokens[$stackPtr]['conditions']) === true) {
+            // Use within the global namespace. Not our concern.
+            return;
+        }
+
+        /*
+         * Find the class within which this parent keyword is used.
+         */
+        $conditions = $tokens[$stackPtr]['conditions'];
+        $conditions = array_reverse($conditions, true);
+        $classPtr   = false;
+
+        foreach ($conditions as $ptr => $type) {
+            if (isset($this->classScopeTokens[$tokens[$ptr]['type']])) {
+                $classPtr = $ptr;
+                break;
+            }
+        }
+
+        if ($classPtr === false) {
+            // Use outside of a class scope. Not our concern.
+            return;
+        }
+
+        if (isset($tokens[$classPtr]['scope_opener']) === false) {
+            // No scope opener known. Probably a parse error.
+            return;
+        }
+
+        $extends = $phpcsFile->findNext(\T_EXTENDS, ($classPtr + 1), $tokens[$classPtr]['scope_opener']);
+        if ($extends !== false) {
+            // Class has a parent.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Using "parent" inside a class without parent is deprecated since PHP 7.4',
+            $stackPtr,
+            'Deprecated'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
@@ -1,0 +1,68 @@
+<?php
+
+// Invalid, but not the concern of this sniff.
+echo parent::class;
+
+function test() {
+    echo parent::class;
+}
+
+// Valid use of the parent keyword.
+class ExtendedClass extends ParentClass
+{
+    public function test() {
+        echo parent::class;
+        $this->foo = parent::$foo;
+        return parent::test();
+    }
+}
+
+class PlainClass {
+    public function create_anon_class() {
+        $anon = new class() extends ParentClass {
+            public function test() {
+                echo parent::class;
+                $this->foo = parent::$foo;
+                return parent::test();
+            }
+        };
+    }
+}
+
+// PHP 7.4: Deprecated parent in class without parent.
+class ParentClass
+{
+    public function test() {
+        echo parent::class;
+        $this->foo = parent::$foo;
+        return parent::test();
+    }
+}
+
+class ImplementedClass implements SomeInterface
+{
+    public function test() {
+        echo parent::class;
+        $this->foo = parent::$foo;
+        return parent::test();
+    }
+}
+
+// Test correct handling of nested classes.
+class NestingStuff extends Nested {
+    public function create_anon_class() {
+        return new class() {
+            public function test() {
+                echo parent::class;
+                $this->foo = parent::$foo;
+                return parent::test();
+            }
+        };
+    }
+}
+
+// Intentional parse error. This has to be the last test in the file.
+class SomeClass extends Something
+    public function test() {
+        return parent::test();
+    }

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Removed use of parent within a class without parent sniff tests.
+ *
+ * @group newRemovedOrphanedParent
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\RemovedOrphanedParentSniff
+ *
+ * @since 9.2.0
+ */
+class RemovedOrphanedParentUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testRemovedOrphanedParent.
+     *
+     * @dataProvider dataRemovedOrphanedParent
+     *
+     * @param int $line The line number where a warning is expected.
+     *
+     * @return void
+     */
+    public function testRemovedOrphanedParent($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, 'Using "parent" inside a class without parent is deprecated since PHP 7.4');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedOrphanedParent()
+     *
+     * @return array
+     */
+    public function dataRemovedOrphanedParent()
+    {
+        return array(
+            array(36),
+            array(37),
+            array(38),
+            array(45),
+            array(46),
+            array(47),
+            array(56),
+            array(57),
+            array(58),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = array();
+        // No errors expected on the first 31 lines.
+        for ($line = 1; $line <= 31; $line++) {
+            $cases[] = array($line);
+        }
+
+        // Add parse error test case.
+        $cases[] = array(67);
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> - Core
>    Using "parent" inside a class without parent is deprecated, and will throw
>    a compile-time error in the future. Currently an error will only be
>    generated if/when the parent is accessed at run-time.

Refs:
* https://github.com/php/php-src/blob/42cc58ff7b2fee1c17a00dc77a4873552ffb577f/UPGRADING#L303
* https://github.com/php/php-src/pull/3404
* https://github.com/php/php-src/pull/3564
* https://github.com/php/php-src/commit/a9e6667817c38f22f4645ec5b4e5c6b0e4b928fa (originally committed as hard compile time error)
* https://github.com/php/php-src/commit/deb44d405eb27a6654ad9a57c1e5f641218b22a4 (reverted back to deprecation error)

Loosely related to #808

---

I've opted to add this sniff to the `Classes` category as the use of the `parent` keyword in a class without parent requires examining the class declaration statement, though it can be argued that it should be in the `Keywords` category as the focus is on the `parent` keyword.