### PR TITLE
NewNegativeStringOffset: add unit test for non-lowercase function calls

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.inc
@@ -31,7 +31,7 @@ mb_ereg_search_setpos(
 	// phpcs:ignore Standard.Category.Sniff -- for reasons.
 );
 
-mb_ereg_search_setpos( -     100);
+MB_ereg_search_setpos( -     100);
 
 $a = file_get_contents($filename, true, $context, -1024, 1024 );
 $a = grapheme_extract($haystack, $size, $extract_type, -10 );
@@ -44,5 +44,5 @@ $a = mb_strpos($haystack, $needle, -5 );
 $a = stripos($haystack, $needle, -42 );
 $a = strpos($haystack, $needle, -30 );
 $a = substr_count($haystack, $needle, -20, -10 );
-$a = substr_count($haystack, $needle, -20, 10 );
+$a = Substr_Count($haystack, $needle, -20, 10 );
 $a = substr_count($haystack, $needle, 20, -+-+-10 );

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
@@ -57,7 +57,7 @@ class NewNegativeStringOffsetUnitTest extends BaseSniffTest
     {
         return array(
             array(28, 'position', 'mb_ereg_search_setpos'),
-            array(34, 'position', 'mb_ereg_search_setpos'),
+            array(34, 'position', 'MB_ereg_search_setpos'),
             array(36, 'offset', 'file_get_contents'),
             array(37, 'start', 'grapheme_extract'),
             array(38, 'offset', 'grapheme_stripos'),
@@ -71,7 +71,7 @@ class NewNegativeStringOffsetUnitTest extends BaseSniffTest
             array(45, 'offset', 'strpos'),
             array(46, 'offset', 'substr_count'),
             array(46, 'length', 'substr_count'),
-            array(47, 'offset', 'substr_count'),
+            array(47, 'offset', 'Substr_Count'),
             array(48, 'length', 'substr_count'),
         );
     }


### PR DESCRIPTION
The sniff already handles this correctly, but it was not explicitly tested and if the call to `strtolower()` would be removed, the unit tests would still pass, while they shouldn't.