### PR TITLE
ForbiddenNames: allow for `foreach( ... as list() ) {}`

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -240,6 +240,23 @@ class ForbiddenNamesSniff extends Sniff
         }
 
         /*
+         * Deal with foreach ( ... as list() ).
+         */
+        elseif ($tokens[$stackPtr]['type'] === 'T_AS'
+            && isset($tokens[$stackPtr]['nested_parenthesis']) === true
+            && $tokens[$nextNonEmpty]['code'] === \T_LIST
+        ) {
+            $parentheses = array_reverse($tokens[$stackPtr]['nested_parenthesis'], true);
+            foreach ($parentheses as $open => $close) {
+                if (isset($tokens[$open]['parenthesis_owner'])
+                    && $tokens[$tokens[$open]['parenthesis_owner']]['code'] === \T_FOREACH
+                ) {
+                    return;
+                }
+            }
+        }
+
+        /*
          * Deal with functions declared to return by reference.
          */
         elseif ($tokens[$stackPtr]['type'] === 'T_FUNCTION'

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.inc
@@ -171,6 +171,10 @@ use const MyCONSTANT;
 
 // list
 list( $a, $b, $c ) = $array;
+foreach ($array as list($key, $value)) {}
+foreach ([[1, 2], [2, 3]] as list($a, $b)):
+    // Do something.
+endforeach;
 
 // die
 die();


### PR DESCRIPTION
The changes in PR #923 did not take `foreach ( ...as list() ) {}` into account.

Fixed now. Includes unit test.

Fixes #928
Closes #929