### PR TITLE
Documentation: remove redundant class docblock tags

### DIFF
--- a/PHPCompatibility/AbstractComplexVersionSniff.php
+++ b/PHPCompatibility/AbstractComplexVersionSniff.php
@@ -13,11 +13,7 @@ namespace PHPCompatibility;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\AbstractComplexVersionSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Abstract base class for sniffs based on complex arrays with PHP version information.
  */
 abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersionInterface
 {

--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -15,13 +15,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\AbstractFunctionCallParameterSniff.
- *
  * Abstract class to use as a base for examining the parameter values passed to function calls.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 abstract class AbstractFunctionCallParameterSniff extends Sniff
 {

--- a/PHPCompatibility/AbstractNewFeatureSniff.php
+++ b/PHPCompatibility/AbstractNewFeatureSniff.php
@@ -13,11 +13,7 @@ namespace PHPCompatibility;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\AbstractNewFeatureSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Base class for new feature sniffs.
  */
 abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
 {

--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -13,11 +13,7 @@ namespace PHPCompatibility;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\AbstractRemovedFeatureSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Base class for removed feature sniffs.
  */
 abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
 {

--- a/PHPCompatibility/ComplexVersionInterface.php
+++ b/PHPCompatibility/ComplexVersionInterface.php
@@ -13,15 +13,11 @@ namespace PHPCompatibility;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\ComplexVersionInterface.
+ * Complex Version Interface.
  *
  * Interface to be implemented by sniffs using a multi-dimensional array of
  * PHP features (functions, classes etc) being sniffed for with version
  * information in sub-arrays.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 interface ComplexVersionInterface
 {

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -15,18 +15,12 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\PHPCSHelper
- *
  * PHPCS cross-version compatibility helper class.
  *
  * A number of PHPCS classes were split up into several classes in PHPCS 3.x
  * Those classes cannot be aliased as they don't represent the same object.
  * This class provides helper methods for functions which were contained in
  * one of these classes and which are used within the PHPCompatibility library.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class PHPCSHelper
 {

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -17,12 +17,7 @@ use PHP_CodeSniffer_Sniff as PHPCS_Sniff;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniff.
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2014 Cu.be Solutions bvba
+ * Base class from which all PHPCompatibility sniffs extend.
  */
 abstract class Sniff implements PHPCS_Sniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -15,15 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Classes\NewAnonymousClasses.
- *
  * Anonymous classes are supported in PHP 7.0
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
  */
 class NewAnonymousClassesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -14,12 +14,7 @@ use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Classes\NewClassesSniff.
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2013 Cu.be Solutions bvba
+ * Detect use of new PHP native classes.
  */
 class NewClassesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -15,15 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Classes\NewConstVisibility.
- *
  * Visibility for class constants is available since PHP 7.1.
  *
  * PHP version 7.1
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewConstVisibilitySniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -15,13 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Classes\NewLateStaticBindingSniff.
+ * Detect use of late static binding as introduced in PHP 5.3.
  *
  * PHP version 5.3
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewLateStaticBindingSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -14,11 +14,7 @@ use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Constants\NewConstantsSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Detect use of new PHP native global constants.
  */
 class NewConstantsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -15,16 +15,10 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Constants\NewMagicClassConstantSniff.
- *
  * The special ClassName::class constant is available as of PHP 5.5.0, and allows for
  * fully qualified class name resolution at compile.
  *
  * PHP version 5.5
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewMagicClassConstantSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -14,11 +14,7 @@ use PHPCompatibility\AbstractRemovedFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Constants\RemovedConstantsSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Detect use of deprecated and/or removed PHP native global constants.
  */
 class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -15,15 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\ControlStructures\DiscouragedSwitchContinue.
- *
  * PHP 7.3 will throw a warning when continue is used to target a switch control structure.
  *
  * PHP version 7.3
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class DiscouragedSwitchContinueSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -14,15 +14,9 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ControlStructures\ForbiddenBreakContinueOutsideLoop.
- *
  * Forbids use of break or continue statements outside of looping structures.
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -15,16 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\ControlStructures\ForbiddenBreakContinueVariableArguments.
- *
  * Forbids variable arguments on break or continue statements.
  *
  * PHP version 5.4
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2012 Cu.be Solutions bvba
  */
 class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -14,15 +14,9 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ControlStructures\ForbiddenSwitchWithMultipleDefaultBlocksSniff.
- *
  * Switch statements can not have multiple default blocks since PHP 7.0
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim@cu.be>
  */
 class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -16,11 +16,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\ControlStructures\NewExecutionDirectivesSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Check for valid execution directives set with `declare()`.
  */
 class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -20,10 +20,6 @@ use PHP_CodeSniffer_File as File;
  * can be referenced (i.e. if it is a variable).
  *
  * PHP version 5.5
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewForeachExpressionReferencingSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -17,10 +17,6 @@ use PHP_CodeSniffer_File as File;
  * Detect unpacking nested arrays with list() in a foreach().
  *
  * PHP version 5.5
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewListInForeachSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -14,15 +14,9 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ControlStructures\NewMultiCatch.
- *
  * Catching multiple exception types in one statement is available since PHP 7.1.
  *
  * PHP version 7.1
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewMultiCatchSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -15,14 +15,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Extensions\RemovedExtensionsSniff.
- *
  * Discourages the use of removed extensions. Suggests alternative extensions if available
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2012 Cu.be Solutions bvba
  */
 class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -15,18 +15,11 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenParameterShadowSuperGlobalsSniff
- *
  * Discourages use of superglobals as parameters for functions.
  *
  * {@internal List of superglobals is maintained in the parent class.}}
  *
  * PHP version 5.4
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Declan Kelly <declankelly90@gmail.com>
- * @copyright 2015 Declan Kelly
  */
 class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -15,15 +15,9 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenParametersWithSameName.
- *
  * Functions can not have multiple parameters with the same name since PHP 7.0
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim@cu.be>
  */
 class ForbiddenParametersWithSameNameSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -22,10 +22,6 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * as any superglobals, $this, or any parameter since PHP 7.1.
  *
  * PHP version 7.1
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ForbiddenVariableNamesInClosureUseSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -15,15 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionDeclarations\NewClosure.
- *
  * Closures are available since PHP 5.3
  *
  * PHP version 5.3
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim@cu.be>
  */
 class NewClosureSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -16,15 +16,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionDeclarations\NewNullableTypes.
- *
  * Nullable type hints and return types are available since PHP 7.1.
  *
  * PHP version 7.1
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewNullableTypesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -15,11 +15,7 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionDeclarations\NewParamTypeDeclarationsSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
+ * Detect and verify the use of parameter type declarations in function declarations.
  */
 class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -14,13 +14,9 @@ use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionDeclarations\NewReturnTypeDeclarationsSniff.
+ * Detect and verify the use of return type declarations in function declarations.
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
  */
 class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -14,16 +14,9 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionDeclarations\NonStaticMagicMethodsSniff.
- *
  * Verifies the use of the correct visibility and static properties of magic methods.
  *
  * PHP version 5.3
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2012 Cu.be Solutions bvba
  */
 class NonStaticMagicMethodsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -14,13 +14,7 @@ use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionNameRestrictions\NewMagicMethodsSniff.
- *
  * Warns for non-magic behaviour of magic methods prior to becoming magic.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewMagicMethodsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -14,13 +14,9 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedMagicAutoloadSniff.
+ * Detect declaration of the magic __autoload() method.
  *
  * PHP version 7.2
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
  */
 class RemovedMagicAutoloadSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -24,10 +24,6 @@ use PHP_CodeSniffer_File as File;
  * "function already declared" error, so not the concern of this sniff.
  *
  * PHP version 7.3
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedNamespacedAssertSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -15,13 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedPHP4StyleConstructorsSniff.
+ * Detect declarations of PHP 4 style constructors which are deprecated as of PHP 7.0.0.
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Koen Eelen <koen.eelen@cu.be>
  */
 class RemovedPHP4StyleConstructorsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -16,8 +16,6 @@ use PHP_CodeSniffer_Standards_AbstractScopeSniff as PHPCS_AbstractScopeSniff;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionNameRestrictions\ReservedFunctionNamesSniff.
- *
  * All function and method names starting with double underscore are reserved by PHP.
  *
  * {@internal Extends an upstream sniff to benefit from the properties contained therein.
@@ -30,10 +28,6 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *            Extending the upstream sniff instead of including it via the ruleset, however,
  *            prevents hard to debug issues of errors not being reported from the upstream sniff
  *            if this library is used in combination with other rulesets.}}
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ReservedFunctionNamesSniff extends PHPCS_CamelCapsFunctionNameSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionUse\ArgumentFunctionsUsageSniff.
+ * Detect usage of func_get_args(), func_get_arg() and func_num_args().
  *
  * - Prior to PHP 5.3, these functions could not be used as a function call parameter.
  *
@@ -26,10 +26,6 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *   functions would already generate a warning prior to PHP 5.3.
  *
  * PHP version 5.3
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ArgumentFunctionsUsageSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -15,11 +15,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionUse\newFunctionParametersSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
+ * Detect use of new function parameters in calls to native PHP functions.
  */
 class NewFunctionParametersSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -14,11 +14,7 @@ use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionUse\newFunctionsSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
+ * Detect calls to new native PHP functions.
  */
 class NewFunctionsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -14,11 +14,7 @@ use PHPCompatibility\Sniffs\FunctionUse\RequiredToOptionalFunctionParametersSnif
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionUse\OptionalToRequiredFunctionParametersSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Detect missing required function parameters in calls to native PHP functions.
  */
 class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFunctionParametersSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -15,11 +15,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionParametersSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
+ * Detect use of deprecated/removed function parameters in calls to native PHP functions.
  */
 class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -14,11 +14,7 @@ use PHPCompatibility\AbstractRemovedFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionsSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
+ * Detect calls to deprecated/removed native PHP functions.
  */
 class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -15,11 +15,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\FunctionUse\RequiredToOptionalFunctionParametersSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Detect missing required function parameters in calls to native PHP functions.
  */
 class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSniff
 {

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -15,15 +15,9 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Generators\NewGeneratorReturnSniff.
- *
  * As of PHP 7.0, a return statement can be used within a generator for a final expression to be returned.
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewGeneratorReturnSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -14,14 +14,7 @@ use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\IniDirectives\NewIniDirectivesSniff.
- *
  * Discourages the use of new INI directives through ini_set() or ini_get().
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2013 Cu.be Solutions bvba
  */
 class NewIniDirectivesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -14,14 +14,7 @@ use PHPCompatibility\AbstractRemovedFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\IniDirectives\RemovedIniDirectivesSniff.
- *
  * Discourages the use of deprecated and removed INI directives through ini_set() or ini_get().
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2012 Cu.be Solutions bvba
  */
 class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -14,15 +14,9 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\InitialValue\NewConstantArraysUsingConstSniff.
- *
  * Constant arrays using the const keyword in PHP 5.6
  *
  * PHP version 5.6
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewConstantArraysUsingConstSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -14,15 +14,9 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\InitialValue\NewConstantArraysUsingDefineSniff.
- *
  * Constant arrays using define in PHP 7.0
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim@cu.be>
  */
 class NewConstantArraysUsingDefineSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -16,18 +16,12 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\InitialValue\NewConstantScalarExpressionsSniff.
- *
  * Since PHP 5.6, it is now possible to provide a scalar expression involving
  * numeric and string literals and/or constants in contexts where PHP previously
  * expected a static value, such as constant and property declarations and
  * default function arguments.
  *
  * PHP version 5.6
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewConstantScalarExpressionsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -15,8 +15,6 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\InitialValue\NewHeredocSniff.
- *
  * As of PHP 5.3.0, it's possible to initialize static variables, class properties
  * and constants declared using the `const` keyword, using the Heredoc syntax.
  * And while not documented, heredoc initialization can now also be used for function param defaults.
@@ -26,10 +24,6 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHPCompatibility library until such time as there is a PHP version in which this would be accepted.
  *
  * PHP version 5.3
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewHeredocSniff extends NewConstantScalarExpressionsSniff
 {

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -15,11 +15,7 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Interfaces\InternalInterfacesSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Detect classes which implement PHP native interfaces intended only for PHP internal use.
  */
 class InternalInterfacesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -15,11 +15,7 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Interfaces\NewInterfacesSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Detect use of new PHP native interfaces and unsupported interface methods.
  */
 class NewInterfacesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -14,16 +14,10 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Keywords\CaseSensitiveKeywordsSniff.
- *
  * Prior to PHP 5.5, cases existed where the self, parent, and static keywords
  * were treated in a case sensitive fashion.
  *
  * PHP version 5.5
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class CaseSensitiveKeywordsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -15,18 +15,12 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesAsDeclaredClassSniff.
- *
  * Prohibits the use of some reserved keywords to name a class, interface, trait or namespace.
  * Emits errors for reserved words and warnings for soft-reserved words.
  *
  * @see http://php.net/manual/en/reserved.other-reserved-words.php
  *
  * PHP version 7.0+
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ForbiddenNamesAsDeclaredSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -15,14 +15,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesAsInvokedFunctionsSniff.
- *
  * Prohibits the use of reserved keywords invoked as functions.
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Jansen Price <jansen.price@gmail.com>
- * @copyright 2012 Cu.be Solutions bvba
  */
 class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -15,14 +15,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesSniff.
- *
  * Prohibits the use of reserved keywords as class, function, namespace or constant names.
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2012 Cu.be Solutions bvba
  */
 class ForbiddenNamesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -15,12 +15,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Keywords\NewKeywordsSniff.
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2013 Cu.be Solutions bvba
+ * Detect use of new PHP keywords.
  */
 class NewKeywordsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -15,15 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\LanguageConstructs\NewEmptyNonVariableSniff.
- *
  * Verify that nothing but variables are passed to empty().
  *
  * PHP version 5.5
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewEmptyNonVariableSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -14,12 +14,7 @@ use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\LanguageConstructs\NewLanguageConstructsSniff.
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2013 Cu.be Solutions bvba
+ * Detect use of new PHP language constructs.
  */
 class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -21,10 +21,6 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * This affects all list constructs where non-unique variables are used.
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class AssignmentOrderSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -15,15 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Lists\ForbiddenEmptyListAssignmentSniff.
- *
  * Empty list() assignments have been removed in PHP 7.0
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim@cu.be>
  */
 class ForbiddenEmptyListAssignmentSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -15,15 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Lists\NewKeyedListSniff.
- *
  * "You can now specify keys in list(), or its new shorthand [] syntax. "
  *
  * PHP version 7.1
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewKeyedListSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -17,10 +17,6 @@ use PHP_CodeSniffer_File as File;
  * Detect reference assignments in array destructuring using (short) list.
  *
  * PHP version 7.3
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewListReferenceAssignmentSniff extends NewKeyedListSniff
 {

--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -14,17 +14,11 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Lists\NewShortListSniff.
- *
  * "The shorthand array syntax ([]) may now be used to destructure arrays for
  * assignments (including within foreach), as an alternative to the existing
  * list() syntax, which is still supported."
  *
  * PHP version 7.1
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewShortListSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -14,15 +14,9 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Miscellaneous\RemovedAlternativePHPTags.
- *
  * Check for usage of alternative PHP tags - removed in PHP 7.0.
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  *
  * Based on `Generic_Sniffs_PHP_DisallowAlternativePHPTags` by Juliette Reinders Folmer
  * which was merged into PHPCS 2.7.0.

--- a/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
@@ -14,11 +14,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Miscellaneous\ValidIntegersSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Check for valid integer types and values.
  */
 class ValidIntegersSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -16,15 +16,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Operators\ForbiddenNegativeBitshift.
- *
  * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0.
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim@cu.be>
  */
 class ForbiddenNegativeBitshiftSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -14,12 +14,7 @@ use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Operators\NewOperatorsSniff.
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2013 Cu.be Solutions bvba
+ * Detect use of new PHP operators.
  */
 class NewOperatorsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -14,17 +14,10 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Operators\NewShortTernarySniff.
- *
  * Performs checks on ternary operators, specifically that the middle expression
  * is not omitted for versions that don't support this.
  *
  * PHP version 5.3
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Ben Selby <bselby@plus.net>
- * @copyright 2012 Ben Selby
  */
 class NewShortTernarySniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -14,16 +14,10 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\ForbiddenGetClassNullSniff.
- *
  * Detect: Passing `null` to get_class() is no longer allowed as of PHP 7.2.
  * This will now result in an E_WARNING being thrown.
  *
  * PHP version 7.2
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -14,13 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\NewArrayReduceInitialTypeSniff.
- *
  * Detect: In PHP 5.2 and lower, the $initial parameter had to be an integer.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -14,13 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\NewFopenModesSniff.
- *
  * Detect: Changes in allowed values for the fopen() $mode parameter.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -14,11 +14,7 @@ use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\NewHashAlgorithmsSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Detect the use of newly introduced hash algorithms.
  */
 class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -14,16 +14,10 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\NewNegativeStringOffsetSniff.
- *
  * Detect: negative string offsets as parameters passed to functions where this
  * was not allowed prior to PHP 7.1.
  *
  * PHP version 7.1
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -14,13 +14,7 @@ use PHPCompatibility\Sniffs\ParameterValues\RemovedPCREModifiersSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\NewPCREModifiers.
- *
  * Check for usage of newly added regex modifiers for PCRE functions.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -14,13 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\NewPackFormatSniff.
- *
  * Detect: Changes in the allowed values for $format passed to pack().
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -14,16 +14,9 @@ use PHPCompatibility\AbstractRemovedFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\RemovedHashAlgorithmsSniff.
- *
  * Discourages the use of deprecated and removed hash algorithms.
  *
  * PHP version 5.4
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2012 Cu.be Solutions bvba
  */
 class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -14,8 +14,6 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\RemovedIconvEncodingSniff.
- *
  * Detect: "The iconv and mbstring configuration options related to encoding
  * have been deprecated in favour of default_charset."
  *
@@ -23,10 +21,6 @@ use PHP_CodeSniffer_File as File;
  * only the iconv function is handled.}}
  *
  * PHP version 5.6
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -15,13 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\RemovedMbstringModifiersSniff.
+ * Check for use of deprecated and removed regex modifiers for MbString regex functions.
  *
  * PHP version 7.1
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -14,16 +14,10 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\RemovedNonCryptoHashSniff.
- *
  * Detect: "The hash_hmac(), hash_hmac_file(), hash_pbkdf2(), and hash_init()
  * (with HASH_HMAC) functions no longer accept non-cryptographic hashes."
  *
  * PHP version 7.2
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -15,17 +15,10 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\RemovedPCREModifiersSniff.
- *
  * Check for usage of the `e` modifier with PCRE functions which is deprecated since PHP 5.5
  * and removed as of PHP 7.0.
  *
  * PHP version 5.5
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2014 Cu.be Solutions bvba
  */
 class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -14,17 +14,11 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\ParameterValues\RemovedSetlocaleStringSniff.
- *
  * Detect: Support for the category parameter passed as a string has been removed.
  * Only LC_* constants can be used as of this version [7.0.0].
  *
  * PHP version 4.2
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -15,17 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Syntax\ForbiddenCallTimePassByReference.
- *
  * Discourages the use of call time pass by references
  *
  * PHP version 5.4
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Gary Rogers <gmrwebde@gmail.com>
- * @author    Florian Grandel <jerico.dev@gmail.com>
- * @copyright 2009 Florian Grandel
  */
 class ForbiddenCallTimePassByReferenceSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -15,16 +15,10 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Syntax\NewDynamicAccessToStaticSniff.
- *
  * As of PHP 5.3, static properties and methods as well as class constants
  * can be accessed using a dynamic (variable) class name.
  *
  * PHP version 5.3
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewDynamicAccessToStaticSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -24,10 +24,6 @@ use PHP_CodeSniffer_File as File;
  *   start of any of its lines.
  *
  * PHP version 7.3
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewFlexibleHeredocNowdocSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -15,13 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Syntax\NewFunctionCallTrailingCommaSniff.
+ * Detect trailing comma's in function calls, isset() and unset() as allowed since PHP 7.3.
  *
  * PHP version 7.3
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewFunctionCallTrailingCommaSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -14,15 +14,9 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Syntax\NewShortArray.
- *
  * Short array syntax is available since PHP 5.4
  *
  * PHP version 5.4
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Alex Miroshnikov <unknown@example.com>
  */
 class NewShortArraySniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -15,16 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Syntax\RemovedNewReferenceSniff.
- *
  * Discourages the use of assigning the return value of new by reference
  *
  * PHP version 5.4
- *
- * @category  PHP
- * @package   PHPCompatibility
- * @author    Wim Godden <wim.godden@cu.be>
- * @copyright 2012 Cu.be Solutions bvba
  */
 class RemovedNewReferenceSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -15,11 +15,7 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\TypeCasts\NewTypeCastsSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Detect use of newly introduced type casts.
  */
 class NewTypeCastsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -14,11 +14,7 @@ use PHPCompatibility\AbstractRemovedFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\TypeCasts\RemovedTypeCastsSniff.
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * Detect use of deprecated/removed type casts.
  */
 class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -15,8 +15,6 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * \PHPCompatibility\Sniffs\Upgrade\LowPHPCSSniff.
- *
  * Add a notification for users of low PHPCS versions.
  *
  * Originally PHPCompatibility supported PHPCS 1.5.x, 2.x and since PHPCompatibility 8.0.0, 3.x.
@@ -29,10 +27,7 @@ use PHP_CodeSniffer_File as File;
  * This sniff adds an explicit error/warning for users of the standard
  * using a PHPCS version below the recommended version.
  *
- * @category Upgrade
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
- * @since    8.2.0
+ * @since 8.2.0
  */
 class LowPHPCSSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -15,13 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\UseDeclarations\NewGroupUseDeclarationsSniff.
+ * Detect group use declarations as introduced in PHP 7.0.
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
  */
 class NewGroupUseDeclarationsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -15,17 +15,11 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\UseDeclarations\NewUseConstFunctionSniff.
- *
  * The use operator has been extended to support importing functions and
  * constants in addition to classes. This is achieved via the use function
  * and use const constructs, respectively.
  *
  * PHP version 5.6
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewUseConstFunctionSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -15,15 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Variables\ForbiddenGlobalVariableVariableSniff.
- *
  * Variable variables are forbidden with global
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim@cu.be>
  */
 class ForbiddenGlobalVariableVariableSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -15,15 +15,9 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Variables\NewUniformVariableSyntax.
- *
  * The interpretation of variable variables has changed in PHP 7.0.
  *
  * PHP version 7.0
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewUniformVariableSyntaxSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -16,13 +16,7 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * \PHPCompatibility\Sniffs\Variables\RemovedPredefinedGlobalVariablesSniff.
- *
  * Discourages the use of removed global variables. Suggests alternative extensions if available
- *
- * @category PHP
- * @package  PHPCompatibility
- * @author   Wim Godden <wim.godden@cu.be>
  */
 class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -19,10 +19,6 @@ use PHP_CodeSniffer_File as File;
  *
  * Adds PHPCS sniffing logic and custom assertions for PHPCS errors and
  * warnings.
- *
- * @uses    \PHPUnit_Framework_TestCase
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class BaseSniffTest extends PHPUnit_TestCase
 {

--- a/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group classes
  *
  * @covers \PHPCompatibility\Sniffs\Classes\NewAnonymousClassesSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class NewAnonymousClassesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -22,10 +22,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintName
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintToken
  * @covers \PHPCompatibility\Sniff::getTypeHintsFromFunctionDeclaration
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class NewClassesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group classes
  *
  * @covers \PHPCompatibility\Sniffs\Classes\NewConstVisibilitySniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewConstVisibilityUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group classes
  *
  * @covers \PHPCompatibility\Sniffs\Classes\NewLateStaticBindingSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewLateStaticBindingUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group constants
  *
  * @covers \PHPCompatibility\Sniffs\Constants\NewConstantsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewConstantsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group constants
  *
  * @covers \PHPCompatibility\Sniffs\Constants\NewMagicClassConstantSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewMagicClassConstantUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group constants
  *
  * @covers \PHPCompatibility\Sniffs\Constants\RemovedConstantsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedConstantsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\DiscouragedSwitchContinueSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
@@ -21,10 +21,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\ForbiddenBreakContinueOutsideLoopSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ForbiddenBreakContinueOutsideLoopUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -23,10 +23,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\ForbiddenBreakContinueVariableArgumentsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\ForbiddenSwitchWithMultipleDefaultBlocksSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\NewExecutionDirectivesSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewExecutionDirectivesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/NewForeachExpressionReferencingUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewForeachExpressionReferencingUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\NewForeachExpressionReferencingSniff
  * @covers \PHPCompatibility\Sniff::isVariable
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewForeachExpressionReferencingUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\NewListInForeachSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewListInForeachUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group exceptions
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\NewMultiCatchSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewMultiCatchUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\PHPCSHelper;
  * @group extensions
  *
  * @covers \PHPCompatibility\Sniffs\Extensions\RemovedExtensionsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class RemovedExtensionsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group superglobals
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenParameterShadowSuperGlobalsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ForbiddenParameterShadowSuperGlobalsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenParametersWithSameNameSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
@@ -21,10 +21,6 @@ use PHPCompatibility\PHPCSHelper;
  * @group functionDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenVariableNamesInClosureUseSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ForbiddenVariableNamesInClosureUseUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewClosureSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class NewClosureUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
@@ -21,10 +21,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewNullableTypesSniff
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintToken
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewNullableTypesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group typeDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewParamTypeDeclarationsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -21,10 +21,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewReturnTypeDeclarationsSniff
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintToken
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -21,10 +21,6 @@ use PHPCompatibility\PHPCSHelper;
  * @group magicMethods
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NonStaticMagicMethodsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class NonStaticMagicMethodsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -21,10 +21,6 @@ use PHPCompatibility\PHPCSHelper;
  * @group magicMethods
  *
  * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\NewMagicMethodsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewMagicMethodsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -21,10 +21,6 @@ use PHPCompatibility\PHPCSHelper;
  *
  * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedMagicAutoloadSniff
  * @covers \PHPCompatibility\Sniff::determineNamespace
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim.godden@cu.be>
  */
 class RemovedMagicAutoloadUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -21,10 +21,6 @@ use PHPCompatibility\PHPCSHelper;
  *
  * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedNamespacedAssertSniff
  * @covers \PHPCompatibility\Sniff::determineNamespace
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedNamespacedAssertUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedPHP4StyleConstructorsSniff
  * @covers \PHPCompatibility\Sniff::determineNamespace
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Koen Eelen <koen.eelen@cu.be>
  */
 class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionNameRestrictions
  *
  * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\ReservedFunctionNamesSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ReservedFunctionNamesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\ArgumentFunctionsUsageSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ArgumentFunctionsUsageUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\NewFunctionParametersSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class NewFunctionParametersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\NewFunctionsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class NewFunctionsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\OptionalToRequiredFunctionParametersSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionParametersSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class RemovedFunctionParametersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class RemovedFunctionsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\RequiredToOptionalFunctionParametersSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group generators
  *
  * @covers \PHPCompatibility\Sniffs\Generators\NewGeneratorReturnSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewGeneratorReturnUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group iniDirectives
  *
  * @covers \PHPCompatibility\Sniffs\IniDirectives\NewIniDirectivesSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class NewIniDirectivesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group iniDirectives
  *
  * @covers \PHPCompatibility\Sniffs\IniDirectives\RemovedIniDirectivesSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class RemovedIniDirectivesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group initialValue
  *
  * @covers \PHPCompatibility\Sniffs\InitialValue\NewConstantArraysUsingConstSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewConstantArraysUsingConstUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group initialValue
  *
  * @covers \PHPCompatibility\Sniffs\InitialValue\NewConstantArraysUsingDefineSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\PHPCSHelper;
  * @group initialValue
  *
  * @covers \PHPCompatibility\Sniffs\InitialValue\NewConstantScalarExpressionsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewConstantScalarExpressionsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\PHPCSHelper;
  * @group initialValue
  *
  * @covers \PHPCompatibility\Sniffs\InitialValue\NewHeredocSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewHeredocUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group interfaces
  *
  * @covers \PHPCompatibility\Sniffs\Interfaces\InternalInterfacesSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class InternalInterfacesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -22,10 +22,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintName
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintToken
  * @covers \PHPCompatibility\Sniff::getTypeHintsFromFunctionDeclaration
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewInterfacesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group keywords
  *
  * @covers \PHPCompatibility\Sniffs\Keywords\CaseSensitiveKeywordsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class CaseSensitiveKeywordsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsDeclaredUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsDeclaredUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesAsDeclaredSniff
  * @covers \PHPCompatibility\Sniff::getDeclaredNamespaceName
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ForbiddenNamesAsDeclaredUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsInvokedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsInvokedFunctionsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group keywords
  *
  * @covers \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesAsInvokedFunctionsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class ForbiddenNamesAsInvokedFunctionsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group keywords
  *
  * @covers \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class ForbiddenNamesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group keywords
  *
  * @covers \PHPCompatibility\Sniffs\Keywords\NewKeywordsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class NewKeywordsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\LanguageConstructs\NewEmptyNonVariableSniff
  * @covers \PHPCompatibility\Sniff::isVariable
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewEmptyNonVariableUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group languageConstructs
  *
  * @covers \PHPCompatibility\Sniffs\LanguageConstructs\NewLanguageConstructsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class NewLanguageConstructsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group lists
  *
  * @covers \PHPCompatibility\Sniffs\Lists\AssignmentOrderSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class AssignmentOrderUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group lists
  *
  * @covers \PHPCompatibility\Sniffs\Lists\ForbiddenEmptyListAssignmentSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group lists
  *
  * @covers \PHPCompatibility\Sniffs\Lists\NewKeyedListSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewKeyedListUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group lists
  *
  * @covers \PHPCompatibility\Sniffs\Lists\NewListReferenceAssignmentSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewListReferenceAssignmentUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group lists
  *
  * @covers \PHPCompatibility\Sniffs\Lists\NewShortListSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewShortListUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group miscellaneous
  *
  * @covers \PHPCompatibility\Sniffs\Miscellaneous\RemovedAlternativePHPTagsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedAlternativePHPTagsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group miscellaneous
  *
  * @covers \PHPCompatibility\Sniffs\Miscellaneous\ValidIntegersSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ValidIntegersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group operators
  *
  * @covers \PHPCompatibility\Sniffs\Operators\ForbiddenNegativeBitshiftSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class ForbiddenNegativeBitshiftUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group operators
  *
  * @covers \PHPCompatibility\Sniffs\Operators\NewOperatorsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class NewOperatorsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group operators
  *
  * @covers \PHPCompatibility\Sniffs\Operators\NewShortTernarySniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class NewShortTernaryUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\ForbiddenGetClassNullSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class ForbiddenGetClassNullUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewArrayReduceInitialTypeSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewArrayReduceInitialTypeUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewFopenModesSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewFopenModesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -21,10 +21,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewHashAlgorithmsSniff
  * @covers \PHPCompatibility\Sniff::getHashAlgorithmParameter
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewHashAlgorithmsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewNegativeStringOffsetSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewNegativeStringOffsetUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group regexModifiers
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewPCREModifiersSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewPCREModifiersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewPackFormatSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewPackFormatUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
@@ -21,10 +21,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedHashAlgorithmsSniff
  * @covers \PHPCompatibility\Sniff::getHashAlgorithmParameter
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class RemovedHashAlgorithmsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedIconvEncodingSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedIconvEncodingUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group regexModifiers
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedMbstringModifiersSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedMbstringModifiersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group hashAlgorithms
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedNonCryptoHashSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedNonCryptoHashUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group regexModifiers
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedPCREModifiersSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class RemovedPCREModifiersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedSetlocaleStringSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedSetlocaleStringUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\ForbiddenCallTimePassByReferenceSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class ForbiddenCallTimePassByReferenceUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewArrayStringDereferencingSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewArrayStringDereferencingUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewClassMemberAccessUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewDynamicAccessToStaticSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewDynamicAccessToStaticUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -20,10 +20,6 @@ use PHPCompatibility\PHPCSHelper;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewFlexibleHeredocNowdocSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class NewFunctionArrayDereferencingUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewFunctionCallTrailingCommaSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewShortArraySniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Alex Miroshnikov <unknown@example.com>
  */
 class NewShortArrayUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\RemovedNewReferenceSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Jansen Price <jansen.price@gmail.com>
  */
 class RemovedNewReferenceUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group typeCasts
  *
  * @covers \PHPCompatibility\Sniffs\TypeCasts\NewTypeCastsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewTypeCastsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group typeCasts
  *
  * @covers \PHPCompatibility\Sniffs\TypeCasts\RemovedTypeCastsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class RemovedTypeCastsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group useDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\UseDeclarations\NewGroupUseDeclarationsSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class NewGroupUseDeclarationsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group useDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\UseDeclarations\NewUseConstFunctionSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewUseConstFunctionUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group variables
  *
  * @covers \PHPCompatibility\Sniffs\Variables\ForbiddenGlobalVariableVariableSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class ForbiddenGlobalVariableVariableUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group variables
  *
  * @covers \PHPCompatibility\Sniffs\Variables\NewUniformVariableSyntaxSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class NewUniformVariableSyntaxUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group variables
  *
  * @covers \PHPCompatibility\Sniffs\Variables\RemovedPredefinedGlobalVariablesSniff
- *
- * @uses    \PHPCompatibility\Tests\BaseSniffTest
- * @package PHPCompatibility
- * @author  Wim Godden <wim@cu.be>
  */
 class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Util/Tests/Core/DoesFunctionCallHaveParametersUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/DoesFunctionCallHaveParametersUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityDoesFunctionCallHaveParameters
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class DoesFunctionCallHaveParametersUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
@@ -19,10 +19,6 @@ use PHPCompatibility\Util\Tests\TestHelperPHPCompatibility;
  *
  * @group utilityMiscFunctions
  * @group utilityFunctions
- *
- * @uses    \PHPUnit_Framework_TestCase
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class FunctionsUnitTest extends PHPUnit_TestCase
 {

--- a/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromDoubleColonTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromDoubleColonTokenUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityGetFQClassNameFromDoubleColonToken
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class GetFQClassNameFromDoubleColonTokenUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromNewTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFQClassNameFromNewTokenUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityGetFQClassNameFromNewToken
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class GetFQClassNameFromNewTokenUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/GetFQExtendedClassNameUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFQExtendedClassNameUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityGetFQExtendedClassName
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class GetFQExtendedClassNameUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/GetFunctionParameterCountUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFunctionParameterCountUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityGetFunctionParameterCount
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class GetFunctionParameterCountUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/GetFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/GetFunctionParametersUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityGetFunctionParameters
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class GetFunctionParametersUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/IsClassConstantUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsClassConstantUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityIsClassConstant
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class IsClassConstantUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/IsClassPropertyUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsClassPropertyUnitTest.php
@@ -18,10 +18,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityIsClassProperty
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class IsClassPropertyUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/IsNumberUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsNumberUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityIsNumber
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class IsNumberUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/IsNumericCalculationUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsNumericCalculationUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityIsNumericCalculation
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class IsNumericCalculationUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/IsShortListUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsShortListUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityIsShortList
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class IsShortListUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.php
@@ -17,10 +17,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityIsUseOfGlobalConstant
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class IsUseOfGlobalConstantUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/Core/TokenScopeUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/TokenScopeUnitTest.php
@@ -18,10 +18,6 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @group utilityTokenScope
  * @group utilityFunctions
- *
- * @uses    \PHPCompatibility\Util\Tests\CoreMethodTestFrame
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class TokenScopeUnitTest extends CoreMethodTestFrame
 {

--- a/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
+++ b/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
@@ -17,10 +17,6 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Set up and Tear down methods for testing methods in the Sniff.php file.
- *
- * @uses    \PHPUnit_Framework_TestCase
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 abstract class CoreMethodTestFrame extends PHPUnit_TestCase
 {

--- a/PHPCompatibility/Util/Tests/TestHelperPHPCompatibility.php
+++ b/PHPCompatibility/Util/Tests/TestHelperPHPCompatibility.php
@@ -15,10 +15,6 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Helper class to facilitate testing of the methods within the abstract \PHPCompatibility\Sniff class.
- *
- * @uses    \PHPCompatibility\Sniff
- * @package PHPCompatibility
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 class TestHelperPHPCompatibility extends Sniff
 {


### PR DESCRIPTION
... and remove the FQCN as a class description.

If that would leave the class docblock empty, add a perfunctory class description (where necessary these will be improved upon in a later PR in the series).

This is the second PR in a series to update the docs to align with the proposal in #734.