### PR TITLE
PHP 7.4: new NewProcOpenCmdArray sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * As of PHP 7.4, proc_open() now also accepts an array instead of a string for the command.
+ *
+ * In that case, the process will be opened directly (without going through a shell) and
+ * PHP will take care of any necessary argument escaping.
+ *
+ * PHP version 7.4
+ *
+ * @link https://github.com/php/php-src/blob/3775d47eee38f3b34f800a0b23f840ec7a94e4c7/UPGRADING#L323-L327
+ *
+ * @since 9.3.0
+ */
+class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'proc_open' => true,
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 9.3.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return false;
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 9.3.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[1]) === false) {
+            return;
+        }
+
+        $tokens       = $phpcsFile->getTokens();
+        $targetParam  = $parameters[1];
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], $targetParam['end'], true);
+
+        if ($nextNonEmpty === false) {
+            // Shouldn't be possible.
+            return;
+        }
+
+        if ($tokens[$nextNonEmpty]['code'] !== \T_ARRAY
+            && $tokens[$nextNonEmpty]['code'] !== \T_OPEN_SHORT_ARRAY
+        ) {
+            // Not passed as an array.
+            return;
+        }
+
+        if ($this->supportsBelow('7.3') === true) {
+            $phpcsFile->addError(
+                'The proc_open() function did not accept $cmd to be passed in array format in PHP 7.3 and earlier.',
+                $nextNonEmpty,
+                'Found'
+            );
+        }
+
+        if ($this->supportsAbove('7.4') === true) {
+            if (strpos($targetParam['raw'], 'escapeshellarg(') === false) {
+                // Efficiency: prevent needlessly walking the array.
+                return;
+            }
+
+            $items = $this->getFunctionCallParameters($phpcsFile, $nextNonEmpty);
+
+            if (empty($items)) {
+                return;
+            }
+
+            foreach ($items as $item) {
+                for ($i = $item['start']; $i <= $item['end']; $i++) {
+                    if ($tokens[$i]['code'] !== \T_STRING
+                        || $tokens[$i]['content'] !== 'escapeshellarg'
+                    ) {
+                        continue;
+                    }
+
+                    // @todo Potential future enhancement: check if it's a call to the PHP native function.
+
+                    $phpcsFile->addWarning(
+                        'When passing proc_open() the $cmd parameter as an array, PHP will take care of any necessary argument escaping. Found: %s',
+                        $i,
+                        'Invalid',
+                        array($item['raw'])
+                    );
+
+                    // Only throw one error per array item.
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.inc
@@ -1,0 +1,39 @@
+<?php
+
+// OK.
+$proc = proc_open(
+        '/usr/bin/passwd ' . escapeshellarg($username),
+        $descriptorspec,
+        $pipes
+);
+$proc = proc_open('tail -F /var/log/nginx/stats.access.log', $descriptorspec, $pipes);
+$proc = proc_open('php ' . $abs_path, $spec, $pipes, null, $_ENV);
+
+// Undetermined. Ignore.
+$proc = proc_open($command, $descriptorSpec, $pipes);
+$proc = proc_open(escapeshellarg($scriptFile), $descriptorspec, $pipes, $wd);
+$proc = proc_open(self::COMMAND, $descriptorSpec, $pipes);
+
+// PHP 7.4: passing $cmd as an array.
+$proc = proc_open(['php', '-r', 'echo "Hello World\n";'], $descriptors, $pipes);
+$proc = proc_open(
+    array(
+        'php',
+        '-r',
+        'echo "Hello World\n";',
+    ),
+    $descriptors,
+    $pipes
+);
+
+// PHP 7.4: Warning. PHP will automatically escape arguments when $cmd is passed as an array.
+$proc = proc_open(['php', '-r', escapeshellarg($echo)], $descriptors, $pipes);
+$proc = proc_open(
+    array(
+        'phpcs',
+        '--standard=' . escapeshellarg($standard),
+        './path/to/' . escapeshellarg($file),
+    ),
+    $descriptors,
+    $pipes
+);

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2019 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New passing $allowable_tags as an array to strip_tags() tests.
+ *
+ * @group newProcOpenCmdArray
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewProcOpenCmdArraySniff
+ *
+ * @since 9.3.0
+ */
+class NewProcOpenCmdArrayUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewProcOpenCmdArray
+     *
+     * @dataProvider dataNewProcOpenCmdArray
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testNewProcOpenCmdArray($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '7.3');
+        $error = 'The proc_open() function did not accept $cmd to be passed in array format in PHP 7.3 and earlier.';
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewProcOpenCmdArray()
+     *
+     * @return array
+     */
+    public function dataNewProcOpenCmdArray()
+    {
+        return array(
+            array(18),
+            array(20),
+            array(30),
+            array(32),
+        );
+    }
+
+
+    /**
+     * testInvalidProcOpenCmdArray
+     *
+     * @dataProvider dataInvalidProcOpenCmdArray
+     *
+     * @param int  $line      Line number where the error should occur.
+     * @param bool $itemValue The parameter value detected.
+     *
+     * @return void
+     */
+    public function testInvalidProcOpenCmdArray($line, $itemValue)
+    {
+        $file  = $this->sniffFile(__FILE__, '7.4');
+        $error = 'When passing proc_open() the $cmd parameter as an array, PHP will take care of any necessary argument escaping. Found: ' . $itemValue;
+
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidProcOpenCmdArray()
+     *
+     * @return array
+     */
+    public function dataInvalidProcOpenCmdArray()
+    {
+        return array(
+            array(30, 'escapeshellarg($echo)'),
+            array(34, '\'--standard=\' . escapeshellarg($standard)'),
+            array(35, '\'./path/to/\' . escapeshellarg($file)'),
+        );
+    }
+
+
+    /**
+     * Test the sniff does not throw false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param string $testVersion The testVersion to use.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($testVersion)
+    {
+        $file = $this->sniffFile(__FILE__, $testVersion);
+
+        // No errors expected on the first 16 lines.
+        for ($line = 1; $line <= 16; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array('7.3'),
+            array('7.4'),
+        );
+    }
+
+
+    /*
+     * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors
+     * about independently of the testVersion.
+     */
+}


### PR DESCRIPTION
> proc_open() now accepts an array instead of a string for the command. In
>  this case the process will be opened directly (without going through a
>  shell) and PHP will take care of any necessary argument escaping.
>
>  `proc_open(['php', '-r', 'echo "Hello World\n";'], $descriptors, $pipes);`

Refs:
* https://github.com/php/php-src/blob/3775d47eee38f3b34f800a0b23f840ec7a94e4c7/UPGRADING#L323-L327
* https://github.com/php/php-src/commit/8be051015e04ce6151da77581922eea65330f354

Includes unit tests.

Related to #808