### PR TITLE
RequiredToOptionalFunctionParameters: bug fix for class instantiation

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -177,6 +177,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
             \T_OBJECT_OPERATOR => true,
             \T_FUNCTION        => true,
             \T_CONST           => true,
+            \T_NEW             => true,
         );
 
         $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
@@ -6,3 +6,6 @@ parse_str($str, $output);
 // These are not.
 parse_str($str);
 crypt( $str ); // Recommended.
+
+// Prevent false positive on new. Issue #913.
+$crypt = new Crypt('password');


### PR DESCRIPTION
Prevent recognizing class instantiation as if it were a function call.

Includes unit test.

Fixes #913