### PR TITLE
Documentation: fix up some @internal tags

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -147,8 +147,8 @@ class NewExceptionsFromToStringSniff extends Sniff
         /*
          * Check whether the function has a docblock and if so, whether it contains a @throws tag.
          *
-         * @internal This can be partially replaced by the findCommentAboveFunction()
-         *           utility function in due time.
+         * {@internal This can be partially replaced by the findCommentAboveFunction()
+         *            utility function in due time.}}
          */
         $commentEnd = $phpcsFile->findPrevious($this->docblockIgnoreTokens, ($stackPtr - 1), null, true);
         if ($commentEnd === false || $tokens[$commentEnd]['code'] !== \T_DOC_COMMENT_CLOSE_TAG) {

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -28,8 +28,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://wiki.php.net/rfc/constdereference
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *
- * @internal The reason for splitting the logic of this sniff into different methods is
- *           to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.
+ * {@internal The reason for splitting the logic of this sniff into different methods is
+ *            to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.}}
  *
  * @since 9.3.0 Now also detects dereferencing using curly braces.
  */

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -29,8 +29,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://wiki.php.net/rfc/instance-method-call
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *
- * @internal The reason for splitting the logic of this sniff into different methods is
- *           to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.
+ * {@internal The reason for splitting the logic of this sniff into different methods is
+ *            to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.}}
  *
  * @since 9.3.0 Now also detects class member access on instantiation using curly braces.
  */

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -27,8 +27,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://wiki.php.net/rfc/functionarraydereferencing
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *
- * @internal The reason for splitting the logic of this sniff into different methods is
- *           to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.
+ * {@internal The reason for splitting the logic of this sniff into different methods is
+ *            to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.}}
  *
  * @since 9.3.0 Now also detects dereferencing using curly braces.
  */

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -283,9 +283,9 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
     /**
      * Determine whether a T_STRING is a constant being dereferenced using curly brace syntax.
      *
-     * @internal Note: the first braces for array access to a constant, for some unknown reason,
-     *           can never be curlies, but have to be square brackets.
-     *           Subsequent braces can be curlies.
+     * {@internal Note: the first braces for array access to a constant, for some unknown reason,
+     *            can never be curlies, but have to be square brackets.
+     *            Subsequent braces can be curlies.}}
      *
      * @since 9.3.0
      *


### PR DESCRIPTION
... to comply with the guidelines in the proposed PSR-19: https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc-tags.md#55-internal