### PR TITLE
Removed pfpro extension: add functions and inis

### DIFF
--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -152,7 +152,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
             'alternative' => null,
         ),
         'pfpro_' => array(
-            '5.3' => true,
+            '5.1' => true,
             'alternative' => null,
         ),
         'sqlite' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -34,6 +34,28 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '5.0.5' => true,
             'alternative' => null,
         ),
+
+        'pfpro_cleanup' => array(
+            '5.1' => true,
+            'alternative' => null,
+        ),
+        'pfpro_init' => array(
+            '5.1' => true,
+            'alternative' => null,
+        ),
+        'pfpro_process_raw' => array(
+            '5.1' => true,
+            'alternative' => null,
+        ),
+        'pfpro_process' => array(
+            '5.1' => true,
+            'alternative' => null,
+        ),
+        'pfpro_version' => array(
+            '5.1' => true,
+            'alternative' => null,
+        ),
+
         'call_user_method' => array(
             '5.3' => false,
             '7.0' => true,

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -38,6 +38,27 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             '5.1'         => true,
             'alternative' => 'fbsql.batchsize',
         ),
+        'pfpro.defaulthost' => array(
+            '5.1' => true,
+        ),
+        'pfpro.defaultport' => array(
+            '5.1' => true,
+        ),
+        'pfpro.defaulttimeout' => array(
+            '5.1' => true,
+        ),
+        'pfpro.proxyaddress' => array(
+            '5.1' => true,
+        ),
+        'pfpro.proxyport' => array(
+            '5.1' => true,
+        ),
+        'pfpro.proxylogon' => array(
+            '5.1' => true,
+        ),
+        'pfpro.proxypassword' => array(
+            '5.1' => true,
+        ),
 
         'ifx.allow_persistent' => array(
             '5.2.1' => true,

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -74,7 +74,7 @@ class RemovedExtensionsUnitTest extends BaseSniffTest
             array('msql', '5.3', array(36), '5.2'),
             array('mssql', '7.0', array(63), '5.6'),
             array('ovrimos', '5.1', array(44), '5.0'),
-            array('pfpro_', '5.3', array(46), '5.2'),
+            array('pfpro_', '5.1', array(46), '5.0'),
             array('sqlite', '5.4', array(48), '5.3'),
             // array('sybase', '7.0', array(xx), '5.6'), sybase_ct ???
             array('yp', '5.1', array(54), '5.0'),

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -216,3 +216,10 @@ ibase_service_detach();
 ibase_set_event_handler();
 ibase_trans();
 ibase_wait_event();
+
+// Pfpro extension - PHP 5.1
+pfpro_cleanup();
+pfpro_init();
+pfpro_process_raw();
+pfpro_process();
+pfpro_version();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -287,6 +287,12 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('ibase_set_event_handler', '7.4', array(216), '7.3'),
             array('ibase_trans', '7.4', array(217), '7.3'),
             array('ibase_wait_event', '7.4', array(218), '7.3'),
+
+            array('pfpro_cleanup', '5.1', array(221), '5.0'),
+            array('pfpro_init', '5.1', array(222), '5.0'),
+            array('pfpro_process_raw', '5.1', array(223), '5.0'),
+            array('pfpro_process', '5.1', array(224), '5.0'),
+            array('pfpro_version', '5.1', array(225), '5.0'),
         );
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -213,3 +213,24 @@ $a = ini_get('ibase.dateformat');
 
 ini_set('ibase.timeformat', '%Y-%m-%d');
 $a = ini_get('ibase.timeformat');
+
+ini_set('pfpro.defaulthost', 'string');
+$a = ini_get('pfpro.defaulthost');
+
+ini_set('pfpro.defaultport', 'string');
+$a = ini_get('pfpro.defaultport');
+
+ini_set('pfpro.defaulttimeout', 'string');
+$a = ini_get('pfpro.defaulttimeout');
+
+ini_set('pfpro.proxyaddress', 'string');
+$a = ini_get('pfpro.proxyaddress');
+
+ini_set('pfpro.proxyport', 'string');
+$a = ini_get('pfpro.proxyport');
+
+ini_set('pfpro.proxylogon', 'string');
+$a = ini_get('pfpro.proxylogon');
+
+ini_set('pfpro.proxypassword', 'string');
+$a = ini_get('pfpro.proxypassword');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -277,6 +277,14 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             array('ibase.timestampformat', '7.4', array(208, 209), '7.3'),
             array('ibase.dateformat', '7.4', array(211, 212), '7.3'),
             array('ibase.timeformat', '7.4', array(214, 215), '7.3'),
+
+            array('pfpro.defaulthost', '5.1', array(217, 218), '5.0'),
+            array('pfpro.defaultport', '5.1', array(220, 221), '5.0'),
+            array('pfpro.defaulttimeout', '5.1', array(223, 224), '5.0'),
+            array('pfpro.proxyaddress', '5.1', array(226, 227), '5.0'),
+            array('pfpro.proxyport', '5.1', array(229, 230), '5.0'),
+            array('pfpro.proxylogon', '5.1', array(232, 233), '5.0'),
+            array('pfpro.proxypassword', '5.1', array(235, 236), '5.0'),
         );
     }
 


### PR DESCRIPTION
* Fixes the version number of the extension removal.
* Adds the removed functions to the `RemovedFunctions` sniff.
* Adds the removed ini directives to the `RemovedIniDirectives` sniff.

---

### RemovedExtensions: fix removal version number for pfpro

Base on what can be found via the Wayback machine, the "Verisign Payflow Pro" Extension - `pfpro` - was moved to PECL with the release of PHP 5.1.0.

Ref: https://web.archive.org/web/20070226211109/http://www.php.net/manual/en/ref.pfpro.php

### RemovedIniDirectives: add removed pfpro extension directives

Refs: https://web.archive.org/web/20070226211109/http://www.php.net/manual/en/ref.pfpro.php

### RemovedFunctions: add removed pfpro extension functions

Refs: https://web.archive.org/web/20070226211109/http://www.php.net/manual/en/ref.pfpro.php