### PR TITLE
PHP 7.4: unbundle ext/recode

### DIFF
--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -155,6 +155,10 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
             '5.1' => true,
             'alternative' => null,
         ),
+        'recode' => array(
+            '7.4' => true,
+            'alternative' => 'iconv or mbstring',
+        ),
         'sqlite' => array(
             '5.4' => true,
             'alternative' => null,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -928,6 +928,18 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.4' => false,
             'alternative' => 'ldap_search()',
         ),
+        'recode_file' => array(
+            '7.4' => true,
+            'alternative' => 'the iconv or mbstring extension',
+        ),
+        'recode_string' => array(
+            '7.4' => true,
+            'alternative' => 'the iconv or mbstring extension',
+        ),
+        'recode' => array(
+            '7.4' => true,
+            'alternative' => 'the iconv or mbstring extension',
+        ),
         'wddx_add_vars' => array(
             '7.4' => true,
             'alternative' => null,

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.inc
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.inc
@@ -77,6 +77,7 @@ ereg_replace(); // Non-whitelisted.
 
 ibase_trans();
 wddx_deserialize();
+recode();
 
 // Don't throw errors during live code review.
 ereg($a, $b

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -132,6 +132,7 @@ class RemovedExtensionsUnitTest extends BaseSniffTest
             array('ming', '5.3', 'pecl/ming', array(32), '5.2'),
             array('ncurses', '5.3', 'pecl/ncurses', array(40), '5.2'),
             array('oracle', '5.1', 'oci8 or pdo_oci', array(42), '5.0'),
+            array('recode', '7.4', 'iconv or mbstring', array(80), '7.3'),
             array('sybase', '5.3', 'sybase_ct', array(50), '5.2'),
             array('w32api', '5.1', 'pecl/ffi', array(52), '5.0'),
             array('wddx', '7.4', 'pecl/wddx', array(79), '7.3'),

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -233,3 +233,6 @@ wddx_serialize_value();
 wddx_serialize_vars();
 ldap_control_paged_result_response();
 ldap_control_paged_result();
+recode_file();
+recode_string();
+recode();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -308,6 +308,53 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
 
 
     /**
+     * testRemovedFunctionWithAlternative
+     *
+     * @dataProvider dataRemovedFunctionWithAlternative
+     *
+     * @param string $functionName   Name of the function.
+     * @param string $removedIn      The PHP version in which the function was removed.
+     * @param string $alternative    An alternative function.
+     * @param array  $lines          The line numbers in the test file which apply to this function.
+     * @param string $okVersion      A PHP version in which the function was still valid.
+     * @param string $removedVersion Optional PHP version to test removed message with -
+     *                               if different from the $removedIn version.
+     *
+     * @return void
+     */
+    public function testRemovedFunctionWithAlternative($functionName, $removedIn, $alternative, $lines, $okVersion, $removedVersion = null)
+    {
+        $file = $this->sniffFile(__FILE__, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        $errorVersion = (isset($removedVersion)) ? $removedVersion : $removedIn;
+        $file         = $this->sniffFile(__FILE__, $errorVersion);
+        $error        = "Function {$functionName}() is removed since PHP {$removedIn}; Use {$alternative} instead";
+        foreach ($lines as $line) {
+            $this->assertError($file, $line, $error);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedFunctionWithAlternative()
+     *
+     * @return array
+     */
+    public function dataRemovedFunctionWithAlternative()
+    {
+        return array(
+            array('recode_file', '7.4', 'the iconv or mbstring extension', array(236), '7.3'),
+            array('recode_string', '7.4', 'the iconv or mbstring extension', array(237), '7.3'),
+            array('recode', '7.4', 'the iconv or mbstring extension', array(238), '7.3'),
+        );
+    }
+
+
+    /**
      * testDeprecatedRemovedFunction
      *
      * @dataProvider dataDeprecatedRemovedFunction


### PR DESCRIPTION
### RemovedFunctions: account for removed recode extension

### RemovedExtensions: account for removed recode extension

Refs:
* https://wiki.php.net/rfc/unbundle_recode
* https://www.php.net/manual/en/book.recode.php
* php/php-src@58b607c

Related to #808