### PR TITLE
PHP 7.4: Custom object serialization RFC

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -73,6 +73,14 @@ class NonStaticMagicMethodsSniff extends Sniff
         '__set_state' => array(
             'static'     => true,
         ),
+        '__serialize' => array(
+            'visibility' => 'public',
+            'static'     => false,
+        ),
+        '__unserialize' => array(
+            'visibility' => 'public',
+            'static'     => false,
+        ),
     );
 
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -73,6 +73,15 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
             '5.2'     => true,
             'message' => 'The method %s() was not truly magical in PHP version %s and earlier. The associated magic functionality will only be called when directly combined with echo or print.',
         ),
+
+        '__serialize' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
+        '__unserialize' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.1.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.1.inc
@@ -166,3 +166,22 @@ $wrongStatic = new class
     function __callStatic($name, $arguments) {}
     function __set_state($properties) {}
 }
+
+// PHP 7.4: new __serialize(), unserialize().
+$normal = new class
+{
+    public function __serialize() {}
+    public function __unserialize($data) {}
+}
+
+class PHP74WrongVisibility
+{
+    protected function __serialize() {}
+    private function __unserialize($data) {}
+}
+
+interface PHP74WrongStatic
+{
+    public static function __serialize();
+    static public function __unserialize($data);
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.2.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.2.inc
@@ -11,6 +11,8 @@ trait PlainTrait
     function __sleep() {}
     function __toString() {}
     static function __set_state($properties) {}
+    function __serialize() {}
+    function __unserialize($data) {}
 }
 
 trait NormalTrait
@@ -25,6 +27,8 @@ trait NormalTrait
     public function __sleep() {}
     public function __toString() {}
     public static function __set_state($properties) {}
+    public function __serialize() {}
+    public function __unserialize($data) {}
 }
 
 trait WrongVisibilityTrait
@@ -37,6 +41,8 @@ trait WrongVisibilityTrait
     protected static function __callStatic($name, $arguments) {}
     private function __sleep() {}
     protected function __toString() {}
+    private function __serialize() {}
+    protected function __unserialize($data) {}
 }
 
 trait WrongStaticTrait
@@ -48,5 +54,7 @@ trait WrongStaticTrait
     static function __call($name, $arguments) {}
     function __callStatic($name, $arguments) {}
     function __set_state($properties) {}
+    public static function __serialize() {}
+    static public function __unserialize($data) {}
 }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -150,19 +150,24 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             array('__sleep', 'public', 'private', 155),
             array('__toString', 'public', 'protected', 156),
 
+            // PHP 7.4: __(un)serialize()
+            array('__serialize', 'public', 'protected', 179),
+            array('__unserialize', 'public', 'private', 180),
+
             /*
              * nonstatic_magic_methods_traits.php
              */
             // Trait.
-            array('__get', 'public', 'private', 32, true),
-            array('__set', 'public', 'protected', 33, true),
-            array('__isset', 'public', 'private', 34, true),
-            array('__unset', 'public', 'protected', 35, true),
-            array('__call', 'public', 'private', 36, true),
-            array('__callStatic', 'public', 'protected', 37, true),
-            array('__sleep', 'public', 'private', 38, true),
-            array('__toString', 'public', 'protected', 39, true),
-
+            array('__get', 'public', 'private', 36, true),
+            array('__set', 'public', 'protected', 37, true),
+            array('__isset', 'public', 'private', 38, true),
+            array('__unset', 'public', 'protected', 39, true),
+            array('__call', 'public', 'private', 40, true),
+            array('__callStatic', 'public', 'protected', 41, true),
+            array('__sleep', 'public', 'private', 42, true),
+            array('__toString', 'public', 'protected', 43, true),
+            array('__serialize', 'public', 'private', 44, true),
+            array('__unserialize', 'public', 'protected', 45, true),
         );
     }
 
@@ -229,16 +234,21 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             array('__unset', 164),
             array('__call', 165),
 
+            // PHP 7.4: __(un)serialize()
+            array('__serialize', 185),
+            array('__unserialize', 186),
+
             /*
              * nonstatic_magic_methods_traits.php
              */
             // Trait.
-            array('__get', 44, true),
-            array('__set', 45, true),
-            array('__isset', 46, true),
-            array('__unset', 47, true),
-            array('__call', 48, true),
-
+            array('__get', 50, true),
+            array('__set', 51, true),
+            array('__isset', 52, true),
+            array('__unset', 53, true),
+            array('__call', 54, true),
+            array('__serialize', 57, true),
+            array('__unserialize', 58, true),
         );
     }
 
@@ -294,8 +304,8 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
              * nonstatic_magic_methods_traits.php
              */
             // Trait.
-            array('__callStatic', 49, true),
-            array('__set_state', 50, true),
+            array('__callStatic', 55, true),
+            array('__set_state', 56, true),
 
         );
     }
@@ -404,6 +414,10 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             array(143),
             array(144),
 
+            // PHP 7.4: __(un)serialize()
+            array(173),
+            array(174),
+
             /*
              * nonstatic_magic_methods_traits.php
              */
@@ -417,9 +431,9 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             array(11, true),
             array(12, true),
             array(13, true),
+            array(14, true),
+            array(15, true),
             // Normal trait.
-            array(18, true),
-            array(19, true),
             array(20, true),
             array(21, true),
             array(22, true),
@@ -428,7 +442,10 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             array(25, true),
             array(26, true),
             array(27, true),
-
+            array(28, true),
+            array(29, true),
+            array(30, true),
+            array(31, true),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.1.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.1.inc
@@ -67,3 +67,14 @@ $a = new class
     public function __invoke($x) {}
     public function __debugInfo() {}
 }
+
+/*
+ * PHP 7.4: new (un)serialize magic methods.
+ */
+function __serialize() {} // OK, not in OO scope.
+function __unserialize($data) {} // OK, not in OO scope.
+
+class PHP74NewMagic {
+    public function __serialize() {}
+    public function __unserialize($data) {}
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.2.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.2.inc
@@ -10,4 +10,6 @@ trait MyTrait
     public static function __callStatic($name, $arguments) {}
     public function __invoke($x) {}
     public function __debugInfo() {}
+    public function __serialize() {}
+    public function __unserialize($data) {}
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -120,7 +120,7 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
     public function dataNewMagicMethod()
     {
         return array(
-            // File: new_magic_methods.php.
+            // File: NewMagicMethodsUnitTest.1.inc.
             array('__get', '4.4', array(22, 34, 61), '5.0'),
             array('__isset', '5.0', array(23, 35, 62), '5.1'),
             array('__unset', '5.0', array(24, 36, 63), '5.1'),
@@ -128,8 +128,10 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
             array('__callStatic', '5.2', array(27, 39, 66), '5.3'),
             array('__invoke', '5.2', array(28, 40, 67), '5.3'),
             array('__debugInfo', '5.5', array(29, 41, 68), '5.6'),
+            array('__serialize', '7.3', array(78), '7.4'),
+            array('__unserialize', '7.3', array(79), '7.4'),
 
-            // File: new_magic_methods_traits.php.
+            // File: NewMagicMethodsUnitTest.2.inc.
             array('__get', '4.4', array(5), '5.0', true),
             array('__isset', '5.0', array(6), '5.1', true),
             array('__unset', '5.0', array(7), '5.1', true),
@@ -137,6 +139,8 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
             array('__callStatic', '5.2', array(10), '5.3', true),
             array('__invoke', '5.2', array(11), '5.3', true),
             array('__debugInfo', '5.5', array(12), '5.6', true),
+            array('__serialize', '7.3', array(13), '7.4', true),
+            array('__unserialize', '7.3', array(14), '7.4', true),
         );
     }
 
@@ -175,12 +179,12 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
     public function dataChangedToStringMethod()
     {
         return array(
-            // File: new_magic_methods.php.
+            // File: NewMagicMethodsUnitTest.1.inc.
             array(26),
             array(38),
             array(65),
 
-            // File: new_magic_methods_traits.php.
+            // File: NewMagicMethodsUnitTest.2.inc.
             array(9, true),
         );
     }
@@ -256,6 +260,8 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
             array(52),
             array(53),
             array(54),
+            array(74),
+            array(75),
         );
     }
 
@@ -267,11 +273,11 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        // File: new_magic_methods.php.
+        // File: NewMagicMethodsUnitTest.1.inc.
         $file = $this->getTestFile(false, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
 
-        // File: new_magic_methods_traits.php.
+        // File: NewMagicMethodsUnitTest.2.inc.
         $file = $this->getTestFile(true, '99.0'); // High version beyond newest addition.
         $this->assertNoViolation($file);
     }


### PR DESCRIPTION
## PHP 7.4/NewMagicMethods: handle new __(un)serialize()

> A new mechanism for custom object serialization has been added, which uses two new magic methods:
>
>     ```php
>     // Returns array containing all the necessary state of the object.
>     public function __serialize(): array;
>
>     // Restores the object state from the given data array.
>     public function __unserialize(array $data): void;
>     ```
>
> The new serialization mechanism supersedes the Serializable interface, which will be deprecated in the future.

Refs:
* https://wiki.php.net/rfc/custom_object_serialization
* https://github.com/php/php-src/blob/3775d47eee38f3b34f800a0b23f840ec7a94e4c7/UPGRADING#L305-L315
* php/php-src#3761
* php/php-src@d373c11

Includes unit tests.

## PHP 7.4/NonStaticMagicMethods: handle new __(un)serialize()

From the RFC:

> **Creating objects in __unserialize()**
>
> Some people have expressed a desire to make __unserialize() a static method which creates and returns the unserialized object (rather than first constructing the object and then calling __unserialize() to initialize it).
>
> This would allow an even greater degree of control over the serialization mechanism, for example it would allow to return an already existing object from __unserialize().
>
> However, allowing this would once again require immediately calling __unserialize() functions (interleaved with unserialization) to make the object available for backreferences, which would reintroduce some of the problems that Serializable suffers from. As such, this will not be supported.

Refs:
* https://wiki.php.net/rfc/custom_object_serialization
* https://github.com/php/php-src/blob/3775d47eee38f3b34f800a0b23f840ec7a94e4c7/UPGRADING#L305-L315
* php/php-src#3761
* php/php-src@d373c11

Includes unit tests.

Related to #808