### PR TITLE
Remove duplicate array entries

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -849,10 +849,6 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '5.4' => false,
             '5.5' => true,
         ),
-        'datefmt_get_calendar_object' => array(
-            '5.4' => false,
-            '5.5' => true,
-        ),
         'intlcal_create_instance' => array(
             '5.4' => false,
             '5.5' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -30,7 +30,6 @@ class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
      * @var array
      */
     protected $targetFunctions = array(
-        'preg_replace'                => true,
         'preg_filter'                 => true,
         'preg_grep'                   => true,
         'preg_match_all'              => true,


### PR DESCRIPTION
Both the `NewFunctions` sniff as well as the `NewPCREModifiers` sniff had an array which contained a duplicate entry.

Fixed now.