### PR TITLE
PHP 5.4: new NewHTMLEntitiesEncodingDefault sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * As of PHP 5.4, the default character set for htmlspecialchars(), htmlentities()
+ * and html_entity_decode() is now UTF-8, instead of ISO-8859-1.
+ *
+ * PHP version 5.4
+ *
+ * @link https://www.php.net/manual/en/migration54.other.php
+ * @link https://www.php.net/manual/en/function.htmlentities.php#refsect1-function.htmlentities-changelog
+ * @link https://www.php.net/manual/en/function.htmlspecialchars.php#refsect1-function.htmlspecialchars-changelog
+ *
+ * @since 9.3.0
+ */
+class NewHTMLEntitiesEncodingDefaultSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * Key is the function name, value the 1-based parameter position of
+     * the $encoding parameter.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'html_entity_decode' => 3,
+        'htmlentities'       => 3,
+        'htmlspecialchars'   => 3,
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * Note: This sniff should only trigger errors when both PHP 5.3 or lower,
+     * as well as PHP 5.4 or higher need to be supported within the application.
+     *
+     * @since 9.3.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('5.3') === false || $this->supportsAbove('5.4') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $functionLC = strtolower($functionName);
+        if (isset($parameters[$this->targetFunctions[$functionLC]]) === true) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'The default value of the $encoding parameter for %s() was changed from ISO-8859-1 to UTF-8 in PHP 5.4. For cross-version compatibility, the $encoding parameter should be explicitly set.',
+            $stackPtr,
+            'NotSet',
+            array($functionName)
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.inc
@@ -1,0 +1,11 @@
+<?php
+
+// OK.
+echo htmlentities( $string, ENT_QUOTES, 'UTF-8' );
+echo htmlspecialchars( $string, ENT_COMPAT, $encoding, false );
+echo html_entity_decode( $string, ENT_COMPAT, $encoding );
+
+// Not OK - error.
+echo htmlentities( $string, $flags );
+echo htmlspecialchars($string);
+echo HTML_entity_decode( $string, ENT_COMPAT );

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New htmlentities(), htmlspecialchars() encoding default tests.
+ *
+ * @group newHTMLEntitiesEncodingDefault
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewHTMLEntitiesEncodingDefaultSniff
+ *
+ * @since 9.3.0
+ */
+class NewHTMLEntitiesEncodingDefaultUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewHTMLEntitiesEncodingDefault
+     *
+     * @dataProvider dataNewHTMLEntitiesEncodingDefault
+     *
+     * @param int    $line     Line number where the error should occur.
+     * @param string $function The name of the function called.
+     *
+     * @return void
+     */
+    public function testNewHTMLEntitiesEncodingDefault($line, $function)
+    {
+        $file  = $this->sniffFile(__FILE__, '5.3-5.4');
+        $error = "The default value of the \$encoding parameter for {$function}() was changed from ISO-8859-1 to UTF-8 in PHP 5.4";
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewHTMLEntitiesEncodingDefault()
+     *
+     * @return array
+     */
+    public function dataNewHTMLEntitiesEncodingDefault()
+    {
+        return array(
+            array(9, 'htmlentities'),
+            array(10, 'htmlspecialchars'),
+            array(11, 'HTML_entity_decode'),
+        );
+    }
+
+
+    /**
+     * Test that there are no false positives.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '5.3-5.4');
+
+        // No errors expected on the first 7 lines.
+        for ($line = 1; $line <= 7; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @dataProvider dataNoViolationsInFileOnValidVersion
+     *
+     * @param string $testVersion The testVersion to use.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion($testVersion)
+    {
+        $file = $this->sniffFile(__FILE__, $testVersion);
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolationsInFileOnValidVersion()
+     *
+     * @return array
+     */
+    public function dataNoViolationsInFileOnValidVersion()
+    {
+        return array(
+            array('5.0-5.3'),
+            array('5.4-'),
+        );
+    }
+}


### PR DESCRIPTION
> The default character set for htmlspecialchars() and htmlentities() is now UTF-8, instead of ISO-8859-1.

**Note**:  The new sniff will only throw an error when the `testVersion` indicates that both PHP < 5.4 as well as PHP 5.4+ need to be supported.

Refs:
* https://www.php.net/manual/en/migration54.other.php
* https://www.php.net/manual/en/function.htmlentities.php#refsect1-function.htmlentities-changelog
* https://www.php.net/manual/en/function.htmlspecialchars.php#refsect1-function.htmlspecialchars-changelog

Related to #839