### PR TITLE
PHP 5.2/7.4: new RemovedMbStrrposEncodingThirdParam sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Removed mb_strrpos() with encoding as 3rd argument.
+ *
+ * The encoding parameter was moved from the third position to the fourth in PHP 5.2.0.
+ * For backward compatibility, encoding could be specified as the third parameter, but doing
+ * so is deprecated and will be removed in the future.
+ *
+ * Between PHP 5.2 and PHP 7.3, this was a deprecation in documentation only.
+ * As of PHP 7.4, a deprecation warning will be thrown if an encoding is passed as the 3rd
+ * argument.
+ * As of PHP 8, the argument is expected to change to accept an integer only.
+ *
+ * PHP version 5.2
+ * PHP version 7.4
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_7_4#mb_strrpos_with_encoding_as_3rd_argument
+ * @link https://github.com/php/php-src/commit/39e756e7fe7b08092b4a75cf253442cba826e910
+ *
+ * @since 9.3.0
+ */
+class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'mb_strrpos' => true,
+    );
+
+    /**
+     * Tokens which should be recognized as text.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    private $textStringTokens = array(
+        \T_CONSTANT_ENCAPSED_STRING,
+        \T_DOUBLE_QUOTED_STRING,
+        \T_HEREDOC,
+        \T_NOWDOC,
+    );
+
+    /**
+     * Tokens which should be recognized as numbers.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    private $numberTokens = array(
+        \T_LNUMBER => \T_LNUMBER,
+        \T_DNUMBER => \T_DNUMBER,
+        \T_MINUS   => \T_MINUS,
+        \T_PLUS    => \T_PLUS,
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 9.3.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return $this->supportsAbove('5.2') === false;
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[3]) === false) {
+            // Optional third parameter not set.
+            return;
+        }
+
+        if (isset($parameters[4]) === true) {
+            // Encoding set as fourth parameter set.
+            return;
+        }
+
+        $targetParam = $parameters[3];
+        $targets     = $this->numberTokens + Tokens::$emptyTokens;
+        $nonNumber   = $phpcsFile->findNext($targets, $targetParam['start'], ($targetParam['end'] + 1), true);
+        if ($nonNumber === false) {
+            return;
+        }
+
+        if ($this->isNumericCalculation($phpcsFile, $targetParam['start'], $targetParam['end']) === true) {
+            return;
+        }
+
+        $hasString = $phpcsFile->findNext($this->textStringTokens, $targetParam['start'], ($targetParam['end'] + 1));
+        if ($hasString === false) {
+            // No text strings found. Undetermined.
+            return;
+        }
+
+        $error = 'Passing the encoding to mb_strrpos() as third parameter is soft deprecated since PHP 5.2';
+        if ($this->supportsAbove('7.4') === true) {
+            $error .= ' and hard deprecated since PHP 7.4';
+        }
+
+        $error .= '. Use an explicit 0 as the offset in the third parameter.';
+
+        $phpcsFile->addWarning(
+            $error,
+            $targetParam['start'],
+            'Deprecated'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.inc
@@ -1,0 +1,24 @@
+<?php
+
+// OK.
+mb_strrpos('abc abc abc', 'abc');
+mb_strrpos('abc abc abc', 'abc', 0);
+mb_strrpos(
+    'abc abc abc',
+    'abc',
+    /* comment*/
+    10 // phpcs:ignore Something
+);
+mb_strrpos('abc abc abc', 'abc', $offset, $encoding);
+mb_strrpos('abc abc abc', 'abc', -5);
+mb_strrpos('abc abc abc', 'abc', +1.2); // Float will be cast to int, so this is fine.
+mb_strrpos('abc abc abc', 'abc', 'UTF-' + 8);
+
+// Ignoring. Can not be reliably determined:
+mb_strrpos('abc abc abc', 'abc', $offset);
+mb_strrpos('abc abc abc', 'abc', $encoding);
+
+// PHP 5.2/7.4: deprecated encoding as third param.
+mb_strrpos('abc abc abc', 'abc', 'UTF-8');
+mb_strrpos('abc abc abc', 'abc', "utf-$utfType");
+mb_strrpos('abc abc abc', 'abc', 'utf-' . $utfType);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Removed mb_strrpos() encoding as third parameter Sniff tests
+ *
+ * @group removedMbStrrposEncodingThirdParam
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedMbStrrposEncodingThirdParamSniff
+ *
+ * @since 9.3.0
+ */
+class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testRemovedMbStrrposEncodingThirdParam
+     *
+     * @dataProvider dataRemovedMbStrrposEncodingThirdParam
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedMbStrrposEncodingThirdParam($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '5.2');
+        $error = 'Passing the encoding to mb_strrpos() as third parameter is soft deprecated since PHP 5.2';
+        $this->assertWarning($file, $line, $error);
+
+        $file   = $this->sniffFile(__FILE__, '7.4');
+        $error .= ' and hard deprecated since PHP 7.4.';
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedMbStrrposEncodingThirdParam()
+     *
+     * @return array
+     */
+    public function dataRemovedMbStrrposEncodingThirdParam()
+    {
+        return array(
+            array(22),
+            array(23),
+            array(24),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '5.2');
+
+        // No errors expected on the first 20 lines.
+        for ($line = 1; $line <= 20; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> The encoding parameter was moved from the third position to the fourth in PHP 5.2.0.
> For backward compatibility, encoding could be specified as the third parameter, but doing
> so is deprecated and will be removed in the future.

Between PHP 5.2 and PHP 7.3, this was a deprecation in documentation only.
As of PHP 7.4, a deprecation warning will be thrown if an encoding is passed as the 3rd argument.
As of PHP 8, the argument is expected to change to accept an integer only.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#mb_strrpos_with_encoding_as_3rd_argument
 * https://github.com/php/php-src/commit/39e756e7fe7b08092b4a75cf253442cba826e910

Related to #808