### PR TITLE
Travis: don't allow PHP 7.4 build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - "7.4snapshot"
 
 env:
   global:
@@ -70,7 +69,7 @@ jobs:
     # These are basically the same builds as in the Coverage stage, but then without doing
     # the code-coverage.
     - stage: quicktest
-      php: 7.3
+      php: "7.4snapshot"
       env: PHPCS_VERSION="dev-master" LINT=1
     - php: 7.3
       env: PHPCS_VERSION="2.3.0"
@@ -109,8 +108,12 @@ jobs:
     # While on PHPCS 2.x, the tests won't fail, on PHPCS 3.x < 3.3.1, they will.
     - php: 7.3
       env: PHPCS_VERSION="3.4.*" LINT=1
+    - php: 7.3
+      env: PHPCS_VERSION="dev-master"
     - php: "7.4snapshot"
-      env: PHPCS_VERSION=">=2.0,<3.0"
+      env: PHPCS_VERSION=">=2.0,<3.0" LINT=1
+    - php: "7.4snapshot"
+      env: PHPCS_VERSION="2.3.0"
 
     #### CODE COVERAGE STAGE ####
     # N.B.: Coverage is only checked on the lowest and highest stable PHP versions for all PHPCS versions.
@@ -121,7 +124,7 @@ jobs:
     # would be preferred.
     # Docs: https://docs.travis-ci.com/user/languages/php/#custom-php-configuration
     - stage: coverage
-      php: 7.3
+      php: "7.4snapshot"
       env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="^2.0" CUSTOM_INI=1
     - php: 7.3
       env: PHPCS_VERSION="2.3.0" COVERALLS_VERSION="^2.0"
@@ -138,10 +141,6 @@ jobs:
     - php: 5.3
       dist: precise
       env: PHPCS_VERSION="2.3.0" COVERALLS_VERSION="^1.0"
-
-  allow_failures:
-    # Allow failures for unstable builds.
-    - php: "7.4snapshot"
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PHP Compatibility Coding Standard for PHP CodeSniffer
 [![Coverage Status](https://coveralls.io/repos/github/PHPCompatibility/PHPCompatibility/badge.svg?branch=develop)](https://coveralls.io/github/PHPCompatibility/PHPCompatibility?branch=develop)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcompatibility/php-compatibility.svg?maxAge=3600)](https://packagist.org/packages/phpcompatibility/php-compatibility)
-[![Tested on PHP 5.3 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.3%20|%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%20nightly-brightgreen.svg?maxAge=2419200)](https://travis-ci.org/PHPCompatibility/PHPCompatibility)
+[![Tested on PHP 5.3 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.3%20|%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20-brightgreen.svg?maxAge=2419200)](https://travis-ci.org/PHPCompatibility/PHPCompatibility)
 
 
 This is a set of sniffs for [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) that checks for PHP cross-version compatibility.
@@ -54,6 +54,8 @@ PHP CodeSniffer 2.3.0 is required for 90% of the sniffs, PHP CodeSniffer 2.6.0 o
 For running the sniffs on PHP 7.3, it is recommended to use PHP_CodeSniffer 3.3.1+, or, if needs be, PHP_CodeSniffer 2.9.2.
 PHP_CodeSniffer < 2.9.2/3.3.1 is not fully compatible with PHP 7.3, which effectively means that PHPCompatibility can't be either.
 While the sniffs will still work in _most_ cases, you can expect PHP warnings to be thrown.
+
+For running the sniffs on PHP 7.4, it is recommended to use PHP_CodeSniffer 3.5.0+.
 
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP CodeSniffer 3.x.
 


### PR DESCRIPTION
As [PHP 7.4 has been released](https://www.php.net/archive/2019.php#2019-11-28-1), the build against PHP 7.4 should no longer be allowed to fail.

Includes some tweaking of the matrix to have the coverage stage and the quick test stage include PHP 7.4.