### PR TITLE
PHP 7.4: RemovedFunctions: account for deprecated LDAP functions

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -920,6 +920,14 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.4' => true,
             'alternative' => null,
         ),
+        'ldap_control_paged_result_response' => array(
+            '7.4' => false,
+            'alternative' => 'ldap_search()',
+        ),
+        'ldap_control_paged_result' => array(
+            '7.4' => false,
+            'alternative' => 'ldap_search()',
+        ),
         'wddx_add_vars' => array(
             '7.4' => true,
             'alternative' => null,

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -231,3 +231,5 @@ wddx_packet_end();
 wddx_packet_start();
 wddx_serialize_value();
 wddx_serialize_vars();
+ldap_control_paged_result_response();
+ldap_control_paged_result();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -183,6 +183,9 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('mbereg_search_getregs', '7.3', 'mb_ereg_search_getregs()', array(164), '7.2'),
             array('mbereg_search_getpos', '7.3', 'mb_ereg_search_getpos()', array(165), '7.2'),
             array('mbereg_search_setpos', '7.3', 'mb_ereg_search_setpos()', array(166), '7.2'),
+
+            array('ldap_control_paged_result_response', '7.4', 'ldap_search()', array(234), '7.3'),
+            array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
         );
     }
 


### PR DESCRIPTION
> - LDAP:
>    ldap_control_paged_result_response and ldap_control_paged_result are
>    deprecated. Pagination controls can be sent along with ldap_search instead.

Refs:
* https://github.com/php/php-src/blob/42cc58ff7b2fee1c17a00dc77a4873552ffb577f/UPGRADING#L316
* https://github.com/php/php-src/commit/d93ce1795979e31255717fd770a2f0e901c06081

Loosely related to #808