### PR TITLE
ValidIntegers: bug fix - binary and hex numbers are case-insensitive

### DIFF
--- a/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
@@ -121,12 +121,12 @@ class ValidIntegersSniff extends Sniff
         }
 
         if ($this->isLowPHPVersion === false) {
-            return (preg_match('`^0b[0-1]+$`D', $token['content']) === 1);
+            return (preg_match('`^0b[0-1]+$`iD', $token['content']) === 1);
         }
         // Pre-5.4, binary strings are tokenized as T_LNUMBER (0) + T_STRING ("b01010101").
         // At this point, we don't yet care whether it's a valid binary int, that's a separate check.
         else {
-            return($token['content'] === '0' && $tokens[$stackPtr + 1]['code'] === \T_STRING && preg_match('`^b[0-9]+$`D', $tokens[$stackPtr + 1]['content']) === 1);
+            return($token['content'] === '0' && $tokens[$stackPtr + 1]['code'] === \T_STRING && preg_match('`^b[0-9]+$`iD', $tokens[$stackPtr + 1]['content']) === 1);
         }
     }
 
@@ -148,7 +148,7 @@ class ValidIntegersSniff extends Sniff
             // If it's an invalid binary int, the token will be split into two T_LNUMBER tokens.
             return ($tokens[$stackPtr + 1]['code'] === \T_LNUMBER);
         } else {
-            return (preg_match('`^b[0-1]+$`D', $tokens[$stackPtr + 1]['content']) === 0);
+            return (preg_match('`^b[0-1]+$`iD', $tokens[$stackPtr + 1]['content']) === 0);
         }
     }
 

--- a/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.inc
+++ b/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.inc
@@ -10,3 +10,6 @@ $invalidOctal = 091;
 
 $hex = '0xaa78b5';
 $hex = 'aa78b5'; // Ok.
+
+$binaryUpper = 0B10001;
+$hexUpper = '0Xbb99EF';

--- a/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.php
@@ -59,6 +59,7 @@ class ValidIntegersUnitTest extends BaseSniffTest
         return array(
             array(3, '0b001001101', true),
             array(4, '0b01', false),
+            array(14, '0B10001', true),
         );
     }
 
@@ -128,18 +129,55 @@ class ValidIntegersUnitTest extends BaseSniffTest
     /**
      * testHexNumericString
      *
+     * @dataProvider dataHexNumericString
+     *
+     * @param int    $line Line number where the error should occur.
+     * @param string $hex  Hexidecminal number as a string.
+     *
      * @return void
      */
-    public function testHexNumericString()
+    public function testHexNumericString($line, $hex)
     {
-        $error = 'The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7. Found: \'0xaa78b5\'';
+        $error = "The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7. Found: '{$hex}'";
 
         $file = $this->sniffFile(__FILE__, '5.6');
-        $this->assertWarning($file, 11, $error);
+        $this->assertWarning($file, $line, $error);
+
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testHexNumericString()
+     *
+     * @return array
+     */
+    public function dataHexNumericString()
+    {
+        // phpcs:disable PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound
+        return array(
+            array(11, '0xaa78b5'),
+            array(15, '0Xbb99EF'),
+        );
+        // phpcs:enable
+    }
+
+
+    /**
+     * testHexNumericString.
+     *
+     * @dataProvider dataHexNumericString
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesHexNumericString()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertNoViolation($file, 12);
 
         $file = $this->sniffFile(__FILE__, '7.0');
-        $this->assertError($file, 11, $error);
         $this->assertNoViolation($file, 12);
     }
 


### PR DESCRIPTION
* Hex numbers were already handled correctly, but there was no unit test safe-guarding the case-insensitive matching.
* Binary numbers using an uppercase `B` were _not_ handled correctly so far.
    This has been fixed, including adding a unit test to safe guard this.