### PR TITLE
Documentation: add docblocks to class constants

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -27,6 +27,16 @@ use PHP_CodeSniffer_Tokens as Tokens;
 abstract class Sniff implements PHPCS_Sniff
 {
 
+    /**
+     * Regex to match variables in a double quoted string.
+     *
+     * This matches plain variables, but also more complex variables, such
+     * as $obj->prop, self::prop and $var[].
+     *
+     * @since 7.1.2
+     *
+     * @var string
+     */
     const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';
 
     /**

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -23,6 +23,14 @@ use PHP_CodeSniffer_File as File;
  */
 class BaseSniffTest extends PHPUnit_TestCase
 {
+
+    /**
+     * The name of the standard as registered with PHPCS.
+     *
+     * @since 7.1.3
+     *
+     * @var string
+     */
     const STANDARD_NAME = 'PHPCompatibility';
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -28,8 +28,19 @@ use PHPCompatibility\Tests\BaseSniffTest;
 class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
 {
 
+    /**
+     * Error message snippet for the variable argument error.
+     *
+     * @var string
+     */
     const ERROR_TYPE_VARIABLE = 'a variable argument';
-    const ERROR_TYPE_ZERO     = '0 as an argument';
+
+    /**
+     * Error message snippet for the zero argument error.
+     *
+     * @var string
+     */
+    const ERROR_TYPE_ZERO = '0 as an argument';
 
     /**
      * testBreakAndContinueVariableArgument

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
@@ -25,8 +25,19 @@ use PHPCompatibility\PHPCSHelper;
  */
 class ForbiddenVariableNamesInClosureUseUnitTest extends BaseSniffTest
 {
+
+    /**
+     * The name of the main test case file.
+     *
+     * @var string
+     */
     const TEST_FILE = 'ForbiddenVariableNamesInClosureUseUnitTest.1.inc';
 
+    /**
+     * The name of a secondary test case file which similates live coding.
+     *
+     * @var string
+     */
     const TEST_FILE_LIVE_CODING = 'ForbiddenVariableNamesInClosureUseUnitTest.2.inc';
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -25,7 +25,20 @@ use PHPCompatibility\PHPCSHelper;
  */
 class RemovedMagicAutoloadUnitTest extends BaseSniffTest
 {
-    const TEST_FILE            = 'RemovedMagicAutoloadUnitTest.1.inc';
+
+    /**
+     * The name of the main test case file.
+     *
+     * @var string
+     */
+    const TEST_FILE = 'RemovedMagicAutoloadUnitTest.1.inc';
+
+    /**
+     * The name of a secondary test case file to test against false positives
+     * for namespaced function declarations.
+     *
+     * @var string
+     */
     const TEST_FILE_NAMESPACED = 'RemovedMagicAutoloadUnitTest.2.inc';
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -25,7 +25,19 @@ use PHPCompatibility\PHPCSHelper;
  */
 class RemovedNamespacedAssertUnitTest extends BaseSniffTest
 {
-    const TEST_FILE            = 'RemovedNamespacedAssertUnitTest.1.inc';
+
+    /**
+     * The name of the primary test case file containing code in the global namespace.
+     *
+     * @var string
+     */
+    const TEST_FILE = 'RemovedNamespacedAssertUnitTest.1.inc';
+
+    /**
+     * The name of a secondary test case file containing code in a unscoped namespace.
+     *
+     * @var string
+     */
     const TEST_FILE_NAMESPACED = 'RemovedNamespacedAssertUnitTest.2.inc';
 
     /**

--- a/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
@@ -26,6 +26,11 @@ use PHPCompatibility\PHPCSHelper;
 class NewPHPOpenTagEOFUnitTest extends BaseSniffTest
 {
 
+    /**
+     * Sprintf template for the names of the numbered test case files.
+     *
+     * @var string
+     */
     const TEST_FILE = 'NewPHPOpenTagEOFUnitTest.%d.inc';
 
 

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -24,6 +24,12 @@ use PHPCompatibility\PHPCSHelper;
  */
 class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
 {
+
+    /**
+     * Sprintf template for the names of the numbered test case files.
+     *
+     * @var string
+     */
     const TEST_FILE = 'NewFlexibleHeredocNowdocUnitTest.%d.inc';
 
     /**


### PR DESCRIPTION
Note: only the docblocks for user-facing code and abstract classes contain `@since` tags.