### PR TITLE
NewExceptionsFromToString: 2 bugfixes + 1 enhancement

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -32,7 +32,7 @@ class NewExceptionsFromToStringSniff extends Sniff
      *
      * @var array
      */
-    public $ooScopeTokens = array(
+    protected $ooScopeTokens = array(
         'T_CLASS'      => true,
         'T_TRAIT'      => true,
         'T_ANON_CLASS' => true,

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * As of PHP 7.4, throwing exceptions from a __toString() method is allowed.
@@ -39,6 +40,20 @@ class NewExceptionsFromToStringSniff extends Sniff
     );
 
     /**
+     * Tokens which should be ignore when they preface a function declaration
+     * when trying to find the docblock (if any).
+     *
+     * Array will be added to in the register() method.
+     *
+     * @since 9.3.0
+     *
+     * @var array
+     */
+    private $docblockIgnoreTokens = array(
+        \T_WHITESPACE => \T_WHITESPACE,
+    );
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 9.2.0
@@ -47,6 +62,12 @@ class NewExceptionsFromToStringSniff extends Sniff
      */
     public function register()
     {
+        // Enhance the array of tokens to ignore for finding the docblock.
+        $this->docblockIgnoreTokens += Tokens::$methodPrefixes;
+        if (isset(Tokens::$phpcsCommentTokens)) {
+            $this->docblockIgnoreTokens += Tokens::$phpcsCommentTokens;
+        }
+
         return array(\T_FUNCTION);
     }
 
@@ -87,8 +108,9 @@ class NewExceptionsFromToStringSniff extends Sniff
         /*
          * Examine the content of the function.
          */
-        $error    = 'Throwing exceptions from __toString() was not allowed prior to PHP 7.4';
-        $throwPtr = $tokens[$stackPtr]['scope_opener'];
+        $error       = 'Throwing exceptions from __toString() was not allowed prior to PHP 7.4';
+        $throwPtr    = $tokens[$stackPtr]['scope_opener'];
+        $errorThrown = false;
 
         do {
             $throwPtr = $phpcsFile->findNext(\T_THROW, ($throwPtr + 1), $tokens[$stackPtr]['scope_closer']);
@@ -113,7 +135,35 @@ class NewExceptionsFromToStringSniff extends Sniff
 
             if ($inTryCatch === false) {
                 $phpcsFile->addError($error, $throwPtr, 'Found');
+                $errorThrown = true;
             }
         } while (true);
+
+        if ($errorThrown === true) {
+            // We've already thrown an error for this method, no need to examine the docblock.
+            return;
+        }
+
+        /*
+         * Check whether the function has a docblock and if so, whether it contains a @throws tag.
+         *
+         * @internal This can be partially replaced by the findCommentAboveFunction()
+         *           utility function in due time.
+         */
+        $commentEnd = $phpcsFile->findPrevious($this->docblockIgnoreTokens, ($stackPtr - 1), null, true);
+        if ($commentEnd === false || $tokens[$commentEnd]['code'] !== \T_DOC_COMMENT_CLOSE_TAG) {
+            return;
+        }
+
+        $commentStart = $tokens[$commentEnd]['comment_opener'];
+        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
+            if ($tokens[$tag]['content'] !== '@throws') {
+                continue;
+            }
+
+            // Found a throws tag.
+            $phpcsFile->addError($error, $stackPtr, 'ThrowsTagFoundInDocblock');
+            break;
+        }
     }
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.inc
@@ -98,3 +98,62 @@ function IrrelevantTryCatchOutsideFunctionScope() {
         // ...
     }
 }
+
+// Issue #863 Uncaught exception thrown from called function/method. Detect via docblock.
+class NoDocblock {
+    public function __toString() {
+        return $obj->methodThrowingException('should not trigger the sniff');
+    }
+}
+
+class DocblockNoThrows {
+    /**
+     * Convert to string.
+     *
+     * @internal Some internal note.
+     * @todo     Remove exception.
+     * @random   Just testing that other tags are correctly ignored.
+     * @codeCoverageIgnore
+     */
+    public function __toString() {
+        return $obj->methodThrowingException('should not trigger the sniff');
+    }
+}
+
+class DetectBasedOnDocblock {
+    /**
+     * Convert to string.
+     *
+     * @todo   Remove exception.
+     * @throws SomeException
+     */
+    public function __toString() {
+        return $obj->methodThrowingException('should trigger the sniff');
+    }
+}
+
+class DetectBasedOnIncorrectDocblock {
+    /**
+     * Convert to string.
+     *
+     * @throws SomeException
+     */
+    public function __toString() {
+        return $obj->method_call();
+    }
+}
+
+class CaughtExceptionButDocblockStillSaysThrows {
+    /**
+     * Convert to string.
+     *
+     * @throws SomeException
+     */
+    public function __toString() {
+        try {
+            throw new \LogicException('');
+        } catch (\Exception $e) {
+            // ...
+        }
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.inc
@@ -59,3 +59,42 @@ $anon = new class() {
         return $this->foo;
     }
 };
+
+// Issue #863 Exception in try/catch.
+class CaughtException {
+    public function __toString() {
+        try {
+            throw new \LogicException('should not trigger the sniff');
+        } catch (\Exception $e) {
+            // ...
+        }
+    }
+}
+
+class CaughtAndUnCaughtException {
+    public function __toString() {
+        try {
+            throw new \LogicException('should not trigger the sniff');
+        } catch (\Exception $e) {
+            // ...
+            throw new \RuntimeException('should trigger the sniff');
+        }
+
+        throw $obj->methodThrowingException('should trigger the sniff');
+    }
+}
+
+function IrrelevantTryCatchOutsideFunctionScope() {
+    try {
+        $anon = new class() {
+            public function __toString() {
+                if ( is_int($this->foo) ) {
+                    throw new Exception('Foo is int');
+                }
+                return $this->foo;
+            }
+        }
+    } catch (\Exception $e) {
+        // ...
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
@@ -84,6 +84,9 @@ class NewExceptionsFromToStringUnitTest extends BaseSniffTest
             array(39),
             array(48, true),
             array(57),
+            array(80),
+            array(83),
+            array(92),
         );
     }
 
@@ -117,6 +120,13 @@ class NewExceptionsFromToStringUnitTest extends BaseSniffTest
         for ($line = 1; $line <= 34; $line++) {
             $cases[] = array($line);
         }
+
+        // No false positive for try/catch.
+        for ($line = 64; $line <= 79; $line++) {
+            $cases[] = array($line);
+        }
+
+        $cases[] = array(90);
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
@@ -87,6 +87,9 @@ class NewExceptionsFromToStringUnitTest extends BaseSniffTest
             array(80),
             array(83),
             array(92),
+            array(130),
+            array(141),
+            array(152),
         );
     }
 
@@ -121,12 +124,23 @@ class NewExceptionsFromToStringUnitTest extends BaseSniffTest
             $cases[] = array($line);
         }
 
+        $cases[] = array(37);
+        $cases[] = array(46);
+        $cases[] = array(55);
+
         // No false positive for try/catch.
         for ($line = 64; $line <= 79; $line++) {
             $cases[] = array($line);
         }
 
         $cases[] = array(90);
+
+        // No false positive for docblock check.
+        for ($line = 103; $line <= 122; $line++) {
+            $cases[] = array($line);
+        }
+
+        $cases[] = array(154);
 
         return $cases;
     }


### PR DESCRIPTION
## NewExceptionsFromToString: property should not be public

The `$ooScopeTokens` property is not intended to be set via a custom ruleset, so the property should never have been `public`.

## NewExceptionsFromToString: ignore caught exceptions

When an exception is thrown within a `try/catch` block, ignore it.

This changes the sniff, in that previously only one error per method would be thrown. Now, an error will be thrown for each `throw` tag not in a `try/catch`.

## NewExceptionsFromToString: detect thrown exceptions from docblock

This adds an additional check based on the docblock to attempt to catch exceptions thrown indirectly from this method.

If the docblock indicates that the function may throw an exception, trust it.

The additional check will only be run if the search for the `throw` keyword didn't yield any errors.

---

Fixes #863