### PR TITLE
RemovedPHP4StyleConstructors: should not apply to interfaces

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -31,7 +31,6 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
     {
         return array(
             \T_CLASS,
-            \T_INTERFACE,
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
@@ -52,7 +52,6 @@ class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
             array(3),
             array(18),
             array(33),
-            array(37),
             array(66),
         );
     }
@@ -86,6 +85,7 @@ class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
             array(9),
             array(12),
             array(26),
+            array(37),
             array(41),
             array(42),
             array(47),


### PR DESCRIPTION
Introduced in #751 / PHPCompatibility 9.1.0.

While interfaces can declare methods with the same name as the interface, as the class in which the method will be implemented will be called differently, those methods will never be seen as constructors, so shouldn't trigger this error.

Mea culpa.

Related: squizlabs/PHP_CodeSniffer#2663

Also see: https://3v4l.org/qbXJS