### PR TITLE
RemovedTernaryAssociativity: fix false positive unit test for PHPCS 2.x

### DIFF
--- a/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
@@ -26,6 +26,13 @@ class RemovedTernaryAssociativityUnitTest extends BaseSniffTest
 {
 
     /**
+     * Total number of lines in the test case file (including blank lines at the end).
+     *
+     * @var int
+     */
+    protected $totalLines = 127;
+
+    /**
      * Lines on which to expect errors.
      *
      * @var array
@@ -101,12 +108,10 @@ class RemovedTernaryAssociativityUnitTest extends BaseSniffTest
      */
     public function testNoFalsePositives()
     {
-        $file     = $this->sniffFile(__FILE__, '7.4');
-        $tokens   = $file->getTokens();
-        $lastLine = $tokens[($file->numTokens - 1)]['line'];
-        $exclude  = array_flip($this->problemLines);
+        $file    = $this->sniffFile(__FILE__, '7.4');
+        $exclude = array_flip($this->problemLines);
 
-        for ($line = 1; $line <= $lastLine; $line++) {
+        for ($line = 1; $line <= $this->totalLines; $line++) {
             if (isset($exclude[$line])) {
                 continue;
             }


### PR DESCRIPTION
While examining something else, I noticed that the `testNoFalsePositives()` unit test for the `RemovedTernaryAssociativity` sniff was being marked as "Risky" by PHPUnit when run in combination with PHPCS 2.x.

Turns out that with how we are running the unit tests in PHPCompatibility for PHPCS 2.x, we don't have access to the token array from within the unit tests, which effectively means that the logic which created the data range to test in the `testNoFalsePositives()` test would yield an empty range of lines, resulting in no assertions being made.

While not as shiny as having the test case file line count calculated automatically, setting it via a property - which will need to be updated whenever the unit test case file is adjusted ! -, fixes this and will allow this unit test to run properly in combination with PHPCS 2.x.