### PR TITLE
PHP 7.4: new NewIDNVariantDefault sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * The default value for the $variant parameter has changed from INTL_IDNA_VARIANT_2003
+ * to INTL_IDNA_VARIANT_UTS46.
+ *
+ * PHP version 7.4
+ *
+ * @link https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003
+ * @link https://www.php.net/manual/en/function.idn-to-ascii.php
+ * @link https://www.php.net/manual/en/function.idn-to-utf8.php
+ *
+ * @since 9.3.0
+ */
+class NewIDNVariantDefaultSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * Key is the function name, value the 1-based parameter position of
+     * the $variant parameter.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'idn_to_ascii' => 3,
+        'idn_to_utf8'  => 3,
+    );
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * Note: This sniff should only trigger errors when both PHP 7.3 or lower,
+     * as well as PHP 7.4 or higher need to be supported within the application.
+     *
+     * @since 9.3.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('7.3') === false || $this->supportsAbove('7.4') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $functionLC = strtolower($functionName);
+        if (isset($parameters[$this->targetFunctions[$functionLC]]) === true) {
+            return;
+        }
+
+        $error = 'The default value of the %s() $variant parameter has changed from INTL_IDNA_VARIANT_2003 to INTL_IDNA_VARIANT_UTS46 in PHP 7.4. For optimal cross-version compatibility, the $variant parameter should be explicitly set.';
+        $phpcsFile->addError(
+            $error,
+            $stackPtr,
+            'NotSet',
+            array($functionName)
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.inc
@@ -1,0 +1,13 @@
+<?php
+
+// OK.
+echo idn_to_ascii('täst.de', $options, $variant, $idna_info);
+echo idn_to_ascii( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+echo idn_to_utf8('xn--tst-qla.de', $options, $variant, $idna_info);
+echo idn_to_utf8( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003 );
+
+// Cross-version changed default.
+echo idn_to_ascii('täst.de');
+echo idn_to_ascii( $domain, IDNA_DEFAULT);
+echo IDN_to_utf8('xn--tst-qla.de');
+echo idn_to_utf8( $domain, IDNA_DEFAULT);

--- a/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New default value for the IDN $variant parameter Sniff tests.
+ *
+ * @group newIDNVariantDefault
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewIDNVariantDefaultSniff
+ *
+ * @since 9.3.0
+ */
+class NewIDNVariantDefaultUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewIDNVariantDefault
+     *
+     * @dataProvider dataNewIDNVariantDefault
+     *
+     * @param int    $line     Line number where the error should occur.
+     * @param string $function Function name.
+     *
+     * @return void
+     */
+    public function testNewIDNVariantDefault($line, $function)
+    {
+        $file  = $this->sniffFile(__FILE__, '7.3-');
+        $error = 'The default value of the ' . $function . '() $variant parameter has changed from INTL_IDNA_VARIANT_2003 to INTL_IDNA_VARIANT_UTS46 in PHP 7.4.';
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewIDNVariantDefault()
+     *
+     * @return array
+     */
+    public function dataNewIDNVariantDefault()
+    {
+        return array(
+            array(10, 'idn_to_ascii'),
+            array(11, 'idn_to_ascii'),
+            array(12, 'IDN_to_utf8'),
+            array(13, 'idn_to_utf8'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3-');
+
+        // No errors expected on the first 8 lines.
+        for ($line = 1; $line <= 8; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @dataProvider dataNoViolationsInFileOnValidVersion
+     *
+     * @param string $testVersion The testVersion to use.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion($testVersion)
+    {
+        $file = $this->sniffFile(__FILE__, $testVersion);
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolationsInFileOnValidVersion()
+     *
+     * @return array
+     */
+    public function dataNoViolationsInFileOnValidVersion()
+    {
+        return array(
+            array('7.1-7.3'),
+            array('7.4-'),
+        );
+    }
+}


### PR DESCRIPTION
> Intl:
> The default parameter value of idn_to_ascii() and idn_to_utf8() is now
> INTL_IDNA_VARIANT_UTS46 instead of the deprecated INTL_IDNA_VARIANT_2003.

**Note**:  The new sniff will only throw an error when the `testVersion` indicates that both PHP < 7.4 as well as PHP 7.4+ need to be supported.

There is a risk in that, i.e. when people use PHPCompatibility against their code using only their current server version, `7.2`, and when upgrading the server version, only the new version, `7.4`, they will not be shown this message in either run.

The other side of that coin is that it prevents unnecessary errors/warnings for code which only needs to support one PHP version and is therefore not directly affected by this change.

This should possibly be addressed in the `Readme` by advising people to use a `testVersion` spanning both the old and the new server version, `7.2-7.4` when they are testing if their server can safely be upgraded.

Refs:
* https://github.com/php/php-src/blob/86d751f696786bcb95c580482c9884e41ccf2406/UPGRADING#L66-L68
* https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003
* https://www.php.net/manual/en/function.idn-to-ascii.php
* https://www.php.net/manual/en/function.idn-to-utf8.php
* https://github.com/php/php-src/commit/01912f93c3f702b5b34a0a9a4c8f529785b0286a

Related to #808