### PR TITLE
Travis: update stage conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,11 @@ env:
 stages:
   - name: sniff
   - name: quicktest
-    if: type = push AND branch != master
+    if: type = push AND branch NOT IN (master, develop)
   - name: test
-    if: branch = master
+    if: branch IN (master, develop)
   - name: coverage
-    if: branch = master
+    if: branch IN (master, develop)
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
As `develop` is now the default branch, the conditions based on which the various build stages are being triggered need to be updated, otherwise, builds will only run the `sniff` stage for pull requests against `develop`.