### PR TITLE
ForbiddenToStringParameters: property should not be public

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -35,7 +35,7 @@ class ForbiddenToStringParametersSniff extends Sniff
      *
      * @var array
      */
-    public $ooScopeTokens = array(
+    protected $ooScopeTokens = array(
         'T_CLASS'      => true,
         'T_INTERFACE'  => true,
         'T_TRAIT'      => true,


### PR DESCRIPTION
The `$ooScopeTokens` property is not intended to be set via a custom ruleset, so the property should never have been `public`.