### PR TITLE
PHP 5.1: new ForbiddenAbstractPrivateMethods sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/ForbiddenAbstractPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenAbstractPrivateMethodsSniff.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * Abstract private methods are not allowed since PHP 5.1.
+ *
+ * Abstract private methods were supported between PHP 5.0.0 and PHP 5.0.4, but
+ * were then disallowed on the grounds that the behaviours of private and abstract
+ * are mutually exclusive.
+ *
+ * @link https://www.php.net/manual/en/migration51.oop.php#migration51.oop-methods
+ *
+ * PHP version 5.1
+ *
+ * @since 9.2.0
+ */
+class ForbiddenAbstractPrivateMethodsSniff extends Sniff
+{
+
+    /**
+     * Valid scopes to check for abstract private methods.
+     *
+     * @since 9.2.0
+     *
+     * @var array
+     */
+    public $ooScopeTokens = array(
+        'T_CLASS'      => true,
+        'T_TRAIT'      => true,
+        'T_ANON_CLASS' => true,
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.2.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(\T_FUNCTION);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.2.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('5.1') === false) {
+            return;
+        }
+
+        if ($this->validDirectScope($phpcsFile, $stackPtr, $this->ooScopeTokens) === false) {
+            // Function, not method.
+            return;
+        }
+
+        $properties = $phpcsFile->getMethodProperties($stackPtr);
+        if ($properties['scope'] !== 'private' || $properties['is_abstract'] !== true) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Abstract methods cannot be declared as private since PHP 5.1',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Classes/ForbiddenAbstractPrivateMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/ForbiddenAbstractPrivateMethodsUnitTest.inc
@@ -1,0 +1,41 @@
+<?php
+
+abstract class CrossVersionValid
+{
+    abstract public function publicOverload();
+    abstract protected static function protectedOverload();
+    private function privateNonOverloadable() {}
+}
+
+trait CrossVersionValidTrait
+{
+    abstract public static function publicOverload();
+    abstract protected function protectedOverload();
+    private function privateNonOverloadable() {}
+}
+
+// Abstract methods can not be declared in an anonymous class as the abstract keyword
+// will not be accepted for the class, but that is not our concern.
+$anon = new class() {
+    abstract public static function publicOverload();
+    abstract protected function protectedOverload();
+    private function privateNonOverloadable() {}
+};
+
+// PHP 5.1: abstract functions can not be private.
+abstract class CrossVersionValid
+{
+    abstract private function privateOverload();
+    static private abstract function privateStaticOverload();
+}
+
+trait CrossVersionValidTrait
+{
+    abstract private function privateOverload();
+    static private abstract function privateStaticOverload();
+}
+
+$anon = new class() {
+    abstract private function privateOverload();
+    static private abstract function privateStaticOverload();
+};

--- a/PHPCompatibility/Tests/Classes/ForbiddenAbstractPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenAbstractPrivateMethodsUnitTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
+
+/**
+ * Forbidden parameters passed to __toString() sniff tests.
+ *
+ * @group newForbiddenAbstractPrivateMethods
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\ForbiddenAbstractPrivateMethodsSniff
+ *
+ * @since 9.2.0
+ */
+class ForbiddenAbstractPrivateMethodsUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Set up skip condition.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, both abstract classes
+        // as well as traits are not recognized, so the tests would never pass.
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(\PHP_VERSION_ID, '50400', '<')) {
+            $this->markTestSkipped('Traits and abstract classes are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
+            return;
+        }
+
+        parent::setUp();
+    }
+
+
+    /**
+     * testForbiddenAbstractPrivateMethods.
+     *
+     * @dataProvider dataForbiddenAbstractPrivateMethods
+     *
+     * @param int $line The line number where a warning is expected.
+     *
+     * @return void
+     */
+    public function testForbiddenAbstractPrivateMethods($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.1');
+        $this->assertError($file, $line, 'Abstract methods cannot be declared as private since PHP 5.1');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenAbstractPrivateMethods()
+     *
+     * @return array
+     */
+    public function dataForbiddenAbstractPrivateMethods()
+    {
+        return array(
+            array(28),
+            array(29),
+            array(34),
+            array(35),
+            array(39),
+            array(40),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = array();
+        // No errors expected on the first 24 lines.
+        for ($line = 1; $line <= 24; $line++) {
+            $cases[] = array($line);
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Abstract private methods were supported between PHP 5.0.0 and PHP 5.0.4, but were then disallowed on the grounds that the behaviours of private and abstract are mutually exclusive.

Ref:
* https://www.php.net/manual/en/migration51.oop.php#migration51.oop-methods

Note: the tests cannot be run on PHPCS 2.3.x in combination with PHP < 5.4.