### PR TITLE
NewMagicMethods: recognize __construct() and __destruct()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -34,6 +34,14 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
      * @var array(string => array(string => int|string|null))
      */
     protected $newMagicMethods = array(
+        '__construct' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        '__destruct' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
         '__get' => array(
             '4.4' => false,
             '5.0' => true,

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.1.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.1.inc
@@ -5,8 +5,6 @@
  */
 class MyOkClass
 {
-    public function __construct() {}
-    public function __destruct() {}
     public function __call($name, $arguments) {}
     public function __set($name, $value) {}
     public function __sleep() {}
@@ -19,6 +17,8 @@ class MyOkClass
  */
 class MyClass
 {
+    public function __construct() {}
+    public function __destruct() {}
     public function __get($name) {}
     public function __isset($name) {}
     public function __unset($name) {}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.2.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.2.inc
@@ -12,4 +12,6 @@ trait MyTrait
     public function __debugInfo() {}
     public function __serialize() {}
     public function __unserialize($data) {}
+    public function __construct() {}
+    public function __destruct() {}
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -121,6 +121,8 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
     {
         return array(
             // File: NewMagicMethodsUnitTest.1.inc.
+            array('__construct', '4.4', array(20), '5.0'),
+            array('__destruct', '4.4', array(21), '5.0'),
             array('__get', '4.4', array(22, 34, 61), '5.0'),
             array('__isset', '5.0', array(23, 35, 62), '5.1'),
             array('__unset', '5.0', array(24, 36, 63), '5.1'),
@@ -141,6 +143,8 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
             array('__debugInfo', '5.5', array(12), '5.6', true),
             array('__serialize', '7.3', array(13), '7.4', true),
             array('__unserialize', '7.3', array(14), '7.4', true),
+            array('__construct', '4.4', array(15), '5.0', true),
+            array('__destruct', '4.4', array(16), '5.0', true),
         );
     }
 
@@ -220,8 +224,6 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
             array(10),
             array(11),
             array(12),
-            array(13),
-            array(14),
         );
     }
 


### PR DESCRIPTION
Both introduced in PHP 5.0 when the OO model came into play.