### PR TITLE
PHP 7.4: unbundle ext/wddx

### DIFF
--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -172,6 +172,10 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
             '5.1' => true,
             'alternative' => 'pecl/ffi',
         ),
+        'wddx' => array(
+            '7.4' => true,
+            'alternative' => 'pecl/wddx',
+        ),
         'yp' => array(
             '5.1' => true,
             'alternative' => null,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -920,6 +920,30 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.4' => true,
             'alternative' => null,
         ),
+        'wddx_add_vars' => array(
+            '7.4' => true,
+            'alternative' => null,
+        ),
+        'wddx_deserialize' => array(
+            '7.4' => true,
+            'alternative' => null,
+        ),
+        'wddx_packet_end' => array(
+            '7.4' => true,
+            'alternative' => null,
+        ),
+        'wddx_packet_start' => array(
+            '7.4' => true,
+            'alternative' => null,
+        ),
+        'wddx_serialize_value' => array(
+            '7.4' => true,
+            'alternative' => null,
+        ),
+        'wddx_serialize_vars' => array(
+            '7.4' => true,
+            'alternative' => null,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.inc
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.inc
@@ -76,6 +76,7 @@ ereg_translate_to_preg();
 ereg_replace(); // Non-whitelisted.
 
 ibase_trans();
+wddx_deserialize();
 
 // Don't throw errors during live code review.
 ereg($a, $b

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -134,6 +134,7 @@ class RemovedExtensionsUnitTest extends BaseSniffTest
             array('oracle', '5.1', 'oci8 or pdo_oci', array(42), '5.0'),
             array('sybase', '5.3', 'sybase_ct', array(50), '5.2'),
             array('w32api', '5.1', 'pecl/ffi', array(52), '5.0'),
+            array('wddx', '7.4', 'pecl/wddx', array(79), '7.3'),
         );
     }
 
@@ -224,7 +225,7 @@ class RemovedExtensionsUnitTest extends BaseSniffTest
             array(58), // Function declaration.
             array(59), // Class instantiation.
             array(60), // Method call.
-            array(81), // Live coding.
+            array(82), // Live coding.
         );
 
         // Inline setting changes in combination with namespaced sniffs is only supported since PHPCS 2.6.0.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -223,3 +223,11 @@ pfpro_init();
 pfpro_process_raw();
 pfpro_process();
 pfpro_version();
+
+// PHP 7.4.
+wddx_add_vars();
+wddx_deserialize();
+wddx_packet_end();
+wddx_packet_start();
+wddx_serialize_value();
+wddx_serialize_vars();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -293,6 +293,13 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('pfpro_process_raw', '5.1', array(223), '5.0'),
             array('pfpro_process', '5.1', array(224), '5.0'),
             array('pfpro_version', '5.1', array(225), '5.0'),
+
+            array('wddx_add_vars', '7.4', array(228), '7.3'),
+            array('wddx_deserialize', '7.4', array(229), '7.3'),
+            array('wddx_packet_end', '7.4', array(230), '7.3'),
+            array('wddx_packet_start', '7.4', array(231), '7.3'),
+            array('wddx_serialize_value', '7.4', array(232), '7.3'),
+            array('wddx_serialize_vars', '7.4', array(233), '7.3'),
         );
     }
 


### PR DESCRIPTION
### RemovedFunctions: account for removed wddx extension
### RemovedExtensions: account for removed wddx extension

Refs:
* https://wiki.php.net/rfc/deprecate-and-remove-ext-wddx
* php/php-src@6ac8b0a
* php/php-src@6bbb18a

Related to #808