### PR TITLE
Documentation: improve sniff class descriptions

### DIFF
--- a/PHPCompatibility/AbstractComplexVersionSniff.php
+++ b/PHPCompatibility/AbstractComplexVersionSniff.php
@@ -14,6 +14,8 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Abstract base class for sniffs based on complex arrays with PHP version information.
+ *
+ * @since 7.1.0
  */
 abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersionInterface
 {

--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -16,6 +16,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Abstract class to use as a base for examining the parameter values passed to function calls.
+ *
+ * @since 8.2.0
  */
 abstract class AbstractFunctionCallParameterSniff extends Sniff
 {

--- a/PHPCompatibility/AbstractNewFeatureSniff.php
+++ b/PHPCompatibility/AbstractNewFeatureSniff.php
@@ -14,6 +14,8 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Base class for new feature sniffs.
+ *
+ * @since 7.1.0
  */
 abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
 {

--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -14,6 +14,8 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Base class for removed feature sniffs.
+ *
+ * @since 7.1.0
  */
 abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
 {

--- a/PHPCompatibility/ComplexVersionInterface.php
+++ b/PHPCompatibility/ComplexVersionInterface.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer_File as File;
  * Interface to be implemented by sniffs using a multi-dimensional array of
  * PHP features (functions, classes etc) being sniffed for with version
  * information in sub-arrays.
+ *
+ * @since 7.1.0
  */
 interface ComplexVersionInterface
 {

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -27,6 +27,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * lowest supported PHPCS version and the latest PHPCS stable version and
  * to provide the same results cross-version, PHPCompatibility needs to use
  * the up-to-date versions of these methods.
+ *
+ * @since 8.0.0
+ * @since 8.2.0 The duplicate PHPCS methods have been moved from the `Sniff`
+ *              base class to this class.
  */
 class PHPCSHelper
 {

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -21,6 +21,12 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * Those classes cannot be aliased as they don't represent the same object.
  * This class provides helper methods for functions which were contained in
  * one of these classes and which are used within the PHPCompatibility library.
+ *
+ * Additionally, this class contains some duplicates of PHPCS native methods.
+ * These methods have received bug fixes or improved functionality between the
+ * lowest supported PHPCS version and the latest PHPCS stable version and
+ * to provide the same results cross-version, PHPCompatibility needs to use
+ * the up-to-date versions of these methods.
  */
 class PHPCSHelper
 {

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Base class from which all PHPCompatibility sniffs extend.
+ *
+ * @since 5.6
  */
 abstract class Sniff implements PHPCS_Sniff
 {

--- a/PHPCompatibility/Sniffs/Classes/ForbiddenAbstractPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenAbstractPrivateMethodsSniff.php
@@ -17,12 +17,12 @@ use PHP_CodeSniffer_File as File;
  * Abstract private methods are not allowed since PHP 5.1.
  *
  * Abstract private methods were supported between PHP 5.0.0 and PHP 5.0.4, but
- * were then disallowed on the grounds that the behaviours of private and abstract
+ * were then disallowed on the grounds that the behaviours of `private` and `abstract`
  * are mutually exclusive.
  *
- * @link https://www.php.net/manual/en/migration51.oop.php#migration51.oop-methods
- *
  * PHP version 5.1
+ *
+ * @link https://www.php.net/manual/en/migration51.oop.php#migration51.oop-methods
  *
  * @since 9.2.0
  */

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -15,9 +15,12 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Anonymous classes are supported in PHP 7.0
+ * Anonymous classes are supported since PHP 7.0.
  *
  * PHP version 7.0
+ *
+ * @link https://www.php.net/manual/en/language.oop5.anonymous.php
+ * @link https://wiki.php.net/rfc/anonymous_classes
  */
 class NewAnonymousClassesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://www.php.net/manual/en/language.oop5.anonymous.php
  * @link https://wiki.php.net/rfc/anonymous_classes
+ *
+ * @since 7.0.0
  */
 class NewAnonymousClassesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -15,6 +15,16 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect use of new PHP native classes.
+ *
+ * The sniff analyses the following constructs to find usage of new classes:
+ * - Class instantiation using the `new` keyword.
+ * - (Anonymous) Class declarations to detect new classes being extended by userland classes.
+ * - Static use of class properties, constants or functions using the double colon.
+ * - Function/closure declarations to detect new classes used as parameter type declarations.
+ * - Function/closure declarations to detect new classes used as return type declarations.
+ * - Try/catch statements to detect new exception classes being caught.
+ *
+ * PHP version All
  */
 class NewClassesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -25,6 +25,10 @@ use PHP_CodeSniffer_File as File;
  * - Try/catch statements to detect new exception classes being caught.
  *
  * PHP version All
+ *
+ * @since 5.5
+ * @since 5.6   Now extends the base `Sniff` class.
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` class.
  */
 class NewClassesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://wiki.php.net/rfc/class_const_visibility
  * @link https://www.php.net/manual/en/language.oop5.constants.php#language.oop5.basic.class.this
+ *
+ * @since 7.0.7
  */
 class NewConstVisibilitySniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -18,6 +18,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * Visibility for class constants is available since PHP 7.1.
  *
  * PHP version 7.1
+ *
+ * @link https://wiki.php.net/rfc/class_const_visibility
+ * @link https://www.php.net/manual/en/language.oop5.constants.php#language.oop5.basic.class.this
  */
 class NewConstVisibilitySniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -17,7 +17,14 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * Detect use of late static binding as introduced in PHP 5.3.
  *
+ * Checks for:
+ * - Late static binding as introduced in PHP 5.3.
+ * - Late static binding being used outside of class scope (unsupported).
+ *
  * PHP version 5.3
+ *
+ * @link https://www.php.net/manual/en/language.oop5.late-static-bindings.php
+ * @link https://wiki.php.net/rfc/lsb_parentself_forwarding
  */
 class NewLateStaticBindingSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -25,6 +25,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://www.php.net/manual/en/language.oop5.late-static-bindings.php
  * @link https://wiki.php.net/rfc/lsb_parentself_forwarding
+ *
+ * @since 7.0.3
+ * @since 9.0.0 Renamed from `LateStaticBindingSniff` to `NewLateStaticBindingSniff`.
  */
 class NewLateStaticBindingSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -15,10 +15,11 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Typed properties are available since PHP 7.4.
+ * Typed class property declarations are available since PHP 7.4.
  *
  * PHP version 7.4
  *
+ * @link https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.typed-properties
  * @link https://wiki.php.net/rfc/typed_properties_v2
  *
  * @since 9.2.0

--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -14,14 +14,14 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Using "parent" inside a class without parent is deprecated since PHP 7.4.
+ * Using `parent` inside a class without parent is deprecated since PHP 7.4.
  *
  * This will throw a compile-time error in the future. Currently an error will only
  * be generated if/when the parent is accessed at run-time.
  *
- * @link https://github.com/php/php-src/blob/42cc58ff7b2fee1c17a00dc77a4873552ffb577f/UPGRADING#L303
- *
  * PHP version 7.4
+ *
+ * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.parent
  *
  * @since 9.2.0
  */

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer_File as File;
  * Detect use of new PHP native global constants.
  *
  * PHP version All
+ *
+ * @since 8.1.0
  */
 class NewConstantsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -15,6 +15,8 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect use of new PHP native global constants.
+ *
+ * PHP version All
  */
 class NewConstantsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -24,6 +24,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://wiki.php.net/rfc/class_name_scalars
  * @link https://www.php.net/manual/en/language.oop5.constants.php#example-186
+ *
+ * @since 7.1.4
+ * @since 7.1.5 Removed the incorrect checks against invalid usage of the constant.
  */
 class NewMagicClassConstantSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -15,10 +15,15 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * The special ClassName::class constant is available as of PHP 5.5.0, and allows for
- * fully qualified class name resolution at compile.
+ * Detect usage of the magic `::class` constant introduced in PHP 5.5.
+ *
+ * The special `ClassName::class` constant is available as of PHP 5.5.0, and allows
+ * for fully qualified class name resolution at compile time.
  *
  * PHP version 5.5
+ *
+ * @link https://wiki.php.net/rfc/class_name_scalars
+ * @link https://www.php.net/manual/en/language.oop5.constants.php#example-186
  */
 class NewMagicClassConstantSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -15,6 +15,8 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect use of deprecated and/or removed PHP native global constants.
+ *
+ * PHP version All
  */
 class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -17,6 +17,8 @@ use PHP_CodeSniffer_File as File;
  * Detect use of deprecated and/or removed PHP native global constants.
  *
  * PHP version All
+ *
+ * @since 8.1.0
  */
 class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -28,6 +28,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://github.com/php/php-src/commit/04e3523b7d095341f65ed5e71a3cac82fca690e4
  *       (actual implementation which is different from the RFC).
  * @link https://www.php.net/manual/en/control-structures.switch.php
+ *
+ * @since 8.2.0
  */
 class DiscouragedSwitchContinueSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -15,9 +15,19 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * PHP 7.3 will throw a warning when continue is used to target a switch control structure.
+ * Detect use of `continue` in `switch` control structures.
+ *
+ * As of PHP 7.3, PHP will throw a warning when `continue` is used to target a `switch`
+ * control structure.
+ * The sniff takes numeric arguments used with `continue` into account.
  *
  * PHP version 7.3
+ *
+ * @link https://www.php.net/manual/en/migration73.incompatible.php#migration73.incompatible.core.continue-targeting-switch
+ * @link https://wiki.php.net/rfc/continue_on_switch_deprecation
+ * @link https://github.com/php/php-src/commit/04e3523b7d095341f65ed5e71a3cac82fca690e4
+ *       (actual implementation which is different from the RFC).
+ * @link https://www.php.net/manual/en/control-structures.switch.php
  */
 class DiscouragedSwitchContinueSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer_File as File;
  * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.break-continue
  * @link https://www.php.net/manual/en/control-structures.break.php
  * @link https://www.php.net/manual/en/control-structures.continue.php
+ *
+ * @since 7.0.7
  */
 class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -14,9 +14,13 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Forbids use of break or continue statements outside of looping structures.
+ * Detect using `break` and/or `continue` statements outside of a looping structure.
  *
  * PHP version 7.0
+ *
+ * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.break-continue
+ * @link https://www.php.net/manual/en/control-structures.break.php
+ * @link https://www.php.net/manual/en/control-structures.continue.php
  */
 class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -26,6 +26,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://www.php.net/manual/en/migration54.incompatible.php
  * @link https://www.php.net/manual/en/control-structures.break.php
  * @link https://www.php.net/manual/en/control-structures.continue.php
+ *
+ * @since 5.5
+ * @since 5.6 Now extends the base `Sniff` class.
  */
 class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -15,9 +15,17 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Forbids variable arguments on break or continue statements.
+ * Detects using 0 and variable numeric arguments on `break` and `continue` statements.
+ *
+ * This sniff checks for:
+ * - Using `break` and/or `continue` with a variable as the numeric argument.
+ * - Using `break` and/or `continue` with a zero - 0 - as the numeric argument.
  *
  * PHP version 5.4
+ *
+ * @link https://www.php.net/manual/en/migration54.incompatible.php
+ * @link https://www.php.net/manual/en/control-structures.break.php
+ * @link https://www.php.net/manual/en/control-structures.continue.php
  */
 class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -20,6 +20,8 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://wiki.php.net/rfc/switch.default.multiple
  * @link https://www.php.net/manual/en/control-structures.switch.php
+ *
+ * @since 7.0.0
  */
 class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -14,9 +14,12 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Switch statements can not have multiple default blocks since PHP 7.0
+ * Switch statements can not have multiple default blocks since PHP 7.0.
  *
  * PHP version 7.0
+ *
+ * @link https://wiki.php.net/rfc/switch.default.multiple
+ * @link https://www.php.net/manual/en/control-structures.switch.php
  */
 class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -17,6 +17,20 @@ use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Check for valid execution directives set with `declare()`.
+ *
+ * The sniff contains three distinct checks:
+ * - Check if the execution directive used is valid. PHP currently only supports
+ *   three execution directives.
+ * - Check if the execution directive used is available in the PHP versions
+ *   for which support is being checked.
+ *   In the case of the `encoding` directive on PHP 5.3, support is conditional
+ *   on the `--enable-zend-multibyte` compilation option. This will be indicated as such.
+ * - Check whether the value for the directive is valid.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/control-structures.declare.php
+ * @link https://wiki.php.net/rfc/scalar_type_hints_v5#strict_types_declare_directive
  */
 class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -31,6 +31,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://www.php.net/manual/en/control-structures.declare.php
  * @link https://wiki.php.net/rfc/scalar_type_hints_v5#strict_types_declare_directive
+ *
+ * @since 7.0.3
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
  */
 class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -14,12 +14,14 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * New `foreach` Expression Referencing.
+ * Detect `foreach` expression referencing.
  *
- * Before PHP 5.5.0, referencing $value is only possible if the iterated array
- * can be referenced (i.e. if it is a variable).
+ * Before PHP 5.5.0, referencing `$value` in a `foreach` was only possible
+ * if the iterated array could be referenced (i.e. if it is a variable).
  *
  * PHP version 5.5
+ *
+ * @link https://www.php.net/manual/en/control-structures.foreach.php
  */
 class NewForeachExpressionReferencingSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -22,6 +22,8 @@ use PHP_CodeSniffer_File as File;
  * PHP version 5.5
  *
  * @link https://www.php.net/manual/en/control-structures.foreach.php
+ *
+ * @since 9.0.0
  */
 class NewForeachExpressionReferencingSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer_File as File;
  * @link https://www.php.net/manual/en/migration55.new-features.php#migration55.new-features.foreach-list
  * @link https://wiki.php.net/rfc/foreachlist
  * @link https://www.php.net/manual/en/control-structures.foreach.php#control-structures.foreach.list
+ *
+ * @since 9.0.0
  */
 class NewListInForeachSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -14,9 +14,13 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Detect unpacking nested arrays with list() in a foreach().
+ * Detect unpacking nested arrays with `list()` in a `foreach()` as available since PHP 5.5.
  *
  * PHP version 5.5
+ *
+ * @link https://www.php.net/manual/en/migration55.new-features.php#migration55.new-features.foreach-list
+ * @link https://wiki.php.net/rfc/foreachlist
+ * @link https://www.php.net/manual/en/control-structures.foreach.php#control-structures.foreach.list
  */
 class NewListInForeachSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -17,6 +17,10 @@ use PHP_CodeSniffer_File as File;
  * Catching multiple exception types in one statement is available since PHP 7.1.
  *
  * PHP version 7.1
+ *
+ * @link https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.mulit-catch-exception-handling
+ * @link https://wiki.php.net/rfc/multiple-catch
+ * @link https://www.php.net/manual/en/language.exceptions.php#language.exceptions.catch
  */
 class NewMultiCatchSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer_File as File;
  * @link https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.mulit-catch-exception-handling
  * @link https://wiki.php.net/rfc/multiple-catch
  * @link https://www.php.net/manual/en/language.exceptions.php#language.exceptions.catch
+ *
+ * @since 7.0.7
  */
 class NewMultiCatchSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -15,7 +15,22 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Discourages the use of removed extensions. Suggests alternative extensions if available
+ * Detect the use of deprecated and/or removed PHP extensions.
+ *
+ * This sniff examines function calls made and flags function calls to functions
+ * prefixed with the dedicated prefix from a deprecated/removed native PHP extension.
+ *
+ * Suggests alternative extensions if available.
+ *
+ * As userland functions may be prefixed with a prefix also used by a native
+ * PHP extension, the sniff offers the ability to whitelist specific functions
+ * from being flagged by this sniff via a property in a custom ruleset
+ * (since PHPCompatibility 7.0.2).
+ *
+ * {@internal This sniff is a candidate for removal once all functions from all
+ * deprecated/removed extensions have been added to the RemovedFunctions sniff.}}
+ *
+ * PHP version All
  */
 class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -31,6 +31,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * deprecated/removed extensions have been added to the RemovedFunctions sniff.}}
  *
  * PHP version All
+ *
+ * @since 5.5
+ * @since 7.1.0 Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
  */
 class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -15,11 +15,13 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Discourages use of superglobals as parameters for functions.
+ * Detect the use of superglobals as parameters for functions, support for which was removed in PHP 5.4.
  *
  * {@internal List of superglobals is maintained in the parent class.}}
  *
  * PHP version 5.4
+ *
+ * @link https://www.php.net/manual/en/migration54.incompatible.php
  */
 class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -22,6 +22,8 @@ use PHP_CodeSniffer_File as File;
  * PHP version 5.4
  *
  * @link https://www.php.net/manual/en/migration54.incompatible.php
+ *
+ * @since 7.0.0
  */
 class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer_File as File;
  * Functions can not have multiple parameters with the same name since PHP 7.0
  *
  * PHP version 7.0
+ *
+ * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.func-parameters
  */
 class ForbiddenParametersWithSameNameSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -20,6 +20,8 @@ use PHP_CodeSniffer_File as File;
  * PHP version 7.0
  *
  * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.func-parameters
+ *
+ * @since 7.0.0
  */
 class ForbiddenParametersWithSameNameSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -17,11 +17,12 @@ use PHP_CodeSniffer_File as File;
 /**
  * As of PHP 5.3, the __toString() magic method can no longer accept arguments.
  *
- * Sister-sniff to PHPCompatibility.MethodUse.ForbiddenToStringParameters.
- *
- * @link https://www.php.net/manual/en/migration53.incompatible.php
+ * Sister-sniff to `PHPCompatibility.MethodUse.ForbiddenToStringParameters`.
  *
  * PHP version 5.3
+ *
+ * @link https://www.php.net/manual/en/migration53.incompatible.php
+ * @link https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
  *
  * @since 9.2.0
  */

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -16,12 +16,15 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * PHP 7.1 Forbidden variable names in closure use statements.
+ * Detect variable names forbidden to be used in closure `use` statements.
  *
- * Variables bound to a closure via the use construct cannot use the same name
- * as any superglobals, $this, or any parameter since PHP 7.1.
+ * Variables bound to a closure via the `use` construct cannot use the same name
+ * as any superglobals, `$this`, or any parameter since PHP 7.1.
  *
  * PHP version 7.1
+ *
+ * @link https://www.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.lexical-names
+ * @link https://www.php.net/manual/en/functions.anonymous.php
  */
 class ForbiddenVariableNamesInClosureUseSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -25,6 +25,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://www.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.lexical-names
  * @link https://www.php.net/manual/en/functions.anonymous.php
+ *
+ * @since 7.1.4
  */
 class ForbiddenVariableNamesInClosureUseSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -34,6 +34,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://www.php.net/manual/en/functions.anonymous.php
  * @link https://wiki.php.net/rfc/closures
  * @link https://wiki.php.net/rfc/closures/object-extension
+ *
+ * @since 7.0.0
  */
 class NewClosureSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -15,9 +15,25 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Closures are available since PHP 5.3
+ * Detect closures and verify that the features used are supported.
+ *
+ * Version based checks:
+ * - Closures are available since PHP 5.3.
+ * - Closures can be declared as `static` since PHP 5.4.
+ * - Closures can use the `$this` variable within a class context since PHP 5.4.
+ * - Closures can use `self`/`parent`/`static` since PHP 5.4.
+ *
+ * Version independent checks:
+ * - Static closures don't have access to the `$this` variable.
+ * - Closures declared outside of a class context don't have access to the `$this`
+ *   variable unless bound to an object.
  *
  * PHP version 5.3
+ * PHP version 5.4
+ *
+ * @link https://www.php.net/manual/en/functions.anonymous.php
+ * @link https://wiki.php.net/rfc/closures
+ * @link https://wiki.php.net/rfc/closures/object-extension
  */
 class NewClosureSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -15,11 +15,12 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * As of PHP 7.4, throwing exceptions from a __toString() method is allowed.
- *
- * @link https://wiki.php.net/rfc/tostring_exceptions
+ * As of PHP 7.4, throwing exceptions from a `__toString()` method is allowed.
  *
  * PHP version 7.4
+ *
+ * @link https://wiki.php.net/rfc/tostring_exceptions
+ * @link https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
  *
  * @since 9.2.0
  */

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -23,6 +23,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.nullable-types
  * @link https://wiki.php.net/rfc/nullable_types
  * @link https://www.php.net/manual/en/functions.arguments.php#example-146
+ *
+ * @since 7.0.7
  */
 class NewNullableTypesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -16,9 +16,13 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Nullable type hints and return types are available since PHP 7.1.
+ * Nullable parameter type declarations and return types are available since PHP 7.1.
  *
  * PHP version 7.1
+ *
+ * @link https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.nullable-types
+ * @link https://wiki.php.net/rfc/nullable_types
+ * @link https://www.php.net/manual/en/functions.arguments.php#example-146
  */
 class NewNullableTypesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -38,6 +38,10 @@ use PHP_CodeSniffer_File as File;
  * @link https://wiki.php.net/rfc/scalar_type_hints_v5
  * @link https://wiki.php.net/rfc/iterable
  * @link https://wiki.php.net/rfc/object-typehint
+ *
+ * @since 7.0.0
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
+ * @since 9.0.0 Renamed from `NewScalarTypeDeclarationsSniff` to `NewParamTypeDeclarationsSniff`.
  */
 class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -16,6 +16,28 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect and verify the use of parameter type declarations in function declarations.
+ *
+ * Parameter type declarations - class/interface names only - is available since PHP 5.0.
+ * - Since PHP 5.1, the `array` keyword can be used.
+ * - Since PHP 5.2, `self` and `parent` can be used. Previously, those were interpreted as
+ *   class names.
+ * - Since PHP 5.4, the `callable` keyword.
+ * - Since PHP 7.0, scalar type declarations are available.
+ * - Since PHP 7.1, the `iterable` pseudo-type is available.
+ * - Since PHP 7.2, the generic `object` type is available.
+ *
+ * Additionally, this sniff does a cursory check for typical invalid type declarations,
+ * such as:
+ * - `boolean` (should be `bool`), `integer` (should be `int`) and `static`.
+ * - `self`/`parent` as type declaration used outside class context throws a fatal error since PHP 7.0.
+ *
+ * PHP version 5.0+
+ *
+ * @link https://www.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration
+ * @link https://wiki.php.net/rfc/callable
+ * @link https://wiki.php.net/rfc/scalar_type_hints_v5
+ * @link https://wiki.php.net/rfc/iterable
+ * @link https://wiki.php.net/rfc/object-typehint
  */
 class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -16,7 +16,18 @@ use PHP_CodeSniffer_File as File;
 /**
  * Detect and verify the use of return type declarations in function declarations.
  *
- * PHP version 7.0
+ * Return type declarations are available since PHP 7.0.
+ * - Since PHP 7.1, the `iterable` and `void` pseudo-types are available.
+ * - Since PHP 7.2, the generic `object` type is available.
+ *
+ * PHP version 7.0+
+ *
+ * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.return-type-declarations
+ * @link https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @link https://wiki.php.net/rfc/return_types
+ * @link https://wiki.php.net/rfc/iterable
+ * @link https://wiki.php.net/rfc/void_return_type
+ * @link https://wiki.php.net/rfc/object-typehint
  */
 class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -28,6 +28,10 @@ use PHP_CodeSniffer_File as File;
  * @link https://wiki.php.net/rfc/iterable
  * @link https://wiki.php.net/rfc/void_return_type
  * @link https://wiki.php.net/rfc/object-typehint
+ *
+ * @since 7.0.0
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
+ * @since 7.1.2 Renamed from `NewScalarReturnTypeDeclarationsSniff` to `NewReturnTypeDeclarationsSniff`.
  */
 class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -16,7 +16,12 @@ use PHP_CodeSniffer_File as File;
 /**
  * Verifies the use of the correct visibility and static properties of magic methods.
  *
+ * The requirements have always existed, but as of PHP 5.3, a warning will be thrown
+ * when magic methods have the wrong modifiers.
+ *
  * PHP version 5.3
+ *
+ * @link https://www.php.net/manual/en/language.oop5.magic.php
  */
 class NonStaticMagicMethodsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -22,6 +22,9 @@ use PHP_CodeSniffer_File as File;
  * PHP version 5.3
  *
  * @link https://www.php.net/manual/en/language.oop5.magic.php
+ *
+ * @since 5.5
+ * @since 5.6 Now extends the base `Sniff` class.
  */
 class NonStaticMagicMethodsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -15,6 +15,12 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Warns for non-magic behaviour of magic methods prior to becoming magic.
+ *
+ * PHP version 5.0+
+ *
+ * @link https://www.php.net/manual/en/language.oop5.magic.php
+ * @link https://wiki.php.net/rfc/closures#additional_goodyinvoke
+ * @link https://wiki.php.net/rfc/debug-info
  */
 class NewMagicMethodsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -21,6 +21,9 @@ use PHP_CodeSniffer_File as File;
  * @link https://www.php.net/manual/en/language.oop5.magic.php
  * @link https://wiki.php.net/rfc/closures#additional_goodyinvoke
  * @link https://wiki.php.net/rfc/debug-info
+ *
+ * @since 7.0.4
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
  */
 class NewMagicMethodsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -23,6 +23,9 @@ use PHP_CodeSniffer_File as File;
  * @link https://www.php.net/manual/en/migration72.deprecated.php#migration72.deprecated.__autoload-method
  * @link https://wiki.php.net/rfc/deprecations_php_7_2#autoload
  * @link https://www.php.net/manual/en/function.autoload.php
+ *
+ * @since 8.1.0
+ * @since 9.0.0 Renamed from `DeprecatedMagicAutoloadSniff` to `RemovedMagicAutoloadSniff`.
  */
 class RemovedMagicAutoloadSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -14,9 +14,15 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Detect declaration of the magic __autoload() method.
+ * Detect declaration of the magic `__autoload()` method.
+ *
+ * This method has been deprecated in PHP 7.2 in favour of `spl_autoload_register()`.
  *
  * PHP version 7.2
+ *
+ * @link https://www.php.net/manual/en/migration72.deprecated.php#migration72.deprecated.__autoload-method
+ * @link https://wiki.php.net/rfc/deprecations_php_7_2#autoload
+ * @link https://www.php.net/manual/en/function.autoload.php
  */
 class RemovedMagicAutoloadSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -14,16 +14,20 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Removed Namespaced Assert.
+ * Detect declaration of a namespaced function called `assert()`.
  *
  * As of PHP 7.3, a compile-time deprecation warning will be thrown when a function
  * called `assert()` is declared. In PHP 8 this will become a compile-error.
  *
  * Methods are unaffected.
- * Global, non-namespaced, assert() function declarations were always a fatal
+ * Global, non-namespaced, `assert()` function declarations were always a fatal
  * "function already declared" error, so not the concern of this sniff.
  *
  * PHP version 7.3
+ *
+ * @link https://www.php.net/manual/en/migration73.deprecated.php#migration73.deprecated.core.assert
+ * @link https://wiki.php.net/rfc/deprecations_php_7_3#defining_a_free-standing_assert_function
+ * @link https://www.php.net/manual/en/function.assert.php
  */
 class RemovedNamespacedAssertSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -28,6 +28,8 @@ use PHP_CodeSniffer_File as File;
  * @link https://www.php.net/manual/en/migration73.deprecated.php#migration73.deprecated.core.assert
  * @link https://wiki.php.net/rfc/deprecations_php_7_3#defining_a_free-standing_assert_function
  * @link https://www.php.net/manual/en/function.assert.php
+ *
+ * @since 9.0.0
  */
 class RemovedNamespacedAssertSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -30,6 +30,11 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://www.php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors
  * @link https://wiki.php.net/rfc/remove_php4_constructors
  * @link https://www.php.net/manual/en/language.oop5.decon.php
+ *
+ * @since 7.0.0
+ * @since 7.0.8 This sniff now throws a warning instead of an error as the functionality is
+ *              only deprecated (for now).
+ * @since 9.0.0 Renamed from `DeprecatedPHP4StyleConstructorsSniff` to `RemovedPHP4StyleConstructorsSniff`.
  */
 class RemovedPHP4StyleConstructorsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -17,7 +17,19 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * Detect declarations of PHP 4 style constructors which are deprecated as of PHP 7.0.0.
  *
+ * PHP 4 style constructors - methods that have the same name as the class they are defined in -
+ * are deprecated as of PHP 7.0.0, and will be removed in the future.
+ * PHP 7 will emit `E_DEPRECATED` if a PHP 4 constructor is the only constructor defined
+ * within a class. Classes that implement a `__construct()` method are unaffected.
+ *
+ * Note: Methods with the same name as the class they are defined in _within a namespace_
+ * are not recognized as constructors anyway and therefore outside the scope of this sniff.
+ *
  * PHP version 7.0
+ *
+ * @link https://www.php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors
+ * @link https://wiki.php.net/rfc/remove_php4_constructors
+ * @link https://www.php.net/manual/en/language.oop5.decon.php
  */
 class RemovedPHP4StyleConstructorsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -18,6 +18,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * All function and method names starting with double underscore are reserved by PHP.
  *
+ * PHP version All
+ *
  * {@internal Extends an upstream sniff to benefit from the properties contained therein.
  *            The properties are lists of valid PHP magic function and method names, which
  *            should be ignored for the purposes of this sniff.
@@ -29,8 +31,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *            prevents hard to debug issues of errors not being reported from the upstream sniff
  *            if this library is used in combination with other rulesets.}}
  *
+ * @link https://www.php.net/manual/en/language.oop5.magic.php
+ *
  * @since 8.2.0 This was previously, since 7.0.3, checked by the upstream sniff.
- * @since 9.3.2 The sniff will now ignore functions marked as @deprecated by design.
+ * @since 9.3.2 The sniff will now ignore functions marked as `@deprecated` by design.
  */
 class ReservedFunctionNamesSniff extends PHPCS_CamelCapsFunctionNameSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -20,10 +20,12 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * instead of the original since PHP 7.0.
  *
  * `func_get_arg()`, `func_get_args()`, `debug_backtrace()` and exception backtraces
- * will no longer report the original value that was passed to a parameter, but will
- * instead provide the current value (which might have been modified).
+ * will no longer report the original parameter value as was passed to the function,
+ * but will instead provide the current value (which might have been modified).
  *
  * PHP version 7.0
+ *
+ * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.func-parameter-modified
  *
  * @since 9.1.0
  */

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -28,6 +28,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version 5.3
  *
  * @link https://www.php.net/manual/en/migration53.incompatible.php
+ *
+ * @since 8.2.0
  */
 class ArgumentFunctionsUsageSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -15,10 +15,10 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Detect usage of func_get_args(), func_get_arg() and func_num_args().
+ * Detect usage of `func_get_args()`, `func_get_arg()` and `func_num_args()` in invalid context.
  *
+ * Checks for:
  * - Prior to PHP 5.3, these functions could not be used as a function call parameter.
- *
  * - Calling these functions from the outermost scope of a file which has been included by
  *   calling `include` or `require` from within a function in the calling file, worked
  *   prior to PHP 5.3. As of PHP 5.3, this will generate a warning and will always return false/-1.
@@ -26,6 +26,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *   functions would already generate a warning prior to PHP 5.3.
  *
  * PHP version 5.3
+ *
+ * @link https://www.php.net/manual/en/migration53.incompatible.php
  */
 class ArgumentFunctionsUsageSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -16,6 +16,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Detect use of new function parameters in calls to native PHP functions.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/doc.changelog.php
  */
 class NewFunctionParametersSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -20,6 +20,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version All
  *
  * @link https://www.php.net/manual/en/doc.changelog.php
+ *
+ * @since 7.0.0
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
  */
 class NewFunctionParametersSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -15,6 +15,8 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect calls to new native PHP functions.
+ *
+ * PHP version All
  */
 class NewFunctionsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -17,6 +17,11 @@ use PHP_CodeSniffer_File as File;
  * Detect calls to new native PHP functions.
  *
  * PHP version All
+ *
+ * @since 5.5
+ * @since 5.6   Now extends the base `Sniff` class instead of the upstream
+ *              `Generic.PHP.ForbiddenFunctions` sniff.
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
  */
 class NewFunctionsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -21,6 +21,9 @@ use PHP_CodeSniffer_File as File;
  * PHP version All
  *
  * @link https://www.php.net/manual/en/doc.changelog.php
+ *
+ * @since 8.1.0
+ * @since 9.0.0 Renamed from `OptionalRequiredFunctionParametersSniff` to `OptionalToRequiredFunctionParametersSniff`.
  */
 class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFunctionParametersSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -15,6 +15,12 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect missing required function parameters in calls to native PHP functions.
+ *
+ * Specifically when those function parameters used to be optional in older PHP versions.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/doc.changelog.php
  */
 class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFunctionParametersSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -16,6 +16,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Detect use of deprecated/removed function parameters in calls to native PHP functions.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/doc.changelog.php
  */
 class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -20,6 +20,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version All
  *
  * @link https://www.php.net/manual/en/doc.changelog.php
+ *
+ * @since 7.0.0
+ * @since 7.1.0 Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
  */
 class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -19,6 +19,12 @@ use PHP_CodeSniffer_File as File;
  * Suggests alternative if available.
  *
  * PHP version All
+ *
+ * @since 5.5
+ * @since 5.6   Now extends the base `Sniff` class instead of the upstream
+ *              `Generic.PHP.ForbiddenFunctions` sniff.
+ * @since 7.1.0 Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
+ * @since 9.0.0 Renamed from `DeprecatedFunctionsSniff` to `RemovedFunctionsSniff`.
  */
 class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -15,6 +15,10 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect calls to deprecated/removed native PHP functions.
+ *
+ * Suggests alternative if available.
+ *
+ * PHP version All
  */
 class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -22,6 +22,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version All
  *
  * @link https://www.php.net/manual/en/doc.changelog.php
+ *
+ * @since 7.0.3
+ * @since 7.1.0 Now extends the `AbstractComplexVersionSniff` instead of the base `Sniff` class.
+ * @since 9.0.0 Renamed from `RequiredOptionalFunctionParametersSniff` to `RequiredToOptionalFunctionParametersSniff`.
  */
 class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSniff
 {

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -16,6 +16,12 @@ use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Detect missing required function parameters in calls to native PHP functions.
+ *
+ * Specifically when those function parameters are no longer required in more recent PHP versions.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/doc.changelog.php
  */
 class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSniff
 {

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -15,9 +15,13 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * As of PHP 7.0, a return statement can be used within a generator for a final expression to be returned.
+ * As of PHP 7.0, a `return` statement can be used within a generator for a final expression to be returned.
  *
  * PHP version 7.0
+ *
+ * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.generator-return-expressions
+ * @link https://wiki.php.net/rfc/generator-return-expressions
+ * @link https://www.php.net/manual/en/language.generators.syntax.php
  */
 class NewGeneratorReturnSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -22,6 +22,8 @@ use PHP_CodeSniffer_File as File;
  * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.generator-return-expressions
  * @link https://wiki.php.net/rfc/generator-return-expressions
  * @link https://www.php.net/manual/en/language.generators.syntax.php
+ *
+ * @since 8.2.0
  */
 class NewGeneratorReturnSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -20,6 +20,11 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://www.php.net/manual/en/ini.list.php
  * @link https://www.php.net/manual/en/ini.core.php
+ *
+ * @since 5.5
+ * @since 7.0.7 When a new directive is used with `ini_set()`, the sniff will now throw an error
+ *              instead of a warning.
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
  */
 class NewIniDirectivesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -14,7 +14,12 @@ use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Discourages the use of new INI directives through ini_set() or ini_get().
+ * Detect the use of new INI directives through `ini_set()` or `ini_get()`.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/ini.list.php
+ * @link https://www.php.net/manual/en/ini.core.php
  */
 class NewIniDirectivesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -14,7 +14,12 @@ use PHPCompatibility\AbstractRemovedFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Discourages the use of deprecated and removed INI directives through ini_set() or ini_get().
+ * Detect the use of deprecated and removed INI directives through `ini_set()` or `ini_get()`.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/ini.list.php
+ * @link https://www.php.net/manual/en/ini.core.php
  */
 class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -20,6 +20,13 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://www.php.net/manual/en/ini.list.php
  * @link https://www.php.net/manual/en/ini.core.php
+ *
+ * @since 5.5
+ * @since 7.0.0 This sniff now throws a warning (deprecated) or an error (removed) depending
+ *              on the `testVersion` set. Previously it would always throw a warning.
+ * @since 7.0.1 The sniff will now only throw warnings for `ini_get()`.
+ * @since 7.1.0 Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
+ * @since 9.0.0 Renamed from `DeprecatedIniDirectivesSniff` to `RemovedIniDirectivesSniff`.
  */
 class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -14,9 +14,13 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Constant arrays using the const keyword in PHP 5.6
+ * Detect declaration of constants using the `const` keyword with a (constant) array value
+ * as supported since PHP 5.6.
  *
  * PHP version 5.6
+ *
+ * @link https://wiki.php.net/rfc/const_scalar_exprs
+ * @link https://www.php.net/manual/en/language.constants.syntax.php
  */
 class NewConstantArraysUsingConstSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -21,6 +21,9 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://wiki.php.net/rfc/const_scalar_exprs
  * @link https://www.php.net/manual/en/language.constants.syntax.php
+ *
+ * @since 7.1.4
+ * @since 9.0.0 Renamed from `ConstantArraysUsingConstSniff` to `NewConstantArraysUsingConstSniff`.
  */
 class NewConstantArraysUsingConstSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -14,9 +14,13 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Constant arrays using define in PHP 7.0
+ * Detect declaration of constants using `define()` with a (constant) array value
+ * as supported since PHP 7.0.
  *
  * PHP version 7.0
+ *
+ * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.define-array
+ * @link https://www.php.net/manual/en/language.constants.syntax.php
  */
 class NewConstantArraysUsingDefineSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -21,6 +21,9 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.define-array
  * @link https://www.php.net/manual/en/language.constants.syntax.php
+ *
+ * @since 7.0.0
+ * @since 9.0.0 Renamed from `ConstantArraysUsingDefineSniff` to `NewConstantArraysUsingDefineSniff`.
  */
 class NewConstantArraysUsingDefineSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -16,12 +16,17 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
+ * Detect constant scalar expressions being used to set an initial value.
+ *
  * Since PHP 5.6, it is now possible to provide a scalar expression involving
  * numeric and string literals and/or constants in contexts where PHP previously
  * expected a static value, such as constant and property declarations and
- * default function arguments.
+ * default values for function parameters.
  *
  * PHP version 5.6
+ *
+ * @link https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.const-scalar-exprs
+ * @link https://wiki.php.net/rfc/const_scalar_exprs
  */
 class NewConstantScalarExpressionsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -27,6 +27,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.const-scalar-exprs
  * @link https://wiki.php.net/rfc/const_scalar_exprs
+ *
+ * @since 8.2.0
  */
 class NewConstantScalarExpressionsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -15,6 +15,8 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
+ * Detect a heredoc being used to set an initial value.
+ *
  * As of PHP 5.3.0, it's possible to initialize static variables, class properties
  * and constants declared using the `const` keyword, using the Heredoc syntax.
  * And while not documented, heredoc initialization can now also be used for function param defaults.
@@ -24,6 +26,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHPCompatibility library until such time as there is a PHP version in which this would be accepted.
  *
  * PHP version 5.3
+ *
+ * @link https://www.php.net/manual/en/migration53.new-features.php
+ * @link https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc
  */
 class NewHeredocSniff extends NewConstantScalarExpressionsSniff
 {

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -29,6 +29,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://www.php.net/manual/en/migration53.new-features.php
  * @link https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc
+ *
+ * @since 7.1.4
+ * @since 8.2.0 Now extends the NewConstantScalarExpressionsSniff instead of the base Sniff class.
+ * @since 9.0.0 Renamed from `NewHeredocInitializeSniff` to `NewHeredocSniff`.
  */
 class NewHeredocSniff extends NewConstantScalarExpressionsSniff
 {

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -22,6 +22,8 @@ use PHP_CodeSniffer_File as File;
  * @link https://www.php.net/manual/en/class.traversable.php
  * @link https://www.php.net/manual/en/class.throwable.php
  * @link https://www.php.net/manual/en/class.datetimeinterface.php
+ *
+ * @since 7.0.3
  */
 class InternalInterfacesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -16,6 +16,12 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect classes which implement PHP native interfaces intended only for PHP internal use.
+ *
+ * PHP version 5.0+
+ *
+ * @link https://www.php.net/manual/en/class.traversable.php
+ * @link https://www.php.net/manual/en/class.throwable.php
+ * @link https://www.php.net/manual/en/class.datetimeinterface.php
  */
 class InternalInterfacesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -18,6 +18,11 @@ use PHP_CodeSniffer_File as File;
  * Detect use of new PHP native interfaces and unsupported interface methods.
  *
  * PHP version 5.0+
+ *
+ * @since 7.0.3
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
+ * @since 7.1.4 Now also detects new interfaces when used as parameter type declarations.
+ * @since 8.2.0 Now also detects new interfaces when used as return type declarations.
  */
 class NewInterfacesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -16,6 +16,8 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect use of new PHP native interfaces and unsupported interface methods.
+ *
+ * PHP version 5.0+
  */
 class NewInterfacesSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -14,10 +14,14 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Prior to PHP 5.5, cases existed where the self, parent, and static keywords
+ * Detect usage of `self`, `parent` and `static` and verify they are lowercase.
+ *
+ * Prior to PHP 5.5, cases existed where the `self`, `parent`, and `static` keywords
  * were treated in a case sensitive fashion.
  *
  * PHP version 5.5
+ *
+ * @link https://www.php.net/manual/en/migration55.incompatible.php#migration55.incompatible.self-parent-static
  */
 class CaseSensitiveKeywordsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -22,6 +22,8 @@ use PHP_CodeSniffer_File as File;
  * PHP version 5.5
  *
  * @link https://www.php.net/manual/en/migration55.incompatible.php#migration55.incompatible.self-parent-static
+ *
+ * @since 7.1.4
  */
 class CaseSensitiveKeywordsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -15,12 +15,14 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Prohibits the use of some reserved keywords to name a class, interface, trait or namespace.
+ * Detects the use of some reserved keywords to name a class, interface, trait or namespace.
+ *
  * Emits errors for reserved words and warnings for soft-reserved words.
  *
- * @see http://php.net/manual/en/reserved.other-reserved-words.php
- *
  * PHP version 7.0+
+ *
+ * @link https://www.php.net/manual/en/reserved.other-reserved-words.php
+ * @link https://wiki.php.net/rfc/reserve_more_types_in_php_7
  */
 class ForbiddenNamesAsDeclaredSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -23,6 +23,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://www.php.net/manual/en/reserved.other-reserved-words.php
  * @link https://wiki.php.net/rfc/reserve_more_types_in_php_7
+ *
+ * @since 7.0.8
+ * @since 7.1.4 This sniff now throws a warning (soft reserved) or an error (reserved) depending
+ *              on the `testVersion` set. Previously it would always throw an error.
  */
 class ForbiddenNamesAsDeclaredSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -16,6 +16,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Prohibits the use of reserved keywords invoked as functions.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/reserved.keywords.php
  */
 class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -20,6 +20,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version All
  *
  * @link https://www.php.net/manual/en/reserved.keywords.php
+ *
+ * @since 5.5
  */
 class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -15,7 +15,11 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Prohibits the use of reserved keywords as class, function, namespace or constant names.
+ * Detects the use of reserved keywords as class, function, namespace or constant names.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/reserved.keywords.php
  */
 class ForbiddenNamesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -20,6 +20,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version All
  *
  * @link https://www.php.net/manual/en/reserved.keywords.php
+ *
+ * @since 5.5
  */
 class ForbiddenNamesSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -24,6 +24,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://wiki.php.net/rfc/generators
  * @link https://wiki.php.net/rfc/finally
  * @link https://wiki.php.net/rfc/generator-delegation
+ *
+ * @since 5.5
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
  */
 class NewKeywordsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -16,6 +16,14 @@ use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Detect use of new PHP keywords.
+ *
+ * PHP version All
+ *
+ * @link https://wiki.php.net/rfc/heredoc-with-double-quotes
+ * @link https://wiki.php.net/rfc/horizontalreuse (traits)
+ * @link https://wiki.php.net/rfc/generators
+ * @link https://wiki.php.net/rfc/finally
+ * @link https://wiki.php.net/rfc/generator-delegation
  */
 class NewKeywordsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -17,7 +17,12 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * Verify that nothing but variables are passed to empty().
  *
+ * Prior to PHP 5.5, `empty()` only supported variables; anything else resulted in a parse error.
+ *
  * PHP version 5.5
+ *
+ * @link https://wiki.php.net/rfc/empty_isset_exprs
+ * @link https://www.php.net/manual/en/function.empty.php
  */
 class NewEmptyNonVariableSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -23,6 +23,11 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://wiki.php.net/rfc/empty_isset_exprs
  * @link https://www.php.net/manual/en/function.empty.php
+ *
+ * @since 7.0.4
+ * @since 9.0.0 The "is the parameter a variable" determination has been abstracted out
+ *              and moved to a separate method `Sniff::isVariable()`.
+ * @since 9.0.0 Renamed from `EmptyNonVariableSniff` to `NewEmptyNonVariableSniff`.
  */
 class NewEmptyNonVariableSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -21,6 +21,10 @@ use PHP_CodeSniffer_File as File;
  * @link https://wiki.php.net/rfc/namespaceseparator
  * @link https://wiki.php.net/rfc/variadics
  * @link https://wiki.php.net/rfc/argument_unpacking
+ *
+ * @since 5.6
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
+ * @since 9.0.0 Detection for new operator tokens has been moved to the `NewOperators` sniff.
  */
 class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -15,6 +15,12 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect use of new PHP language constructs.
+ *
+ * PHP version All
+ *
+ * @link https://wiki.php.net/rfc/namespaceseparator
+ * @link https://wiki.php.net/rfc/variadics
+ * @link https://wiki.php.net/rfc/argument_unpacking
  */
 class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -15,12 +15,16 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * List assignment order.
+ * Detect code affected by the changed list assignment order in PHP 7.0+.
  *
- * The list() construct no longer assigns variables in reverse order.
+ * The `list()` construct no longer assigns variables in reverse order.
  * This affects all list constructs where non-unique variables are used.
  *
  * PHP version 7.0
+ *
+ * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.list.order
+ * @link https://wiki.php.net/rfc/abstract_syntax_tree#changes_to_list
+ * @link https://www.php.net/manual/en/function.list.php
  */
 class AssignmentOrderSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -25,6 +25,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.list.order
  * @link https://wiki.php.net/rfc/abstract_syntax_tree#changes_to_list
  * @link https://www.php.net/manual/en/function.list.php
+ *
+ * @since 9.0.0
  */
 class AssignmentOrderSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -15,9 +15,13 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Empty list() assignments have been removed in PHP 7.0
+ * Support for empty `list()` expressions has been removed in PHP 7.0.
  *
  * PHP version 7.0
+ *
+ * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.list.empty
+ * @link https://wiki.php.net/rfc/abstract_syntax_tree#changes_to_list
+ * @link https://www.php.net/manual/en/function.list.php
  */
 class ForbiddenEmptyListAssignmentSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -22,6 +22,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.list.empty
  * @link https://wiki.php.net/rfc/abstract_syntax_tree#changes_to_list
  * @link https://www.php.net/manual/en/function.list.php
+ *
+ * @since 7.0.0
  */
 class ForbiddenEmptyListAssignmentSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://wiki.php.net/rfc/list_keys
  * @link https://www.php.net/manual/en/function.list.php
+ *
+ * @since 9.0.0
  */
 class NewKeyedListSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -15,9 +15,12 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * "You can now specify keys in list(), or its new shorthand [] syntax. "
+ * Since PHP 7.1, you can specify keys in `list()`, or its new shorthand `[]` syntax.
  *
  * PHP version 7.1
+ *
+ * @link https://wiki.php.net/rfc/list_keys
+ * @link https://www.php.net/manual/en/function.list.php
  */
 class NewKeyedListSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -17,6 +17,10 @@ use PHP_CodeSniffer_File as File;
  * Detect reference assignments in array destructuring using (short) list.
  *
  * PHP version 7.3
+ *
+ * @link https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.destruct-reference
+ * @link https://wiki.php.net/rfc/list_reference_assignment
+ * @link https://www.php.net/manual/en/function.list.php
  */
 class NewListReferenceAssignmentSniff extends NewKeyedListSniff
 {

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer_File as File;
  * @link https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.destruct-reference
  * @link https://wiki.php.net/rfc/list_reference_assignment
  * @link https://www.php.net/manual/en/function.list.php
+ *
+ * @since 9.0.0
  */
 class NewListReferenceAssignmentSniff extends NewKeyedListSniff
 {

--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -14,11 +14,16 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * "The shorthand array syntax ([]) may now be used to destructure arrays for
- * assignments (including within foreach), as an alternative to the existing
- * list() syntax, which is still supported."
+ * Detect short list syntax for symmetric array destructuring.
+ *
+ * "The shorthand array syntax (`[]`) may now be used to destructure arrays for
+ * assignments (including within `foreach`), as an alternative to the existing
+ * `list()` syntax, which is still supported."
  *
  * PHP version 7.1
+ *
+ * @link https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.symmetric-array-destructuring
+ * @link https://wiki.php.net/rfc/short_list_syntax
  */
 class NewShortListSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -24,6 +24,8 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.symmetric-array-destructuring
  * @link https://wiki.php.net/rfc/short_list_syntax
+ *
+ * @since 9.0.0
  */
 class NewShortListSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
@@ -15,13 +15,14 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * As of PHP 5.3, the __toString() magic method can no longer be passed arguments.
+ * As of PHP 5.3, the `__toString()` magic method can no longer be passed arguments.
  *
- * Sister-sniff to PHPCompatibility.FunctionDeclarations.ForbiddenToStringParameters.
- *
- * @link https://www.php.net/manual/en/migration53.incompatible.php
+ * Sister-sniff to `PHPCompatibility.FunctionDeclarations.ForbiddenToStringParameters`.
  *
  * PHP version 5.3
+ *
+ * @link https://www.php.net/manual/en/migration53.incompatible.php
+ * @link https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
  *
  * @since 9.2.0
  */

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -15,15 +15,16 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Detect direct calls to the __clone() magic method which is allowed since PHP 7.0.
+ * Detect direct calls to the `__clone()` magic method, which is allowed since PHP 7.0.
  *
- * "Doing calls like $obj->__clone() is now allowed. This was the only magic method
+ * "Doing calls like `$obj->__clone()` is now allowed. This was the only magic method
  *  that had a compile-time check preventing some calls to it, which doesn't make sense.
  *  If we allow all other magic methods to be called, there's no reason to forbid this one."
  *
  * PHP version 7.0
  *
  * @link https://wiki.php.net/rfc/abstract_syntax_tree#directly_calling_clone_is_allowed
+ * @link https://www.php.net/manual/en/language.oop5.cloning.php
  *
  * @since 9.1.0
  */

--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -21,14 +21,15 @@ use PHP_CodeSniffer_File as File;
  * > `<? php` and resulted in a syntax error (with short_open_tag=1) or was
  * > interpreted as a literal `<?php` string (with short_open_tag=0).
  *
- * @internal Due to an issue with the Tokenizer, this sniff will not work correctly
- *           on PHP 5.3 in combination with PHPCS < 2.6.0 when short_open_tag is `On`.
- *           As this is causing "Undefined offset" notices, there is nothing we can
- *           do to work-around this.
- *
- * @link https://github.com/php/php-src/blob/30de357fa14480468132bbc22a272aeb91789ba8/UPGRADING#L37-L40
+ * {@internal Due to an issue with the Tokenizer, this sniff will not work correctly
+ *            on PHP 5.3 in combination with PHPCS < 2.6.0 when short_open_tag is `On`.
+ *            As this is causing "Undefined offset" notices, there is nothing we can
+ *            do to work-around this.}}
  *
  * PHP version 7.4
+ *
+ * @link https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.php-tag
+ * @link https://github.com/php/php-src/blob/30de357fa14480468132bbc22a272aeb91789ba8/UPGRADING#L37-L40
  *
  * @since 9.3.0
  */

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -23,6 +23,8 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://wiki.php.net/rfc/remove_alternative_php_tags
  * @link https://www.php.net/manual/en/language.basic-syntax.phptags.php
+ *
+ * @since 7.0.4
  */
 class RemovedAlternativePHPTagsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -14,12 +14,15 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Check for usage of alternative PHP tags - removed in PHP 7.0.
+ * Check for use of alternative PHP tags, support for which was removed in PHP 7.0.
+ *
+ * {@internal Based on `Generic.PHP.DisallowAlternativePHPTags` by Juliette Reinders Folmer
+ * (with permission) which was merged into PHPCS 2.7.0.}}
  *
  * PHP version 7.0
  *
- * Based on `Generic_Sniffs_PHP_DisallowAlternativePHPTags` by Juliette Reinders Folmer
- * which was merged into PHPCS 2.7.0.
+ * @link https://wiki.php.net/rfc/remove_alternative_php_tags
+ * @link https://www.php.net/manual/en/language.basic-syntax.phptags.php
  */
 class RemovedAlternativePHPTagsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
@@ -29,6 +29,9 @@ use PHP_CodeSniffer_File as File;
  * @link https://wiki.php.net/rfc/binnotation4ints
  * @link https://wiki.php.net/rfc/remove_hex_support_in_numeric_strings
  * @link https://www.php.net/manual/en/language.types.integer.php
+ *
+ * @since 7.0.3
+ * @since 7.0.8 This sniff now throws a warning instead of an error for invalid binary integers.
  */
 class ValidIntegersSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
@@ -15,6 +15,20 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Check for valid integer types and values.
+ *
+ * Checks:
+ * - PHP 5.4 introduced binary integers.
+ * - PHP 7.0 removed tolerance for invalid octals. These were truncated prior to PHP 7
+ *   and give a parse error since PHP 7.
+ * - PHP 7.0 removed support for recognizing hexadecimal numeric strings as numeric.
+ *   Type juggling and recognition was inconsistent prior to PHP 7. As of PHP 7, they
+ *   are no longer treated as numeric.
+ *
+ * PHP version 5.4+
+ *
+ * @link https://wiki.php.net/rfc/binnotation4ints
+ * @link https://wiki.php.net/rfc/remove_hex_support_in_numeric_strings
+ * @link https://www.php.net/manual/en/language.types.integer.php
  */
 class ValidIntegersSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
@@ -15,14 +15,14 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * The operator precedence of concatenation will be lowered in PHP 8.0.
+ * Detect code affected by the change in operator precedence of concatenation in PHP 8.0.
  *
  * In PHP < 8.0 the operator precedence of `.`, `+` and `-` are the same.
  * As of PHP 8.0, the operator precedence of the concatenation operator will be
- * lowered to be right below the '«' and '»' operators.
+ * lowered to be right below the `<<` and `>>` operators.
  *
  * As of PHP 7.4, a deprecation warning will be thrown upon encountering an
- * unparenthesized expression containing an '.' before a '+' or '-'.
+ * unparenthesized expression containing an `.` before a `+` or `-`.
  *
  * PHP version 7.4
  * PHP version 8.0

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -22,6 +22,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://wiki.php.net/rfc/integer_semantics
  * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.integers.negative-bitshift
+ *
+ * @since 7.0.0
  */
 class ForbiddenNegativeBitshiftSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -16,9 +16,12 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0.
+ * Bitwise shifts by negative number will throw an ArithmeticError since PHP 7.0.
  *
  * PHP version 7.0
+ *
+ * @link https://wiki.php.net/rfc/integer_semantics
+ * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.integers.negative-bitshift
  */
 class ForbiddenNegativeBitshiftSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -15,6 +15,13 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect use of new PHP operators.
+ *
+ * PHP version All
+ *
+ * @link https://wiki.php.net/rfc/pow-operator
+ * @link https://wiki.php.net/rfc/combined-comparison-operator
+ * @link https://wiki.php.net/rfc/isset_ternary
+ * @link https://wiki.php.net/rfc/null_coalesce_equal_operator
  */
 class NewOperatorsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -22,6 +22,9 @@ use PHP_CodeSniffer_File as File;
  * @link https://wiki.php.net/rfc/combined-comparison-operator
  * @link https://wiki.php.net/rfc/isset_ternary
  * @link https://wiki.php.net/rfc/null_coalesce_equal_operator
+ *
+ * @since 9.0.0 Detection of new operators was originally included in the
+ *              `NewLanguageConstruct` sniff (since 5.6).
  */
 class NewOperatorsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -23,6 +23,10 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://www.php.net/manual/en/migration53.new-features.php
  * @link https://www.php.net/manual/en/language.operators.comparison.php#language.operators.comparison.ternary
+ *
+ * @since 7.0.0
+ * @since 7.0.8 This sniff now throws an error instead of a warning.
+ * @since 9.0.0 Renamed from `TernaryOperatorsSniff` to `NewShortTernarySniff`.
  */
 class NewShortTernarySniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -14,10 +14,15 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
+ * Detect usage of the short ternary (elvis) operator as introduced in PHP 5.3.
+ *
  * Performs checks on ternary operators, specifically that the middle expression
  * is not omitted for versions that don't support this.
  *
  * PHP version 5.3
+ *
+ * @link https://www.php.net/manual/en/migration53.new-features.php
+ * @link https://www.php.net/manual/en/language.operators.comparison.php#language.operators.comparison.ternary
  */
 class NewShortTernarySniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -19,11 +19,12 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * The left-associativity of the ternary operator is deprecated in PHP 7.4 and
  * removed in PHP 8.0.
  *
- * @link https://wiki.php.net/rfc/ternary_associativity
- * @link https://github.com/php/php-src/pull/4017
- *
  * PHP version 7.4
  * PHP version 8.0
+ *
+ * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.nested-ternary
+ * @link https://wiki.php.net/rfc/ternary_associativity
+ * @link https://github.com/php/php-src/pull/4017
  *
  * @since 9.2.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -14,10 +14,13 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Detect: Passing `null` to get_class() is no longer allowed as of PHP 7.2.
- * This will now result in an E_WARNING being thrown.
+ * Detect: Passing `null` to `get_class()` is no longer allowed as of PHP 7.2.
+ * This will now result in an `E_WARNING` being thrown.
  *
  * PHP version 7.2
+ *
+ * @link https://wiki.php.net/rfc/get_class_disallow_null_parameter
+ * @link https://www.php.net/manual/en/function.get-class.php#refsect1-function.get-class-changelog
  */
 class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -21,6 +21,8 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://wiki.php.net/rfc/get_class_disallow_null_parameter
  * @link https://www.php.net/manual/en/function.get-class.php#refsect1-function.get-class-changelog
+ *
+ * @since 9.0.0
  */
 class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -14,7 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Since PHP 5.3.4, strip_tags() ignores self-closing XHTML tags in allowable_tags
+ * Since PHP 5.3.4, `strip_tags()` ignores self-closing XHTML tags in allowable_tags
  *
  * PHP version 5.3.4
  *

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -20,6 +20,8 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://www.php.net/manual/en/migration53.other.php#migration53.other
  * @link https://www.php.net/manual/en/function.array-reduce.php#refsect1-function.array-reduce-changelog
+ *
+ * @since 9.0.0
  */
 class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -14,7 +14,12 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Detect: In PHP 5.2 and lower, the $initial parameter had to be an integer.
+ * In PHP 5.2 and lower, the `$initial` parameter for `array_reduce()` had to be an integer.
+ *
+ * PHP version 5.3
+ *
+ * @link https://www.php.net/manual/en/migration53.other.php#migration53.other
+ * @link https://www.php.net/manual/en/function.array-reduce.php#refsect1-function.array-reduce-changelog
  */
 class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -14,7 +14,11 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Detect: Changes in allowed values for the fopen() $mode parameter.
+ * Check for valid values for the `fopen()` `$mode` parameter.
+ *
+ * PHP version 5.2+
+ *
+ * @link https://www.php.net/manual/en/function.fopen.php#refsect1-function.fopen-changelog
  */
 class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer_File as File;
  * PHP version 5.2+
  *
  * @link https://www.php.net/manual/en/function.fopen.php#refsect1-function.fopen-changelog
+ *
+ * @since 9.0.0
  */
 class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
@@ -14,12 +14,13 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * As of PHP 5.4, the default character set for htmlspecialchars(), htmlentities()
- * and html_entity_decode() is now UTF-8, instead of ISO-8859-1.
+ * As of PHP 5.4, the default character set for `htmlspecialchars()`, `htmlentities()`
+ * and `html_entity_decode()` is now `UTF-8`, instead of `ISO-8859-1`.
  *
  * PHP version 5.4
  *
  * @link https://www.php.net/manual/en/migration54.other.php
+ * @link https://www.php.net/manual/en/function.html-entity-decode.php#refsect1-function.html-entity-decode-changelog
  * @link https://www.php.net/manual/en/function.htmlentities.php#refsect1-function.htmlentities-changelog
  * @link https://www.php.net/manual/en/function.htmlspecialchars.php#refsect1-function.htmlspecialchars-changelog
  *

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -19,6 +19,9 @@ use PHP_CodeSniffer_File as File;
  * PHP version 5.2+
  *
  * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
+ *
+ * @since 7.0.7
+ * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
  */
 class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -15,6 +15,10 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect the use of newly introduced hash algorithms.
+ *
+ * PHP version 5.2+
+ *
+ * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
  */
 class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
@@ -14,11 +14,12 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * The default value for the $variant parameter has changed from INTL_IDNA_VARIANT_2003
- * to INTL_IDNA_VARIANT_UTS46.
+ * The default value for the `$variant` parameter has changed from `INTL_IDNA_VARIANT_2003`
+ * to `INTL_IDNA_VARIANT_UTS46` in PHP 7.4.
  *
  * PHP version 7.4
  *
+ * @link https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.intl
  * @link https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003
  * @link https://www.php.net/manual/en/function.idn-to-ascii.php
  * @link https://www.php.net/manual/en/function.idn-to-utf8.php

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -15,20 +15,20 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Detect calls to Iconv and Mbstring functions with the optional $charset/$encoding parameter not set.
+ * Detect calls to Iconv and Mbstring functions with the optional `$charset`/`$encoding` parameter not set.
  *
- * The default value for the iconv $charset and the MbString $encoding parameters was changed
- * in PHP 5.6 to the value of `default_charset`, which defaults to UTF-8.
+ * The default value for the iconv `$charset` and the MbString  $encoding` parameters was changed
+ * in PHP 5.6 to the value of `default_charset`, which defaults to `UTF-8`.
  *
- * Previously, the iconv functions would default to the value of iconv.internal_encoding;
- * The mbstring functions would default to the return value of mb_internal_encoding().
- * In both case, this would normally come down to ISO-8859-1.
+ * Previously, the iconv functions would default to the value of `iconv.internal_encoding`;
+ * The Mbstring functions would default to the return value of `mb_internal_encoding()`.
+ * In both case, this would normally come down to `ISO-8859-1`.
  *
  * PHP version 5.6
  *
- * @link https://wiki.php.net/rfc/default_encoding
  * @link https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.default-encoding
  * @link https://www.php.net/manual/en/migration56.deprecated.php#migration56.deprecated.iconv-mbstring-encoding
+ * @link https://wiki.php.net/rfc/default_encoding
  *
  * @since 9.3.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -14,10 +14,12 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Detect: negative string offsets as parameters passed to functions where this
+ * Detect negative string offsets as parameters passed to functions where this
  * was not allowed prior to PHP 7.1.
  *
  * PHP version 7.1
+ *
+ * @link https://wiki.php.net/rfc/negative-string-offsets
  */
 class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -20,6 +20,8 @@ use PHP_CodeSniffer_File as File;
  * PHP version 7.1
  *
  * @link https://wiki.php.net/rfc/negative-string-offsets
+ *
+ * @since 9.0.0
  */
 class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -22,6 +22,9 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
  * @link https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.pcre
+ *
+ * @since 8.2.0
+ * @since 9.0.0 Renamed from `PCRENewModifiersSniff` to `NewPCREModifiersSniff`.
  */
 class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -14,7 +14,14 @@ use PHPCompatibility\Sniffs\ParameterValues\RemovedPCREModifiersSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Check for usage of newly added regex modifiers for PCRE functions.
+ * Check for the use of newly added regex modifiers for PCRE functions.
+ *
+ * Initially just checks for the PHP 7.2 new `J` modifier.
+ *
+ * PHP version 7.2+
+ *
+ * @link https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
+ * @link https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.pcre
  */
 class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -14,7 +14,11 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Detect: Changes in the allowed values for $format passed to pack().
+ * Check for valid values for the `$format` passed to `pack()`.
+ *
+ * PHP version 5.4+
+ *
+ * @link https://www.php.net/manual/en/function.pack.php#refsect1-function.pack-changelog
  */
 class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -19,6 +19,8 @@ use PHP_CodeSniffer_File as File;
  * PHP version 5.4+
  *
  * @link https://www.php.net/manual/en/function.pack.php#refsect1-function.pack-changelog
+ *
+ * @since 9.0.0
  */
 class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -17,12 +17,13 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * The constant value of the password hash algorithm constants has changed in PHP 7.4.
  *
- * Applications correctly using the constants PASSWORD_DEFAULT, PASSWORD_BCRYPT,
- * PASSWORD_ARGON2I, and PASSWORD_ARGON2ID will continue to function correctly.
- * Using an int will still work, but will produce a deprecation warning.
+ * Applications using the constants `PASSWORD_DEFAULT`, `PASSWORD_BCRYPT`,
+ * `PASSWORD_ARGON2I`, and `PASSWORD_ARGON2ID` will continue to function correctly.
+ * Using an integer will still work, but will produce a deprecation warning.
  *
  * PHP version 7.4
  *
+ * @link https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.password-algorithm-constants
  * @link https://wiki.php.net/rfc/password_registry
  *
  * @since 9.3.0

--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -15,14 +15,15 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * As of PHP 7.4, proc_open() now also accepts an array instead of a string for the command.
+ * As of PHP 7.4, `proc_open()` now also accepts an array instead of a string for the command.
  *
  * In that case, the process will be opened directly (without going through a shell) and
  * PHP will take care of any necessary argument escaping.
  *
  * PHP version 7.4
  *
- * @link https://github.com/php/php-src/blob/3775d47eee38f3b34f800a0b23f840ec7a94e4c7/UPGRADING#L323-L327
+ * @link https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.standard.proc-open
+ * @link https://www.php.net/manual/en/function.proc-open.php
  *
  * @since 9.3.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -15,11 +15,12 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * As of PHP 7.4, strip_tags() now also accepts an array of allowed tags.
+ * As of PHP 7.4, `strip_tags()` now also accepts an array of `$allowable_tags`.
  *
  * PHP version 7.4
  *
- * @link https://github.com/php/php-src/blob/3775d47eee38f3b34f800a0b23f840ec7a94e4c7/UPGRADING#L301-L303
+ * @link https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.standard.strip-tags
+ * @link https://www.php.net/manual/en/function.strip-tags.php
  *
  * @since 9.3.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -14,9 +14,11 @@ use PHPCompatibility\AbstractRemovedFeatureSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Discourages the use of deprecated and removed hash algorithms.
+ * Detect the use of deprecated and removed hash algorithms.
  *
  * PHP version 5.4
+ *
+ * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
  */
 class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -19,6 +19,9 @@ use PHP_CodeSniffer_File as File;
  * PHP version 5.4
  *
  * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
+ *
+ * @since 5.5
+ * @since 7.1.0 Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
  */
 class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -14,13 +14,18 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Detect: "The iconv and mbstring configuration options related to encoding
- * have been deprecated in favour of default_charset."
+ * Detect passing deprecated `$type` values to `iconv_get_encoding()`.
+ *
+ * "The iconv and mbstring configuration options related to encoding have been
+ * deprecated in favour of default_charset."
  *
  * {@internal It is unclear which mbstring functions should be targetted, so for now,
  * only the iconv function is handled.}}
  *
  * PHP version 5.6
+ *
+ * @link https://www.php.net/manual/en/migration56.deprecated.php#migration56.deprecated.iconv-mbstring-encoding
+ * @link https://wiki.php.net/rfc/default_encoding
  */
 class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -26,6 +26,8 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://www.php.net/manual/en/migration56.deprecated.php#migration56.deprecated.iconv-mbstring-encoding
  * @link https://wiki.php.net/rfc/default_encoding
+ *
+ * @since 9.0.0
  */
 class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -15,13 +15,14 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Passing the $glue and $pieces parameters to implode() in reverse order has been
- * deprecated in PHP 7.4.
- *
- * @link https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix
- * @link https://php.net/manual/en/function.implode.php
+ * Passing the `$glue` and `$pieces` parameters to `implode()` in reverse order has
+ * been deprecated in PHP 7.4.
  *
  * PHP version 7.4
+ *
+ * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.implode-reverse-parameters
+ * @link https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix
+ * @link https://php.net/manual/en/function.implode.php
  *
  * @since 9.3.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -15,10 +15,10 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Removed mb_strrpos() with encoding as 3rd argument.
+ * Detect passing `$encoding` to `mb_strrpos()` as 3rd argument.
  *
- * The encoding parameter was moved from the third position to the fourth in PHP 5.2.0.
- * For backward compatibility, encoding could be specified as the third parameter, but doing
+ * The `$encoding` parameter was moved from the third position to the fourth in PHP 5.2.0.
+ * For backward compatibility, `$encoding` could be specified as the third parameter, but doing
  * so is deprecated and will be removed in the future.
  *
  * Between PHP 5.2 and PHP 7.3, this was a deprecation in documentation only.
@@ -29,8 +29,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version 5.2
  * PHP version 7.4
  *
+ * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.mbstring
  * @link https://wiki.php.net/rfc/deprecations_php_7_4#mb_strrpos_with_encoding_as_3rd_argument
- * @link https://github.com/php/php-src/commit/39e756e7fe7b08092b4a75cf253442cba826e910
+ * @link https://www.php.net/manual/en/function.mb-strrpos.php
  *
  * @since 9.3.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -23,6 +23,12 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://wiki.php.net/rfc/deprecate_mb_ereg_replace_eval_option
  * @link https://www.php.net/manual/en/function.mb-regex-set-options.php
+ *
+ * @since 7.0.5
+ * @since 7.0.8 This sniff now throws a warning instead of an error as the functionality is
+ *              only deprecated (for now).
+ * @since 8.2.0 Now extends the `AbstractFunctionCallParameterSniff` instead of the base `Sniff` class.
+ * @since 9.0.0 Renamed from `MbstringReplaceEModifierSniff` to `RemovedMbstringModifiersSniff`.
  */
 class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -17,7 +17,12 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * Check for use of deprecated and removed regex modifiers for MbString regex functions.
  *
+ * Initially just checks for the PHP 7.1 deprecated `e` modifier.
+ *
  * PHP version 7.1
+ *
+ * @link https://wiki.php.net/rfc/deprecate_mb_ereg_replace_eval_option
+ * @link https://www.php.net/manual/en/function.mb-regex-set-options.php
  */
 class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -22,6 +22,8 @@ use PHP_CodeSniffer_File as File;
  * PHP version 7.2
  *
  * @link https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.hash-functions
+ *
+ * @since 9.0.0
  */
 class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -14,10 +14,14 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Detect: "The hash_hmac(), hash_hmac_file(), hash_pbkdf2(), and hash_init()
- * (with HASH_HMAC) functions no longer accept non-cryptographic hashes."
+ * Detect usage of non-cryptographic hashes.
+ *
+ * "The `hash_hmac()`, `hash_hmac_file()`, `hash_pbkdf2()`, and `hash_init()`
+ * (with `HASH_HMAC`) functions no longer accept non-cryptographic hashes."
  *
  * PHP version 7.2
+ *
+ * @link https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.hash-functions
  */
 class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -15,10 +15,20 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Check for usage of the `e` modifier with PCRE functions which is deprecated since PHP 5.5
+ * Check for the use of deprecated and removed regex modifiers for PCRE regex functions.
+ *
+ * Initially just checks for the `e` modifier, which was deprecated since PHP 5.5
  * and removed as of PHP 7.0.
  *
+ * {@internal If and when this sniff would need to start checking for other modifiers, a minor
+ * refactor will be needed as all references to the `e` modifier are currently hard-coded.}}
+ *
  * PHP version 5.5
+ * PHP version 7.0
+ *
+ * @link https://wiki.php.net/rfc/remove_preg_replace_eval_modifier
+ * @link https://wiki.php.net/rfc/remove_deprecated_functionality_in_php7
+ * @link https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
  */
 class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -29,6 +29,12 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://wiki.php.net/rfc/remove_preg_replace_eval_modifier
  * @link https://wiki.php.net/rfc/remove_deprecated_functionality_in_php7
  * @link https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
+ *
+ * @since 5.6
+ * @since 7.0.8 This sniff now throws a warning (deprecated) or an error (removed) depending
+ *              on the `testVersion` set. Previously it would always throw an error.
+ * @since 8.2.0 Now extends the `AbstractFunctionCallParameterSniff` instead of the base `Sniff` class.
+ * @since 9.0.0 Renamed from `PregReplaceEModifierSniff` to `RemovedPCREModifiersSniff`.
  */
 class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -24,6 +24,8 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://wiki.php.net/rfc/remove_deprecated_functionality_in_php7
  * @link https://www.php.net/manual/en/function.setlocale.php#refsect1-function.setlocale-changelog
+ *
+ * @since 9.0.0
  */
 class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -14,11 +14,16 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Detect: Support for the category parameter passed as a string has been removed.
- * Only LC_* constants can be used as of this version [7.0.0].
+ * Detect passing a string literal as `$category` to `setlocale()`.
+ *
+ * Support for the category parameter passed as a string has been removed.
+ * Only `LC_*` constants can be used as of PHP 7.0.0.
  *
  * PHP version 4.2
  * PHP version 7.0
+ *
+ * @link https://wiki.php.net/rfc/remove_deprecated_functionality_in_php7
+ * @link https://www.php.net/manual/en/function.setlocale.php#refsect1-function.setlocale-changelog
  */
 class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -23,6 +23,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://wiki.php.net/rfc/calltimebyref
  * @link https://www.php.net/manual/en/language.references.pass.php
+ *
+ * @since 5.5
+ * @since 7.0.8 This sniff now throws a warning (deprecated) or an error (removed) depending
+ *              on the `testVersion` set. Previously it would always throw an error.
  */
 class ForbiddenCallTimePassByReferenceSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -15,9 +15,14 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Discourages the use of call time pass by references
+ * Detect the use of call time pass by reference.
+ *
+ * This behaviour has been deprecated in PHP 5.3 and removed in PHP 5.4.
  *
  * PHP version 5.4
+ *
+ * @link https://wiki.php.net/rfc/calltimebyref
+ * @link https://www.php.net/manual/en/language.references.pass.php
  */
 class ForbiddenCallTimePassByReferenceSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -34,6 +34,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * {@internal The reason for splitting the logic of this sniff into different methods is
  *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}}
  *
+ * @since 7.1.4
  * @since 9.3.0 Now also detects dereferencing using curly braces.
  */
 class NewArrayStringDereferencingSniff extends Sniff

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -15,6 +15,8 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
+ * Detect array and string literal dereferencing.
+ *
  * As of PHP 5.5, array and string literals can now be dereferenced directly to
  * access individual elements and characters.
  *
@@ -24,11 +26,13 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version 5.5
  * PHP version 7.0
  *
+ * @link https://www.php.net/manual/en/migration55.new-features.php#migration55.new-features.const-dereferencing
  * @link https://wiki.php.net/rfc/constdereference
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
+ * @link https://www.php.net/manual/en/language.types.array.php#example-63
  *
  * {@internal The reason for splitting the logic of this sniff into different methods is
- *            to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.}}
+ *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}}
  *
  * @since 9.3.0 Now also detects dereferencing using curly braces.
  */

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -19,6 +19,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * PHP version 7.4
  *
+ * @link https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.unpack-inside-array
  * @link https://wiki.php.net/rfc/spread_operator_for_array
  *
  * @since 9.2.0

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -15,8 +15,10 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * PHP 5.4: Class member access on instantiation has been added, e.g. (new Foo)->bar().
- * PHP 7.0: Class member access on cloning has been added, e.g. (clone $foo)->bar().
+ * Detect class member access on object instantiation/cloning.
+ *
+ * PHP 5.4: Class member access on instantiation has been added, e.g. `(new Foo)->bar()`.
+ * PHP 7.0: Class member access on cloning has been added, e.g. `(clone $foo)->bar()`.
  *
  * As of PHP 7.0, class member access on instantiation also works when using curly braces.
  * While unclear, this most likely has to do with the Uniform Variable Syntax changes.
@@ -24,11 +26,14 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version 5.4
  * PHP version 7.0
  *
+ * @link https://www.php.net/manual/en/language.oop5.basic.php#example-177
+ * @link https://www.php.net/manual/en/language.oop5.cloning.php#language.oop5.traits.properties.example
+ * @link https://www.php.net/manual/en/migration54.new-features.php
  * @link https://wiki.php.net/rfc/instance-method-call
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *
  * {@internal The reason for splitting the logic of this sniff into different methods is
- *            to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.}}
+ *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}}
  *
  * @since 9.3.0 Now also detects class member access on instantiation using curly braces.
  */

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -35,6 +35,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * {@internal The reason for splitting the logic of this sniff into different methods is
  *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}}
  *
+ * @since 8.2.0
  * @since 9.3.0 Now also detects class member access on instantiation using curly braces.
  */
 class NewClassMemberAccessSniff extends Sniff

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -15,10 +15,14 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
+ * Detect dynamic access to static methods and properties, as well as class constants.
+ *
  * As of PHP 5.3, static properties and methods as well as class constants
  * can be accessed using a dynamic (variable) class name.
  *
  * PHP version 5.3
+ *
+ * @link https://www.php.net/manual/en/migration53.new-features.php
  */
 class NewDynamicAccessToStaticSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -23,6 +23,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version 5.3
  *
  * @link https://www.php.net/manual/en/migration53.new-features.php
+ *
+ * @since 8.1.0
+ * @since 9.0.0 Renamed from `DynamicAccessToStaticSniff` to `NewDynamicAccessToStaticSniff`.
  */
 class NewDynamicAccessToStaticSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -27,6 +27,8 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.heredoc
  * @link https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes
+ *
+ * @since 9.0.0
  */
 class NewFlexibleHeredocNowdocSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -15,15 +15,18 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * New Flexible Heredoc Nowdoc.
+ * Detect usage of flexible heredoc/nowdoc and related cross-version incompatibilities.
  *
  * As of PHP 7.3:
- * - The body and the closing marker of a Heredoc/nowdoc can be indented;
+ * - The body and the closing marker of a heredoc/nowdoc can be indented;
  * - The closing marker no longer needs to be on a line by itself;
  * - The heredoc/nowdoc body may no longer contain the closing marker at the
  *   start of any of its lines.
  *
  * PHP version 7.3
+ *
+ * @link https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.heredoc
+ * @link https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes
  */
 class NewFlexibleHeredocNowdocSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -15,6 +15,8 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
+ * Detect function array dereferencing as introduced in PHP 5.4.
+ *
  * PHP 5.4 supports direct array dereferencing on the return of a method/function call.
  *
  * As of PHP 7.0, this also works when using curly braces for the dereferencing.
@@ -23,6 +25,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version 5.4
  * PHP version 7.0
  *
+ * @link https://www.php.net/manual/en/language.types.array.php#example-63
+ * @link https://www.php.net/manual/en/migration54.new-features.php
  * @link https://wiki.php.net/rfc/functionarraydereferencing
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -33,6 +33,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * {@internal The reason for splitting the logic of this sniff into different methods is
  *            to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.}}
  *
+ * @since 7.0.0
  * @since 9.3.0 Now also detects dereferencing using curly braces.
  */
 class NewFunctionArrayDereferencingSniff extends Sniff

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -21,6 +21,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.trailing-commas
  * @link https://wiki.php.net/rfc/trailing-comma-function-calls
+ *
+ * @since 8.2.0
+ * @since 9.0.0 Renamed from `NewTrailingCommaSniff` to `NewFunctionCallTrailingCommaSniff`.
  */
 class NewFunctionCallTrailingCommaSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -15,9 +15,12 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Detect trailing comma's in function calls, isset() and unset() as allowed since PHP 7.3.
+ * Detect trailing comma's in function calls, `isset()` and `unset()` as allowed since PHP 7.3.
  *
  * PHP version 7.3
+ *
+ * @link https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.trailing-commas
+ * @link https://wiki.php.net/rfc/trailing-comma-function-calls
  */
 class NewFunctionCallTrailingCommaSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -20,6 +20,9 @@ use PHP_CodeSniffer_File as File;
  *
  * @link https://wiki.php.net/rfc/shortsyntaxforarrays
  * @link https://www.php.net/manual/en/language.types.array.php#language.types.array.syntax
+ *
+ * @since 7.0.0
+ * @since 9.0.0 Renamed from `ShortArraySniff` to `NewShortArraySniff`.
  */
 class NewShortArraySniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -14,9 +14,12 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 
 /**
- * Short array syntax is available since PHP 5.4
+ * Detect use of short array syntax which is available since PHP 5.4.
  *
  * PHP version 5.4
+ *
+ * @link https://wiki.php.net/rfc/shortsyntaxforarrays
+ * @link https://www.php.net/manual/en/language.types.array.php#language.types.array.syntax
  */
 class NewShortArraySniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -20,9 +20,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * Using the curly brace syntax to access array or string offsets has been deprecated in PHP 7.4.
  *
- * @link https://wiki.php.net/rfc/deprecate_curly_braces_array_access
- *
  * PHP version 7.4
+ *
+ * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace
+ * @link https://wiki.php.net/rfc/deprecate_curly_braces_array_access
  *
  * @since 9.3.0
  */

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -15,9 +15,14 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Discourages the use of assigning the return value of new by reference
+ * Detect the use of assigning the return value of `new` by reference.
  *
- * PHP version 5.4
+ * This syntax has been deprecated since PHP 5.3 and removed in PHP 7.0.
+ *
+ * PHP version 5.3
+ * PHP version 7.0
+ *
+ * @link https://wiki.php.net/rfc/remove_deprecated_functionality_in_php7
  */
 class RemovedNewReferenceSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -23,6 +23,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version 7.0
  *
  * @link https://wiki.php.net/rfc/remove_deprecated_functionality_in_php7
+ *
+ * @since 5.5
+ * @since 9.0.0 Renamed from `DeprecatedNewReferenceSniff` to `RemovedNewReferenceSniff`.
  */
 class RemovedNewReferenceSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
@@ -17,13 +17,15 @@ use PHP_CodeSniffer_File as File;
 /**
  * PHP 7.0 introduced a Unicode codepoint escape sequence.
  *
- * Strings containing a literal \u{ followed by an invalid sequence will cause a fatal error as of PHP 7.0.
+ * Strings containing a literal `\u{` followed by an invalid sequence will cause a
+ * fatal error as of PHP 7.0.
  *
  * PHP version 7.0
  *
- * @link https://wiki.php.net/rfc/unicode_escape
  * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.unicode-codepoint-escape-syntax
  * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.strings.unicode-escapes
+ * @link https://wiki.php.net/rfc/unicode_escape
+ * @link https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.double
  *
  * @since 9.3.0
  */

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -20,6 +20,8 @@ use PHP_CodeSniffer_File as File;
  * PHP version All
  *
  * @link https://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting
+ *
+ * @since 8.0.1
  */
 class NewTypeCastsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -16,6 +16,10 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect use of newly introduced type casts.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting
  */
 class NewTypeCastsSniff extends AbstractNewFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -21,6 +21,9 @@ use PHP_CodeSniffer_File as File;
  * @link https://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting
  * @link https://wiki.php.net/rfc/deprecations_php_7_2#unset_cast
  * @link https://wiki.php.net/rfc/deprecations_php_7_4#the_real_type
+ *
+ * @since 8.0.1
+ * @since 9.0.0 Renamed from `DeprecatedTypeCastsSniff` to `RemovedTypeCastsSniff`.
  */
 class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -15,6 +15,12 @@ use PHP_CodeSniffer_File as File;
 
 /**
  * Detect use of deprecated/removed type casts.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting
+ * @link https://wiki.php.net/rfc/deprecations_php_7_2#unset_cast
+ * @link https://wiki.php.net/rfc/deprecations_php_7_4#the_real_type
  */
 class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -27,6 +27,9 @@ use PHP_CodeSniffer_File as File;
  * This sniff adds an explicit error/warning for users of the standard
  * using a PHPCS version below the recommended version.
  *
+ * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/688
+ * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/835
+ *
  * @since 8.2.0
  */
 class LowPHPCSSniff extends Sniff

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -25,6 +25,8 @@ use PHP_CodeSniffer_File as File;
  * This sniff adds an explicit error/warning for users of the standard
  * using a PHP version below the recommended version.
  *
+ * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/835
+ *
  * @since 9.3.0
  */
 class LowPHPSniff extends Sniff

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -17,7 +17,18 @@ use PHP_CodeSniffer_Tokens as Tokens;
 /**
  * Detect group use declarations as introduced in PHP 7.0.
  *
+ * Checks for:
+ * - Group use statements as introduced in PHP 7.0.
+ * - Trailing comma's in group use statements as allowed since PHP 7.2.
+ *
  * PHP version 7.0
+ * PHP version 7.2
+ *
+ * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.group-use-declarations
+ * @link https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.trailing-comma-in-grouped-namespaces
+ * @link https://wiki.php.net/rfc/group_use_declarations
+ * @link https://wiki.php.net/rfc/list-syntax-trailing-commas
+ * @link https://www.php.net/manual/en/language.namespaces.importing.php#language.namespaces.importing.group
  */
 class NewGroupUseDeclarationsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -29,6 +29,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://wiki.php.net/rfc/group_use_declarations
  * @link https://wiki.php.net/rfc/list-syntax-trailing-commas
  * @link https://www.php.net/manual/en/language.namespaces.importing.php#language.namespaces.importing.group
+ *
+ * @since 7.0.0
+ * @since 8.0.1 Now also checks for trailing comma's in group `use` declarations.
  */
 class NewGroupUseDeclarationsSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -26,6 +26,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.use
  * @link https://wiki.php.net/rfc/use_function
  * @link https://www.php.net/manual/en/language.namespaces.importing.php
+ *
+ * @since 7.1.4
  */
 class NewUseConstFunctionSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -15,11 +15,17 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * The use operator has been extended to support importing functions and
- * constants in addition to classes. This is achieved via the use function
- * and use const constructs, respectively.
+ * Detect importing constants and functions via a `use` statement.
+ *
+ * The `use` operator has been extended to support importing functions and
+ * constants in addition to classes. This is achieved via the `use function`
+ * and `use const` constructs, respectively.
  *
  * PHP version 5.6
+ *
+ * @link https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.use
+ * @link https://wiki.php.net/rfc/use_function
+ * @link https://www.php.net/manual/en/language.namespaces.importing.php
  */
 class NewUseConstFunctionSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -15,9 +15,11 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Variable variables are forbidden with global
+ * Detect use of `global` with variable variables, support for which has been removed in PHP 7.0.
  *
  * PHP version 7.0
+ *
+ * @link https://wiki.php.net/rfc/uniform_variable_syntax#global_keyword_takes_only_simple_variables
  */
 class ForbiddenGlobalVariableVariableSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -20,6 +20,8 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version 7.0
  *
  * @link https://wiki.php.net/rfc/uniform_variable_syntax#global_keyword_takes_only_simple_variables
+ *
+ * @since 7.0.0
  */
 class ForbiddenGlobalVariableVariableSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -16,11 +16,11 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Detect using $this in incompatible contexts.
+ * Detect using `$this` in incompatible contexts.
  *
- * "Whilst $this is considered a special variable in PHP, it lacked proper checks
+ * "Whilst `$this` is considered a special variable in PHP, it lacked proper checks
  *  to ensure it wasn't used as a variable name or reassigned. This has now been
- *  rectified to ensure that $this cannot be a user-defined variable, reassigned
+ *  rectified to ensure that `$this` cannot be a user-defined variable, reassigned
  *  to a different value, or be globalised."
  *
  * This sniff only addresses those situations which did *not* throw an error prior
@@ -29,20 +29,21 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * be sniffed for:
  * - Using $this as static variable. (error _message_ change only).
  *
- * Also, the changes with relation to assigning $this dynamically can not be
+ * Also, the changes with relation to assigning `$this` dynamically can not be
  * sniffed for reliably, so are not covered by this sniff.
- * - Disable ability to re-assign $this indirectly through $$.
- * - Disable ability to re-assign $this indirectly through reference.
- * - Disable ability to re-assign $this indirectly through extract() and parse_str().
+ * - Disable ability to re-assign `$this` indirectly through `$$`.
+ * - Disable ability to re-assign `$this` indirectly through reference.
+ * - Disable ability to re-assign `$this` indirectly through `extract()` and `parse_str()`.
  *
  * Other changes not (yet) covered:
- * - get_defined_vars() always doesn't show value of variable $this.
- * - Always show true $this value in magic method __call().
+ * - `get_defined_vars()` always doesn't show value of variable `$this`.
+ * - Always show true `$this` value in magic method `__call()`.
  *   {@internal This could possibly be covered. Similar logic as "outside object context",
  *   but with function name check and supportsBelow('7.0').}}
  *
  * PHP version 7.1
  *
+ * @link https://www.php.net/manual/en/migration71.other-changes.php#migration71.other-changes.inconsistency-fixes-to-this
  * @link https://wiki.php.net/rfc/this_var
  *
  * @since 9.1.0

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -21,6 +21,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *
  * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
+ *
+ * @since 7.1.2
+ * @since 9.0.0 Renamed from `VariableVariablesSniff` to `NewUniformVariableSyntaxSniff`.
  */
 class NewUniformVariableSyntaxSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -18,6 +18,9 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * The interpretation of variable variables has changed in PHP 7.0.
  *
  * PHP version 7.0
+ *
+ * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect
+ * @link https://wiki.php.net/rfc/uniform_variable_syntax
  */
 class NewUniformVariableSyntaxSniff extends Sniff
 {

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -16,7 +16,11 @@ use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
- * Discourages the use of removed global variables. Suggests alternative extensions if available
+ * Detect the use of removed global variables. Suggests alternatives if available.
+ *
+ * PHP version 5.3+
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_7_2#php_errormsg
  */
 class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 {

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -21,6 +21,15 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * PHP version 5.3+
  *
  * @link https://wiki.php.net/rfc/deprecations_php_7_2#php_errormsg
+ *
+ * @since 5.5   Introduced `LongArrays` sniff.
+ * @since 7.0   Introduced `RemovedGlobalVariables` sniff.
+ * @since 7.0.7 The `LongArrays` sniff now throws a warning for deprecated and an error for removed.
+ *              Previously the `LongArrays` sniff would always throw a warning.
+ * @since 7.1.0 The `RemovedGlobalVariables` sniff now extends the `AbstractNewFeatureSniff`
+ *              instead of the base `Sniff` class.
+ * @since 7.1.3 Merged the `LongArrays` sniff into the `RemovedGlobalVariables` sniff.
+ * @since 9.0.0 Renamed from `RemovedGlobalVariablesSniff` to `RemovedPredefinedGlobalVariablesSniff`.
  */
 class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 {


### PR DESCRIPTION
* Improve short descriptions.
* Where relevant, add long descriptions with more details about the PHP change and how the sniff handles it.
* Add _PHP version x.x_ annotations.
* Add `@link` tags to the relevant PHP documentation which led to the sniff.
* Add `@since` tags with limited class changelog.

And make sure these are in a consistent order as per above.

_These descriptions and such can no doubt still be further improved, but this is a large step in the right direction._

Related to #734