### PR TITLE
Documentation: simplify & sync the sniff test class descriptions

### DIFF
--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -15,7 +15,7 @@ use PHPCompatibility\PHPCSHelper;
 use PHP_CodeSniffer_File as File;
 
 /**
- * BaseSniffTest
+ * Base sniff test class file.
  *
  * Adds PHPCS sniffing logic and custom assertions for PHPCS errors and
  * warnings.

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -19,6 +19,14 @@ use PHP_CodeSniffer_File as File;
  *
  * Adds PHPCS sniffing logic and custom assertions for PHPCS errors and
  * warnings.
+ *
+ * @since 5.5
+ * @since 7.0.4 Caches sniff results per file and testVersion.
+ * @since 7.1.3 Compatible with PHPUnit 6.
+ * @since 7.1.3 Limits the sniff run to the actual sniff being tested.
+ * @since 8.0.0 Compatible with PHP_CodeSniffer 3+.
+ * @since 8.2.0 Allows for sniffs in multiple categories.
+ * @since 9.0.0 Dropped support for PHP_CodeSniffer 1.x.
  */
 class BaseSniffTest extends PHPUnit_TestCase
 {

--- a/PHPCompatibility/Tests/Classes/ForbiddenAbstractPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenAbstractPrivateMethodsUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * Forbidden parameters passed to __toString() sniff tests.
+ * Test the ForbiddenAbstractPrivateMethods sniff.
  *
  * @group newForbiddenAbstractPrivateMethods
  * @group classes

--- a/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group classes
  *
  * @covers \PHPCompatibility\Sniffs\Classes\NewAnonymousClassesSniff
+ *
+ * @since 7.0.0
  */
 class NewAnonymousClassesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Classes;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Anonymous Classes Sniff tests
+ * Test the NewAnonymousClasses sniff.
  *
  * @group newAnonymousClasses
  * @group classes

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -22,6 +22,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintName
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintToken
  * @covers \PHPCompatibility\Sniff::getTypeHintsFromFunctionDeclaration
+ *
+ * @since 5.5
  */
 class NewClassesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Classes;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Classes Sniff tests
+ * Test the NewClasses sniff.
  *
  * @group newClasses
  * @group classes

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Classes;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New const visibility sniff test file
+ * Test the NewConstVisibility sniff.
  *
  * @group newConstVisibility
  * @group classes

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group classes
  *
  * @covers \PHPCompatibility\Sniffs\Classes\NewConstVisibilitySniff
+ *
+ * @since 7.0.7
  */
 class NewConstVisibilityUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Classes;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Late static binding sniff test file
+ * Test the NewLateStaticBinding sniff.
  *
  * @group newLateStaticBinding
  * @group classes

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group classes
  *
  * @covers \PHPCompatibility\Sniffs\Classes\NewLateStaticBindingSniff
+ *
+ * @since 7.0.3
  */
 class NewLateStaticBindingUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Classes;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Typed Properties Sniff tests
+ * Test the NewTypedProperties sniff.
  *
  * @group newTypedProperties
  * @group classes

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Classes;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed use of parent within a class without parent sniff tests.
+ * Test the RemovedOrphanedParent sniff.
  *
  * @group newRemovedOrphanedParent
  * @group classes

--- a/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group constants
  *
  * @covers \PHPCompatibility\Sniffs\Constants\NewConstantsSniff
+ *
+ * @since 8.1.0
  */
 class NewConstantsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Constants;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Constants Sniff tests
+ * Test the NewConstants sniff.
  *
  * @group newConstants
  * @group constants

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group constants
  *
  * @covers \PHPCompatibility\Sniffs\Constants\NewMagicClassConstantSniff
+ *
+ * @since 7.1.4
  */
 class NewMagicClassConstantUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Constants;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New magic ::class constant sniff test file.
+ * Test the NewMagicClassConstant sniff.
  *
  * @group newMagicClassConstant
  * @group constants

--- a/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Constants;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed Constants Sniff tests
+ * Test the RemovedConstants sniff.
  *
  * @group removedConstants
  * @group constants

--- a/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group constants
  *
  * @covers \PHPCompatibility\Sniffs\Constants\RemovedConstantsSniff
+ *
+ * @since 8.1.0
  */
 class RemovedConstantsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\DiscouragedSwitchContinueSniff
+ *
+ * @since 8.2.0
  */
 class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ControlStructures;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Discouraged use of continue within switch sniff test.
+ * Test the DiscouragedSwitchContinue sniff.
  *
  * @group discouragedSwitchContinue
  * @group controlStructures

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\ForbiddenBreakContinueOutsideLoopSniff
+ *
+ * @since 7.0.7
  */
 class ForbiddenBreakContinueOutsideLoopUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
@@ -13,9 +13,7 @@ namespace PHPCompatibility\Tests\ControlStructures;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Forbidden break and continue outside loop sniff test.
- *
- * Checks for using break and continue outside of a looping structure.
+ * Test the ForbiddenBreakContinueOutsideLoop sniff.
  *
  * @group forbiddenBreakContinueOutsideLoop
  * @group controlStructures

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\ForbiddenBreakContinueVariableArgumentsSniff
+ *
+ * @since 5.5
  */
 class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -13,11 +13,7 @@ namespace PHPCompatibility\Tests\ControlStructures;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Forbidden break and continue variable arguments sniff test
- *
- * Checks for using break and continue with a variable afterwards
- *     break $varname
- *     continue $varname
+ * Test the ForbiddenBreakContinueVariableArguments sniff.
  *
  * @group forbiddenBreakContinueVariableArguments
  * @group controlStructures

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ControlStructures;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Switch statements can only have one default case in PHP 7.0
+ * Test the ForbiddenSwitchWithMultipleDefaultBlocks sniff.
  *
  * @group forbiddenSwitchWithMultipleDefaultBlocks
  * @group controlStructures

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\ForbiddenSwitchWithMultipleDefaultBlocksSniff
+ *
+ * @since 7.0.0
  */
 class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ControlStructures;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New execution directives test file
+ * Test the NewExecutionDirectives sniff.
  *
  * @group newExecutionDirectives
  * @group controlStructures

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\NewExecutionDirectivesSniff
+ *
+ * @since 7.0.3
  */
 class NewExecutionDirectivesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/NewForeachExpressionReferencingUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewForeachExpressionReferencingUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ControlStructures;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * PHP 5.5 referencing expressions in foreach sniff test file.
+ * Test the NewForeachExpressionReferencing sniff.
  *
  * @group newForeachExpressionReferencing
  * @group controlStructures

--- a/PHPCompatibility/Tests/ControlStructures/NewForeachExpressionReferencingUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewForeachExpressionReferencingUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\NewForeachExpressionReferencingSniff
  * @covers \PHPCompatibility\Sniff::isVariable
+ *
+ * @since 9.0.0
  */
 class NewForeachExpressionReferencingUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ControlStructures;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * PHP 5.5 list() in foreach sniff test file.
+ * Test the NewListInForeach sniff.
  *
  * @group newListInForeach
  * @group controlStructures

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group controlStructures
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\NewListInForeachSniff
+ *
+ * @since 9.0.0
  */
 class NewListInForeachUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ControlStructures;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New catching multiple exception types sniff test file
+ * Test the NewMultiCatch sniff.
  *
  * @group newMultiCatch
  * @group controlStructures

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group exceptions
  *
  * @covers \PHPCompatibility\Sniffs\ControlStructures\NewMultiCatchSniff
+ *
+ * @since 7.0.7
  */
 class NewMultiCatchUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\PHPCSHelper;
  * @group extensions
  *
  * @covers \PHPCompatibility\Sniffs\Extensions\RemovedExtensionsSniff
+ *
+ * @since 5.5
  */
 class RemovedExtensionsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * Removed extensions sniff tests
+ * Test the RemovedExtensions sniff.
  *
  * @group removedExtensions
  * @group extensions

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group superglobals
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenParameterShadowSuperGlobalsSniff
+ *
+ * @since 7.0.3
  */
 class ForbiddenParameterShadowSuperGlobalsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionDeclarations;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * ForbiddenParameterShadowSuperGlobalsSniffTest
+ * Test the ForbiddenParameterShadowSuperGlobals sniff.
  *
  * @group forbiddenParameterShadowSuperGlobals
  * @group functionDeclarations

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenParametersWithSameNameSniff
+ *
+ * @since 7.0.0
  */
 class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionDeclarations;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Functions can not have multiple parameters with the same name since PHP 7.0 sniff test
+ * Test the ForbiddenParametersWithSameName sniff.
  *
  * @group forbiddenParametersWithSameName
  * @group functionDeclarations

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenToStringParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenToStringParametersUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * Forbidden parameters passed to __toString() sniff tests.
+ * Test the ForbiddenToStringParameters sniff.
  *
  * @group newForbiddenToStringParameters
  * @group functionDeclarations

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * PHP 7.1 Forbidden variable names in closure use statements tests.
+ * Test the ForbiddenVariableNamesInClosureUse sniff.
  *
  * @group forbiddenVariableNamesInClosureUse
  * @group closures

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
@@ -21,6 +21,8 @@ use PHPCompatibility\PHPCSHelper;
  * @group functionDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenVariableNamesInClosureUseSniff
+ *
+ * @since 7.1.4
  */
 class ForbiddenVariableNamesInClosureUseUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewClosureSniff
+ *
+ * @since 7.0.0
  */
 class NewClosureUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionDeclarations;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Closure Sniff tests
+ * Test the NewClosure sniff.
  *
  * @group newClosure
  * @group functionDeclarations

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * Exceptions from __toString() sniff tests.
+ * Test the NewExceptionsFromToString sniff.
  *
  * @group newExceptionsFromToString
  * @group functionDeclarations

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
@@ -21,6 +21,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewNullableTypesSniff
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintToken
+ *
+ * @since 7.0.7
  */
 class NewNullableTypesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionDeclarations;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New nullable type hints / return types sniff test file
+ * Test the NewNullableTypes sniff.
  *
  * @group nullableTypes
  * @group functionDeclarations

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionDeclarations;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New type declarations test file
+ * Test the NewParamTypeDeclarations sniff.
  *
  * @group newParamTypeDeclarations
  * @group functionDeclarations

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group typeDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewParamTypeDeclarationsSniff
+ *
+ * @since 7.0.0
  */
 class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -21,6 +21,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewReturnTypeDeclarationsSniff
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintToken
+ *
+ * @since 7.0.0
  */
 class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionDeclarations;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New return types test file
+ * Test the NewReturnTypeDeclarations sniff.
  *
  * @group newReturnTypeDeclarations
  * @group functionDeclarations

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -21,6 +21,8 @@ use PHPCompatibility\PHPCSHelper;
  * @group magicMethods
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NonStaticMagicMethodsSniff
+ *
+ * @since 5.5
  */
 class NonStaticMagicMethodsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * Non Static Magic Methods Sniff tests
+ * Test the NonStaticMagicMethods sniff.
  *
  * @group nonStaticMagicMethods
  * @group functionDeclarations

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -21,6 +21,8 @@ use PHPCompatibility\PHPCSHelper;
  * @group magicMethods
  *
  * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\NewMagicMethodsSniff
+ *
+ * @since 7.0.4
  */
 class NewMagicMethodsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * New Magic Methods Sniff tests.
+ * Test the NewMagicMethods sniff.
  *
  * @group newMagicMethods
  * @group functionNameRestrictions

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * __autoload deprecation for PHP 7.2 sniff test
+ * Test the RemovedMagicAutoload sniff.
  *
  * @group removedMagicAutoload
  * @group functionNameRestrictions

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -21,6 +21,8 @@ use PHPCompatibility\PHPCSHelper;
  *
  * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedMagicAutoloadSniff
  * @covers \PHPCompatibility\Sniff::determineNamespace
+ *
+ * @since 8.1.0
  */
 class RemovedMagicAutoloadUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -21,6 +21,8 @@ use PHPCompatibility\PHPCSHelper;
  *
  * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedNamespacedAssertSniff
  * @covers \PHPCompatibility\Sniff::determineNamespace
+ *
+ * @since 9.0.0
  */
 class RemovedNamespacedAssertUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * Removal of namespaced free-standing assert() declarations for PHP 7.3 sniff test.
+ * Test the RemovedNamespacedAssert sniff.
  *
  * @group removedNamespacedAssert
  * @group functionNameRestrictions

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionNameRestrictions;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * PHP4 style constructors sniff test
+ * Test the RemovedPHP4StyleConstructors sniff.
  *
  * @group removedPHP4StyleConstructors
  * @group functionNameRestrictions

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedPHP4StyleConstructorsSniff
  * @covers \PHPCompatibility\Sniff::determineNamespace
+ *
+ * @since 7.0.0
  */
 class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionNameRestrictions;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Reserved function names sniff test.
+ * Test the ReservedFunctionNames sniff.
  *
  * @group reservedFunctionNames
  * @group functionNameRestrictions

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionNameRestrictions
  *
  * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\ReservedFunctionNamesSniff
+ *
+ * @since 8.2.0
  */
 class ReservedFunctionNamesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionUse;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Argument Functions Report Current Value sniff tests.
+ * Test the ArgumentFunctionsReportCurrentValue sniff.
  *
  * @group argumentFunctionsReportCurrentValue
  * @group functionUse

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\ArgumentFunctionsUsageSniff
+ *
+ * @since 8.2.0
  */
 class ArgumentFunctionsUsageUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionUse;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Check for the PHP 5.3 changes in allowed usage of the argument functions.
+ * Test the ArgumentFunctionsUsage sniff.
  *
  * @group argumentFunctions
  * @group functionUse

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\NewFunctionParametersSniff
+ *
+ * @since 7.0.0
  */
 class NewFunctionParametersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionUse;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Functions Parameter Sniff tests
+ * Test the NewFunctionParameters sniff.
  *
  * @group newFunctionParameters
  * @group functionUse

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionUse;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Functions Sniff tests
+ * Test the NewFunctions sniff.
  *
  * @group newFunctions
  * @group functionUse

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\NewFunctionsSniff
+ *
+ * @since 5.5
  */
 class NewFunctionsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\OptionalToRequiredFunctionParametersSniff
+ *
+ * @since 8.1.0
  */
 class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionUse;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Optional Required Parameter Sniff test file
+ * Test the OptionalToRequiredFunctionParameters sniff.
  *
  * @group optionalToRequiredFunctionParameters
  * @group functionUse

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionParametersSniff
+ *
+ * @since 7.0.0
  */
 class RemovedFunctionParametersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionUse;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed Functions Parameter Sniff test file
+ * Test the RemovedFunctionParameters sniff.
  *
  * @group removedFunctionParameters
  * @group functionUse

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionUse;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed functions sniff tests
+ * Test the RemovedFunctions sniff.
  *
  * @group removedFunctions
  * @group functionUse

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionsSniff
+ *
+ * @since 5.5
  */
 class RemovedFunctionsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group functionUse
  *
  * @covers \PHPCompatibility\Sniffs\FunctionUse\RequiredToOptionalFunctionParametersSniff
+ *
+ * @since 7.0.3
  */
 class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\FunctionUse;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Required Optional Parameter Sniff test file
+ * Test the RequiredToOptionalFunctionParameters sniff.
  *
  * @group requiredToOptionalFunctionParameters
  * @group functionUse

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Generators;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New generator return expressions in PHP 7.0 sniff test file
+ * Test the NewGeneratorReturn sniff.
  *
  * @group newGeneratorReturn
  * @group generators

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group generators
  *
  * @covers \PHPCompatibility\Sniffs\Generators\NewGeneratorReturnSniff
+ *
+ * @since 8.2.0
  */
 class NewGeneratorReturnUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\IniDirectives;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New ini directives sniff tests
+ * Test the NewIniDirectives sniff.
  *
  * @group newIniDirectives
  * @group iniDirectives

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group iniDirectives
  *
  * @covers \PHPCompatibility\Sniffs\IniDirectives\NewIniDirectivesSniff
+ *
+ * @since 5.5
  */
 class NewIniDirectivesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group iniDirectives
  *
  * @covers \PHPCompatibility\Sniffs\IniDirectives\RemovedIniDirectivesSniff
+ *
+ * @since 5.5
  */
 class RemovedIniDirectivesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\IniDirectives;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed ini directives sniff tests
+ * Test the RemovedIniDirectives sniff.
  *
  * @group removedIniDirectives
  * @group iniDirectives

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\InitialValue;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Constant arrays using the const keyword in PHP 5.6 sniff test file
+ * Test the NewConstantArraysUsingConst sniff.
  *
  * @group newConstantArraysUsingConst
  * @group initialValue

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group initialValue
  *
  * @covers \PHPCompatibility\Sniffs\InitialValue\NewConstantArraysUsingConstSniff
+ *
+ * @since 7.1.4
  */
 class NewConstantArraysUsingConstUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\InitialValue;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Constant arrays using define in PHP 7.0 sniff test file
+ * Test the NewConstantArraysUsingDefine sniff.
  *
  * @group newConstantArraysUsingDefine
  * @group initialValue

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group initialValue
  *
  * @covers \PHPCompatibility\Sniffs\InitialValue\NewConstantArraysUsingDefineSniff
+ *
+ * @since 7.0.0
  */
 class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * New constant scalar expressions in PHP 5.6 sniff test file.
+ * Test the NewConstantScalarExpressions sniff.
  *
  * @group newConstantScalarExpressions
  * @group initialValue

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\PHPCSHelper;
  * @group initialValue
  *
  * @covers \PHPCompatibility\Sniffs\InitialValue\NewConstantScalarExpressionsSniff
+ *
+ * @since 8.2.0
  */
 class NewConstantScalarExpressionsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\PHPCSHelper;
  * @group initialValue
  *
  * @covers \PHPCompatibility\Sniffs\InitialValue\NewHeredocSniff
+ *
+ * @since 7.1.4
  */
 class NewHeredocUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * New initialize with heredoc in PHP 5.3 sniff test file
+ * Test the NewHeredoc sniff.
  *
  * @group newHeredoc
  * @group initialValue

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Interfaces;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Internal Interfaces Sniff tests
+ * Test the InternalInterfaces sniff.
  *
  * @group internalInterfaces
  * @group interfaces

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group interfaces
  *
  * @covers \PHPCompatibility\Sniffs\Interfaces\InternalInterfacesSniff
+ *
+ * @since 7.0.3
  */
 class InternalInterfacesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -22,6 +22,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintName
  * @covers \PHPCompatibility\Sniff::getReturnTypeHintToken
  * @covers \PHPCompatibility\Sniff::getTypeHintsFromFunctionDeclaration
+ *
+ * @since 7.0.3
  */
 class NewInterfacesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Interfaces;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Interfaces Sniff tests
+ * Test the NewInterfaces sniff.
  *
  * @group newInterfaces
  * @group interfaces

--- a/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group keywords
  *
  * @covers \PHPCompatibility\Sniffs\Keywords\CaseSensitiveKeywordsSniff
+ *
+ * @since 7.1.4
  */
 class CaseSensitiveKeywordsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Keywords;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * self, parent and static were sometimes treated case sensitively prior to PHP 5.5.
+ * Test the CaseSensitiveKeywords sniff.
  *
  * @group caseSensitiveKeywords
  * @group keywords

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsDeclaredUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsDeclaredUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Keywords;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Forbidden names as declared name for class, interface, trait or namespace.
+ * Test the ForbiddenNamesAsDeclared sniff.
  *
  * @group forbiddenNamesAsDeclared
  * @group keywords

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsDeclaredUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsDeclaredUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesAsDeclaredSniff
  * @covers \PHPCompatibility\Sniff::getDeclaredNamespaceName
+ *
+ * @since 7.0.8
  */
 class ForbiddenNamesAsDeclaredUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsInvokedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsInvokedFunctionsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group keywords
  *
  * @covers \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesAsInvokedFunctionsSniff
+ *
+ * @since 5.5
  */
 class ForbiddenNamesAsInvokedFunctionsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsInvokedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsInvokedFunctionsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Keywords;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Forbidden names as function invocations sniff test file
+ * Test the ForbiddenNamesAsInvokedFunctions sniff.
  *
  * @group forbiddenNamesAsInvokedFunctions
  * @group keywords

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Keywords;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Forbidden names sniff test
+ * Test the ForbiddenNames sniff.
  *
  * @group forbiddenNames
  * @group keywords

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group keywords
  *
  * @covers \PHPCompatibility\Sniffs\Keywords\ForbiddenNamesSniff
+ *
+ * @since 5.5
  */
 class ForbiddenNamesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Keywords;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New keywords sniff tests
+ * Test the NewKeywords sniff.
  *
  * @group newKeywords
  * @group keywords

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group keywords
  *
  * @covers \PHPCompatibility\Sniffs\Keywords\NewKeywordsSniff
+ *
+ * @since 5.5
  */
 class NewKeywordsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\LanguageConstructs\NewEmptyNonVariableSniff
  * @covers \PHPCompatibility\Sniff::isVariable
+ *
+ * @since 7.0.4
  */
 class NewEmptyNonVariableUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\LanguageConstructs;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Empty with non variable sniff test file
+ * Test the NewEmptyNonVariable sniff.
  *
  * @group newEmptyNonVariable
  * @group languageConstructs

--- a/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group languageConstructs
  *
  * @covers \PHPCompatibility\Sniffs\LanguageConstructs\NewLanguageConstructsSniff
+ *
+ * @since 5.6
  */
 class NewLanguageConstructsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\LanguageConstructs;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New language constructs sniff tests
+ * Test the NewLanguageConstructs sniff.
  *
  * @group newLanguageConstructs
  * @group languageConstructs

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group lists
  *
  * @covers \PHPCompatibility\Sniffs\Lists\AssignmentOrderSniff
+ *
+ * @since 9.0.0
  */
 class AssignmentOrderUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Lists;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * PHP 7.0 assignment order change sniff test file.
+ * Test the AssignmentOrder sniff.
  *
  * @group assignmentOrder
  * @group lists

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Lists;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Empty list() assignments have been removed in PHP 7.0 sniff test file
+ * Test the ForbiddenEmptyListAssignment sniff.
  *
  * @group forbiddenEmptyListAssignment
  * @group lists

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group lists
  *
  * @covers \PHPCompatibility\Sniffs\Lists\ForbiddenEmptyListAssignmentSniff
+ *
+ * @since 7.0.0
  */
 class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group lists
  *
  * @covers \PHPCompatibility\Sniffs\Lists\NewKeyedListSniff
+ *
+ * @since 9.0.0
  */
 class NewKeyedListUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Lists;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * PHP 7.1 keyed lists sniff test file.
+ * Test the NewKeyedList sniff.
  *
  * @group newKeyedList
  * @group lists

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group lists
  *
  * @covers \PHPCompatibility\Sniffs\Lists\NewListReferenceAssignmentSniff
+ *
+ * @since 9.0.0
  */
 class NewListReferenceAssignmentUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Lists;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * PHP 7.3 list reference assignments sniff test file.
+ * Test the NewListReferenceAssignment sniff.
  *
  * @group newListReferenceAssignment
  * @group lists

--- a/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Lists;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * PHP 7.1 symmetric array destructuring sniff test file.
+ * Test the NewShortList sniff.
  *
  * @group newShortList
  * @group lists

--- a/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group lists
  *
  * @covers \PHPCompatibility\Sniffs\Lists\NewShortListSniff
+ *
+ * @since 9.0.0
  */
 class NewShortListUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\MethodUse;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Forbidden parameters passed to __toString() sniff tests.
+ * Test the ForbiddenToStringParameters sniff.
  *
  * @group newForbiddenToStringParameters
  * @group methodUse

--- a/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\MethodUse;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New direct calls to __clone() sniff tests.
+ * Test the NewDirectCallsToClone sniff.
  *
  * @group newDirectCallsToClone
  * @group methodUse

--- a/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * New support for PHP open tag at end of file sniff tests.
+ * Test the NewPHPOpenTagEOF sniff.
  *
  * @group newPHPOpenTagEOF
  * @group miscellaneous

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Miscellaneous;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed alternative PHP tags sniff test file
+ * Test the RemovedAlternativePHPTags sniff.
  *
  * @group removedAlternativePHPTags
  * @group miscellaneous

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group miscellaneous
  *
  * @covers \PHPCompatibility\Sniffs\Miscellaneous\RemovedAlternativePHPTagsSniff
+ *
+ * @since 7.0.4
  */
 class RemovedAlternativePHPTagsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group miscellaneous
  *
  * @covers \PHPCompatibility\Sniffs\Miscellaneous\ValidIntegersSniff
+ *
+ * @since 7.0.3
  */
 class ValidIntegersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/ValidIntegersUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Miscellaneous;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Valid Integers Sniff tests
+ * Test the ValidIntegers sniff.
  *
  * @group validIntegers
  * @group miscellaneous

--- a/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Operators;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Changed Concat Operator Precendence Sniff tests
+ * Test the ChangedConcatOperatorPrecedence sniff.
  *
  * @group changedConcatOperatorPrecedence
  * @group operators

--- a/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group operators
  *
  * @covers \PHPCompatibility\Sniffs\Operators\ForbiddenNegativeBitshiftSniff
+ *
+ * @since 7.0.0
  */
 class ForbiddenNegativeBitshiftUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Operators;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0.
+ * Test the ForbiddenNegativeBitshift sniff.
  *
  * @group forbiddenNegativeBitshift
  * @group operators

--- a/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
@@ -19,6 +19,9 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group operators
  *
  * @covers \PHPCompatibility\Sniffs\Operators\NewOperatorsSniff
+ *
+ * @since 9.0.0 Detection of new operators was originally included in the
+ *              NewLanguageConstructSniff (since 5.6).
  */
 class NewOperatorsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Operators;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New operators sniff tests
+ * Test the NewOperators sniff.
  *
  * @group newOperators
  * @group operators

--- a/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group operators
  *
  * @covers \PHPCompatibility\Sniffs\Operators\NewShortTernarySniff
+ *
+ * @since 7.0.0
  */
 class NewShortTernaryUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Operators;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Short Ternary Sniff tests
+ * Test the NewShortTernary sniff.
  *
  * @group newShortTernary
  * @group operators

--- a/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Operators;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed Ternary Associativity sniff tests.
+ * Test the RemovedTernaryAssociativity sniff.
  *
  * @group removedTernaryAssociativity
  * @group operators

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Passing `null` to get_class() sniff tests.
+ * Test the ForbiddenGetClassNull sniff.
  *
  * @group forbiddenGetClassNull
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\ForbiddenGetClassNullSniff
+ *
+ * @since 9.0.0
  */
 class ForbiddenGetClassNullUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Forbidden self closing XHTML tags in strip_tags() tests.
+ * Test the ForbiddenStripTagsSelfClosingXHTML sniff.
  *
  * @group forbiddenStripTagsSelfClosingXHTML
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Parameter type of the array_reduce() $initial param sniff tests.
+ * Test the NewArrayReduceInitialType sniff.
  *
  * @group newArrayReduceInitialType
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewArrayReduceInitialTypeSniff
+ *
+ * @since 9.0.0
  */
 class NewArrayReduceInitialTypeUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewFopenModesSniff
+ *
+ * @since 9.0.0
  */
 class NewFopenModesUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Allowed values for the fopen() $mode parameter sniff tests.
+ * Test the NewFopenModes sniff.
  *
  * @group newFopenModes
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New htmlentities(), htmlspecialchars() encoding default tests.
+ * Test the NewHTMLEntitiesEncoding sniff.
  *
  * @group newHTMLEntitiesEncodingDefault
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New hash algorithms sniff tests.
+ * Test the NewHashAlgorithms sniff.
  *
  * @group newHashAlgorithms
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -21,6 +21,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewHashAlgorithmsSniff
  * @covers \PHPCompatibility\Sniff::getHashAlgorithmParameter
+ *
+ * @since 7.0.7
  */
 class NewHashAlgorithmsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New default value for the IDN $variant parameter Sniff tests.
+ * Test the NewIDNVariantDefault sniff.
  *
  * @group newIDNVariantDefault
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Iconv/MbString charset/encoding default tests.
+ * Test the NewIconvMbstringCharsetDefault sniff.
  *
  * @group newIconvMbstringCharsetDefault
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Negative string offsets as parameters sniff tests.
+ * Test the NewNegativeStringOffset sniff.
  *
  * @group newNegativeStringOffset
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewNegativeStringOffsetSniff
+ *
+ * @since 9.0.0
  */
 class NewNegativeStringOffsetUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group regexModifiers
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewPCREModifiersSniff
+ *
+ * @since 8.2.0
  */
 class NewPCREModifiersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New PCRE regex modifiers sniff tests.
+ * Test the NewPCREModifiers sniff.
  *
  * @group newPCREModifiers
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Use of new pack() formats sniff tests.
+ * Test the NewPackFormat sniff.
  *
  * @group newPackFormat
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewPackFormatSniff
+ *
+ * @since 9.0.0
  */
 class NewPackFormatUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New password hash algorithm constant values tests.
+ * Test the NewPasswordAlgoConstantValues sniff.
  *
  * @group newPasswordAlgoConstantValues
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New passing $allowable_tags as an array to strip_tags() tests.
+ * Test the NewProcOpenCmdArray sniff.
  *
  * @group newProcOpenCmdArray
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New passing $allowable_tags as an array to strip_tags() tests.
+ * Test the NewStripTagsAllowableTagsArray sniff.
  *
  * @group newStripTagsAllowableTagsArray
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
@@ -21,6 +21,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedHashAlgorithmsSniff
  * @covers \PHPCompatibility\Sniff::getHashAlgorithmParameter
+ *
+ * @since 5.5
  */
 class RemovedHashAlgorithmsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed hash algorithms sniff tests
+ * Test the RemovedHashAlgorithms sniff.
  *
  * @group removedHashAlgorithms
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Deprecated/Removed Iconv encoding types sniff tests.
+ * Test the RemovedIconvEncoding sniff.
  *
  * @group removedIconvEncoding
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedIconvEncodingSniff
+ *
+ * @since 9.0.0
  */
 class RemovedIconvEncodingUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed flexible parameter order for implode() sniff tests.
+ * Test the RemovedImplodeFlexibleParamOrder sniff.
  *
  * @group removedImplodeFlexibleParamOrder
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed mb_strrpos() encoding as third parameter Sniff tests
+ * Test the RemovedMbStrrposEncodingThirdParam sniff.
  *
  * @group removedMbStrrposEncodingThirdParam
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Deprecated Mbstring regex replace e modifier test file.
+ * Test the RemovedMbstringModifiers sniff.
  *
  * @group removedMbstringModifiers
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group regexModifiers
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedMbstringModifiersSniff
+ *
+ * @since 7.0.5
  */
 class RemovedMbstringModifiersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Use of non-cryptographic hashes sniff tests.
+ * Test the RemovedNonCryptoHash sniff.
  *
  * @group removedNonCryptoHash
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group hashAlgorithms
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedNonCryptoHashSniff
+ *
+ * @since 9.0.0
  */
 class RemovedNonCryptoHashUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group regexModifiers
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedPCREModifiersSniff
+ *
+ * @since 5.6
  */
 class RemovedPCREModifiersUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * preg_replace() /e modifier sniff tests
+ * Test the RemovedPCREModifiers sniff.
  *
  * @group removedPCREModifiers
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\ParameterValues;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Passing literal string $category to setlocale() sniff tests.
+ * Test the RemovedSetlocaleString sniff.
  *
  * @group removedSetlocaleString
  * @group parameterValues

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group parameterValues
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedSetlocaleStringSniff
+ *
+ * @since 9.0.0
  */
 class RemovedSetlocaleStringUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Forbidden call time pass by reference sniff test
+ * Test the ForbiddenCallTimePassByReference sniff.
  *
  * @group forbiddenCallTimePassByReference
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\ForbiddenCallTimePassByReferenceSniff
+ *
+ * @since 5.5
  */
 class ForbiddenCallTimePassByReferenceUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewArrayStringDereferencingSniff
+ *
+ * @since 7.1.4
  */
 class NewArrayStringDereferencingUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New array and string literal dereferencing sniff test.
+ * Test the NewArrayStringDereferencing sniff.
  *
  * @group newArrayStringDereferencing
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Array Unpacking Sniff tests
+ * Test the NewArrayUnpacking sniff.
  *
  * @group newArrayUnpacking
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New class member access on instantiation in PHP 5.4 and on cloning in PHP 7.0 sniff test file
+ * Test the NewClassMemberAccess sniff.
  *
  * @group newClassMemberAccess
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff
+ *
+ * @since 8.2.0
  */
 class NewClassMemberAccessUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Dynamic access to static methods and properties sniff test file
+ * Test the NewDynamicAccessToStatic sniff.
  *
  * @group newDynamicAccessToStatic
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewDynamicAccessToStaticSniff
+ *
+ * @since 8.1.0
  */
 class NewDynamicAccessToStaticUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -20,6 +20,8 @@ use PHPCompatibility\PHPCSHelper;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewFlexibleHeredocNowdocSniff
+ *
+ * @since 9.0.0
  */
 class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\PHPCSHelper;
 
 /**
- * Use of flexible heredoc/nowdoc syntax and identifiers in heredoc/nowdoc body tests.
+ * Test the NewFlexibleHeredocNowdoc sniff.
  *
  * @group newFlexibleHeredocNowdoc
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New function array dereferencing sniff tests
+ * Test the NewFunctionArrayDereferencing sniff.
  *
  * @group newFunctionArrayDereferencing
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff
+ *
+ * @since 7.0.0
  */
 class NewFunctionArrayDereferencingUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New function call trailing comma sniff tests
+ * Test the NewFunctionCallTrailingComma sniff.
  *
  * @group newFunctionCallTrailingComma
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewFunctionCallTrailingCommaSniff
+ *
+ * @since 8.2.0
  */
 class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Short array syntax sniff tests
+ * Test the NewShortArray sniff.
  *
  * @group newShortArray
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\NewShortArraySniff
+ *
+ * @since 7.0.0
  */
 class NewShortArrayUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed curly brace syntax for array access sniff tests.
+ * Test the RemovedCurlyBraceArrayAccess sniff.
  *
  * @group removedCurlyBraceArrayAccess
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed new reference sniff tests
+ * Test the RemovedNewReference sniff.
  *
  * @group removedNewReference
  * @group syntax

--- a/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group syntax
  *
  * @covers \PHPCompatibility\Sniffs\Syntax\RemovedNewReferenceSniff
+ *
+ * @since 5.5
  */
 class RemovedNewReferenceUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/TextStrings/NewUnicodeEscapeSequenceUnitTest.php
+++ b/PHPCompatibility/Tests/TextStrings/NewUnicodeEscapeSequenceUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\TextStrings;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Unicode Escape Sequence Sniff tests
+ * Test the NewUnicodeEscapeSequence sniff.
  *
  * @group newUnicodeEscapeSequence
  * @group textStrings

--- a/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group typeCasts
  *
  * @covers \PHPCompatibility\Sniffs\TypeCasts\NewTypeCastsSniff
+ *
+ * @since 8.0.1
  */
 class NewTypeCastsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\TypeCasts;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New type casts sniff tests
+ * Test the NewTypeCasts sniff.
  *
  * @group newTypeCasts
  * @group typeCasts

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\TypeCasts;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Deprecated/Removed type casts sniff tests
+ * Test the RemovedTypeCasts sniff.
  *
  * @group removedTypeCasts
  * @group typeCasts

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group typeCasts
  *
  * @covers \PHPCompatibility\Sniffs\TypeCasts\RemovedTypeCastsSniff
+ *
+ * @since 8.0.1
  */
 class RemovedTypeCastsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Upgrade/LowPHPCSUnitTest.php
+++ b/PHPCompatibility/Tests/Upgrade/LowPHPCSUnitTest.php
@@ -15,7 +15,7 @@ use PHPCompatibility\PHPCSHelper;
 use PHPCompatibility\Sniffs\Upgrade\LowPHPCSSniff;
 
 /**
- * Test throwing the PHPCS Upgrade notice.
+ * Test the LowPHPCS sniff.
  *
  * @group lowPHPCS
  * @group upgrade

--- a/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
+++ b/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
 use PHPCompatibility\Sniffs\Upgrade\LowPHPSniff;
 
 /**
- * Test throwing the PHP Upgrade notice.
+ * Test the LowPHP sniff.
  *
  * @group lowPHP
  * @group upgrade

--- a/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group useDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\UseDeclarations\NewGroupUseDeclarationsSniff
+ *
+ * @since 7.0.0
  */
 class NewGroupUseDeclarationsUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\UseDeclarations;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New use group declaration sniff tests
+ * Test the NewGroupUseDeclarations sniff.
  *
  * @group newGroupUseDeclarations
  * @group useDeclarations

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\UseDeclarations;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New use const function in PHP 5.6 sniff test file
+ * Test the NewUseConstFunction sniff.
  *
  * @group newUseConstFunction
  * @group useDeclarations

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group useDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\UseDeclarations\NewUseConstFunctionSniff
+ *
+ * @since 7.1.4
  */
 class NewUseConstFunctionUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group variables
  *
  * @covers \PHPCompatibility\Sniffs\Variables\ForbiddenGlobalVariableVariableSniff
+ *
+ * @since 7.0.0
  */
 class ForbiddenGlobalVariableVariableUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Variables;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Global with variable variables have been removed in PHP 7.0 sniff test file
+ * Test the ForbiddenGlobalVariableVariable sniff.
  *
  * @group forbiddenGlobalVariableVariable
  * @group variables

--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Variables;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New $this usage limitations sniff tests.
+ * Test the ForbiddenThisUseContexts sniff.
  *
  * @group forbiddenThisUseContexts
  * @group variables

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
@@ -19,6 +19,8 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group variables
  *
  * @covers \PHPCompatibility\Sniffs\Variables\NewUniformVariableSyntaxSniff
+ *
+ * @since 7.1.2
  */
 class NewUniformVariableSyntaxUnitTest extends BaseSniffTest
 {

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Variables;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * New Uniform Variable Syntax sniff test file
+ * Test the NewUniformVariableSyntax sniff.
  *
  * @group newUniformVariableSyntax
  * @group variables

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Tests\Variables;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Removed predefined global variables sniff tests
+ * Test the RemovedPredefinedGlobalVariables sniff.
  *
  * @group removedPredefinedGlobalVariables
  * @group variables

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -19,6 +19,10 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group variables
  *
  * @covers \PHPCompatibility\Sniffs\Variables\RemovedPredefinedGlobalVariablesSniff
+ *
+ * @since 5.5   Introduced as LongArraysSniffTest.
+ * @since 7.0   RemovedVariablesSniffTest.
+ * @since 7.1.3 Merged to one sniff & test.
  */
 class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
 {


### PR DESCRIPTION
... and add `@since` tags to the class docblocks (if they weren't there already).

Related to #734