### PR TITLE
NewShortArray: improve error message

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -53,7 +53,7 @@ class NewShortArraySniff extends Sniff
         $tokens = $phpcsFile->getTokens();
         $token  = $tokens[$stackPtr];
 
-        $error = '%s is available since 5.4';
+        $error = '%s is not supported in PHP 5.3 or lower';
         $data  = array();
 
         if ($token['type'] === 'T_OPEN_SHORT_ARRAY') {

--- a/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
@@ -36,8 +36,8 @@ class NewShortArrayUnitTest extends BaseSniffTest
     public function testViolation($lineOpen, $lineClose)
     {
         $file = $this->sniffFile(__FILE__, '5.3');
-        $this->assertError($file, $lineOpen, 'Short array syntax (open) is available since 5.4');
-        $this->assertError($file, $lineClose, 'Short array syntax (close) is available since 5.4');
+        $this->assertError($file, $lineOpen, 'Short array syntax (open) is not supported in PHP 5.3 or lower');
+        $this->assertError($file, $lineClose, 'Short array syntax (close) is not supported in PHP 5.3 or lower');
     }
 
     /**


### PR DESCRIPTION
Most error messages in PHPCompatibility follow one of the below formats:
* "Feature x is not supported in PHP x.x and below" (new features)
* "Feature x was deprecated in PHP x.x and removed in PHP x.x" (removed features)

The error message for short array syntax did not follow that typical pattern and was confusing to some - I've recently had questions about it from a few different people -, so I'm proposing to adjust the error message to be more in line with other messages in the PHPCompatibility library.