### PR TITLE
NewArrayStringDereferencing: recognize dereferencing using curly braces

### DIFF
--- a/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.inc
@@ -1,9 +1,9 @@
 <?php
 
-// Array and string literal dereferencing.
+// PHP 5.5: Array and string literal dereferencing.
 echo array(1, 2, 3)[0];
 echo [1, 2, 3][0];
-echo [1, [20, 21, 22], 3][1][1]; // Multi-dimensional array - will give two errors in PHPCS < 2.8.2 / bug #1381.
+echo [1, [20, 21, 22], 3][1][1]; // Should give two errors.
 echo 'PHP'[0];
 echo "PHP"[0];
 
@@ -14,3 +14,15 @@ echo 'PHP';
 echo "P{$H}P"[0]; // Parse error.
 echo $array[0];
 echo $string[0];
+
+// PHP 7.0: Array and string literal dereferencing using curly braces.
+// This "silently" started working in PHP 7.0. See: https://3v4l.org/SlXd2
+echo array(1, 2, 3){0};
+echo [1, 2, 3]{0};
+echo [1, [20, 21, 22], 3]{1}{1}; // Should give two errors.
+echo 'PHP'{0};
+echo "PHP"{0};
+
+// Mixing access with square brackets and curly braces.
+echo [1, [20, 21, 22], 3][1]{1}; // Should give two errors (depending on supported PHP version).
+echo [1, [20, 21, 22], 3]{1}[1]; // Should give two errors (depending on supported PHP version).

--- a/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
@@ -29,15 +29,22 @@ class NewArrayStringDereferencingUnitTest extends BaseSniffTest
      *
      * @dataProvider dataArrayStringDereferencing
      *
-     * @param int    $line The line number.
-     * @param string $type Whether this is an array or string dereferencing.
+     * @param int    $line            The line number.
+     * @param string $type            Whether this is an array or string dereferencing.
+     * @param bool   $skipNoViolation Optional. Whether or not to test for no violation.
+     *                                Defaults to false.
      *
      * @return void
      */
-    public function testArrayStringDereferencing($line, $type)
+    public function testArrayStringDereferencing($line, $type, $skipNoViolation = false)
     {
         $file = $this->sniffFile(__FILE__, '5.4');
         $this->assertError($file, $line, "Direct array dereferencing of {$type} is not present in PHP version 5.4 or earlier");
+
+        if ($skipNoViolation === false) {
+            $file = $this->sniffFile(__FILE__, '5.5');
+            $this->assertNoViolation($file, $line);
+        }
     }
 
     /**
@@ -52,9 +59,48 @@ class NewArrayStringDereferencingUnitTest extends BaseSniffTest
         return array(
             array(4, 'arrays'),
             array(5, 'arrays'),
-            array(6, 'arrays'),
+            array(6, 'arrays'), // Error x 2.
             array(7, 'string literals'),
             array(8, 'string literals'),
+            array(27, 'arrays', true),
+            array(28, 'arrays', true),
+        );
+    }
+
+
+    /**
+     * testArrayStringDereferencingUsingCurlies
+     *
+     * @dataProvider dataArrayStringDereferencingUsingCurlies
+     *
+     * @param int    $line The line number.
+     * @param string $type Whether this is an array or string dereferencing.
+     *
+     * @return void
+     */
+    public function testArrayStringDereferencingUsingCurlies($line, $type)
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertError($file, $line, "Direct array dereferencing of {$type} using curly braces is not present in PHP version 5.6 or earlier");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testArrayStringDereferencingUsingCurlies()
+     *
+     * @return array
+     */
+    public function dataArrayStringDereferencingUsingCurlies()
+    {
+        return array(
+            array(20, 'arrays'),
+            array(21, 'arrays'),
+            array(22, 'arrays'), // Error x 2.
+            array(23, 'string literals'),
+            array(24, 'string literals'),
+            array(27, 'arrays'),
+            array(28, 'arrays'),
         );
     }
 
@@ -101,7 +147,7 @@ class NewArrayStringDereferencingUnitTest extends BaseSniffTest
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '5.5');
+        $file = $this->sniffFile(__FILE__, '7.0');
         $this->assertNoViolation($file);
     }
 }


### PR DESCRIPTION
What with PHP 7.4 deprecating the array dereferencing syntax with curly braces, I've been doing some research on where this was supported up to now.

Turns out that, as of PHP 7.0, dereferencing array/string literals using curly braces has been supported.
See: https://3v4l.org/SlXd2

While the PHP 7.0 changelog makes no note of this, the change was probably part of the PHP 7.0 [Uniform Variable Syntax](https://wiki.php.net/rfc/uniform_variable_syntax) changes.

This PR adjusts the `PHPCompatibility.Syntax.NewArrayStringDereferencing` sniff to:
* Also recognize curly braces.;
* Throw an error for each access detected, i.e. `[1, [20, 21, 22], 3][1][1]` would previously throw just the one error, now it will throw two.

Includes unit tests.

The actual logic has been split off to a separate `isArrayStringDereferencing()` method to allow it to be re-used for the upcoming sniff which will detect the PHP 7.4 curly brace deprecation.