### PR TITLE
PHP 5.3: new ForbiddenToStringParameters sniff (part 2)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer_File as File;
 /**
  * As of PHP 5.3, the __toString() magic method can no longer accept arguments.
  *
+ * Sister-sniff to PHPCompatibility.MethodUse.ForbiddenToStringParameters.
+ *
  * @link https://www.php.net/manual/en/migration53.incompatible.php
  *
  * PHP version 5.3

--- a/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\MethodUse;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * As of PHP 5.3, the __toString() magic method can no longer be passed arguments.
+ *
+ * Sister-sniff to PHPCompatibility.FunctionDeclarations.ForbiddenToStringParameters.
+ *
+ * @link https://www.php.net/manual/en/migration53.incompatible.php
+ *
+ * PHP version 5.3
+ *
+ * @since 9.2.0
+ */
+class ForbiddenToStringParametersSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.2.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            \T_DOUBLE_COLON,
+            \T_OBJECT_OPERATOR,
+        );
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.2.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('5.3') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_STRING) {
+            /*
+             * Not a method call.
+             *
+             * Note: This disregards method calls with the method name in a variable, like:
+             *   $method = '__toString';
+             *   $obj->$method();
+             * However, that would be very hard to examine reliably anyway.
+             */
+            return;
+        }
+
+        if (strtolower($tokens[$nextNonEmpty]['content']) !== '__tostring') {
+            // Not a call to the __clone() method.
+            return;
+        }
+
+        $openParens = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
+        if ($openParens === false || $tokens[$openParens]['code'] !== \T_OPEN_PARENTHESIS) {
+            // Not a method call.
+            return;
+        }
+
+        $closeParens = $phpcsFile->findNext(Tokens::$emptyTokens, ($openParens + 1), null, true);
+        if ($closeParens === false || $tokens[$closeParens]['code'] === \T_CLOSE_PARENTHESIS) {
+            // Not a method call.
+            return;
+        }
+
+        // If we're still here, then this is a call to the __toString() magic method passing parameters.
+        $phpcsFile->addError(
+            'The __toString() magic method will no longer accept passed arguments since PHP 5.3',
+            $stackPtr,
+            'Passed'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.inc
@@ -1,0 +1,50 @@
+<?php
+
+// This is fine.
+$obj = new MyClass();
+$obj->__toString();
+$obj::__toString();
+MyClass::__toString(
+	// Comment.
+);
+
+class MyClass {
+    public function foo() {
+        self::__toString();
+        static::__toString();
+        parent::__toString();
+        $this->__toString();
+        $another->__toString( /* Comment */ );
+    }
+}
+
+// Irrelevant, not the magic method.
+echo __toString($param);
+echo Some\NameSp\__toString($param);
+echo namespace\__toString($param);
+MyClass::__TOSTRING; // Constant, not method.
+$obj->property; // Property, not method.
+
+class Bar {
+	public function foo() {
+        $this->__toString; // Property.
+        self::$__toString; // Property.
+        self::__toString; // Constant.
+	}
+}
+
+// PHP 5.3: The __toString() magic method can no longer accept arguments.
+$obj->__toString($param);
+$obj::__toString($param);
+MyClass::__toString($param);
+
+class MyClass {
+    public function foo() {
+		// Includes testing case-insensitivity as function names in PHP are (case-insensitive).
+        self::__toString($param);
+        static::__tostring($param);
+        parent::__toSTRING($param);
+        $this->__toString($param);
+        $another->__toString($param);
+    }
+}

--- a/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\MethodUse;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Forbidden parameters passed to __toString() sniff tests.
+ *
+ * @group newForbiddenToStringParameters
+ * @group methodUse
+ *
+ * @covers \PHPCompatibility\Sniffs\MethodUse\ForbiddenToStringParametersSniff
+ *
+ * @since 9.2.0
+ */
+class ForbiddenToStringParametersUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testForbiddenToStringParameters.
+     *
+     * @dataProvider dataForbiddenToStringParameters
+     *
+     * @param int $line The line number where a warning is expected.
+     *
+     * @return void
+     */
+    public function testForbiddenToStringParameters($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertError($file, $line, 'The __toString() magic method will no longer accept passed arguments since PHP 5.3');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenToStringParameters()
+     *
+     * @return array
+     */
+    public function dataForbiddenToStringParameters()
+    {
+        return array(
+            array(37),
+            array(38),
+            array(39),
+            array(44),
+            array(45),
+            array(46),
+            array(47),
+            array(48),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = array();
+        // No errors expected on the first 21 lines.
+        for ($line = 1; $line <= 35; $line++) {
+            $cases[] = array($line);
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.2');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> The __toString() magic method can no longer accept arguments.

Ref: https://www.php.net/manual/en/migration53.incompatible.php

This introduces a sister-sniff called `PHPCompatibility.MethodUse.ForbiddenToStringParameters` to the `PHPCompatibility.FunctionDeclarations.ForbiddenToStringParameters` which will detect parameters being passed in direct calls to the magic `__toString()` method. (as per my previous remark in #815)

> Potential additional enhancement which could be added (now or later):
>
> * Check whether direct calls to `__toString()` methods pass arguments, i.e. `self::__toString($param)`, `$obj->__toString($param)`.
