### PR TITLE
RemovedImplodeFlexibleParamOrder: fix two bugs + one enhancement

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.inc
@@ -51,3 +51,18 @@ implode( compact( $piece1, $piece2, $piece3 ), $glue );
 // Special cased PHP native constants.
 implode( $pieces, PHP_EOL );
 implode( $pieces, DIRECTORY_SEPARATOR );
+
+// Issue #890 - Hardening for ternary as part of second param.
+$defaults = [
+    'class'    => implode(
+        ' ',
+        array_filter( [ 'a' => $type === 'a' ? '-' : '|', ] )
+    ),
+];
+
+// Efficiency, second param doesn't even need to be examined here.
+implode( ( $type === 'a' ? '-' : '|' ), (array) $pieces );
+
+// Recognize array casts.
+implode( $glue, (array) $object ); // OK.
+implode( (array) $object, $glue ); // Error.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
@@ -66,6 +66,7 @@ class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTest
             array(49, 'implode'),
             array(52, 'implode'),
             array(53, 'implode'),
+            array(68, 'implode'),
         );
     }
 
@@ -73,16 +74,39 @@ class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTest
     /**
      * testNoFalsePositives
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = array();
 
         // No errors expected on the first 27 lines.
         for ($line = 1; $line <= 27; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = array($line);
         }
+
+        $data[] = array(57);
+        $data[] = array(64);
+        $data[] = array(67);
+
+        return $data;
     }
 
 


### PR DESCRIPTION
Bugs:
1. "Empty" tokens (whitespace, comments) were not disregarded when determining whether the first parameter was only a text string, which could lead to the second parameter being examined when it doesn't need to be.
2. If either parameter contained a ternary, potentially nested in some other construct, the ternary would confuse the sniff.

Both fixed now.

In addition to this if one of the parameters contains an `(array)` cast, let's presume that's the array parameter. This may lead to some false positives for complexly build parameters, but we'll deal with that later if needs be.

Includes unit tests.

Fixes #890