### PR TITLE
PHP 7.4/RemovedFunctionParameters: handle deprecated curl_version() $age

### DIFF
--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -13,3 +13,9 @@ ldap_next_attribute( $link_identifier, $result_entry_identifier, $ber_identifier
 
 define('CONSTANT', 'foo'); // OK.
 define( 'CONSTANT', 'foo', true, );
+
+curl_version(); // OK.
+curl_version( CURLVERSION_NOW ); // OK.
+curl_version( 4 ); // OK when on Curl version 4.
+curl_version( 10505678 );
+curl_version( $age );

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -157,9 +157,17 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
      */
     public function dataDeprecatedParameter()
     {
-        return array(
+        $data = array(
             array('define', 'case_insensitive', '7.3', array(15), '7.2'),
+            array('curl_version', 'age', '7.4', array(20), '7.3'),
+            array('curl_version', 'age', '7.4', array(21), '7.3'),
         );
+
+        if (\CURLVERSION_NOW !== 4) {
+            $data[] = array('curl_version', 'age', '7.4', array(19), '7.3');
+        }
+
+        return $data;
     }
 
 
@@ -187,11 +195,19 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
      */
     public function dataNoFalsePositives()
     {
-        return array(
+        $data = array(
             array(4),
             array(5),
             array(14),
+            array(17),
+            array(18),
         );
+
+        if (\CURLVERSION_NOW === 4) {
+            $data[] = array(19);
+        }
+
+        return $data;
     }
 
 


### PR DESCRIPTION
> The $version parameter of curl_version() is deprecated. If any value not
> equal to the default CURLVERSION_NOW is passed, a warning is raised and the
> parameter is ignored.

Notes:
* While the changelog and the PHP native deprecation message call the parameter `$version`, the documentation calls it `$age`, so that's the parameter name used for the error message.
* Using the `CURL_VERSION_NOW` constant for the value is still fine, so the sniff takes that into account.

Refs:
* https://github.com/php/php-src/blob/86d751f696786bcb95c580482c9884e41ccf2406/UPGRADING#L55-L57
* https://www.php.net/manual/en/function.curl-version.php
* https://github.com/php/php-src/commit/357da6bc59268755323bc924b0aae93374c7e227

Related to #808