### PR TITLE
ForbiddenParametersWithSameName: bug fix - variables names are case-sensitive

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -72,7 +72,7 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
 
         $paramNames = array();
         foreach ($parameters as $param) {
-            $paramNames[] = strtolower($param['name']);
+            $paramNames[] = $param['name'];
         }
 
         if (\count($paramNames) !== \count(array_unique($paramNames))) {

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.inc
@@ -4,7 +4,9 @@ function foo($a, $b, $unused, $unused) { }
 
 function foobaz() {} // No parameters = no error.
 
-function ($a, $b, $unused, $unused) {} // Anonymous function with params of same name.
+function ($a, $b, $unused, $unused) {}; // Anonymous function with params of same name.
+
+function varsAreCaseSensitive( $a, $A ) {}
 
 // Don't throw errors during live code review.
 function foobar($a,$a

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
@@ -81,6 +81,7 @@ class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTest
     {
         return array(
             array(5),
+            array(9),
             array(10),
         );
     }


### PR DESCRIPTION
While it most definitely should be considered bad practice to use the same name in a different case for two different parameters for the same function, it is not problematic from a PHP/PHPCompatibility point of view.

Variables in PHP are _case-sensitive_, so should be treated as such for the purposes of this sniff.

See: https://3v4l.org/9QXAL

Looks like this bug has been in the sniff from the very beginning - #110 -, so in a way quite surprising that we've not had any bug reports about it.

Includes unit test.