### PR TITLE
PHP 7.4/NewFunctions: handle new imagecreatefromtga()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -1854,6 +1854,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.3' => false,
             '7.4' => true,
         ),
+        'imagecreatefromtga' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
         'mb_str_split' => array(
             '7.3' => false,
             '7.4' => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -484,3 +484,4 @@ pcntl_unshare();
 sapi_windows_set_ctrl_handler();
 sapi_windows_generate_ctrl_event();
 password_algos();
+imagecreatefromtga();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -537,6 +537,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('sapi_windows_set_ctrl_handler', '7.3', array(484), '7.4'),
             array('sapi_windows_generate_ctrl_event', '7.3', array(485), '7.4'),
             array('password_algos', '7.3', array(486), '7.4'),
+            array('imagecreatefromtga', '7.3', array(487), '7.4'),
         );
     }
 


### PR DESCRIPTION
>  GD:
>  Added `imagecreatefromtga()` function, which allows reading images in TGA
>  format. TGA support is now also indicated by `gd_info()` and `imagetypes()`.
>  Note that TGA images are not recognized by `imagecreatefromstring()` and `getimagesize()`.

Refs:
* https://github.com/php/php-src/blob/3775d47eee38f3b34f800a0b23f840ec7a94e4c7/UPGRADING#L461-L465
* https://github.com/php/php-src/commit/81fd113506e4c5833e64998651f232734ebb2cb7

Related to #808