### PR TITLE
PHP 7.4: New RemovedCurlyBraceArrayAccess sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -1,0 +1,361 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Syntax;
+
+use PHPCompatibility\Sniff;
+use PHPCompatibility\Sniffs\Syntax\NewArrayStringDereferencingSniff;
+use PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff;
+use PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Using the curly brace syntax to access array or string offsets has been deprecated in PHP 7.4.
+ *
+ * @link https://wiki.php.net/rfc/deprecate_curly_braces_array_access
+ *
+ * PHP version 7.4
+ *
+ * @since 9.3.0
+ */
+class RemovedCurlyBraceArrayAccessSniff extends Sniff
+{
+
+    /**
+     * Instance of the NewArrayStringDereferencing sniff.
+     *
+     * @since 9.3.0
+     *
+     * @var \PHPCompatibility\Sniffs\Syntax\NewArrayStringDereferencingSniff
+     */
+    private $newArrayStringDereferencing;
+
+    /**
+     * Target tokens as register by the NewArrayStringDereferencing sniff.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    private $newArrayStringDereferencingTargets;
+
+    /**
+     * Instance of the NewClassMemberAccess sniff.
+     *
+     * @since 9.3.0
+     *
+     * @var \PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff
+     */
+    private $newClassMemberAccess;
+
+    /**
+     * Target tokens as register by the NewClassMemberAccess sniff.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    private $newClassMemberAccessTargets;
+
+    /**
+     * Instance of the NewFunctionArrayDereferencing sniff.
+     *
+     * @since 9.3.0
+     *
+     * @var \PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff
+     */
+    private $newFunctionArrayDereferencing;
+
+    /**
+     * Target tokens as register by the NewFunctionArrayDereferencing sniff.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    private $newFunctionArrayDereferencingTargets;
+
+
+    /**
+     * Constructor.
+     *
+     * @since 9.3.0
+     */
+    public function __construct()
+    {
+        $this->newArrayStringDereferencing   = new NewArrayStringDereferencingSniff();
+        $this->newClassMemberAccess          = new NewClassMemberAccessSniff();
+        $this->newFunctionArrayDereferencing = new NewFunctionArrayDereferencingSniff();
+    }
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.3.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $targets = array(
+            array(
+                \T_VARIABLE,
+                \T_STRING, // Constants.
+            ),
+        );
+
+        // Registers T_ARRAY, T_OPEN_SHORT_ARRAY and T_CONSTANT_ENCAPSED_STRING.
+        $additionalTargets                        = $this->newArrayStringDereferencing->register();
+        $this->newArrayStringDereferencingTargets = array_flip($additionalTargets);
+        $targets[] = $additionalTargets;
+
+        // Registers T_NEW and T_CLONE.
+        $additionalTargets                 = $this->newClassMemberAccess->register();
+        $this->newClassMemberAccessTargets = array_flip($additionalTargets);
+        $targets[]                         = $additionalTargets;
+
+        // Registers T_STRING.
+        $additionalTargets = $this->newFunctionArrayDereferencing->register();
+        $this->newFunctionArrayDereferencingTargets = array_flip($additionalTargets);
+        $targets[] = $additionalTargets;
+
+        return call_user_func_array('array_merge', $targets);
+    }
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $braces = array();
+
+        // Note: Overwriting braces in each `if` is fine as only one will match anyway.
+        if ($tokens[$stackPtr]['code'] === \T_VARIABLE) {
+            $braces = $this->isVariableArrayAccess($phpcsFile, $stackPtr);
+        }
+
+        if (isset($this->newArrayStringDereferencingTargets[$tokens[$stackPtr]['code']])) {
+            $dereferencing = $this->newArrayStringDereferencing->isArrayStringDereferencing($phpcsFile, $stackPtr);
+            if (isset($dereferencing['braces'])) {
+                $braces = $dereferencing['braces'];
+            }
+        }
+
+        if (isset($this->newClassMemberAccessTargets[$tokens[$stackPtr]['code']])) {
+            $braces = $this->newClassMemberAccess->isClassMemberAccess($phpcsFile, $stackPtr);
+        }
+
+        if (isset($this->newFunctionArrayDereferencingTargets[$tokens[$stackPtr]['code']])) {
+            $braces = $this->newFunctionArrayDereferencing->isFunctionArrayDereferencing($phpcsFile, $stackPtr);
+        }
+
+        if (empty($braces) && $tokens[$stackPtr]['code'] === \T_STRING) {
+            $braces = $this->isConstantArrayAccess($phpcsFile, $stackPtr);
+        }
+
+        if (empty($braces)) {
+            return;
+        }
+
+        foreach ($braces as $open => $close) {
+            // Some of the functions will sniff for both curlies as well as square braces.
+            if ($tokens[$open]['code'] !== \T_OPEN_CURLY_BRACKET) {
+                continue;
+            }
+
+            // Make sure there is something between the braces, otherwise it's still not curly brace array access.
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($open + 1), $close, true);
+            if ($nextNonEmpty === false) {
+                // Nothing between the brackets. Parse error. Ignore.
+                continue;
+            }
+
+            // OK, so we've found curly brace array access.
+            $snippet = $phpcsFile->getTokensAsString($stackPtr, (($close - $stackPtr) + 1));
+            $fix     = $phpcsFile->addFixableWarning(
+                'Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4. Found: %s',
+                $open,
+                'Found',
+                array($snippet)
+            );
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->replaceToken($open, '[');
+                $phpcsFile->fixer->replaceToken($close, ']');
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+    }
+
+
+    /**
+     * Determine whether a variable is being dereferenced using curly brace syntax.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return array An array with the stack pointers to the open/close braces of
+     *               the curly brace array access, or an empty array if no curly
+     *               brace array access was detected.
+     */
+    protected function isVariableArrayAccess(File $phpcsFile, $stackPtr)
+    {
+        $tokens  = $phpcsFile->getTokens();
+        $current = $stackPtr;
+        $braces  = array();
+
+        do {
+            $current = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), null, true);
+            if ($current === false) {
+                break;
+            }
+
+            // Skip over square bracket array access. Bracket styles can be mixed.
+            if ($tokens[$current]['code'] === \T_OPEN_SQUARE_BRACKET
+                && isset($tokens[$current]['bracket_closer']) === true
+                && $current === $tokens[$current]['bracket_opener']
+            ) {
+                $current = $tokens[$current]['bracket_closer'];
+                continue;
+            }
+
+            // Handle property access.
+            if ($tokens[$current]['code'] === \T_OBJECT_OPERATOR) {
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), null, true);
+                if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_STRING) {
+                    // Live coding or parse error.
+                    break;
+                }
+
+                $current = $nextNonEmpty;
+                continue;
+            }
+
+            if ($tokens[$current]['code'] === \T_OPEN_CURLY_BRACKET) {
+                if (isset($tokens[$current]['bracket_closer']) === false) {
+                    // Live coding or parse error.
+                    break;
+                }
+
+                $braces[$current] = $tokens[$current]['bracket_closer'];
+
+                // Continue, just in case there is nested access using curly braces, i.e. `$a{$i}{$j};`.
+                $current = $tokens[$current]['bracket_closer'];
+                continue;
+            }
+
+            // If we're still here, we've reached the end of the variable.
+            break;
+
+        } while (true);
+
+        return $braces;
+    }
+
+
+    /**
+     * Determine whether a T_STRING is a constant being dereferenced using curly brace syntax.
+     *
+     * @internal Note: the first braces for array access to a constant, for some unknown reason,
+     *           can never be curlies, but have to be square brackets.
+     *           Subsequent braces can be curlies.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return array An array with the stack pointers to the open/close braces of
+     *               the curly brace array access, or an empty array if no curly
+     *               brace array access was detected.
+     */
+    protected function isConstantArrayAccess(File $phpcsFile, $stackPtr)
+    {
+        $tokens       = $phpcsFile->getTokens();
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+        if ($this->isUseOfGlobalConstant($phpcsFile, $stackPtr) === false
+            && $tokens[$prevNonEmpty]['code'] !== \T_DOUBLE_COLON // Class constant access.
+        ) {
+            return array();
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
+            return array();
+        }
+
+        if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_SQUARE_BRACKET
+            || isset($tokens[$nextNonEmpty]['bracket_closer']) === false
+        ) {
+            // Array access for constants must start with square brackets.
+            return array();
+        }
+
+        $current = $tokens[$nextNonEmpty]['bracket_closer'];
+        $braces  = array();
+
+        do {
+            $current = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), null, true);
+            if ($current === false) {
+                break;
+            }
+
+            // Skip over square bracket array access. Bracket styles can be mixed.
+            if ($tokens[$current]['code'] === \T_OPEN_SQUARE_BRACKET
+                && isset($tokens[$current]['bracket_closer']) === true
+                && $current === $tokens[$current]['bracket_opener']
+            ) {
+                $current = $tokens[$current]['bracket_closer'];
+                continue;
+            }
+
+            if ($tokens[$current]['code'] === \T_OPEN_CURLY_BRACKET) {
+                if (isset($tokens[$current]['bracket_closer']) === false) {
+                    // Live coding or parse error.
+                    break;
+                }
+
+                $braces[$current] = $tokens[$current]['bracket_closer'];
+
+                // Continue, just in case there is nested access using curly braces, i.e. `$a{$i}{$j};`.
+                $current = $tokens[$current]['bracket_closer'];
+                continue;
+            }
+
+            // If we're still here, we've reached the end of the variable.
+            break;
+
+        } while (true);
+
+        return $braces;
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This is fine cross-version.
+ */
+echo $array[1]; // prints 2
+echo $string[0]; // prints "f"
+
+echo $array[$i];
+echo $array[$i + 1];
+echo $array[++$i];
+
+echo $array['a'][0];
+
+class Foo {
+    public function bar() {
+        echo $this->array_num[0],PHP_EOL;
+        echo self::$array_ass['a'],PHP_EOL;
+        echo static::CSTRING[1],PHP_EOL;
+    }
+}
+
+echo $obj->array_num[0],PHP_EOL;
+echo Foo::$array_ass['a'],PHP_EOL;
+echo Foo::CSTRING[1],PHP_EOL;
+
+
+/*
+ * Parse errors, not our concern.
+ */
+$array{} = 3; // Parse error: syntax error, unexpected '}'
+$array{ /*comment*/ } = 3; // Parse error: syntax error, unexpected '}'
+$array = {1, 2}; // Parse error: syntax error, unexpected '{'
+{$one, $two} = $array; // Parse error: syntax error, unexpected ','
+
+
+/*
+ * Some alternative uses of curlies which shouldn't generate false positives.
+ */
+echo ${$var};
+echo ${$var['key1']['key2']};
+echo $obj->{$var['key']};
+echo $obj->{$var['key']}();
+echo myClass::{$var['key']}();
+echo myClass::{$var['key1']['key2']['key3']}();
+class Foo {}
+if ($var['a']) {}
+
+
+/*
+ * PHP 7.4: deprecated curly brace array access syntax.
+ */
+echo $array{1};
+echo $string{0};
+
+echo $array{$i};
+echo $array{$i + 1};
+echo $array{++$i};
+
+echo $array{'a'}{0}; // Error x 2.
+
+// Combining both accesses types.
+echo $array[0]{0};
+echo $array{0}[0];
+echo myClass::{$var['key1']{'key2'}{'key3'}}(); // Error x 2.
+
+// Check code style independence.
+echo $array{ /*comment */ $i}[0];
+echo $array[$i] /* comment */ {0};
+
+echo $array /*comment*/ {'a'}[0];
+echo $array
+	['a']
+	{0};
+
+// Also applies to properties and constants.
+class Foo {
+    public function bar() {
+        echo $this->array_num{1}, PHP_EOL;
+        echo self::$array_ass{'b'}, PHP_EOL;
+    }
+}
+
+echo $obj->array_num{1}, PHP_EOL;
+echo Foo::$array_ass{'b'}, PHP_EOL;
+
+/*
+ * Additional tests based on tests found in the merged PHP Core PR.
+ */
+const D_1 = null ?? A[1]{'undefined'}['index'] ?? 1;
+const D_2 = null ?? A['undefined']{'index'} ?? 2;
+const D_3 = null ?? A[1]{0}{2} ?? 3; // Error x 2.
+const D_4 = A[1]{0} ?? 4;
+
+echo self::MY_CONST[0]{1};
+echo $this->MY_CONST[0]{1};
+
+isset($string{"foo"}{"bar"}); // Error x 2.
+$str{-strlen($str)} = strtoupper($str{0}); // Error x 2.
+$ret['requestId']   = (ord($data{2}) << 8) + ord($data{3}); // Error x 2.
+
+/*
+ * Array and string literal dereferencing using curly braces.
+ */
+echo array(1, 2, 3){0};
+echo [1, 2, 3]{0};
+echo [1, [20, 21, 22], 3]{1}{1}; // Error x 2.
+echo 'PHP'{0};
+echo "PHP"{0};
+const FOO_DEPRECATED = "BAR"{0};
+
+/*
+ * Class member access on instantiation/cloning using curly braces.
+ */
+(new foo){0};
+$a = (new Foo( array(1, array(4, 5), 3) )){1}{0}; // Error x 2.
+echo (clone $iterable){20};
+
+// Mixing access with square brackets and curly braces.
+$a = (new Foo( array(1, array(4, 5), 3) )){1}[0];
+$a = (clone $iterable)[1]{0};
+
+/*
+ * Function array dereferencing using curly braces.
+ */
+echo test(){0};
+echo $foo->bar(){1}{0}; // Error x 2.
+echo $foo->bar()->baz(){2};
+echo testClass::another_test(){0};
+
+// Mixing access with square brackets and curly braces.
+echo $foo->bar()->baz()[0]{2};
+echo $foo->bar()->baz(){0}[2];
+
+/* Live coding. Intentional parse error. This has to be the last test in the file. */
+$a = $b[0] + $c['something']{

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This is fine cross-version.
+ */
+echo $array[1]; // prints 2
+echo $string[0]; // prints "f"
+
+echo $array[$i];
+echo $array[$i + 1];
+echo $array[++$i];
+
+echo $array['a'][0];
+
+class Foo {
+    public function bar() {
+        echo $this->array_num[0],PHP_EOL;
+        echo self::$array_ass['a'],PHP_EOL;
+        echo static::CSTRING[1],PHP_EOL;
+    }
+}
+
+echo $obj->array_num[0],PHP_EOL;
+echo Foo::$array_ass['a'],PHP_EOL;
+echo Foo::CSTRING[1],PHP_EOL;
+
+
+/*
+ * Parse errors, not our concern.
+ */
+$array{} = 3; // Parse error: syntax error, unexpected '}'
+$array{ /*comment*/ } = 3; // Parse error: syntax error, unexpected '}'
+$array = {1, 2}; // Parse error: syntax error, unexpected '{'
+{$one, $two} = $array; // Parse error: syntax error, unexpected ','
+
+
+/*
+ * Some alternative uses of curlies which shouldn't generate false positives.
+ */
+echo ${$var};
+echo ${$var['key1']['key2']};
+echo $obj->{$var['key']};
+echo $obj->{$var['key']}();
+echo myClass::{$var['key']}();
+echo myClass::{$var['key1']['key2']['key3']}();
+class Foo {}
+if ($var['a']) {}
+
+
+/*
+ * PHP 7.4: deprecated curly brace array access syntax.
+ */
+echo $array[1];
+echo $string[0];
+
+echo $array[$i];
+echo $array[$i + 1];
+echo $array[++$i];
+
+echo $array['a'][0]; // Error x 2.
+
+// Combining both accesses types.
+echo $array[0][0];
+echo $array[0][0];
+echo myClass::{$var['key1']['key2']['key3']}(); // Error x 2.
+
+// Check code style independence.
+echo $array[ /*comment */ $i][0];
+echo $array[$i] /* comment */ [0];
+
+echo $array /*comment*/ ['a'][0];
+echo $array
+	['a']
+	[0];
+
+// Also applies to properties and constants.
+class Foo {
+    public function bar() {
+        echo $this->array_num[1], PHP_EOL;
+        echo self::$array_ass['b'], PHP_EOL;
+    }
+}
+
+echo $obj->array_num[1], PHP_EOL;
+echo Foo::$array_ass['b'], PHP_EOL;
+
+/*
+ * Additional tests based on tests found in the merged PHP Core PR.
+ */
+const D_1 = null ?? A[1]['undefined']['index'] ?? 1;
+const D_2 = null ?? A['undefined']['index'] ?? 2;
+const D_3 = null ?? A[1][0][2] ?? 3; // Error x 2.
+const D_4 = A[1][0] ?? 4;
+
+echo self::MY_CONST[0][1];
+echo $this->MY_CONST[0][1];
+
+isset($string["foo"]["bar"]); // Error x 2.
+$str[-strlen($str)] = strtoupper($str[0]); // Error x 2.
+$ret['requestId']   = (ord($data[2]) << 8) + ord($data[3]); // Error x 2.
+
+/*
+ * Array and string literal dereferencing using curly braces.
+ */
+echo array(1, 2, 3)[0];
+echo [1, 2, 3][0];
+echo [1, [20, 21, 22], 3][1][1]; // Error x 2.
+echo 'PHP'[0];
+echo "PHP"[0];
+const FOO_DEPRECATED = "BAR"[0];
+
+/*
+ * Class member access on instantiation/cloning using curly braces.
+ */
+(new foo)[0];
+$a = (new Foo( array(1, array(4, 5), 3) ))[1][0]; // Error x 2.
+echo (clone $iterable)[20];
+
+// Mixing access with square brackets and curly braces.
+$a = (new Foo( array(1, array(4, 5), 3) ))[1][0];
+$a = (clone $iterable)[1][0];
+
+/*
+ * Function array dereferencing using curly braces.
+ */
+echo test()[0];
+echo $foo->bar()[1][0]; // Error x 2.
+echo $foo->bar()->baz()[2];
+echo testClass::another_test()[0];
+
+// Mixing access with square brackets and curly braces.
+echo $foo->bar()->baz()[0][2];
+echo $foo->bar()->baz()[0][2];
+
+/* Live coding. Intentional parse error. This has to be the last test in the file. */
+$a = $b[0] + $c['something']{

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Removed curly brace syntax for array access sniff tests.
+ *
+ * @group removedCurlyBraceArrayAccess
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\RemovedCurlyBraceArrayAccessSniff
+ *
+ * @since 9.3.0
+ */
+class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testRemovedCurlyBraceArrayAccess
+     *
+     * @dataProvider dataRemovedCurlyBraceArrayAccess
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testRemovedCurlyBraceArrayAccess($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertWarning($file, $line, 'Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedCurlyBraceArrayAccess()
+     *
+     * @return array
+     */
+    public function dataRemovedCurlyBraceArrayAccess()
+    {
+        return array(
+            array(53),
+            array(54),
+            array(56),
+            array(57),
+            array(58),
+            array(60), // x2.
+            array(63),
+            array(64),
+            array(65), // x2.
+            array(68),
+            array(69),
+            array(71),
+            array(74),
+            array(79),
+            array(80),
+            array(84),
+            array(85),
+            array(90),
+            array(91),
+            array(92), // x2.
+            array(93),
+            array(95),
+            array(96),
+            array(98), // x2.
+            array(99), // x2.
+            array(100), // x2.
+            array(105),
+            array(106),
+            array(107), // x2.
+            array(108),
+            array(109),
+            array(110),
+            array(115),
+            array(116), // x2.
+            array(117),
+            array(120),
+            array(121),
+            array(126),
+            array(127), // x2.
+            array(128),
+            array(129),
+            array(132),
+            array(133),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+
+        // No errors expected on the first 49 lines.
+        for ($line = 1; $line <= 49; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        // ...and on the last few lines.
+        for ($line = 135; $line <= 137; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> The array and string offset access syntax using curly braces is deprecated.
> Use $str[$idx] instead of $str{$idx}.

Refs:
* https://wiki.php.net/rfc/deprecate_curly_braces_array_access
* https://github.com/php/php-src/blob/ef165b4422f4cef60f963833dddffa26fe1b2759/UPGRADING#L351-L353
* https://github.com/php/php-src/pull/4416
* https://github.com/php/php-src/commit/d574df63dc375f5fc9202ce5afde23f866b6450a

## Implementation notes

Based on a lot of testing, I have come to the conclusion that the curly braces for array access worked in quite a lot of cases, though mostly since PHP 7.0.

The other sniffs which should take curly brace access into account - `NewArrayStringDereferencing`, `NewClassMemberAccess` and `NewFunctionArrayDereferencing` - have been adjusted in separate PRs. See: #851, #852, #853

This PR can only be merged after those PRs have been merged as it re-uses logic from those sniffs.

### Other tests

Based on the above mentioned tests, I also found that - yes, curly brace array access is supported on constants, but only when the first set of braces is square brackets.
See:
* https://3v4l.org/WIUHk
* https://3v4l.org/OWSq6
* https://3v4l.org/e6YWk

## Auto-fixing

In contrast to any other PHPCompatibility sniff, this sniff contains an auto-fixer.

For larger codebases, this issue can be quite time-consuming to fix, while fixing this automatically is trivial.

This also makes this sniff a fully fledged alternative to the [migration script](https://gist.github.com/theodorejb/763b83a43522b0fc1755a537663b1863) provided by PHP itself.

**Important**: At this moment, the PHPCompatibility unit test suite does not contain a mechanism to test the fixer.
A typical `.fixed` file which would be expected by the PHPCS native test suite to verify the fixer results _is_ included with this PR though.

## Tests run

I have run the sniff, as well as the fixer, over a number of medium to large codebases and have found _no_ false positives.

I have compared the results of a few of these projects with [the list compiled by Nikita](https://gist.github.com/nikic/b5f811e0423bf051f4492cd6e0c0273e) and for the compared results, the outcome is 100% the same.

Related to #808