### PR TITLE
NewClassMemberAccess: recognize member access using curly braces

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -17,17 +17,22 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff.
- *
  * PHP 5.4: Class member access on instantiation has been added, e.g. (new Foo)->bar().
  * PHP 7.0: Class member access on cloning has been added, e.g. (clone $foo)->bar().
+ *
+ * As of PHP 7.0, class member access on instantiation also works when using curly braces.
+ * While unclear, this most likely has to do with the Uniform Variable Syntax changes.
  *
  * PHP version 5.4
  * PHP version 7.0
  *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * @link https://wiki.php.net/rfc/instance-method-call
+ * @link https://wiki.php.net/rfc/uniform_variable_syntax
+ *
+ * @internal The reason for splitting the logic of this sniff into different methods is
+ *           to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.
+ *
+ * @since 9.3.0 Now also detects class member access on instantiation using curly braces.
  */
 class NewClassMemberAccessSniff extends Sniff
 {
@@ -56,45 +61,19 @@ class NewClassMemberAccessSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-
-        if ($tokens[$stackPtr]['code'] === \T_NEW && $this->supportsBelow('5.3') !== true) {
-            return;
-        } elseif ($tokens[$stackPtr]['code'] === \T_CLONE && $this->supportsBelow('5.6') !== true) {
+        if ($this->supportsBelow('5.6') === false) {
             return;
         }
 
-        if (isset($tokens[$stackPtr]['nested_parenthesis']) === false) {
-            // The `new className/clone $a` has to be in parentheses, without is not supported.
+        $pointers = $this->isClassMemberAccess($phpcsFile, $stackPtr);
+        if (empty($pointers)) {
             return;
         }
 
-        $parenthesisCloser = end($tokens[$stackPtr]['nested_parenthesis']);
-        $parenthesisOpener = key($tokens[$stackPtr]['nested_parenthesis']);
+        $tokens     = $phpcsFile->getTokens();
+        $supports53 = $this->supportsBelow('5.3');
 
-        if (isset($tokens[$parenthesisOpener]['parenthesis_owner']) === true) {
-            // If there is an owner, these parentheses are for a different purpose.
-            return;
-        }
-
-        $prevBeforeParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($parenthesisOpener - 1), null, true);
-        if ($prevBeforeParenthesis !== false && $tokens[$prevBeforeParenthesis]['code'] === \T_STRING) {
-            // This is most likely a function call with the new/cloned object as a parameter.
-            return;
-        }
-
-        $nextAfterParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, ($parenthesisCloser + 1), null, true);
-        if ($nextAfterParenthesis === false) {
-            // Live coding.
-            return;
-        }
-
-        if ($tokens[$nextAfterParenthesis]['code'] !== \T_OBJECT_OPERATOR
-            && $tokens[$nextAfterParenthesis]['code'] !== \T_OPEN_SQUARE_BRACKET
-        ) {
-            return;
-        }
-
+        $error     = 'Class member access on object %s was not supported in PHP %s or earlier';
         $data      = array('instantiation', '5.3');
         $errorCode = 'OnNewFound';
 
@@ -103,11 +82,103 @@ class NewClassMemberAccessSniff extends Sniff
             $errorCode = 'OnCloneFound';
         }
 
-        $phpcsFile->addError(
-            'Class member access on object %s was not supported in PHP %s or earlier',
-            $parenthesisCloser,
-            $errorCode,
-            $data
-        );
+        foreach ($pointers as $open => $close) {
+            $itemData      = $data;
+            $itemErrorCode = $errorCode;
+
+            if ($tokens[$stackPtr]['code'] === \T_NEW
+                && $tokens[$open]['code'] !== \T_OPEN_CURLY_BRACKET
+            ) {
+                if ($supports53 === true) {
+                    $phpcsFile->addError($error, $open, $itemErrorCode, $itemData);
+                }
+                continue;
+            }
+
+            if ($tokens[$stackPtr]['code'] === \T_NEW
+                && $tokens[$open]['code'] === \T_OPEN_CURLY_BRACKET
+            ) {
+                // Non-curlies was already handled above.
+                $itemData      = array('instantiation using curly braces', '5.6');
+                $itemErrorCode = 'OnNewFoundUsingCurlies';
+            }
+
+            $phpcsFile->addError($error, $open, $itemErrorCode, $itemData);
+        }
+    }
+
+
+    /**
+     * Check if the class being instantiated/cloned is being dereferenced.
+     *
+     * @since 9.3.0 Logic split off from the process method.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return array Array containing the stack pointers to the object operator or
+     *               the open/close braces involved in the class member access;
+     *               or an empty array if no class member access was detected.
+     */
+    public function isClassMemberAccess(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['nested_parenthesis']) === false) {
+            // The `new className/clone $a` has to be in parentheses, without is not supported.
+            return array();
+        }
+
+        $parenthesisCloser = end($tokens[$stackPtr]['nested_parenthesis']);
+        $parenthesisOpener = key($tokens[$stackPtr]['nested_parenthesis']);
+
+        if (isset($tokens[$parenthesisOpener]['parenthesis_owner']) === true) {
+            // If there is an owner, these parentheses are for a different purpose.
+            return array();
+        }
+
+        $prevBeforeParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($parenthesisOpener - 1), null, true);
+        if ($prevBeforeParenthesis !== false && $tokens[$prevBeforeParenthesis]['code'] === \T_STRING) {
+            // This is most likely a function call with the new/cloned object as a parameter.
+            return array();
+        }
+
+        $braces = array();
+        $end    = $parenthesisCloser;
+
+        do {
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true, null, true);
+            if ($nextNonEmpty === false) {
+                break;
+            }
+
+            if ($tokens[$nextNonEmpty]['code'] === \T_OBJECT_OPERATOR) {
+                // No need to walk any further if this is object access.
+                $braces[$nextNonEmpty] = true;
+                break;
+            }
+
+            if ($tokens[$nextNonEmpty]['code'] === \T_OPEN_SQUARE_BRACKET
+                || $tokens[$nextNonEmpty]['code'] === \T_OPEN_CURLY_BRACKET // PHP 7.0+.
+            ) {
+                if (isset($tokens[$nextNonEmpty]['bracket_closer']) === false) {
+                    // Live coding or parse error.
+                    break;
+                }
+
+                $braces[$nextNonEmpty] = $tokens[$nextNonEmpty]['bracket_closer'];
+
+                // Continue, just in case there is nested array access, i.e. `(new Foo())[1][0];`.
+                $end = $tokens[$nextNonEmpty]['bracket_closer'];
+                continue;
+            }
+
+            // If we're still here, we've reached the end.
+            break;
+
+        } while (true);
+
+        return $braces;
     }
 }

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.inc
@@ -42,7 +42,7 @@ try {
 (new $foo())->bar;
 (new foo)[0];
 
-$a = (new Foo( array(1, array(4, 5), 3) ))[1][0];
+$a = (new Foo( array(1, array(4, 5), 3) ))[1][0]; // Should give two errors.
 
 var_dump((new Bar)->y);
 $closure = function() {return (new $x)->y;};
@@ -103,3 +103,16 @@ $b = (clone $foo)->bar();
 echo (clone $iterable)[20];
 
 $date1 = (clone ($_date1 <= $_date2 ? $_date1 : $_date2))->format('Y');
+
+/*
+ * PHP 7.0: class member access on instantiation using curly braces.
+ * This "silently" started working in PHP 7.0. See: https://3v4l.org/KsEgH
+ */
+(new foo){0};
+$a = (new Foo( array(1, array(4, 5), 3) )){1}{0}; // Should give two errors.
+
+echo (clone $iterable){20};
+
+// Mixing access with square brackets and curly braces.
+$a = (new Foo( array(1, array(4, 5), 3) )){1}[0]; // Should give two errors (depending on supported PHP version).
+$a = (clone $iterable)[1]{0}; // Should give two errors (depending on supported PHP version).

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
@@ -29,14 +29,21 @@ class NewClassMemberAccessUnitTest extends BaseSniffTest
      *
      * @dataProvider dataNewClassMemberAccess
      *
-     * @param int $line The line number.
+     * @param int  $line            The line number.
+     * @param bool $skipNoViolation Optional. Whether or not to test for no violation.
+     *                              Defaults to false.
      *
      * @return void
      */
-    public function testNewClassMemberAccess($line)
+    public function testNewClassMemberAccess($line, $skipNoViolation = false)
     {
         $file = $this->sniffFile(__FILE__, '5.3');
         $this->assertError($file, $line, 'Class member access on object instantiation was not supported in PHP 5.3 or earlier');
+
+        if ($skipNoViolation === false) {
+            $file = $this->sniffFile(__FILE__, '5.4');
+            $this->assertNoViolation($file, $line);
+        }
     }
 
     /**
@@ -59,7 +66,7 @@ class NewClassMemberAccessUnitTest extends BaseSniffTest
             array(51),
             array(52),
             array(54),
-            array(57),
+            array(58),
             array(60),
             array(61),
             array(62),
@@ -68,11 +75,45 @@ class NewClassMemberAccessUnitTest extends BaseSniffTest
             array(76),
             array(79),
             array(82),
-            array(86),
+            array(87),
             array(91),
             array(96),
+            array(117, true),
         );
     }
+
+
+    /**
+     * testNewClassMemberAccessUsingCurlies
+     *
+     * @dataProvider dataNewClassMemberAccessUsingCurlies
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewClassMemberAccessUsingCurlies($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertError($file, $line, 'Class member access on object instantiation using curly braces was not supported in PHP 5.6 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewClassMemberAccessUsingCurlies()
+     *
+     * @return array
+     */
+    public function dataNewClassMemberAccessUsingCurlies()
+    {
+        return array(
+            array(111),
+            array(112), // Error x 2.
+            array(117),
+        );
+    }
+
 
     /**
      * testCloneClassMemberAccess
@@ -102,6 +143,8 @@ class NewClassMemberAccessUnitTest extends BaseSniffTest
             array(101),
             array(103),
             array(105),
+            array(114),
+            array(118), // Error x 2.
         );
     }
 


### PR DESCRIPTION
What with PHP 7.4 deprecating the array dereferencing syntax with curly braces, I've been doing some research on where this was supported up to now.

Turns out that, as of PHP 7.0, dereferencing class member access on instantiation using curly braces has been supported.
See: https://3v4l.org/KsEgH

While the PHP 7.0 changelog makes no note of this, the change was probably part of the PHP 7.0 [Uniform Variable Syntax](https://wiki.php.net/rfc/uniform_variable_syntax) changes.

This PR adjusts the `PHPCompatibility.Syntax.NewClassMemberAcces` sniff to:
* Also recognize curly braces.;
* Throw an error for each access detected, i.e. `(new Foo( array(1, array(4, 5), 3) ))[1][0]` would previously throw just the one error, now it will throw two.
* Throw the error on the token used for the access, not on the closing parenthesis of the parentheses wrappers.

Includes unit tests.

Note: no changes are made regarding class member access on `clone` as this only came into PHP in PHP 7.0, so both square brackets as well as curlies have been supported from the introduction of the feature. See: https://3v4l.org/fl7L9

The actual logic has been split off to a separate `isClassMemberAccess()` method to allow it to be re-used for the upcoming sniff which will detect the PHP 7.4 curly brace deprecation.