### PR TITLE
PHP 7.4/RemovedTypeCasts: handle deprecated (real) typecast

### DIFF
--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -35,6 +35,11 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
             'alternative' => 'unset()',
             'description' => 'unset',
         ),
+        'T_DOUBLE_CAST' => array(
+            '7.4'         => false,
+            'alternative' => '(float)',
+            'description' => 'real',
+        ),
     );
 
 
@@ -67,6 +72,12 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
     {
         $tokens    = $phpcsFile->getTokens();
         $tokenType = $tokens[$stackPtr]['type'];
+
+        // Special case `T_DOUBLE_CAST` as the same token is used for (float) and (double) casts.
+        if ($tokenType === 'T_DOUBLE_CAST' && strpos($tokens[$stackPtr]['content'], 'real') === false) {
+            // Float/double casts, not (real) cast.
+            return;
+        }
 
         $itemInfo = array(
             'name'        => $tokenType,

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.inc
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.inc
@@ -2,11 +2,16 @@
 
 // Some other type casts.
 (string) 1234;
-(real) '1.5';
+(float) '1.5';
 
-// Deprecated introduced type casts.
+// Deprecated unset type cast.
 (unset) $a;
 
 // Verify space & case independency.
 (	unset	) $a;
 ( Unset ) $a;
+
+// Deprecated real type cast.
+$a = (real) '1.5';
+$a = ( real ) '1.5';
+$a = (double) '1.5'; // Make sure this doesn't throw a false positive.

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
@@ -65,6 +65,7 @@ class RemovedTypeCastsUnitTest extends BaseSniffTest
     {
         return array(
             array('The unset cast', '7.2', 'unset()', array(8, 11, 12), '7.1'),
+            array('The real cast', '7.4', '(float)', array(15, 16), '7.3'),
         );
     }
 
@@ -96,6 +97,7 @@ class RemovedTypeCastsUnitTest extends BaseSniffTest
         return array(
             array(4),
             array(5),
+            array(17),
         );
     }
 


### PR DESCRIPTION
As of PHP 7.4, using the `(real)` type-cast will emit a deprecation notice.
This type-cast is expected to be removed in PHP 8.0.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#the_real_type
* https://github.com/php/php-src/pull/4390
* https://github.com/php/php-src/commit/e41b7f6db42472158fd44bb502ee1b8e51dca610

Related to #808