### PR TITLE
Sniff::getReturnTypeHintName(): defensive coding

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1016,7 +1016,7 @@ abstract class Sniff implements PHPCS_Sniff
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the return type token.
      *
-     * @return string|false The name of the return type token.
+     * @return string The name of the return type token.
      */
     public function getReturnTypeHintName(File $phpcsFile, $stackPtr)
     {
@@ -1028,7 +1028,7 @@ abstract class Sniff implements PHPCS_Sniff
             || ($tokens[$colon]['code'] !== \T_COLON && $tokens[$colon]['code'] !== \T_INLINE_ELSE)
         ) {
             // Shouldn't happen, just in case.
-            return;
+            return '';
         }
 
         $returnTypeHint = '';

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -805,7 +805,11 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      */
     private function processReturnTypeToken(File $phpcsFile, $stackPtr)
     {
-        $returnTypeHint   = $this->getReturnTypeHintName($phpcsFile, $stackPtr);
+        $returnTypeHint = $this->getReturnTypeHintName($phpcsFile, $stackPtr);
+        if (empty($returnTypeHint)) {
+            return;
+        }
+
         $returnTypeHint   = ltrim($returnTypeHint, '\\');
         $returnTypeHintLc = strtolower($returnTypeHint);
 

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -294,7 +294,11 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      */
     private function processReturnTypeToken(File $phpcsFile, $stackPtr)
     {
-        $returnTypeHint   = $this->getReturnTypeHintName($phpcsFile, $stackPtr);
+        $returnTypeHint = $this->getReturnTypeHintName($phpcsFile, $stackPtr);
+        if (empty($returnTypeHint)) {
+            return;
+        }
+
         $returnTypeHint   = ltrim($returnTypeHint, '\\');
         $returnTypeHintLc = strtolower($returnTypeHint);
 


### PR DESCRIPTION
Use a consistent return type and proper return value checking where the function is used.