### PR TITLE
PHP 7.4/NewHashAlgorithms: add new `crc32c` hash algo

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -99,6 +99,10 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
             '7.0' => false,
             '7.1' => true,
         ),
+        'crc32c' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.inc
@@ -31,3 +31,4 @@ hash_hmac('sha3-224');
 hash_init('sha3-256');
 hash_pbkdf2('sha3-384');
 hash('sha3-512');
+hash('crc32c');

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -74,6 +74,7 @@ class NewHashAlgorithmsUnitTest extends BaseSniffTest
             array('sha3-256', '7.0', 31, '7.1'),
             array('sha3-384', '7.0', 32, '7.1'),
             array('sha3-512', '7.0', 33, '7.1'),
+            array('crc32c', '7.3', 34, '7.4'),
         );
     }
 


### PR DESCRIPTION
> - Hash:
>    Added "crc32c" hash using Castagnoli's polynomial. This crc32 variant is
>    used by storage systems, such as iSCSI, SCTP, Btrfs and ext4.

Refs:
* https://github.com/php/php-src/blob/3775d47eee38f3b34f800a0b23f840ec7a94e4c7/UPGRADING#L258-L260
* https://github.com/php/php-src/commit/c79ce48ddb2125a3d19723e0fbca1bd770bacab7

Related to #808