### PR TITLE
PHP 7.4: NewClasses: add ReflectionReference class

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -565,6 +565,11 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '7.2' => false,
             '7.3' => true,
         ),
+
+        'ReflectionReference' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -341,3 +341,4 @@ $test = new SQLiteException();
 class MyClosedGeneratorException extends ClosedGeneratorException {}
 function SodiumExceptionTypeHint( SodiumException $a ) {}
 $test = new com_exception();
+$test = new ReflectionReference;

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -194,6 +194,7 @@ class NewClassesUnitTest extends BaseSniffTest
             array('SodiumException', '7.1', array(342), '7.2'),
             array('CompileError', '7.2', array(249), '7.3'),
             array('JsonException', '7.2', array(250, 339), '7.3'),
+            array('ReflectionReference', '7.3', array(344), '7.4'),
         );
     }
 


### PR DESCRIPTION
> - Reflection:
>    A new ReflectionReference class has been added, which allows detecting
>    references and comparing them for identity.

Refs:
* https://wiki.php.net/rfc/reference_reflection
* https://github.com/php/php-src/blob/42cc58ff7b2fee1c17a00dc77a4873552ffb577f/UPGRADING#L388-L391
* https://github.com/php/php-src/pull/3550
* https://github.com/php/php-src/commit/6347f0b937cc3fb3edb38003a41f3f9e8608831d

Related to #808