### PR TITLE
NewDirectCallsToClone: bug fix - exclude class internal calls

### DIFF
--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -31,6 +31,17 @@ class NewDirectCallsToCloneSniff extends Sniff
 {
 
     /**
+     * Tokens which indicate class internal use.
+     *
+     * @var array
+     */
+    protected $classInternal = array(
+        T_PARENT => true,
+        T_SELF   => true,
+        T_STATIC => true,
+    );
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 9.1.0
@@ -85,6 +96,12 @@ class NewDirectCallsToCloneSniff extends Sniff
         $nextNextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
         if ($nextNextNonEmpty === false || $tokens[$nextNextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
             // Not a method call.
+            return;
+        }
+
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($prevNonEmpty === false || isset($this->classInternal[$tokens[$prevNonEmpty]['code']])) {
+            // Class internal call to __clone().
             return;
         }
 

--- a/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.inc
+++ b/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.inc
@@ -15,7 +15,8 @@ class ABC {
 }
 
 /*
- * These should be flagged.
+ * These are class internal calls to __clone(), this is fine.
+ * See: https://github.com/PHPCompatibility/PHPCompatibility/issues/629#issuecomment-532607809
  */
 class DEF {
     function something()
@@ -26,5 +27,8 @@ class DEF {
     }
 }
 
+/*
+ * These should be flagged.
+ */
 $a = (new ABC()) ->  /* comment */ __clone();
 StaticClass::__clone();

--- a/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
@@ -50,11 +50,8 @@ class NewDirectCallsToCloneUnitTest extends BaseSniffTest
     public function dataDirectCallToClone()
     {
         return array(
-            array(23),
-            array(24),
-            array(25),
-            array(29),
-            array(30),
+            array(33),
+            array(34),
         );
     }
 
@@ -83,15 +80,13 @@ class NewDirectCallsToCloneUnitTest extends BaseSniffTest
      */
     public function dataNoFalsePositives()
     {
-        return array(
-            array(6),
-            array(7),
-            array(8),
-            array(9),
-            array(10),
-            array(11),
-            array(14),
-        );
+        $cases = array();
+        // No errors expected on the first 29 lines.
+        for ($line = 1; $line <= 29; $line++) {
+            $cases[] = array($line);
+        }
+
+        return $cases;
     }
 
 


### PR DESCRIPTION
Direct calls to `__clone()` from within a class using `self`, `static` or `parent` were always allowed.

Ref: https://3v4l.org/BmmPT

Fixes https://github.com/PHPCompatibility/PHPCompatibility/issues/629#issuecomment-532607809