### PR TITLE
NewInterfaces: update reference URLs

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -103,8 +103,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      */
     protected $unsupportedMethods = array(
         'Serializable' => array(
-            '__sleep'  => 'http://php.net/serializable',
-            '__wakeup' => 'http://php.net/serializable',
+            '__sleep'  => 'https://www.php.net/serializable',
+            '__wakeup' => 'https://www.php.net/serializable',
         ),
     );
 

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -96,7 +96,7 @@ class NewInterfacesUnitTest extends BaseSniffTest
     public function testUnsupportedMethods($line, $methodName)
     {
         $file = $this->sniffFile(__FILE__, '5.1'); // Version in which the Serializable interface was introduced.
-        $this->assertError($file, $line, "Classes that implement interface Serializable do not support the method {$methodName}(). See http://php.net/serializable");
+        $this->assertError($file, $line, "Classes that implement interface Serializable do not support the method {$methodName}(). See https://www.php.net/serializable");
     }
 
     /**


### PR DESCRIPTION
The base URL for the php.net manual site has changed.