### PR TITLE
NewFunctionArrayDereferencing: recognize function array dereferencing using curly braces

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -16,13 +16,21 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff.
+ * PHP 5.4 supports direct array dereferencing on the return of a method/function call.
+ *
+ * As of PHP 7.0, this also works when using curly braces for the dereferencing.
+ * While unclear, this most likely has to do with the Uniform Variable Syntax changes.
  *
  * PHP version 5.4
+ * PHP version 7.0
  *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
+ * @link https://wiki.php.net/rfc/functionarraydereferencing
+ * @link https://wiki.php.net/rfc/uniform_variable_syntax
+ *
+ * @internal The reason for splitting the logic of this sniff into different methods is
+ *           to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.
+ *
+ * @since 9.3.0 Now also detects dereferencing using curly braces.
  */
 class NewFunctionArrayDereferencingSniff extends Sniff
 {
@@ -47,26 +55,81 @@ class NewFunctionArrayDereferencingSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.3') === false) {
+        if ($this->supportsBelow('5.6') === false) {
             return;
         }
 
+        $dereferencing = $this->isFunctionArrayDereferencing($phpcsFile, $stackPtr);
+        if (empty($dereferencing)) {
+            return;
+        }
+
+        $tokens     = $phpcsFile->getTokens();
+        $supports53 = $this->supportsBelow('5.3');
+
+        foreach ($dereferencing as $openBrace => $closeBrace) {
+            if ($supports53 === true
+                && $tokens[$openBrace]['type'] === 'T_OPEN_SQUARE_BRACKET'
+            ) {
+                $phpcsFile->addError(
+                    'Function array dereferencing is not present in PHP version 5.3 or earlier',
+                    $openBrace,
+                    'Found'
+                );
+
+                continue;
+            }
+
+            // PHP 7.0 function array dereferencing using curly braces.
+            if ($tokens[$openBrace]['type'] === 'T_OPEN_CURLY_BRACKET') {
+                $phpcsFile->addError(
+                    'Function array dereferencing using curly braces is not present in PHP version 5.6 or earlier',
+                    $openBrace,
+                    'FoundUsingCurlies'
+                );
+            }
+        }
+    }
+
+
+    /**
+     * Check if the return of a function/method call is being dereferenced.
+     *
+     * @since 9.3.0 Logic split off from the process method.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return array Array containing stack pointers to the open/close braces
+     *               involved in the function dereferencing;
+     *               or an empty array if no function dereferencing was detected.
+     */
+    public function isFunctionArrayDereferencing(File $phpcsFile, $stackPtr)
+    {
         $tokens = $phpcsFile->getTokens();
 
         // Next non-empty token should be the open parenthesis.
         $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
         if ($openParenthesis === false || $tokens[$openParenthesis]['code'] !== \T_OPEN_PARENTHESIS) {
-            return;
+            return array();
         }
 
         // Don't throw errors during live coding.
         if (isset($tokens[$openParenthesis]['parenthesis_closer']) === false) {
-            return;
+            return array();
         }
 
         // Is this T_STRING really a function or method call ?
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($prevToken !== false && \in_array($tokens[$prevToken]['code'], array(\T_DOUBLE_COLON, \T_OBJECT_OPERATOR), true) === false) {
+        if ($prevToken !== false
+            && \in_array($tokens[$prevToken]['code'], array(\T_DOUBLE_COLON, \T_OBJECT_OPERATOR), true) === false
+        ) {
+            if ($tokens[$prevToken]['code'] === \T_BITWISE_AND) {
+                // This may be a function declared by reference.
+                $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
+            }
+
             $ignore = array(
                 \T_FUNCTION  => true,
                 \T_CONST     => true,
@@ -78,18 +141,39 @@ class NewFunctionArrayDereferencingSniff extends Sniff
 
             if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
                 // Not a call to a PHP function or method.
-                return;
+                return array();
             }
         }
 
-        $closeParenthesis = $tokens[$openParenthesis]['parenthesis_closer'];
-        $nextNonEmpty     = $phpcsFile->findNext(Tokens::$emptyTokens, ($closeParenthesis + 1), null, true, null, true);
-        if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['type'] === 'T_OPEN_SQUARE_BRACKET') {
-            $phpcsFile->addError(
-                'Function array dereferencing is not present in PHP version 5.3 or earlier',
-                $nextNonEmpty,
-                'Found'
-            );
-        }
+        $current = $tokens[$openParenthesis]['parenthesis_closer'];
+        $braces  = array();
+
+        do {
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), null, true, null, true);
+            if ($nextNonEmpty === false) {
+                break;
+            }
+
+            if ($tokens[$nextNonEmpty]['type'] === 'T_OPEN_SQUARE_BRACKET'
+                || $tokens[$nextNonEmpty]['type'] === 'T_OPEN_CURLY_BRACKET' // PHP 7.0+.
+            ) {
+                if (isset($tokens[$nextNonEmpty]['bracket_closer']) === false) {
+                    // Live coding or parse error.
+                    break;
+                }
+
+                $braces[$nextNonEmpty] = $tokens[$nextNonEmpty]['bracket_closer'];
+
+                // Continue, just in case there is nested array access, i.e. `echo $foo->bar()[0][2];`.
+                $current = $tokens[$nextNonEmpty]['bracket_closer'];
+                continue;
+            }
+
+            // If we're still here, we've reached the end of the function call.
+            break;
+
+        } while (true);
+
+        return $braces;
     }
 }

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.inc
@@ -15,5 +15,23 @@ echo $foo->bar()[1];
 echo $foo->bar()->baz()[2];
 echo testClass::another_test()[0];
 
+/*
+ * PHP 7.0: function array dereferencing using curly braces.
+ * This "silently" started working in PHP 7.0. See: https://3v4l.org/a1TW6
+ */
+echo test(){0};
+echo $foo->bar(){1};
+echo $foo->bar()->baz(){2};
+echo testClass::another_test(){0};
+
+// Mixing access with square brackets and curly braces.
+echo $foo->bar()->baz()[0]{2}; // Should give two errors (depending on supported PHP version).
+echo $foo->bar()->baz(){0}[2]; // Should give two errors (depending on supported PHP version).
+
+// Prevent curly braces false positive on function declared by reference.
+function &test() {
+	echo '123';
+}
+
 // Don't throw errors during live code review.
 echo test(

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
@@ -29,14 +29,21 @@ class NewFunctionArrayDereferencingUnitTest extends BaseSniffTest
      *
      * @dataProvider dataArrayDereferencing
      *
-     * @param int $line Line number with valid code.
+     * @param int  $line            The line number.
+     * @param bool $skipNoViolation Optional. Whether or not to test for no violation.
+     *                              Defaults to false.
      *
      * @return void
      */
-    public function testArrayDereferencing($line)
+    public function testArrayDereferencing($line, $skipNoViolation = false)
     {
         $file = $this->sniffFile(__FILE__, '5.3');
         $this->assertError($file, $line, 'Function array dereferencing is not present in PHP version 5.3 or earlier');
+
+        if ($skipNoViolation === false) {
+            $file = $this->sniffFile(__FILE__, '5.4');
+            $this->assertNoViolation($file, $line);
+        }
     }
 
     /**
@@ -53,6 +60,43 @@ class NewFunctionArrayDereferencingUnitTest extends BaseSniffTest
             array(14),
             array(15),
             array(16),
+            array(28, true),
+            array(29, true),
+        );
+    }
+
+
+    /**
+     * testArrayDereferencingUsingCurlies
+     *
+     * @dataProvider dataArrayDereferencingUsingCurlies
+     *
+     * @param int $line Line number with valid code.
+     *
+     * @return void
+     */
+    public function testArrayDereferencingUsingCurlies($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertError($file, $line, 'Function array dereferencing using curly braces is not present in PHP version 5.6 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testArrayDereferencingUsingCurlies()
+     *
+     * @return array
+     */
+    public function dataArrayDereferencingUsingCurlies()
+    {
+        return array(
+            array(22),
+            array(23),
+            array(24),
+            array(25),
+            array(28),
+            array(29),
         );
     }
 
@@ -87,7 +131,8 @@ class NewFunctionArrayDereferencingUnitTest extends BaseSniffTest
             array(9),
             array(10),
             array(11),
-            array(19),
+            array(32),
+            array(37),
         );
     }
 
@@ -99,7 +144,7 @@ class NewFunctionArrayDereferencingUnitTest extends BaseSniffTest
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '5.4');
+        $file = $this->sniffFile(__FILE__, '7.0');
         $this->assertNoViolation($file);
     }
 }


### PR DESCRIPTION
What with PHP 7.4 deprecating the array dereferencing syntax with curly braces, I've been doing some research on where this was supported up to now.

Turns out that, as of PHP 7.0, function array dereferencing using curly braces has been supported.
See: https://3v4l.org/a1TW6

While the PHP 7.0 changelog makes no note of this, the change was probably part of the PHP 7.0 [Uniform Variable Syntax](https://wiki.php.net/rfc/uniform_variable_syntax) changes.

This PR adjusts the `PHPCompatibility.Syntax.NewFunctionArrayDereferencing` sniff to:
* Also recognize curly braces.;
* Throw an error for each access detected, i.e. `$foo->bar()[1][0]` would previously throw just the one error, now it will throw two.
* Throw the error on the token used for the access, not on the closing parenthesis of the function call.

Includes unit tests.

The actual logic has been split off to a separate `isFunctionArrayDereferencing()` method to allow it to be re-used for the upcoming sniff which will detect the PHP 7.4 curly brace deprecation.