### PR TITLE
RemovedPHP4StyleConstructors: efficiency fix

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -87,7 +87,13 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
         $newConstructorFound = false;
         $oldConstructorFound = false;
         $oldConstructorPos   = -1;
-        while (($nextFunc = $phpcsFile->findNext(\T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
+        while (($nextFunc = $phpcsFile->findNext(array(\T_FUNCTION, T_DOC_COMMENT_OPEN_TAG), ($nextFunc + 1), $scopeCloser)) !== false) {
+            // Skip over docblocks.
+            if ($tokens[$nextFunc]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+                $nextFunc = $tokens[$nextFunc]['comment_closer'];
+                continue;
+            }
+
             $functionScopeCloser = $nextFunc;
             if (isset($tokens[$nextFunc]['scope_closer'])) {
                 // Normal (non-interface, non-abstract) method.

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.inc
@@ -62,8 +62,23 @@ class new {}
 
 // Testing empty/invalid function name condition.
 class InvalidSwitchFunctionName {
-	function switch() {}
-	function InvalidSwitchFunctionName() {}
+    function switch() {}
+    function InvalidSwitchFunctionName() {}
+}
+
+// Simple test of the docblock skipping code.
+class bar {
+    /**
+     * This
+     * docblock
+     * should
+     * be
+     * skipped
+     * over.
+     */
+    function __construct() {
+        echo 'I am the real constructor';
+    }
 }
 
 // Must be last test: testing class without scope closer.


### PR DESCRIPTION
Make the sniff a little faster by skipping over complete docblocks instead of walking them via `findNext()`.