### PR TITLE
PHP 7.4/NewClasses: add WeakReferences

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -570,6 +570,10 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '7.3' => false,
             '7.4' => true,
         ),
+        'WeakReference' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -342,3 +342,4 @@ class MyClosedGeneratorException extends ClosedGeneratorException {}
 function SodiumExceptionTypeHint( SodiumException $a ) {}
 $test = new com_exception();
 $test = new ReflectionReference;
+function DateTimeReturnTypeHint( $a ) : WeakReference {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -195,6 +195,7 @@ class NewClassesUnitTest extends BaseSniffTest
             array('CompileError', '7.2', array(249), '7.3'),
             array('JsonException', '7.2', array(250, 339), '7.3'),
             array('ReflectionReference', '7.3', array(344), '7.4'),
+            array('WeakReference', '7.3', array(345), '7.4'),
         );
     }
 


### PR DESCRIPTION
> Support for WeakReferences has been added.

Refs:
* https://wiki.php.net/rfc/weakrefs
* https://github.com/php/php-src/blob/fd6874c64d9e1d80b68b1035c1bb962ffd507798/UPGRADING#L221
* https://github.com/php/php-src/commit/6529d7acd9912a609924633a43e6562799566225

Related to #808