### PR TITLE
PHP 7.4: new NewStripTagsAllowableTagsArray sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * As of PHP 7.4, strip_tags() now also accepts an array of allowed tags.
+ *
+ * PHP version 7.4
+ *
+ * @link https://github.com/php/php-src/blob/3775d47eee38f3b34f800a0b23f840ec7a94e4c7/UPGRADING#L301-L303
+ *
+ * @since 9.3.0
+ */
+class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'strip_tags' => true,
+    );
+
+    /**
+     * Text string tokens to examine.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    private $textStringTokens = array(
+        \T_CONSTANT_ENCAPSED_STRING => true,
+        \T_DOUBLE_QUOTED_STRING     => true,
+        \T_INLINE_HTML              => true,
+        \T_HEREDOC                  => true,
+        \T_NOWDOC                   => true,
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 9.3.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return false;
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[2]) === false) {
+            return;
+        }
+
+        $tokens       = $phpcsFile->getTokens();
+        $targetParam  = $parameters[2];
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], $targetParam['end'], true);
+
+        if ($nextNonEmpty === false) {
+            // Shouldn't be possible.
+            return;
+        }
+
+        if ($tokens[$nextNonEmpty]['code'] !== \T_ARRAY
+            && $tokens[$nextNonEmpty]['code'] !== \T_OPEN_SHORT_ARRAY
+        ) {
+            // Not passed as a hard-coded array.
+            return;
+        }
+
+        if ($this->supportsBelow('7.3') === true) {
+            $phpcsFile->addError(
+                'The strip_tags() function did not accept $allowable_tags to be passed in array format in PHP 7.3 and earlier.',
+                $nextNonEmpty,
+                'Found'
+            );
+        }
+
+        if ($this->supportsAbove('7.4') === true) {
+            if (strpos($targetParam['raw'], '>') === false) {
+                // Efficiency: prevent needlessly walking the array.
+                return;
+            }
+
+            $items = $this->getFunctionCallParameters($phpcsFile, $nextNonEmpty);
+
+            if (empty($items)) {
+                return;
+            }
+
+            foreach ($items as $item) {
+                for ($i = $item['start']; $i <= $item['end']; $i++) {
+                    if ($tokens[$i]['code'] === \T_STRING
+                        || $tokens[$i]['code'] === \T_VARIABLE
+                    ) {
+                        // Variable, constant, function call. Ignore complete item as undetermined.
+                        break;
+                    }
+
+                    if (isset($this->textStringTokens[$tokens[$i]['code']]) === true
+                        && strpos($tokens[$i]['content'], '>') !== false
+                    ) {
+
+                        $phpcsFile->addWarning(
+                            'When passing strip_tags() the $allowable_tags parameter as an array, the tags should not be enclosed in <> brackets. Found: %s',
+                            $i,
+                            'Invalid',
+                            array($item['raw'])
+                        );
+
+                        // Only throw one error per array item.
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.inc
@@ -1,0 +1,34 @@
+<?php
+
+// OK.
+$str = strip_tags($str);
+$str = strip_tags($input, '<a><p>');
+
+// Undetermined. Ignore.
+$str = strip_tags($str, $allowable_tags);
+$str = strip_tags($str, self::ALLOWABLE_TAGS);
+$str = strip_tags($str, MyClass::get_allowable_tags(['a', 'p']));
+
+// PHP 7.4: passing $allowable_tags as an array.
+$str = strip_tags($input, ['a', 'p']);
+$str = strip_tags(
+    $input,
+    array(
+        'a',
+        'p'
+    )
+);
+
+// PHP 7.4: Warning. Incorrectly passing $allowable_tags as an array.
+$str = strip_tags($input, ['<a>', '<p>']);
+$str = strip_tags(
+    $input,
+    array(
+        '<a>',
+        '<p>'
+    ),
+);
+
+// Prevent false positive.
+$str = strip_tags($input, ['br', ...function_call('<a>,<p>')]); // PHP 7.4 syntax: unpacking within an array.
+$str = strip_tags($input, []);

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New passing $allowable_tags as an array to strip_tags() tests.
+ *
+ * @group newStripTagsAllowableTagsArray
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewStripTagsAllowableTagsArraySniff
+ *
+ * @since 9.3.0
+ */
+class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewStripTagsAllowableTagsArray
+     *
+     * @dataProvider dataNewStripTagsAllowableTagsArray
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testNewStripTagsAllowableTagsArray($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '7.3');
+        $error = 'The strip_tags() function did not accept $allowable_tags to be passed in array format in PHP 7.3 and earlier.';
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewStripTagsAllowableTagsArray()
+     *
+     * @return array
+     */
+    public function dataNewStripTagsAllowableTagsArray()
+    {
+        return array(
+            array(13),
+            array(16),
+            array(23),
+            array(26),
+            array(33),
+            array(34),
+        );
+    }
+
+
+    /**
+     * testInvalidStripTagsAllowableTagsArray
+     *
+     * @dataProvider dataInvalidStripTagsAllowableTagsArray
+     *
+     * @param int  $line       Line number where the error should occur.
+     * @param bool $paramValue The parameter value detected.
+     *
+     * @return void
+     */
+    public function testInvalidStripTagsAllowableTagsArray($line, $paramValue)
+    {
+        $file  = $this->sniffFile(__FILE__, '7.4');
+        $error = 'When passing strip_tags() the $allowable_tags parameter as an array, the tags should not be enclosed in <> brackets. Found: ' . $paramValue;
+
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidStripTagsAllowableTagsArray()
+     *
+     * @return array
+     */
+    public function dataInvalidStripTagsAllowableTagsArray()
+    {
+        return array(
+            array(23, "'<a>'"),
+            array(23, "'<p>'"),
+            array(27, "'<a>'"),
+            array(28, "'<p>'"),
+        );
+    }
+
+    /**
+     * testNoFalsePositivesInvalidStripTagsAllowableTagsArray
+     *
+     * @dataProvider dataNoFalsePositivesInvalidStripTagsAllowableTagsArray
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesInvalidStripTagsAllowableTagsArray($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesInvalidStripTagsAllowableTagsArray()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesInvalidStripTagsAllowableTagsArray()
+    {
+        return array(
+            array(33),
+            array(34),
+        );
+    }
+
+    /**
+     * Test the sniff does not throw false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param string $testVersion The testVersion to use.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($testVersion)
+    {
+        $file = $this->sniffFile(__FILE__, $testVersion);
+
+        // No errors expected on the first 11 lines.
+        for ($line = 1; $line <= 11; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array('7.3'),
+            array('7.4'),
+        );
+    }
+
+
+    /*
+     * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors
+     * about independently of the testVersion.
+     */
+}


### PR DESCRIPTION
> `strip_tags()` now also accepts an array of allowed tags: Instead of
`strip_tags($str, '<a><p>')` you can now write `strip_tags($str, ['a', 'p'])`.

Refs:
* https://github.com/php/php-src/blob/3775d47eee38f3b34f800a0b23f840ec7a94e4c7/UPGRADING#L301-L303
* https://github.com/php/php-src/commit/b1e9c73b2777b802925bcdcec6d7012b6d98f1cb

Includes unit tests.

Related to #808