### PR TITLE
PHP 7.4/RemovedIniDirectives: handle deprecated allow_url_include

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -250,6 +250,9 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             '7.3' => false, // Has been marked as deprecated in the manual from before this time. Now hard-deprecated.
         ),
 
+        'allow_url_include' => array(
+            '7.4' => false,
+        ),
         'ibase.allow_persistent' => array(
             '7.4' => true,
         ),

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -234,3 +234,6 @@ $a = ini_get('pfpro.proxylogon');
 
 ini_set('pfpro.proxypassword', 'string');
 $a = ini_get('pfpro.proxypassword');
+
+ini_set('allow_url_include', 'On');
+$a = ini_get('allow_url_include');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -152,6 +152,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             array('track_errors', '7.2', array(172, 173), '7.1'),
 
             array('pdo_odbc.db2_instance_name', '7.3', array(184, 185), '7.2'),
+
+            array('allow_url_include', '7.4', array(238, 239), '7.3'),
         );
     }
 


### PR DESCRIPTION
> The `allow_url_include` ini directive is deprecated. Enabling it will generate a deprecation notice at startup.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_4#allow_url_include
* https://github.com/php/php-src/blob/86d751f696786bcb95c580482c9884e41ccf2406/UPGRADING#L372-L373
* https://github.com/php/php-src/commit/b3f74b0b7d89ee8efe6897b9ed6397d8b80a15e0

Related to #808