### PR TITLE
RemovedMbstringModifiers: add unit test for non-lowercase function calls

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.inc
@@ -12,7 +12,7 @@ mb_regex_set_options( 'ims' );
 
 // These should all be flagged.
 mb_ereg_replace( $pattern, $replace, $subject, 'e' );
-mb_eregi_replace( $pattern, $replace, $subject, "seim" );
+MB_eregi_replace( $pattern, $replace, $subject, "seim" );
 mb_regex_set_options( 'im' . 'se' );
 
 // Interpolated strings: These should NOT be flagged.
@@ -23,7 +23,7 @@ mb_regex_set_options( 'im' . "$se" );
 // Interpolated strings: These should all be flagged.
 mb_ereg_replace( $pattern, $replace, $subject, "e$m" );
 mb_eregi_replace( $pattern, $replace, $subject, "me$i" );
-mb_regex_set_options( 'im' . "{$se}e" );
+Mb_Regex_Set_Options( 'im' . "{$se}e" );
 
 // Verify the sniff also pick up on the function aliases.
 mbereg_replace( $pattern, $replace, $subject, 'e' );


### PR DESCRIPTION
The sniff already handles this correctly, but it was not explicitly tested and if the call to `strtolower()` would be removed, the unit tests would still pass, while they shouldn't.