### PR TITLE
ReservedFunctionNames: ignore deprecated functions

### DIFF
--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -98,9 +98,9 @@ $a = new class {
 $b = function ($a) {};
 
 class ClassContainingClosure {
-	public function methodContainingClosure() {
-		$a = function($c) {};
-	}
+    public function methodContainingClosure() {
+        $a = function($c) {};
+    }
 }
 
 class Nested {
@@ -111,4 +111,26 @@ class Nested {
             }
         };
     }
+}
+
+/**
+ * Function description.
+ *
+ * @since 1.2.3
+ * @deprecated 2.3.4
+ *
+ * @return void
+ */
+function __deprecatedFunction() {}
+
+class Deprecated {
+    /**
+     * Function description.
+     *
+     * @since 1.2.3
+     * @deprecated 2.3.4
+     *
+     * @return void
+     */
+    public static function __deprecatedMethod() {}
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -151,6 +151,9 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
             array(98),
             array(101),
             array(102),
+
+            array(124),
+            array(135),
         );
     }
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -164,6 +164,9 @@
 
         <!-- Having a @see or @internal tag before the @category tag is fine. -->
         <exclude name="PEAR.Commenting.ClassComment.CategoryTagOrder"/>
+
+        <!-- Using @since for class changelog demands multiple tags. -->
+        <exclude name="PEAR.Commenting.ClassComment.DuplicateSinceTag"/>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
Check the function docblock for a `@deprecated` tag and if found, bow out.

Includes unit tests.

Fixes #911