### PR TITLE
PHP 7.4/RemovedFunctions: handle removed functions from the Deprecations RFC

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -728,6 +728,10 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             'alternative' => null,
         ),
 
+        'is_real' => array(
+            '7.4' => false,
+            'alternative' => 'is_float()',
+        ),
         'ibase_add_user' => array(
             '7.4' => true,
             'alternative' => null,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -748,6 +748,10 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.4' => false,
             'alternative' => 'is_float()',
         ),
+        'money_format' => array(
+            '7.4' => false,
+            'alternative' => 'NumberFormatter::formatCurrency()',
+        ),
         'ibase_add_user' => array(
             '7.4' => true,
             'alternative' => null,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -732,6 +732,10 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.4' => false,
             'alternative' => 'mb_convert_encoding(), iconv() or UConverter',
         ),
+        'ezmlm_hash' => array(
+            '7.4' => false,
+            'alternative' => null,
+        ),
         'get_magic_quotes_gpc' => array(
             '7.4' => false,
             'alternative' => null,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -728,6 +728,10 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             'alternative' => null,
         ),
 
+        'convert_cyr_string' => array(
+            '7.4' => false,
+            'alternative' => 'mb_convert_encoding(), iconv() or UConverter',
+        ),
         'get_magic_quotes_gpc' => array(
             '7.4' => false,
             'alternative' => null,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -756,6 +756,10 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.4' => false,
             'alternative' => 'NumberFormatter::formatCurrency()',
         ),
+        'restore_include_path' => array(
+            '7.4' => false,
+            'alternative' => "ini_restore('include_path')",
+        ),
         'ibase_add_user' => array(
             '7.4' => true,
             'alternative' => null,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -736,6 +736,10 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.4' => false,
             'alternative' => null,
         ),
+        'hebrevc' => array(
+            '7.4' => false,
+            'alternative' => null,
+        ),
         'is_real' => array(
             '7.4' => false,
             'alternative' => 'is_float()',

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -728,6 +728,14 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             'alternative' => null,
         ),
 
+        'get_magic_quotes_gpc' => array(
+            '7.4' => false,
+            'alternative' => null,
+        ),
+        'get_magic_quotes_runtime' => array(
+            '7.4' => false,
+            'alternative' => null,
+        ),
         'is_real' => array(
             '7.4' => false,
             'alternative' => 'is_float()',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -242,4 +242,5 @@ get_magic_quotes_runtime();
 hebrevc($str));
 convert_cyr_string($str, 'k', 'i');
 money_format();
+ezmlm_hash();
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -240,3 +240,4 @@ is_real();
 get_magic_quotes_gpc();
 get_magic_quotes_runtime();
 hebrevc($str));
+convert_cyr_string($str, 'k', 'i');

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -236,3 +236,4 @@ ldap_control_paged_result();
 recode_file();
 recode_string();
 recode();
+is_real();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -237,3 +237,5 @@ recode_file();
 recode_string();
 recode();
 is_real();
+get_magic_quotes_gpc();
+get_magic_quotes_runtime();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -241,3 +241,5 @@ get_magic_quotes_gpc();
 get_magic_quotes_runtime();
 hebrevc($str));
 convert_cyr_string($str, 'k', 'i');
+money_format();
+

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -243,4 +243,5 @@ hebrevc($str));
 convert_cyr_string($str, 'k', 'i');
 money_format();
 ezmlm_hash();
+restore_include_path();
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -239,3 +239,4 @@ recode();
 is_real();
 get_magic_quotes_gpc();
 get_magic_quotes_runtime();
+hebrevc($str));

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -191,6 +191,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('convert_cyr_string', '7.4', 'mb_convert_encoding(), iconv() or UConverter', array(243), '7.3'),
             array('is_real', '7.4', 'is_float()', array(239), '7.3'),
             array('money_format', '7.4', 'NumberFormatter::formatCurrency()', array(244), '7.3'),
+            array('restore_include_path', '7.4', "ini_restore('include_path')", array(246), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
         );

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -68,6 +68,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('ldap_sort', '7.0', array(97), '5.6'),
             array('fgetss', '7.3', array(167), '7.2'),
             array('gzgetss', '7.3', array(168), '7.2'),
+            array('ezmlm_hash', '7.4', array(245), '7.3'),
             array('get_magic_quotes_gpc', '7.4', array(240), '7.3'),
             array('get_magic_quotes_runtime', '7.4', array(241), '7.3'),
             array('hebrevc', '7.4', array(242), '7.3'),

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -68,6 +68,8 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('ldap_sort', '7.0', array(97), '5.6'),
             array('fgetss', '7.3', array(167), '7.2'),
             array('gzgetss', '7.3', array(168), '7.2'),
+            array('get_magic_quotes_gpc', '7.4', array(240), '7.3'),
+            array('get_magic_quotes_runtime', '7.4', array(241), '7.3'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -70,6 +70,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('gzgetss', '7.3', array(168), '7.2'),
             array('get_magic_quotes_gpc', '7.4', array(240), '7.3'),
             array('get_magic_quotes_runtime', '7.4', array(241), '7.3'),
+            array('hebrevc', '7.4', array(242), '7.3'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -184,7 +184,8 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('mbereg_search_getpos', '7.3', 'mb_ereg_search_getpos()', array(165), '7.2'),
             array('mbereg_search_setpos', '7.3', 'mb_ereg_search_setpos()', array(166), '7.2'),
 
-            array('ldap_control_paged_result_response', '7.4', 'ldap_search()', array(234), '7.3'),
+            array('is_real', '7.4', 'is_float()', array(239), '7.3'),
+            array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
         );
     }

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -189,6 +189,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
 
             array('convert_cyr_string', '7.4', 'mb_convert_encoding(), iconv() or UConverter', array(243), '7.3'),
             array('is_real', '7.4', 'is_float()', array(239), '7.3'),
+            array('money_format', '7.4', 'NumberFormatter::formatCurrency()', array(244), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
         );

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -187,6 +187,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('mbereg_search_getpos', '7.3', 'mb_ereg_search_getpos()', array(165), '7.2'),
             array('mbereg_search_setpos', '7.3', 'mb_ereg_search_setpos()', array(166), '7.2'),
 
+            array('convert_cyr_string', '7.4', 'mb_convert_encoding(), iconv() or UConverter', array(243), '7.3'),
             array('is_real', '7.4', 'is_float()', array(239), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),


### PR DESCRIPTION
Related to #808

## PHP 7.4/RemovedFunctions: handle deprecated is_real()

As of PHP 7.4, the `is_real()` function is deprecated. Use `is_float()` instead.

This function is expected to be removed in PHP 8.0.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#the_real_type
* php/php-src#4390
* php/php-src@4e19069

## PHP 7.4/RemovedFunctions: handle deprecated magic quote related functions

>  PHP's infamous `magic_quotes` configuration was removed in PHP 5.4 and the function implementations of checking whether or not these settings have been enabled have returned `false` since then. With PHP 7.0 not having `magic_quotes` at all, it is time to deprecate these functions and remove them entirely.
>
> Proposal: Mark `get_magic_quotes_gpc()` and `get_magic_quotes_runtime()` as deprecated. This should only impact legacy code bases prior to PHP 5.4, running non-supported versions of PHP.

These functions are expected to be removed in PHP 8.0.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#magic_quotes_legacy
* php/php-src#4390
* php/php-src@b2ea507

## PHP 7.4/RemovedFunctions: handle deprecated hebrevc()

> The `hebrevc()` function is equivalent to calling `nl2br()` on the result of `hebrev()`, which is a function to convert Hebrew text from logical to visual ordering. While `nl2br(hebrev($str))` is already preferable over `hebrevc($str)` for readability reasons, use of visual ordering is only relevant in contexts that do not have proper Unicode bidi support, such as certain terminals. As detailed in W3C Visual vs. logical ordering of text, visual ordering should never be used for HTML. The `hebrevc()` function is an explicit violation of this principle.
>
> Proposal: Mark `hebrevc()` as deprecated.

This function is expected to be removed in PHP 8.0.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#hebrevc_function
* php/php-src#4390
* php/php-src@4e4d8a4

**Note**: While `nl2br(hebrev($str))` is equivalent, as visual ordering shouldn't be used in HTML and `nl2br()` is only useful in HTML contexts, this equivalent has _not_ been marked as a valid alternative.

## PHP 7.4/RemovedFunctions: handle deprecated convert_cyr_string()

> The `convert_cyr_string()` function allows conversion between Cyrillic character sets. The character sets are specified using obscure single character names, such as `convert_cyr_string($str, 'k', 'i')`. This is a legacy function from a time where PHP did not provide general functions for conversion between character sets. Nowadays one of `mb_convert_encoding()`, `iconv()` or `UConverter` may be used for this purpose.
>
> Proposal: Mark `convert_cyr_string()` as deprecated.

This function is expected to be removed in PHP 8.0.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#convert_cyr_string
* php/php-src#4390
* php/php-src@b3668aa

## PHP 7.4/RemovedFunctions: handle deprecated money_format()

> The `money_format()` function formats currency values using locale-specific settings. It is based on the `strfmon()` C function, which is not supported on all platforms. Most notably it is not available on Windows. Nowadays the `NumberFormatter::formatCurrency()` method provided by `intl` should be used instead, which is both platform-independent and does not rely on the system locale. Additionally, `intl` also provides the ability to parse currency values using `NumberFormatter::parseCurrency()`.
>
> Furthermore, the `strfmon()` implementation seems to have an internal buffer overrun on macos, which indicates that this functionality is not well tested.

This function is expected to be removed in PHP 8.0.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#money_format
* php/php-src#4390
* php/php-src@b1cdf06

## PHP 7.4/RemovedFunctions: handle deprecated ezmlm_hash()

> The `ezmlm_hash()` function creates hashes of email addresses which the EZMLM/QMail mailing list system understands. This function is of very limited usefulness for the average PHP developer as the EZMLM/QMail system is barely maintained and its last release was in 2007. The function was most likely originally added for use in the php.net mailing list infrastructure. It can be trivially reimplemented in userland code if needed.
>
> Proposal: Mark `ezmlm_hash()` as deprecated.

This function is expected to be removed in PHP 8.0.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#ezmlm_hash
* php/php-src#4390
* php/php-src@e9e2fa4

## PHP 7.4/RemovedFunctions: handle deprecated restore_include_path()

> This function is essentially an “alias” of doing `ini_restore('include_path')`. Unlike other functions like `restore_error_handler()` or `restore_exception_handler()`, this function does not operate on a stack and always resets to the original/initial value. While you can use `set_error_handler()` and `restore_error_handler()` as a pair, doing the same with `set_include_path() and `restore_include_path()` is not safe. As such, this function does not offer any benefit over `ini_restore('include_path')` and just causes wrong expectations.
>
> Proposal: Mark `restore_include_path()` as deprecated.

This function is expected to be removed in PHP 8.0.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#restore_include_path_function
* php/php-src#4390
* php/php-src@964de03