### PR TITLE
CS: add two new rules

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -299,7 +299,7 @@ abstract class Sniff implements PHPCS_Sniff
      */
     public function arrayKeysToLowercase($array)
     {
-        return array_change_key_case($array, CASE_LOWER);
+        return array_change_key_case($array, \CASE_LOWER);
     }
 
 
@@ -1490,7 +1490,7 @@ abstract class Sniff implements PHPCS_Sniff
      */
     protected function isNumber(File $phpcsFile, $start, $end, $allowFloats = false)
     {
-        $stringTokens  = Tokens::$heredocTokens + Tokens::$stringTokens;
+        $stringTokens = Tokens::$heredocTokens + Tokens::$stringTokens;
 
         $validTokens             = array();
         $validTokens[\T_LNUMBER] = true;

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -188,7 +188,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      */
     public function getErrorInfo(array $itemArray, array $itemInfo)
     {
-        $errorInfo = parent::getErrorInfo($itemArray, $itemInfo);
+        $errorInfo                        = parent::getErrorInfo($itemArray, $itemInfo);
         $errorInfo['conditional_version'] = '';
         $errorInfo['condition']           = '';
 

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -178,7 +178,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
          */
         if (empty($translate) === false) {
             $this->translateContentToToken = $translate;
-            $tokens[] = \T_STRING;
+            $tokens[]                      = \T_STRING;
         }
 
         return $tokens;

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -55,7 +55,7 @@ class NewListReferenceAssignmentSniff extends NewKeyedListSniff
      */
     protected function examineList(File $phpcsFile, $opener, $closer)
     {
-        $start   = $opener;
+        $start = $opener;
         while (($start = $this->hasTargetInList($phpcsFile, $start, $closer)) !== false) {
             $phpcsFile->addError(
                 'Reference assignments within list constructs are not supported in PHP 7.2 or earlier.',

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -29,7 +29,7 @@ class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
 {
 
     const ERROR_TYPE_VARIABLE = 'a variable argument';
-    const ERROR_TYPE_ZERO = '0 as an argument';
+    const ERROR_TYPE_ZERO     = '0 as an argument';
 
     /**
      * testBreakAndContinueVariableArgument

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -122,6 +122,17 @@
         <severity>0</severity>
     </rule>
 
+    <!-- Align the equal operator in assignment blocks. -->
+    <rule ref="Generic.Formatting.MultipleStatementAlignment">
+        <properties>
+            <property name="maxPadding" value="25"/>
+        </properties>
+    </rule>
+
+	<rule ref="PEAR.Files.IncludingFile">
+        <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
+	</rule>
+
 
     <!--
         Inline Documentation check.


### PR DESCRIPTION
1. Add the `MultipleStatementAlignment` sniff
    The code base basically already complies with this rule, which demands that the assignment operators for blocks of variable assignments are aligned.
    When an assignment is not in a block, there should be exactly one space between the variable and the assignment.
    Includes fixing up the code base for the very few places where the code didn't comply yet.
2. Add the `IncludingFile` sniff
    Again, the code base already complies with this rule, safe for the unit test bootstrap, in which case it is ok that the code doesn't comply.

Includes one minor consistency fix, prefixing a global constant when used with a namespace separator to indicate global namespace.