### PR TITLE
Travis: ignore PHP deprecation notices for stable PHPCS releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,6 +150,13 @@ before_install:
       phpenv config-rm xdebug.ini || echo 'No xdebug config.'
     fi
 
+  # On stable PHPCS versions, allow for PHP deprecation notices.
+  # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" && $PHPCS_VERSION != "dev-master" ]]; then
+      echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    fi
+
   # Allow for testing with different PHP ini configurations.
   - |
     if [[ "$CUSTOM_INI" == 1 ]]; then


### PR DESCRIPTION
The unit tests will fail when a PHP warning/notice/deprecation notice is encountered.

Deprecation notices thrown by already released PHPCS versions won't get fixed anymore (in that version), so failing the unit tests on those is moot and will skew the reliability of the Travis results.

To see the effect you'd need to check the Travis logs for the PHP 7.4 builds and compare them with a recent build on another branch.

While the PHP 7.4 builds against stable PHPCS versions - even with this fix - still show as failed, they now clearly show the problem of why those builds are failing and, luckily, I'd already identified the same earlier, so once PR #836 has been merged - as well as this PR / or after a rebase of this PR after the merge -, the PHP 7.4 builds against stable PHPCS versions should start showing as _green_.