### PR TITLE
PHP 7.4/NewIniDirectives: detect new  zend.exception_ignore_args directive

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -502,6 +502,11 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '7.2' => false,
             '7.3' => true,
         ),
+
+        'zend.exception_ignore_args' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
     );
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -334,3 +334,6 @@ $test = ini_get('session.cookie_samesite');
 
 ini_set('imap.enable_insecure_rsh', 1);
 $test = ini_get('imap.enable_insecure_rsh');
+
+ini_set('zend.exception_ignore_args', 1);
+$test = ini_get('zend.exception_ignore_args');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -191,6 +191,8 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('syslog.ident', '7.3', array(314, 315), '7.2'),
             array('syslog.filter', '7.3', array(317, 318), '7.2'),
             array('session.cookie_samesite', '7.3', array(332, 333), '7.2'),
+
+            array('zend.exception_ignore_args', '7.4', array(338, 339), '7.3'),
         );
     }
 


### PR DESCRIPTION
> - zend.exception_ignore_args
>    . New INI directive which displays or hides arguments from the stack traces
generated for exceptions.

Refs:
* https://github.com/php/php-src/blob/30de357fa14480468132bbc22a272aeb91789ba8/UPGRADING#L597-L599
* https://github.com/php/php-src/commit/0819e6dc9b4788e5d44b64f8e606a56c969a1588#diff-7748eb3bfdd3bf962553f6f9f2723c45

Related to #808