### PR TITLE
PHP 7.4: new NewPasswordAlgoConstantValues sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * The constant value of the password hash algorithm constants has changed in PHP 7.4.
+ *
+ * Applications correctly using the constants PASSWORD_DEFAULT, PASSWORD_BCRYPT,
+ * PASSWORD_ARGON2I, and PASSWORD_ARGON2ID will continue to function correctly.
+ * Using an int will still work, but will produce a deprecation warning.
+ *
+ * PHP version 7.4
+ *
+ * @link https://wiki.php.net/rfc/password_registry
+ *
+ * @since 9.3.0
+ */
+class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * Key is the function name, value the 1-based parameter position of
+     * the $encoding parameter.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'password_hash'         => 2,
+        'password_needs_rehash' => 2,
+    );
+
+    /**
+     * Tokens types which indicate that the parameter passed is not the PHP native constant.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    private $invalidTokenTypes = array(
+        \T_NULL                     => true,
+        \T_TRUE                     => true,
+        \T_FALSE                    => true,
+        \T_LNUMBER                  => true,
+        \T_DNUMBER                  => true,
+        \T_CONSTANT_ENCAPSED_STRING => true,
+        \T_DOUBLE_QUOTED_STRING     => true,
+        \T_HEREDOC                  => true,
+        \T_NOWDOC                   => true,
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 9.3.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('7.4') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $functionLC = strtolower($functionName);
+        if (isset($parameters[$this->targetFunctions[$functionLC]]) === false) {
+            return;
+        }
+
+        $targetParam = $parameters[$this->targetFunctions[$functionLC]];
+        $tokens      = $phpcsFile->getTokens();
+
+        for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            if (isset($this->invalidTokenTypes[$tokens[$i]['code']]) === true) {
+                $phpcsFile->addWarning(
+                    'The value of the password hash algorithm constants has changed in PHP 7.4. Pass a PHP native constant to the %s() function instead of using the value of the constant. Found: %s',
+                    $stackPtr,
+                    'NotAlgoConstant',
+                    array(
+                        $functionName,
+                        $targetParam['raw'],
+                    )
+                );
+
+                break;
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
@@ -1,0 +1,26 @@
+<?php
+
+// OK.
+$hash = password_hash( $password, PASSWORD_DEFAULT, $options );
+$hash = password_hash( $password, PASSWORD_BCRYPT, $options );
+$hash = password_needs_rehash( $password, PASSWORD_ARGON2I, $options );
+$hash = password_hash(
+	$password,
+	// comment.
+	PASSWORD_ARGON2ID,
+	$options
+);
+
+// Undetermined. Ignore.
+$hash = password_hash( $password, $algo, $options );
+$hash = password_hash( $password, $this->get_algo(), $options );
+$hash = password_hash( $password, static::ALGO, $options );
+
+// Not OK - error.
+$hash = PassWord_hash( $password, null, $options );
+$hash = password_hash( $password, +1, $options );
+$hash = password_needs_rehash( $password, 2, $options );
+$hash = password_hash( $password, 3, $options );
+$hash = password_hash( $password, '2y', $options );
+$hash = password_HASH( $password, "argon{$type}", $options );
+$hash = password_needs_rehash( $password, 'argon2id', $options );

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New password hash algorithm constant values tests.
+ *
+ * @group newPasswordAlgoConstantValues
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewPasswordAlgoConstantValuesSniff
+ *
+ * @since 9.3.0
+ */
+class NewPasswordAlgoConstantValuesUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewPasswordAlgoConstantValues
+     *
+     * @dataProvider dataNewPasswordAlgoConstantValues
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testNewPasswordAlgoConstantValues($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '7.4');
+        $error = 'The value of the password hash algorithm constants has changed in PHP 7.4';
+
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewPasswordAlgoConstantValues()
+     *
+     * @return array
+     */
+    public function dataNewPasswordAlgoConstantValues()
+    {
+        return array(
+            array(20),
+            array(21),
+            array(22),
+            array(23),
+            array(24),
+            array(25),
+            array(26),
+        );
+    }
+
+
+    /**
+     * Test that there are no false positives.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+
+        // No errors expected on the first 18 lines.
+        for ($line = 1; $line <= 18; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Password hashing algorithm identifiers are now nullable strings rather
>  than integers.
>
>  * PASSWORD_DEFAULT was int 1; now is null
>  * PASSWORD_BCRYPT was int 1; now is string '2y'
>  * PASSWORD_ARGON2I was int 2; now is string 'argon2i'
>  * PASSWORD_ARGON2ID was int 3; now is string 'argon2id'
>
>  Applications correctly using the constants PASSWORD_DEFAULT,
>  PASSWORD_BCRYPT, PASSWORD_ARGON2I, and PASSWORD_ARGON2ID will continue to
function correctly.

Refs:
* https://wiki.php.net/rfc/password_registry
* https://github.com/php/php-src/blob/86d751f696786bcb95c580482c9884e41ccf2406/UPGRADING#L131-L141
* https://github.com/php/php-src/commit/534df87c9e3c28001986e70844e0ad04e5708d3d

Includes unit tests.

**Note**: while deprecated in name, it looks like the deprecation warning for use of the _constant value_ rather than the _constant_ has not been implemented.
All the more reason, of course, that the sniff is necessary.

Related to #808