### PR TITLE
PHP 7.0: new NewUnicodeEscapeSequence sniff

### DIFF
--- a/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\TextStrings;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_Exception as PHPCS_Exception;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * PHP 7.0 introduced a Unicode codepoint escape sequence.
+ *
+ * Strings containing a literal \u{ followed by an invalid sequence will cause a fatal error as of PHP 7.0.
+ *
+ * PHP version 7.0
+ *
+ * @link https://wiki.php.net/rfc/unicode_escape
+ * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.unicode-codepoint-escape-syntax
+ * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.strings.unicode-escapes
+ *
+ * @since 9.3.0
+ */
+class NewUnicodeEscapeSequenceSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.3.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            \T_CONSTANT_ENCAPSED_STRING,
+            \T_DOUBLE_QUOTED_STRING,
+            \T_HEREDOC,
+        );
+    }
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check whether this is a single quoted or double quoted string.
+        if ($tokens[$stackPtr]['code'] === \T_CONSTANT_ENCAPSED_STRING) {
+
+            // Find the start of the - potentially multi-line - text string.
+            $start = $stackPtr;
+            for ($i = ($stackPtr - 1); $i >= 0; $i--) {
+                if ($tokens[$i]['code'] === \T_WHITESPACE) {
+                    continue;
+                }
+
+                if ($tokens[$i]['code'] === \T_CONSTANT_ENCAPSED_STRING) {
+                    $start = $i;
+                    continue;
+                }
+
+                break;
+            }
+
+            try {
+                $textString = $this->getCompleteTextString($phpcsFile, $start, false);
+            } catch (PHPCS_Exception $e) {
+                // Something went wrong determining the start of the text string.
+                return;
+            }
+
+            $startQuote = $textString[0];
+            $endQuote   = substr($textString, -1);
+            if (($startQuote === "'" && $endQuote === "'")
+                || $startQuote !== $endQuote
+            ) {
+                // Single quoted string, not our concern.
+                return;
+            }
+        }
+
+        $content = $this->stripQuotes($tokens[$stackPtr]['content']);
+        $count   = preg_match_all('`(?<!\\\\)\\\\u\{([^}\n\r]*)(\})?`', $content, $matches, \PREG_SET_ORDER);
+        if ($count === false || $count === 0) {
+            return;
+        }
+
+        foreach ($matches as $match) {
+            $valid = false; // If the close curly is missing, we have an incomplete escape sequence.
+            if (isset($match[2])) {
+                $valid = $this->isValidUnicodeEscapeSequence($match[1]);
+            }
+
+            if ($this->supportsBelow('5.6') === true && $valid === true) {
+                $phpcsFile->addError(
+                    'Unicode codepoint escape sequences are not supported in PHP 5.6 or earlier. Found: %s',
+                    $stackPtr,
+                    'Found',
+                    array($match[0])
+                );
+            }
+
+            if ($this->supportsAbove('7.0') === true && $valid === false) {
+                $phpcsFile->addError(
+                    'Strings containing a literal \u{ followed by an invalid unicode codepoint escape sequence will cause a fatal error in PHP 7.0 and above. Escape the leading backslash to prevent this. Found: %s',
+                    $stackPtr,
+                    'Invalid',
+                    array($match[0])
+                );
+            }
+        }
+    }
+
+
+    /**
+     * Verify if the codepoint in a unicode escape sequence is valid.
+     *
+     * @since 9.3.0
+     *
+     * @param string $codepoint The codepoint as a string.
+     *
+     * @return bool
+     */
+    protected function isValidUnicodeEscapeSequence($codepoint)
+    {
+        if (trim($codepoint) === '') {
+            return false;
+        }
+
+        // Check if it's a valid hex codepoint.
+        if (preg_match('`^[0-9A-F]+$`iD', $codepoint, $match) !== 1) {
+            return false;
+        }
+
+        if (hexdec($codepoint) > 1114111) {
+            // Outside of the maximum permissable range.
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/PHPCompatibility/Tests/TextStrings/NewUnicodeEscapeSequenceUnitTest.inc
+++ b/PHPCompatibility/Tests/TextStrings/NewUnicodeEscapeSequenceUnitTest.inc
@@ -1,0 +1,61 @@
+<?php
+
+// This is fine cross-version.
+json_decode("\"\u202e\"");
+echo 'single quoted: \u{aa}';
+echo "This is a text to explain the escape sequence which looks like \\u{9999} (escaped)";
+
+$location_vars = array("c\u0327ity", "state");
+var_dump("\u");
+var_dump("\ufoobar");
+
+echo 'multi-line
+"text \u{aa} text"
+string with quotes inside';
+
+// This will not be recognized as an escape sequence, i.e. no space allowed between the \u and the {.
+echo "\u
+{1F602}";
+
+/*
+ * PHP 7.0: Sequences which resemble unicode escape sequences, but are not
+ * and will now throw a parse error.
+ *
+ * Unit tests largely taken from the PHP native merged PR.
+ */
+// This will be a parse error in PHP 7.0.
+echo "\u{foobar"; // Incomplete.
+echo "\u{9999"; // Incomplete.
+echo "\u{}"; // Empty.
+var_dump("\u{+1F602}"); // Positive sign is not allowed.
+var_dump("\u{-1F602}"); // Negative sign is not allowed.
+var_dump("\u{1F602 }"); // Whitespace is not allowed.
+
+// Parse error: This is outside of the maximum permissable range.
+echo "\u{110000}"; // U+10FFFF + 1
+
+/*
+ * PHP 7.0: Unicode codepoint escape sequences.
+ * Unit tests largely taken from the RFC.
+ */
+echo "\u{aa}";
+echo <<<EOD
+Some text \u{0000aa}
+and some more \u{9999} text
+EOD;
+echo "\u{9999}";
+echo "ma\u{00F1}ana";
+echo "man\u{0303}ana";
+echo "\u{1F602}";
+
+echo "multi-line
+'text \u{aa} text'
+string with quotes inside";
+
+echo "\u{202E}Reversed text";
+
+// Surrogate pairs are non-well-formed UTF-8 - however, it is sometimes useful
+// to be able to produce these (e.g. CESU-8 handling)
+var_dump(bin2hex("\u{D801}"));
+var_dump(bin2hex("\u{DC00}"));
+var_dump(bin2hex("\u{D801}\u{DC00}")); // CESU-8 encoding of U+10400

--- a/PHPCompatibility/Tests/TextStrings/NewUnicodeEscapeSequenceUnitTest.php
+++ b/PHPCompatibility/Tests/TextStrings/NewUnicodeEscapeSequenceUnitTest.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\TextStrings;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New Unicode Escape Sequence Sniff tests
+ *
+ * @group newUnicodeEscapeSequence
+ * @group textStrings
+ *
+ * @covers \PHPCompatibility\Sniffs\TextStrings\NewUnicodeEscapeSequenceSniff
+ *
+ * @since 9.3.0
+ */
+class NewUnicodeEscapeSequenceUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewUnicodeEscapeSequence
+     *
+     * @dataProvider dataNewUnicodeEscapeSequence
+     *
+     * @param int    $line     Line number where the error should occur.
+     * @param string $sequence The unicode escape sequence found.
+     *
+     * @return void
+     */
+    public function testNewUnicodeEscapeSequence($line, $sequence)
+    {
+        $file  = $this->sniffFile(__FILE__, '5.6');
+        $error = 'Unicode codepoint escape sequences are not supported in PHP 5.6 or earlier. Found: ' . $sequence;
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * dataNewUnicodeEscapeSequence
+     *
+     * @see testNewUnicodeEscapeSequence()
+     *
+     * @return array
+     */
+    public function dataNewUnicodeEscapeSequence()
+    {
+        return array(
+            array(41, '\u{aa}'),
+            array(43, '\u{0000aa}'),
+            array(44, '\u{9999}'),
+            array(46, '\u{9999}'),
+            array(47, '\u{00F1}'),
+            array(48, '\u{0303}'),
+            array(49, '\u{1F602}'),
+            array(52, '\u{aa}'),
+            array(55, '\u{202E}'),
+            array(59, '\u{D801}'),
+            array(60, '\u{DC00}'),
+            array(61, '\u{D801}'),
+            array(61, '\u{DC00}'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositivesNewSequence
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesNewSequence()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+
+        // No errors expected on the first 40 lines.
+        for ($line = 1; $line <= 40; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * testNewUnicodeEscapeSequenceFatals
+     *
+     * @dataProvider dataNewUnicodeEscapeSequenceFatals
+     *
+     * @param int    $line     Line number where the error should occur.
+     * @param string $sequence The invalid unicode escape sequence found.
+     *
+     * @return void
+     */
+    public function testNewUnicodeEscapeSequenceFatals($line, $sequence)
+    {
+        $file  = $this->sniffFile(__FILE__, '7.0');
+        $error = 'Strings containing a literal \u{ followed by an invalid unicode codepoint escape sequence will cause a fatal error in PHP 7.0 and above. Escape the leading backslash to prevent this. Found: ' . $sequence;
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * dataNewUnicodeEscapeSequenceFatals
+     *
+     * @see testNewUnicodeEscapeSequenceFatals()
+     *
+     * @return array
+     */
+    public function dataNewUnicodeEscapeSequenceFatals()
+    {
+        return array(
+            array(27, '\u{foobar'),
+            array(28, '\u{9999'),
+            array(29, '\u{}'),
+            array(30, '\u{+1F602}'),
+            array(31, '\u{-1F602}'),
+            array(32, '\u{1F602 }'),
+            array(35, '\u{110000}'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositivesFatals
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesFatals()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+
+        // No errors expected on the first 25 lines.
+        for ($line = 1; $line <= 25; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        // No errors expected on the last 20 or so lines.
+        for ($line = 40; $line <= 62; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /*
+     * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw errors
+     * in all testVersions.
+     */
+}


### PR DESCRIPTION
> ### Unicode codepoint escape syntax
>
> This takes a Unicode codepoint in hexadecimal form, and outputs that codepoint in UTF-8 to a double-quoted string or a heredoc. Any valid codepoint is accepted, with leading 0's being optional.
> ```php
> echo "\u{aa}";
> echo "\u{0000aa}";
> echo "\u{9999}";
> ```

> ### `\u{` may cause errors ¶
>
> Due to the addition of the new Unicode codepoint escape syntax, strings containing a literal `\u{` followed by an invalid sequence will cause a fatal error. To avoid this, the leading backslash should be escaped.

Refs:
* https://wiki.php.net/rfc/unicode_escape
* https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.unicode-codepoint-escape-syntax
* https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.strings.unicode-escapes
* php/php-src@bae46f3

Includes unit tests.

## Implementation notes

1. This introduces a new sniff category `TextStrings`.
2. This adds a new `Sniff::getCompleteTextString()` utility method to get all parts of a multi-line text string.
    This method is a duplicate of a new utility method which will be introduced in PHPCS 3.5.0.
    The upstream version is accompanied by plenty of unit tests.
