### PR TITLE
PHP 7.4: NewFunctions: add various new functions

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -1850,7 +1850,27 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.3' => true,
         ),
 
+        'get_mangled_object_vars' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
         'mb_str_split' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
+        'openssl_x509_verify' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
+        'pcntl_unshare' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
+        'sapi_windows_set_ctrl_handler' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
+        'sapi_windows_generate_ctrl_event' => array(
             '7.3' => false,
             '7.4' => true,
         ),

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -478,3 +478,8 @@ oci_set_call_timeout();
 oci_set_db_operation();
 
 mb_str_split();
+get_mangled_object_vars();
+openssl_x509_verify();
+pcntl_unshare();
+sapi_windows_set_ctrl_handler();
+sapi_windows_generate_ctrl_event();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -531,6 +531,11 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('oci_set_db_operation', '7.2.13', array(478), '7.3', '7.2'),
 
             array('mb_str_split', '7.3', array(480), '7.4'),
+            array('get_mangled_object_vars', '7.3', array(481), '7.4'),
+            array('openssl_x509_verify', '7.3', array(482), '7.4'),
+            array('pcntl_unshare', '7.3', array(483), '7.4'),
+            array('sapi_windows_set_ctrl_handler', '7.3', array(484), '7.4'),
+            array('sapi_windows_generate_ctrl_event', '7.3', array(485), '7.4'),
         );
     }
 


### PR DESCRIPTION
> - Core:
>    Added `get_mangled_object_vars($object)` function, which returns the mangled
>    object properties. It returns the same result as `(array) $object`, with the
>    exception that it ignores overloaded array casts, such as used by
>    `ArrayObject`.
>
> - OpenSSL:
>    Added `openssl_x509_verify(mixed cert, mixed key)` function that verifies the
>    signature of the certificate using a public key. A wrapper around the
>    OpenSSL's `X509_verify()` function.
>    See <https://github.com/php/php-src/pull/3624>.
>
> - Pcntl:
>    Added bool `pcntl_unshare(int flags)` function which allows to dissociate
>    parts of the process execution context which are currently being shared with
>    other processes. Explicitly, it allows you to unshare the mount, IPC, UTS,
>    network, PID, user and cgroup namespaces.
>
> - Standard
>    * bool `sapi_windows_set_ctrl_handler(callable handler, [, bool add = true])` -
>       set or remove a handler function upon receiving a CTRL event. The handler
>       function is expected have a signature "function handler(int $event)".
>    * bool `sapi_windows_generate_ctrl_event(int type, int pid)` - send a CTRL event
>       to another process.

Refs:
* https://github.com/php/php-src/blob/42cc58ff7b2fee1c17a00dc77a4873552ffb577f/UPGRADING#L348-L379

Loosely related to #808