### PR TITLE
PHP 7.4: NewFunctions: add password_algos()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -1862,6 +1862,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.3' => false,
             '7.4' => true,
         ),
+        'password_algos' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
         'pcntl_unshare' => array(
             '7.3' => false,
             '7.4' => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -483,3 +483,4 @@ openssl_x509_verify();
 pcntl_unshare();
 sapi_windows_set_ctrl_handler();
 sapi_windows_generate_ctrl_event();
+password_algos();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -536,6 +536,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('pcntl_unshare', '7.3', array(483), '7.4'),
             array('sapi_windows_set_ctrl_handler', '7.3', array(484), '7.4'),
             array('sapi_windows_generate_ctrl_event', '7.3', array(485), '7.4'),
+            array('password_algos', '7.3', array(486), '7.4'),
         );
     }
 


### PR DESCRIPTION
> - Standard
>    array password_algos() - return a complete list of all registered password
>    hashing algorithms. For more details see the RFC:
>    https://wiki.php.net/rfc/password_registry

Refs:
* https://github.com/php/php-src/blob/8f4e24eeef7bd1c39fabf5bea016abb287a4c606/UPGRADING#L380
* https://wiki.php.net/rfc/password_registry
* https://github.com/php/php-src/pull/3609
* https://github.com/php/php-src/commit/534df87c9e3c28001986e70844e0ad04e5708d3d

Related to #808