### PR TITLE
PHP 5.6: new NewIconvMbstringCharsetDefault sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Detect calls to Iconv and Mbstring functions with the optional $charset/$encoding parameter not set.
+ *
+ * The default value for the iconv $charset and the MbString $encoding parameters was changed
+ * in PHP 5.6 to the value of `default_charset`, which defaults to UTF-8.
+ *
+ * Previously, the iconv functions would default to the value of iconv.internal_encoding;
+ * The mbstring functions would default to the return value of mb_internal_encoding().
+ * In both case, this would normally come down to ISO-8859-1.
+ *
+ * PHP version 5.6
+ *
+ * @link https://wiki.php.net/rfc/default_encoding
+ * @link https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.default-encoding
+ * @link https://www.php.net/manual/en/migration56.deprecated.php#migration56.deprecated.iconv-mbstring-encoding
+ *
+ * @since 9.3.0
+ */
+class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * Only those functions where the charset/encoding parameter is optional need to be listed.
+     *
+     * Key is the function name, value the 1-based parameter position of
+     * the $charset/$encoding parameter.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'iconv_mime_decode_headers' => 3,
+        'iconv_mime_decode'         => 3,
+        'iconv_mime_encode'         => 3, // Special case.
+        'iconv_strlen'              => 2,
+        'iconv_strpos'              => 4,
+        'iconv_strrpos'             => 3,
+        'iconv_substr'              => 4,
+
+        'mb_check_encoding'         => 2,
+        'mb_chr'                    => 2,
+        'mb_convert_case'           => 3,
+        'mb_convert_encoding'       => 3,
+        'mb_convert_kana'           => 3,
+        'mb_decode_numericentity'   => 3,
+        'mb_encode_numericentity'   => 3,
+        'mb_ord'                    => 2,
+        'mb_scrub'                  => 2,
+        'mb_strcut'                 => 4,
+        'mb_stripos'                => 4,
+        'mb_stristr'                => 4,
+        'mb_strlen'                 => 2,
+        'mb_strpos'                 => 4,
+        'mb_strrchr'                => 4,
+        'mb_strrichr'               => 4,
+        'mb_strripos'               => 4,
+        'mb_strrpos'                => 4,
+        'mb_strstr'                 => 4,
+        'mb_strtolower'             => 2,
+        'mb_strtoupper'             => 2,
+        'mb_strwidth'               => 2,
+        'mb_substr_count'           => 3,
+        'mb_substr'                 => 4,
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * Note: This sniff should only trigger errors when both PHP 5.5 or lower,
+     * as well as PHP 5.6 or higher need to be supported within the application.
+     *
+     * @since 9.3.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('5.5') === false || $this->supportsAbove('5.6') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $functionLC = strtolower($functionName);
+        if ($functionLC === 'iconv_mime_encode') {
+            // Special case the iconv_mime_encode() function.
+            return $this->processIconvMimeEncode($phpcsFile, $stackPtr, $functionName, $parameters);
+        }
+
+        if (isset($parameters[$this->targetFunctions[$functionLC]]) === true) {
+            return;
+        }
+
+        $paramName = '$encoding';
+        if (strpos($functionLC, 'iconv_') === 0) {
+            $paramName = '$charset';
+        } elseif ($functionLC === 'mb_convert_encoding') {
+            $paramName = '$from_encoding';
+        }
+
+        $error = 'The default value of the %1$s parameter for %2$s() was changed from ISO-8859-1 to UTF-8 in PHP 5.6. For cross-version compatibility, the %1$s parameter should be explicitly set.';
+        $data  = array(
+            $paramName,
+            $functionName,
+        );
+
+        $phpcsFile->addError($error, $stackPtr, 'NotSet', $data);
+    }
+
+    /**
+     * Process the parameters of a matched call to the iconv_mime_encode() function.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processIconvMimeEncode(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $error = 'The default value of the %s parameter index for iconv_mime_encode() was changed from ISO-8859-1 to UTF-8 in PHP 5.6. For cross-version compatibility, the %s should be explicitly set.';
+
+        $functionLC = strtolower($functionName);
+        if (isset($parameters[$this->targetFunctions[$functionLC]]) === false) {
+            $phpcsFile->addError(
+                $error,
+                $stackPtr,
+                'PreferencesNotSet',
+                array(
+                    '$preferences[\'input/output-charset\']',
+                    '$preferences[\'input-charset\'] and $preferences[\'output-charset\'] indexes',
+                )
+            );
+
+            return;
+        }
+
+        $tokens        = $phpcsFile->getTokens();
+        $targetParam   = $parameters[$this->targetFunctions[$functionLC]];
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+        if ($firstNonEmpty === false) {
+            // Parse error or live coding.
+            return;
+        }
+
+        if ($tokens[$firstNonEmpty]['code'] === \T_ARRAY
+            || $tokens[$firstNonEmpty]['code'] === \T_OPEN_SHORT_ARRAY
+        ) {
+            $hasInputCharset  = preg_match('`([\'"])input-charset\1\s*=>`', $targetParam['raw']);
+            $hasOutputCharset = preg_match('`([\'"])output-charset\1\s*=>`', $targetParam['raw']);
+            if ($hasInputCharset === 1 && $hasOutputCharset === 1) {
+                // Both input as well as output charset are set.
+                return;
+            }
+
+            if ($hasInputCharset !== 1) {
+                $phpcsFile->addError(
+                    $error,
+                    $firstNonEmpty,
+                    'InputPreferenceNotSet',
+                    array(
+                        '$preferences[\'input-charset\']',
+                        '$preferences[\'input-charset\'] index',
+                    )
+                );
+            }
+
+            if ($hasOutputCharset !== 1) {
+                $phpcsFile->addError(
+                    $error,
+                    $firstNonEmpty,
+                    'OutputPreferenceNotSet',
+                    array(
+                        '$preferences[\'output-charset\']',
+                        '$preferences[\'output-charset\'] index',
+                    )
+                );
+            }
+
+            return;
+        }
+
+        // The $preferences parameter was passed, but it was a variable/constant/output of a function call.
+        $phpcsFile->addWarning(
+            $error,
+            $firstNonEmpty,
+            'Undetermined',
+            array(
+                '$preferences[\'input/output-charset\']',
+                '$preferences[\'input-charset\'] and $preferences[\'output-charset\'] indexes',
+            )
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * OK.
+ */
+$a = iconv($in_charset, $out_charset, $str); // OK: parameters not optional.
+$a = iconv($in_charset); // OK: parameters not optional. Will throw fatal "Too few arguments passed" error.
+
+$a = iconv_mime_decode_headers( $encoded_headers, $mode, $charset );
+$a = iconv_mime_decode( $encoded_header, $mode, $charset );
+$a = iconv_strlen($str, $charset);
+$a = iconv_strpos ( $haystack, $needle, 0, 'UTF-8' );
+$a = iconv_strrpos($haystack, $needle, $charset );
+$a = iconv_substr($str, $offset, $length, ini_get("iconv.internal_encoding"));
+
+$a = mb_check_encoding($var, $encoding);
+$a = mb_chr($cp, $encoding);
+$a = mb_convert_case( $str, MB_CASE_TITLE, mb_internal_encoding() );
+$a = mb_convert_encoding( $str, $to_encoding, $from_encoding );
+$a = mb_convert_kana( $str, $option, $encoding );
+$a = mb_decode_numericentity($str, $convmap, $encoding, true);
+$a = mb_encode_numericentity($str, $convmap, $encoding, true);
+$a = mb_ord( $str, $encoding );
+$a = mb_scrub( $str, $encoding );
+$a = mb_strcut($str, $start, $length, $encoding);
+$a = mb_stripos( $haystack, $needle, $offset, $encoding );
+$a = mb_stristr( $haystack, $needle, true, $encoding );
+$a = mb_strlen($str, $encoding);
+$a = mb_strpos( $haystack, $needle, $offset, $encoding );
+$a = mb_strrchr( $haystack, $needle, $part, $encoding );
+$a = mb_strrichr( $haystack, $needle, $part, $encoding );
+$a = mb_strripos( $haystack, $needle, $offset, $encoding );
+$a = mb_strrpos( $haystack, $needle, $offset, $encoding );
+$a = mb_strstr( $haystack, $needle, true, $encoding );
+$a = mb_strtolower( $str, $encoding );
+$a = mb_strtoupper( $str, $encoding );
+$a = mb_strwidth( $str, $encoding );
+$a = mb_substr_count( $haystack, $needle, $encoding );
+$a = mb_substr($str, $start, $length, $encoding);
+
+/*
+ * Error: parameter not set.
+ */
+$a = iconv_mime_decode_headers( $encoded_headers, $mode );
+$a = iconv_mime_decode( $encoded_header, $mode );
+$a = Iconv_Strlen($str);
+$a = iconv_strpos ( $haystack, $needle );
+$a = iconv_strrpos($haystack, $needle );
+$a = iconv_substr($str, $offset);
+
+$a = mb_check_encoding($var);
+$a = MB_chr($cp);
+$a = mb_convert_case( $str, MB_CASE_UPPER );
+$a = mb_convert_encoding( $str, $to_encoding );
+$a = mb_convert_kana( $str, $option );
+$a = mb_decode_numericentity($str, $convmap);
+$a = mb_encode_numericentity($str, $convmap);
+$a = mb_ord( $str );
+$a = mb_scrub($str);
+$a = mb_strcut($str, $start);
+$a = mb_stripos( $haystack, $needle );
+$a = mb_stristr( $haystack, $needle );
+$a = mb_strlen($str);
+$a = mb_strpos( $haystack, $needle );
+$a = mb_strrchr( $haystack, $needle, $part );
+$a = mb_strrichr( $haystack, $needle );
+$a = mb_strripos( $haystack, $needle, $offset );
+$a = mb_strrpos( $haystack, $needle );
+$a = mb_strstr( $haystack, $needle, true );
+$a = mb_strtolower($str);
+$a = mb_strtoupper( $str );
+$a = mb_strwidth( $str );
+$a = mb_substr_count( $haystack, $needle );
+$a = mb_substr($str, $start);
+
+/*
+ * iconv_mime_encode() specific tests.
+ */
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    array(
+        'scheme'           => 'Q',
+        'input-charset'    => 'ISO-8859-1',
+        'output-charset'   => 'UTF-8',
+        'line-length'      => 80,
+        'line-break-chars' => "\n",
+    )
+); // OK. Parameter set and the expected array keys set as well.
+
+$a = Iconv_Mime_Encode( $field_name, $field_value ); // Error: $preferences not set.
+$a = ICONV_mime_encode( $field_name, $field_value, $preferences ); // Warning: unclear whether array keys are set or not.
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    array(
+        'scheme'           => 'Q',
+        'input-charset'    => 'ISO-8859-1',
+        'line-break-chars' => "\n",
+    )
+); // Error: 'output-charset' not set.
+
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    [
+        'output-charset'   => 'UTF-8',
+        'line-length'      => 80,
+    ]
+); // Error: 'input-charset' not set.

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New Iconv/MbString charset/encoding default tests.
+ *
+ * @group newIconvMbstringCharsetDefault
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewIconvMbstringCharsetDefaultSniff
+ *
+ * @since 9.3.0
+ */
+class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewIconvMbstringCharsetDefault
+     *
+     * @dataProvider dataNewIconvMbstringCharsetDefault
+     *
+     * @param int    $line      Line number where the error should occur.
+     * @param string $function  The name of the function called.
+     * @param string $paramName The name of parameter which is missing.
+     *                          Defaults to `$encoding`.
+     *
+     * @return void
+     */
+    public function testNewIconvMbstringCharsetDefault($line, $function, $paramName = '$encoding')
+    {
+        $file  = $this->sniffFile(__FILE__, '5.4-7.0');
+        $error = "The default value of the {$paramName} parameter for {$function}() was changed from ISO-8859-1 to UTF-8 in PHP 5.6";
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewIconvMbstringCharsetDefault()
+     *
+     * @return array
+     */
+    public function dataNewIconvMbstringCharsetDefault()
+    {
+        return array(
+            array(44, 'iconv_mime_decode_headers', '$charset'),
+            array(45, 'iconv_mime_decode', '$charset'),
+            array(46, 'Iconv_Strlen', '$charset'),
+            array(47, 'iconv_strpos', '$charset'),
+            array(48, 'iconv_strrpos', '$charset'),
+            array(49, 'iconv_substr', '$charset'),
+
+            array(51, 'mb_check_encoding'),
+            array(52, 'MB_chr'),
+            array(53, 'mb_convert_case'),
+            array(54, 'mb_convert_encoding', '$from_encoding'),
+            array(55, 'mb_convert_kana'),
+            array(56, 'mb_decode_numericentity'),
+            array(57, 'mb_encode_numericentity'),
+            array(58, 'mb_ord'),
+            array(59, 'mb_scrub'),
+            array(60, 'mb_strcut'),
+            array(61, 'mb_stripos'),
+            array(62, 'mb_stristr'),
+            array(63, 'mb_strlen'),
+            array(64, 'mb_strpos'),
+            array(65, 'mb_strrchr'),
+            array(66, 'mb_strrichr'),
+            array(67, 'mb_strripos'),
+            array(68, 'mb_strrpos'),
+            array(69, 'mb_strstr'),
+            array(70, 'mb_strtolower'),
+            array(71, 'mb_strtoupper'),
+            array(72, 'mb_strwidth'),
+            array(73, 'mb_substr_count'),
+            array(74, 'mb_substr'),
+        );
+    }
+
+
+    /**
+     * Test that there are no false positives.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '5.4-7.0');
+
+        // No errors expected on the first 40 lines.
+        for ($line = 1; $line <= 40; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Test the special handling of calls to iconv_mime_encode().
+     *
+     * @return void
+     */
+    public function testIconvMimeEncode()
+    {
+        $file  = $this->sniffFile(__FILE__, '5.4-7.0');
+        $error = 'The default value of the %s parameter index for iconv_mime_encode() was changed from ISO-8859-1 to UTF-8 in PHP 5.6';
+
+        $this->assertError($file, 91, sprintf($error, '$preferences[\'input/output-charset\']'));
+        $this->assertWarning($file, 92, sprintf($error, '$preferences[\'input/output-charset\']'));
+        $this->assertError($file, 96, sprintf($error, '$preferences[\'output-charset\']'));
+        $this->assertError($file, 106, sprintf($error, '$preferences[\'input-charset\']'));
+    }
+
+
+    /**
+     * Test that there are no false positives.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesIconvMimeEncode()
+    {
+        $file = $this->sniffFile(__FILE__, '5.4-7.0');
+
+        // No errors expected on line 79 - 89.
+        for ($line = 79; $line <= 89; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @dataProvider dataNoViolationsInFileOnValidVersion
+     *
+     * @param string $testVersion The testVersion to use.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion($testVersion)
+    {
+        $file = $this->sniffFile(__FILE__, $testVersion);
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolationsInFileOnValidVersion()
+     *
+     * @return array
+     */
+    public function dataNoViolationsInFileOnValidVersion()
+    {
+        return array(
+            array('-5.5'),
+            array('5.6-'),
+        );
+    }
+}


### PR DESCRIPTION
> all functions that take encoding option use php.internal_encoding as default (e.g. htmlentities/mb_strlen/mb_regex/etc)

**Note**:  The new sniff will only throw an error when the `testVersion` indicates that both PHP < 5.6 as well as PHP 5.6+ need to be supported.

Refs:
* https://wiki.php.net/rfc/default_encoding
* https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.default-encoding
* https://www.php.net/manual/en/migration56.deprecated.php#migration56.deprecated.iconv-mbstring-encoding

Includes unit tests.

Fixes #839

## Notes

This PR does not address the `mb_erg..()` functions. For those to work correctly cross-version the encoding needs to be set using the [`mb_regex_encoding()`](https://www.php.net/manual/en/function.mb-regex-encoding.php) function.
As PHPCS cannot determine whether this has already been done in another file/scope, sniffing for this would yield too many false positives.