### PR TITLE
Documentation: add `@since` tags to method, property and constant docblocks

### DIFF
--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -53,6 +53,8 @@ if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
      * {@internal When `installed_paths` is set via the ruleset, this autoloader
      * is needed to run the sniffs.
      * Upstream issue: {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/1591} }}
+     *
+     * @since 8.0.0
      */
     spl_autoload_register(function ($class) {
         // Only try & load our own classes.

--- a/PHPCompatibility/AbstractComplexVersionSniff.php
+++ b/PHPCompatibility/AbstractComplexVersionSniff.php
@@ -23,6 +23,8 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
      * Handle the retrieval of relevant information and - if necessary - throwing of an
      * error/warning for an item.
      *
+     * @since 7.1.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the relevant token in
      *                                         the stack.
@@ -44,6 +46,8 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
     /**
      * Determine whether an error/warning should be thrown for an item based on collected information.
      *
+     * @since 7.1.0
+     *
      * @param array $errorInfo Detail information about an item.
      *
      * @return bool
@@ -53,6 +57,8 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
 
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
+     *
+     * @since 7.1.0
      *
      * @return array
      */
@@ -66,6 +72,8 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
      * Retrieve a subset of an item array containing only the array keys which
      * contain PHP version information.
      *
+     * @since 7.1.0
+     *
      * @param array $itemArray Version and other information about an item.
      *
      * @return array Array with only the version information.
@@ -78,6 +86,8 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
 
     /**
      * Get the item name to be used for the creation of the error code and in the error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemInfo  Base information about the item.
      * @param array $errorInfo Detail information about an item.
@@ -93,6 +103,8 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
     /**
      * Get the error message template for a specific sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     abstract protected function getErrorMsgTemplate();
@@ -100,6 +112,8 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
 
     /**
      * Allow for concrete child classes to filter the error message before it's passed to PHPCS.
+     *
+     * @since 7.1.0
      *
      * @param string $error     The error message which was created.
      * @param array  $itemInfo  Base information about the item this error message applies to.
@@ -115,6 +129,8 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
 
     /**
      * Allow for concrete child classes to filter the error data before it's passed to PHPCS.
+     *
+     * @since 7.1.0
      *
      * @param array $data      The error data array which was created.
      * @param array $itemInfo  Base information about the item this error message applies to.

--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -26,6 +26,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      * the method called is of the right class/object.
      * Checking that is outside of the scope of this abstract sniff.
      *
+     * @since 8.2.0
+     *
      * @var bool False (default) if the sniff is looking for function calls.
      *           True if the sniff is looking for method calls.
      */
@@ -33,6 +35,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
 
     /**
      * Functions the sniff is looking for. Should be defined in the child class.
+     *
+     * @since 8.2.0
      *
      * @var array The only requirement for this array is that the top level
      *            array keys are the names of the functions you're looking for.
@@ -44,6 +48,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
     /**
      * List of tokens which when they preceed the $stackPtr indicate that this
      * is not a function call.
+     *
+     * @since 8.2.0
      *
      * @var array
      */
@@ -60,6 +66,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.2.0
+     *
      * @return array
      */
     public function register()
@@ -73,6 +81,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -131,6 +141,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 8.2.0
+     *
      * If the check done in a child class is not specific to one PHP version,
      * this function should return `false`.
      *
@@ -143,6 +155,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      * Process the parameters of a matched function.
      *
      * This method has to be made concrete in child classes.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.
@@ -160,6 +174,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      *
      * Defaults to doing nothing. Can be overloaded in child classes to handle functions
      * were parameters are expected, but none found.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.

--- a/PHPCompatibility/AbstractNewFeatureSniff.php
+++ b/PHPCompatibility/AbstractNewFeatureSniff.php
@@ -22,6 +22,8 @@ abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
     /**
      * Determine whether an error/warning should be thrown for an item based on collected information.
      *
+     * @since 7.1.0
+     *
      * @param array $errorInfo Detail information about an item.
      *
      * @return bool
@@ -34,6 +36,8 @@ abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -66,6 +70,8 @@ abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
     /**
      * Get the error message template for this sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     protected function getErrorMsgTemplate()
@@ -76,6 +82,8 @@ abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
 
     /**
      * Generates the error or warning for this item.
+     *
+     * @since 7.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the relevant token in

--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -22,6 +22,8 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
     /**
      * Determine whether an error/warning should be thrown for an item based on collected information.
      *
+     * @since 7.1.0
+     *
      * @param array $errorInfo Detail information about an item.
      *
      * @return bool
@@ -37,6 +39,8 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
      *
      * By default, removed feature version arrays, contain an additional 'alternative' array key.
      *
+     * @since 7.1.0
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -47,6 +51,8 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -88,6 +94,8 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
     /**
      * Get the error message template for suggesting an alternative for a specific sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     protected function getAlternativeOptionTemplate()
@@ -98,6 +106,8 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
 
     /**
      * Generates the error or warning for this item.
+     *
+     * @since 7.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the relevant token in

--- a/PHPCompatibility/ComplexVersionInterface.php
+++ b/PHPCompatibility/ComplexVersionInterface.php
@@ -27,6 +27,8 @@ interface ComplexVersionInterface
      * Handle the retrieval of relevant information and - if necessary - throwing of an
      * error/warning for an item.
      *
+     * @since 7.1.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the relevant token in
      *                                         the stack.
@@ -40,6 +42,8 @@ interface ComplexVersionInterface
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -49,6 +53,8 @@ interface ComplexVersionInterface
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -60,6 +66,8 @@ interface ComplexVersionInterface
 
     /**
      * Generates the error or warning for this item.
+     *
+     * @since 7.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the relevant token in

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -28,6 +28,8 @@ class PHPCSHelper
     /**
      * Get the PHPCS version number.
      *
+     * @since 8.0.0
+     *
      * @return string
      */
     public static function getVersion()
@@ -46,6 +48,8 @@ class PHPCSHelper
      * Pass config data to PHPCS.
      *
      * PHPCS cross-version compatibility helper.
+     *
+     * @since 8.0.0
      *
      * @param string      $key   The name of the config value.
      * @param string|null $value The value to set. If null, the config entry
@@ -70,6 +74,8 @@ class PHPCSHelper
     /**
      * Get the value of a single PHPCS config key.
      *
+     * @since 8.0.0
+     *
      * @param string $key The name of the config value.
      *
      * @return string|null
@@ -91,6 +97,8 @@ class PHPCSHelper
      *
      * This config key can be set in the `CodeSniffer.conf` file, on the
      * command-line or in a ruleset.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param string                $key       The name of the config value.
@@ -128,6 +136,8 @@ class PHPCSHelper
      * `$phpcsFile->findStartOfStatement($start, $ignore)` calls.
      *
      * Last synced with PHPCS version: PHPCS 3.3.2 at commit 6ad28354c04b364c3c71a34e4a18b629cc3b231e}}
+     *
+     * @since 9.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
      * @param int                   $start     The position to start searching from in the token stack.
@@ -207,6 +217,8 @@ class PHPCSHelper
      * `$phpcsFile->findEndOfStatement($start, $ignore)` calls.
      *
      * Last synced with PHPCS version: PHPCS 3.3.0-alpha at commit f5d899dcb5c534a1c3cca34668624517856ba823}}
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
      * @param int                   $start     The position to start searching from in the token stack.
@@ -307,6 +319,9 @@ class PHPCSHelper
      *
      * Last synced with PHPCS version: PHPCS 3.1.0-alpha at commit a9efcc9b0703f3f9f4a900623d4e97128a6aafc6}}
      *
+     * @since 7.1.4
+     * @since 8.2.0 Moved from the `Sniff` class to this class.
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
      * @param int                   $stackPtr  The position of the class token in the stack.
      *
@@ -371,6 +386,9 @@ class PHPCSHelper
      * Once the minimum supported PHPCS version for this sniff library goes beyond
      * that, this method can be removed and calls to it replaced with
      * `$phpcsFile->findImplementedInterfaceNames($stackPtr)` calls.}}
+     *
+     * @since 7.0.3
+     * @since 8.2.0 Moved from the `Sniff` class to this class.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the class token.
@@ -453,6 +471,9 @@ class PHPCSHelper
      * class.
      *
      * Last synced with PHPCS version: PHPCS 3.3.0-alpha at commit 53a28408d345044c0360c2c1b4a2aaebf4a3b8c9}}
+     *
+     * @since 7.0.3
+     * @since 8.2.0 Moved from the `Sniff` class to this class.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
      * @param int                   $stackPtr  The position in the stack of the

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -39,6 +39,9 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Used by the ForbiddenParameterShadowSuperGlobals and ForbiddenClosureUseVariableNames sniffs.
      *
+     * @since 7.0.0
+     * @since 7.1.4 Moved from the `ForbiddenParameterShadowSuperGlobals` sniff to the base `Sniff` class.
+     *
      * @var array
      */
     protected $superglobals = array(
@@ -59,6 +62,9 @@ abstract class Sniff implements PHPCS_Sniff
      * Used by the new/removed hash algorithm sniffs.
      * Key is the function name, value is the 1-based parameter position in the function call.
      *
+     * @since 5.5
+     * @since 7.0.7 Moved from the `RemovedHashAlgorithms` sniff to the base `Sniff` class.
+     *
      * @var array
      */
     protected $hashAlgoFunctions = array(
@@ -76,6 +82,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Used by the new/removed ini directives sniffs.
      * Key is the function name, value is the 1-based parameter position in the function call.
+     *
+     * @since 7.1.0
      *
      * @var array
      */
@@ -102,6 +110,9 @@ abstract class Sniff implements PHPCS_Sniff
      *    all versions up to PHP 5.6, and "7.0-" means all versions above PHP 7.0.
      * PHP version numbers should always be in Major.Minor format.  Both "5", "5.3.2"
      * would be treated as invalid, and ignored.
+     *
+     * @since 7.0.0
+     * @since 7.1.3 Now allows for partial ranges such as `5.2-`.
      *
      * @return array $arrTestVersions will hold an array containing min/max version
      *               of PHP that we are checking against (see above).  If only a
@@ -172,6 +183,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Should be used when sniffing for *old* PHP features (deprecated/removed).
      *
+     * @since 5.6
+     *
      * @param string $phpVersion A PHP version number in 'major.minor' format.
      *
      * @return bool True if testVersion has not been provided or if the PHP version
@@ -199,6 +212,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Should be used when sniffing for *new* PHP features.
      *
+     * @since 5.6
+     *
      * @param string $phpVersion A PHP version number in 'major.minor' format.
      *
      * @return bool True if the PHP version is equal to or lower than the lowest
@@ -222,6 +237,8 @@ abstract class Sniff implements PHPCS_Sniff
 
     /**
      * Add a PHPCS message to the output stack as either a warning or an error.
+     *
+     * @since 7.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file the message applies to.
      * @param string                $message   The message.
@@ -251,6 +268,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Pre-empt issues with arbitrary strings being used as error codes in XML and PHP.
      *
+     * @since 7.1.0
+     *
      * @param string $baseString Arbitrary string.
      *
      * @return string
@@ -266,6 +285,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Intended for use with the contents of a T_CONSTANT_ENCAPSED_STRING / T_DOUBLE_QUOTED_STRING.
      *
+     * @since 7.0.6
+     *
      * @param string $string The raw string.
      *
      * @return string String without quotes around it.
@@ -280,6 +301,8 @@ abstract class Sniff implements PHPCS_Sniff
      * Strip variables from an arbitrary double quoted string.
      *
      * Intended for use with the contents of a T_DOUBLE_QUOTED_STRING.
+     *
+     * @since 7.1.2
      *
      * @param string $string The raw string.
      *
@@ -297,6 +320,8 @@ abstract class Sniff implements PHPCS_Sniff
 
     /**
      * Make all top level array keys in an array lowercase.
+     *
+     * @since 7.1.0
      *
      * @param array $array Initial array.
      *
@@ -319,6 +344,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/120
      * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/152
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the function call token.
@@ -390,6 +417,8 @@ abstract class Sniff implements PHPCS_Sniff
      * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/114
      * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/151
      *
+     * @since 7.0.3
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the function call token.
      *
@@ -417,6 +446,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
      * it will tokenize the values / key/value pairs contained in the array call.
+     *
+     * @since 7.0.5 Split off from the `getFunctionCallParameterCount()` method.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the function call token.
@@ -524,6 +555,8 @@ abstract class Sniff implements PHPCS_Sniff
      * of the parameter at a specific offset.
      * If the specified parameter is not found, will return false.
      *
+     * @since 7.0.5
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
      * @param int                   $stackPtr    The position of the function call token.
      * @param int                   $paramOffset The 1-based index position of the parameter to retrieve.
@@ -548,6 +581,8 @@ abstract class Sniff implements PHPCS_Sniff
      * If the optional $validScopes parameter has been passed, the function
      * will check that the token has at least one condition which is of a
      * type defined in $validScopes.
+     *
+     * @since 7.0.5 Largely split off from the `inClassScope()` method.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
      * @param int                   $stackPtr    The position of the token.
@@ -586,6 +621,8 @@ abstract class Sniff implements PHPCS_Sniff
     /**
      * Verify whether a token is within a class scope.
      *
+     * @since 7.0.3
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the token.
      * @param bool                  $strict    Whether to strictly check for the T_CLASS
@@ -614,6 +651,8 @@ abstract class Sniff implements PHPCS_Sniff
      * Returns the fully qualified class name for a new class instantiation.
      *
      * Returns an empty string if the class name could not be reliably inferred.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of a T_NEW token.
@@ -669,6 +708,8 @@ abstract class Sniff implements PHPCS_Sniff
      * Returns an empty string if the class does not extend another class or if
      * the class name could not be reliably inferred.
      *
+     * @since 7.0.3
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of a T_CLASS token.
      *
@@ -704,6 +745,8 @@ abstract class Sniff implements PHPCS_Sniff
      * This can be a call to a method, the use of a property or constant.
      *
      * Returns an empty string if the class name could not be reliably inferred.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of a T_NEW token.
@@ -769,6 +812,8 @@ abstract class Sniff implements PHPCS_Sniff
      * Checks if a class/function/constant name is already fully qualified and
      * if not, enrich it with the relevant namespace information.
      *
+     * @since 7.0.3
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the token.
      * @param string                $name      The class / function / constant name.
@@ -800,6 +845,8 @@ abstract class Sniff implements PHPCS_Sniff
     /**
      * Is the class/function/constant name namespaced or global ?
      *
+     * @since 7.0.3
+     *
      * @param string $FQName Fully Qualified name of a class, function etc.
      *                       I.e. should always start with a `\`.
      *
@@ -820,6 +867,8 @@ abstract class Sniff implements PHPCS_Sniff
 
     /**
      * Determine the namespace name an arbitrary token lives in.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
      * @param int                   $stackPtr  The token position for which to determine the namespace.
@@ -884,6 +933,8 @@ abstract class Sniff implements PHPCS_Sniff
      * For hierarchical namespaces, the name will be composed of several tokens,
      * i.e. MyProject\Sub\Level which will be returned together as one string.
      *
+     * @since 7.0.3
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
      * @param int|bool              $stackPtr  The position of a T_NAMESPACE token.
      *
@@ -939,6 +990,8 @@ abstract class Sniff implements PHPCS_Sniff
      * return type hints correctly.
      *
      * Expects to be passed T_RETURN_TYPE, T_FUNCTION or T_CLOSURE token.
+     *
+     * @since 7.1.2
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the token.
@@ -1021,6 +1074,8 @@ abstract class Sniff implements PHPCS_Sniff
      * Expects to be passed a T_RETURN_TYPE token or the return value from a call to
      * the Sniff::getReturnTypeHintToken() method.
      *
+     * @since 8.2.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the return type token.
      *
@@ -1071,6 +1126,8 @@ abstract class Sniff implements PHPCS_Sniff
      * anonymous classes. Along the same lines, the`getMemberProperties()`
      * method does not support the `var` prefix.
      *
+     * @since 7.1.4
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
      * @param int                   $stackPtr  The position in the stack of the
      *                                         T_VARIABLE token to verify.
@@ -1116,6 +1173,8 @@ abstract class Sniff implements PHPCS_Sniff
     /**
      * Check whether a T_CONST token is a class constant declaration.
      *
+     * @since 7.1.4
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
      * @param int                   $stackPtr  The position in the stack of the
      *                                         T_CONST token to verify.
@@ -1149,6 +1208,8 @@ abstract class Sniff implements PHPCS_Sniff
      * acceptable tokens.
      *
      * Used to check, for instance, if a T_CONST is a class constant.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile   Instance of phpcsFile.
      * @param int                   $stackPtr    The position in the stack of the
@@ -1193,6 +1254,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Strips potential nullable indicator and potential global namespace
      * indicator from the type hints before returning them.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the token.
@@ -1240,6 +1303,8 @@ abstract class Sniff implements PHPCS_Sniff
     /**
      * Get the hash algorithm name from the parameter in a hash function call.
      *
+     * @since 7.0.7 Logic was originally contained in the `RemovedHashAlgorithms` sniff.
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
      * @param int                   $stackPtr  The position of the T_STRING function token.
      *
@@ -1283,6 +1348,8 @@ abstract class Sniff implements PHPCS_Sniff
 
     /**
      * Determine whether an arbitrary T_STRING token is the use of a global constant.
+     *
+     * @since 8.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the T_STRING token.
@@ -1416,6 +1483,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Note: Zero is *not* regarded as a positive number.
      *
+     * @since 8.2.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
      * @param int                   $start       Start of the snippet (inclusive), i.e. this
      *                                           token will be examined as part of the snippet.
@@ -1447,6 +1516,8 @@ abstract class Sniff implements PHPCS_Sniff
      * "undetermined".
      *
      * Note: Zero is *not* regarded as a negative number.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
      * @param int                   $start       Start of the snippet (inclusive), i.e. this
@@ -1481,6 +1552,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Mainly intended for examining variable assignments, function call parameters, array values
      * where the start and end of the snippet to examine is very clear.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
      * @param int                   $start       Start of the snippet (inclusive), i.e. this
@@ -1656,6 +1729,8 @@ abstract class Sniff implements PHPCS_Sniff
      * Mainly intended for examining variable assignments, function call parameters, array values
      * where the start and end of the snippet to examine is very clear.
      *
+     * @since 9.0.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $start     Start of the snippet (inclusive), i.e. this
      *                                         token will be examined as part of the snippet.
@@ -1777,6 +1852,8 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * Note: A variety of PHPCS versions have bugs in the tokenizing of short arrays.
      * In that case, the tokens are identified as T_OPEN/CLOSE_SQUARE_BRACKET.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the function call token.
@@ -1920,6 +1997,8 @@ abstract class Sniff implements PHPCS_Sniff
 
     /**
      * Determine whether the tokens between $start and $end could together represent a variable.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile          The file being scanned.
      * @param int                   $start              Starting point stack pointer. Inclusive.

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -28,6 +28,8 @@ class NewAnonymousClassesSniff extends Sniff
      * The dedicated anonymous class token is added from the `register()`
      * method if the token is available.
      *
+     * @since 7.1.2
+     *
      * @var array
      */
     private $indicators = array(
@@ -36,6 +38,8 @@ class NewAnonymousClassesSniff extends Sniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.0
      *
      * @return array
      */
@@ -51,6 +55,8 @@ class NewAnonymousClassesSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -25,6 +25,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not present) or true (present).
      * If's sufficient to list the first version where the class appears.
      *
+     * @since 5.5
+     *
      * @var array(string => array(string => bool))
      */
     protected $newClasses = array(
@@ -395,6 +397,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      *
      * {@internal Helper to update this list: https://3v4l.org/MhlUp}}
      *
+     * @since 7.1.4
+     *
      * @var array(string => array(string => bool))
      */
     protected $newExceptions = array(
@@ -575,6 +579,17 @@ class NewClassesSniff extends AbstractNewFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     * @since 7.0.3 - Now also targets the `class` keyword to detect extended classes.
+     *              - Now also targets double colons to detect static class use.
+     * @since 7.1.4 - Now also targets anonymous classes to detect extended classes.
+     *              - Now also targets functions/closures to detect new classes used
+     *                as parameter type declarations.
+     *              - Now also targets the `catch` control structure to detect new
+     *                exception classes being caught.
+     * @since 8.2.0 Now also targets the `T_RETURN_TYPE` token to detect new classes used
+     *              as return type declarations.
+     *
      * @return array
      */
     public function register()
@@ -609,6 +624,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -650,6 +667,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test for when a token resulting in a singular class name is encountered.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -696,6 +715,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      *
      * - Detect new classes when used as a parameter type declaration.
      *
+     * @since 7.1.4
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
      *                                         the stack passed in $tokens.
@@ -729,6 +750,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      * Processes this test for when a catch token is encountered.
      *
      * - Detect exceptions when used in a catch statement.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -796,6 +819,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      *
      * - Detect new classes when used as a return type declaration.
      *
+     * @since 8.2.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
      *                                         the stack passed in $tokens.
@@ -828,6 +853,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -840,6 +867,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 7.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -24,6 +24,8 @@ class NewConstVisibilitySniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.7
+     *
      * @return array
      */
     public function register()
@@ -33,6 +35,8 @@ class NewConstVisibilitySniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.7
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -24,6 +24,8 @@ class NewLateStaticBindingSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.3
+     *
      * @return array
      */
     public function register()
@@ -34,6 +36,8 @@ class NewLateStaticBindingSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -29,6 +29,8 @@ class NewTypedPropertiesSniff extends Sniff
     /**
      * Valid property modifier keywords.
      *
+     * @since 9.2.0
+     *
      * @var array
      */
     private $modifierKeywords = array(
@@ -43,6 +45,8 @@ class NewTypedPropertiesSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 9.2.0
+     *
      * @return array
      */
     public function register()
@@ -52,6 +56,8 @@ class NewTypedPropertiesSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -27,6 +27,8 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
      *
      * Note: PHP Constants are case-sensitive!
      *
+     * @since 8.1.0
+     *
      * @var array(string => array(string => bool))
      */
     protected $newConstants = array(
@@ -3681,6 +3683,8 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.1.0
+     *
      * @return array
      */
     public function register()
@@ -3690,6 +3694,8 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -3720,6 +3726,8 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 8.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -3732,6 +3740,8 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 8.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -26,6 +26,8 @@ class NewMagicClassConstantSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.1.4
+     *
      * @return array
      */
     public function register()
@@ -35,6 +37,8 @@ class NewMagicClassConstantSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -30,6 +30,8 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
      *
      * Note: PHP Constants are case-sensitive!
      *
+     * @since 8.1.0
+     *
      * @var array(string => array(string => bool|string))
      */
     protected $removedConstants = array(
@@ -498,6 +500,8 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.1.0
+     *
      * @return array
      */
     public function register()
@@ -508,6 +512,8 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -538,6 +544,8 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 8.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -550,6 +558,8 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 8.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -25,6 +25,8 @@ class DiscouragedSwitchContinueSniff extends Sniff
     /**
      * Token codes of control structures which can be targeted using continue.
      *
+     * @since 8.2.0
+     *
      * @var array
      */
     protected $loopStructures = array(
@@ -38,6 +40,8 @@ class DiscouragedSwitchContinueSniff extends Sniff
     /**
      * Tokens which start a new case within a switch.
      *
+     * @since 8.2.0
+     *
      * @var array
      */
     protected $caseTokens = array(
@@ -49,6 +53,8 @@ class DiscouragedSwitchContinueSniff extends Sniff
      * Token codes which are accepted to determine the level for the continue.
      *
      * This array is enriched with the arithmetic operators in the register() method.
+     *
+     * @since 8.2.0
      *
      * @var array
      */
@@ -62,6 +68,8 @@ class DiscouragedSwitchContinueSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.2.0
+     *
      * @return array
      */
     public function register()
@@ -74,6 +82,8 @@ class DiscouragedSwitchContinueSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -24,6 +24,8 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
     /**
      * Token codes of control structure in which usage of break/continue is valid.
      *
+     * @since 7.0.7
+     *
      * @var array
      */
     protected $validLoopStructures = array(
@@ -37,6 +39,8 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
     /**
      * Token codes which did not correctly get a condition assigned in older PHPCS versions.
      *
+     * @since 7.0.7
+     *
      * @var array
      */
     protected $backCompat = array(
@@ -46,6 +50,8 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.7
      *
      * @return array
      */
@@ -59,6 +65,8 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.7
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -26,6 +26,9 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
      *
      * Array key is the error code. Array value will be used as part of the error message.
      *
+     * @since 7.0.5
+     * @since 7.1.0 Changed from class constants to property.
+     *
      * @var array
      */
     private $errorTypes = array(
@@ -36,6 +39,8 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     *
      * @return array
      */
     public function register()
@@ -45,6 +50,8 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -24,6 +24,8 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -33,6 +35,8 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -28,6 +28,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      * If the execution order is conditional, add the condition as a string to the version nr.
      * If's sufficient to list the first version where the execution directive appears.
      *
+     * @since 7.0.3
+     *
      * @var array(string => array(string => bool|string|array))
      */
     protected $newDirectives = array(
@@ -53,6 +55,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Tokens to ignore when trying to find the value for the directive.
      *
+     * @since 7.0.3
+     *
      * @var array
      */
     protected $ignoreTokens = array();
@@ -60,6 +64,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.3
      *
      * @return array
      */
@@ -74,6 +80,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -138,6 +146,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Determine whether an error/warning should be thrown for an item based on collected information.
      *
+     * @since 7.1.0
+     *
      * @param array $errorInfo Detail information about an item.
      *
      * @return bool
@@ -150,6 +160,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
+     *
+     * @since 7.1.0
      *
      * @param array $itemInfo Base information about the item.
      *
@@ -164,6 +176,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
      *
+     * @since 7.1.0
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -177,6 +191,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -208,6 +224,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Get the error message template for this sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     protected function getErrorMsgTemplate()
@@ -218,6 +236,11 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
     /**
      * Generates the error or warning for this item.
+     *
+     * @since 7.0.3
+     * @since 7.1.0 This method now overloads the method from the `AbstractNewFeatureSniff` class.
+     *              - Renamed from `maybeAddError()` to `addError()`.
+     *              - Changed visibility from `protected` to `public`.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the relevant token in
@@ -248,6 +271,9 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
     /**
      * Generates a error or warning for this sniff.
+     *
+     * @since 7.0.3
+     * @since 7.0.6 Renamed from `addErrorOnInvalidValue()` to `addWarningOnInvalidValue()`.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the execution directive value
@@ -295,6 +321,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      *
      * Callback function to test whether the value for an execution directive is valid.
      *
+     * @since 7.0.3
+     *
      * @param mixed $value The value to test.
      *
      * @return bool
@@ -309,6 +337,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      * Check whether a value is a valid encoding.
      *
      * Callback function to test whether the value for an execution directive is valid.
+     *
+     * @since 7.0.3
      *
      * @param mixed $value The value to test.
      *

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -27,6 +27,8 @@ class NewForeachExpressionReferencingSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 9.0.0
+     *
      * @return array
      */
     public function register()
@@ -36,6 +38,8 @@ class NewForeachExpressionReferencingSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -24,6 +24,8 @@ class NewListInForeachSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 9.0.0
+     *
      * @return array
      */
     public function register()
@@ -33,6 +35,8 @@ class NewListInForeachSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -23,6 +23,8 @@ class NewMultiCatchSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.7
+     *
      * @return array
      */
     public function register()
@@ -32,6 +34,8 @@ class NewMultiCatchSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.7
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -32,6 +32,8 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
      *   </properties>
      * </rule>
      *
+     * @since 7.0.2
+     *
      * @var array
      */
     public $functionWhitelist;
@@ -41,6 +43,8 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
      *
      * The array lists : version number with false (deprecated) and true (removed).
      * If's sufficient to list the first version where the extension was deprecated/removed.
+     *
+     * @since 5.5
      *
      * @var array(string => array(string => bool|string|null))
      */
@@ -182,6 +186,8 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     *
      * @return array
      */
     public function register()
@@ -194,6 +200,8 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -262,6 +270,8 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
      *
      * Parsing the list late as it may be provided as a property, but also inline.
      *
+     * @since 7.0.2
+     *
      * @param string $content Content of the current token.
      *
      * @return bool
@@ -292,6 +302,8 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -304,6 +316,8 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 7.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -27,6 +27,9 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
     /**
      * Register the tokens to listen for.
      *
+     * @since 7.0.0
+     * @since 7.1.3 Allows for closures.
+     *
      * @return array
      */
     public function register()
@@ -39,6 +42,8 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
 
     /**
      * Processes the test.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -25,6 +25,9 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     * @since 7.1.3 Allows for closures.
+     *
      * @return array
      */
     public function register()
@@ -37,6 +40,8 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -32,6 +32,7 @@ class ForbiddenToStringParametersSniff extends Sniff
      * Valid scopes for the __toString() method to live in.
      *
      * @since 9.2.0
+     * @since 9.3.2 Visibility changed from `public` to `protected`.
      *
      * @var array
      */

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -29,6 +29,8 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.1.4
+     *
      * @return array
      */
     public function register()
@@ -38,6 +40,8 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -24,6 +24,8 @@ class NewClosureSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -33,6 +35,13 @@ class NewClosureSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
+     * @since 7.1.4 - Added check for closure being declared as static < 5.4.
+     *              - Added check for use of `$this` variable in class context < 5.4.
+     *              - Added check for use of `$this` variable in static closures (unsupported).
+     *              - Added check for use of `$this` variable outside class context (unsupported).
+     * @since 8.2.0 Added check for use of `self`/`static`/`parent` < 5.4.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token
@@ -155,6 +164,8 @@ class NewClosureSniff extends Sniff
     /**
      * Check whether the closure is declared as static.
      *
+     * @since 7.1.4
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token
      *                                         in the stack passed in $tokens.
@@ -172,6 +183,8 @@ class NewClosureSniff extends Sniff
 
     /**
      * Check if the code within a closure uses the $this variable.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile  The file being scanned.
      * @param int                   $startToken The position within the closure to continue searching from.
@@ -198,6 +211,8 @@ class NewClosureSniff extends Sniff
 
     /**
      * Check if the code within a closure uses "self/parent/static".
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile  The file being scanned.
      * @param int                   $startToken The position within the closure to continue searching from.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -30,6 +30,7 @@ class NewExceptionsFromToStringSniff extends Sniff
      * Valid scopes for the __toString() method to live in.
      *
      * @since 9.2.0
+     * @since 9.3.0 Visibility changed from `public` to `protected`.
      *
      * @var array
      */

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -29,6 +29,8 @@ class NewNullableTypesSniff extends Sniff
      * as in that case we can't distinguish between parameter type hints and
      * return type hints for the error message.}}
      *
+     * @since 7.0.7
+     *
      * @return array
      */
     public function register()
@@ -48,6 +50,8 @@ class NewNullableTypesSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.7
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token
@@ -82,6 +86,8 @@ class NewNullableTypesSniff extends Sniff
     /**
      * Process this test for function tokens.
      *
+     * @since 7.0.7
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token
      *                                         in the stack passed in $tokens.
@@ -109,6 +115,8 @@ class NewNullableTypesSniff extends Sniff
 
     /**
      * Process this test for return type tokens.
+     *
+     * @since 7.0.7
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -26,6 +26,9 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not present) or true (present).
      * If's sufficient to list the first version where the keyword appears.
      *
+     * @since 7.0.0
+     * @since 7.0.3 Now lists all param type declarations, not just the PHP 7+ scalar ones.
+     *
      * @var array(string => array(string => bool))
      */
     protected $newTypes = array(
@@ -77,6 +80,8 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
      *
      * The array lists : the invalid type hint => what was probably intended/alternative.
      *
+     * @since 7.0.3
+     *
      * @var array(string => string)
      */
     protected $invalidTypes = array(
@@ -88,6 +93,9 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.0
+     * @since 7.1.3 Now also checks closures.
      *
      * @return array
      */
@@ -102,6 +110,13 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
+     * @since 7.0.3 - Added check for non-scalar type declarations.
+     *              - Added check for invalid type declarations.
+     *              - Added check for usage of `self` type declaration outside
+     *                class scope.
+     * @since 8.2.0 Added check for `parent` type declaration outside class scope.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -170,6 +185,8 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -182,6 +199,8 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 7.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -27,6 +27,8 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not present) or true (present).
      * If's sufficient to list the first version where the keyword appears.
      *
+     * @since 7.0.0
+     *
      * @var array(string => array(string => bool))
      */
     protected $newTypes = array(
@@ -86,6 +88,9 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     * @since 7.1.2 Now also checks based on the function and closure keywords.
+     *
      * @return array
      */
     public function register()
@@ -105,6 +110,8 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -146,6 +153,8 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -158,6 +167,8 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 7.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -30,6 +30,10 @@ class NonStaticMagicMethodsSniff extends Sniff
      * When a method does not have a specific requirement for either visibility or static,
      * do *not* add the key.
      *
+     * @since 5.5
+     * @since 5.6 The array format has changed to allow the sniff to also verify the
+     *            use of the correct visibility for a magic method.
+     *
      * @var array(string)
      */
     protected $magicMethods = array(
@@ -99,6 +103,10 @@ class NonStaticMagicMethodsSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     * @since 5.6   Now also checks traits.
+     * @since 7.1.4 Now also checks anonymous classes.
+     *
      * @return array
      */
     public function register()
@@ -119,6 +127,8 @@ class NonStaticMagicMethodsSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -26,6 +26,8 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not magic) or true (magic).
      * If's sufficient to list the first version where the method became magic.
      *
+     * @since 7.0.4
+     *
      * @var array(string => array(string => bool|string))
      */
     protected $newMagicMethods = array(
@@ -91,6 +93,8 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.4
+     *
      * @return array
      */
     public function register()
@@ -101,6 +105,8 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -132,6 +138,8 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -145,6 +153,8 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
      *
+     * @since 7.1.0
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -155,6 +165,8 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -178,6 +190,8 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
     /**
      * Get the error message template for this sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     protected function getErrorMsgTemplate()
@@ -188,6 +202,8 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
 
     /**
      * Allow for concrete child classes to filter the error message before it's passed to PHPCS.
+     *
+     * @since 7.1.0
      *
      * @param string $error     The error message which was created.
      * @param array  $itemInfo  Base information about the item this error message applies to.

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -23,6 +23,8 @@ class RemovedMagicAutoloadSniff extends Sniff
     /**
      * Scopes to look for when testing using validDirectScope
      *
+     * @since 8.1.0
+     *
      * @var array
      */
     private $checkForScopes = array(
@@ -36,6 +38,8 @@ class RemovedMagicAutoloadSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.1.0
+     *
      * @return array
      */
     public function register()
@@ -45,6 +49,8 @@ class RemovedMagicAutoloadSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -30,6 +30,8 @@ class RemovedNamespacedAssertSniff extends Sniff
     /**
      * Scopes in which an `assert` function can be declared without issue.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     private $scopes = array(
@@ -41,6 +43,8 @@ class RemovedNamespacedAssertSniff extends Sniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.0.0
      *
      * @return array
      */
@@ -56,6 +60,8 @@ class RemovedNamespacedAssertSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -25,6 +25,8 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -36,6 +38,10 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
+     * @since 7.0.8 The message is downgraded from error to warning as - for now - support
+     *              for PHP4-style constructors is just deprecated, not yet removed.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -37,6 +37,8 @@ class ReservedFunctionNamesSniff extends PHPCS_CamelCapsFunctionNameSniff
 
     /**
      * Overload the constructor to work round various PHPCS cross-version compatibility issues.
+     *
+     * @since 8.2.0
      */
     public function __construct()
     {
@@ -55,6 +57,8 @@ class ReservedFunctionNamesSniff extends PHPCS_CamelCapsFunctionNameSniff
 
     /**
      * Processes the tokens within the scope.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being processed.
      * @param int                   $stackPtr  The position where this token was
@@ -120,6 +124,8 @@ class ReservedFunctionNamesSniff extends PHPCS_CamelCapsFunctionNameSniff
 
     /**
      * Processes the tokens outside the scope.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being processed.
      * @param int                   $stackPtr  The position where this token was

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -34,6 +34,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      * A list of functions that, when called, can behave differently in PHP 7
      * when dealing with parameters of the function they're called in.
      *
+     * @since 9.1.0
+     *
      * @var array
      */
     protected $changedFunctions = array(
@@ -45,6 +47,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
 
     /**
      * Tokens to look out for to allow us to skip past nested scoped structures.
+     *
+     * @since 9.1.0
      *
      * @var array
      */
@@ -66,6 +70,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      * Similarly, as constants won't have parentheses, those don't need to be checked
      * for either.
      *
+     * @since 9.1.0
+     *
      * @var array
      */
     private $noneFunctionCallIndicators = array(
@@ -76,6 +82,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
     /**
      * The tokens for variable incrementing/decrementing.
      *
+     * @since 9.1.0
+     *
      * @var array
      */
     private $plusPlusMinusMinus = array(
@@ -85,6 +93,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
 
     /**
      * Tokens to ignore when determining the start of a statement.
+     *
+     * @since 9.1.0
      *
      * @var array
      */
@@ -98,6 +108,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 9.1.0
+     *
      * @return array
      */
     public function register()
@@ -110,6 +122,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -33,6 +33,8 @@ class ArgumentFunctionsUsageSniff extends Sniff
     /**
      * The target functions for this sniff.
      *
+     * @since 8.2.0
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -45,6 +47,8 @@ class ArgumentFunctionsUsageSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.2.0
+     *
      * @return array
      */
     public function register()
@@ -55,6 +59,8 @@ class ArgumentFunctionsUsageSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -26,6 +26,9 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
      * The index is the location of the parameter in the parameter list, starting at 0 !
      * If's sufficient to list the first version where the function appears.
      *
+     * @since 7.0.0
+     * @since 7.0.2 Visibility changed from `public` to `protected`.
+     *
      * @var array
      */
     protected $newFunctionParameters = array(
@@ -934,6 +937,8 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -946,6 +951,8 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -1002,6 +1009,8 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -1015,6 +1024,8 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
      *
+     * @since 7.1.0
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -1025,6 +1036,8 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -1043,6 +1056,8 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
     /**
      * Get the item name to be used for the creation of the error code.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo  Base information about the item.
      * @param array $errorInfo Detail information about an item.
      *
@@ -1057,6 +1072,8 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
     /**
      * Get the error message template for this sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     protected function getErrorMsgTemplate()
@@ -1067,6 +1084,8 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
 
     /**
      * Allow for concrete child classes to filter the error data before it's passed to PHPCS.
+     *
+     * @since 7.1.0
      *
      * @param array $data      The error data array which was created.
      * @param array $itemInfo  Base information about the item this error message applies to.

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -24,6 +24,13 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not present) or true (present).
      * If's sufficient to list the first version where the function appears.
      *
+     * @since 5.5
+     * @since 5.6   Visibility changed from `protected` to `public`.
+     * @since 7.0.2 Visibility changed back from `public` to `protected`.
+     *              The earlier change was made to be in line with the upstream sniff,
+     *              but that sniff is no longer being extended.
+     * @since 7.0.8 Renamed from `$forbiddenFunctions` to the more descriptive `$newFunctions`.
+     *
      * @var array(string => array(string => bool))
      */
     protected $newFunctions = array(
@@ -1906,6 +1913,8 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.6
+     *
      * @return array
      */
     public function register()
@@ -1918,6 +1927,8 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -1964,6 +1975,8 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -1976,6 +1989,8 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 7.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -27,6 +27,8 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
      * The index is the location of the parameter in the parameter list, starting at 0 !
      * If's sufficient to list the last version in which the parameter was not yet required.
      *
+     * @since 8.1.0
+     *
      * @var array
      */
     protected $functionParameters = array(
@@ -50,6 +52,8 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
     /**
      * Determine whether an error/warning should be thrown for an item based on collected information.
      *
+     * @since 8.1.0
+     *
      * @param array $errorInfo Detail information about an item.
      *
      * @return bool
@@ -64,6 +68,8 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 8.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -105,6 +111,8 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
 
     /**
      * Generates the error or warning for this item.
+     *
+     * @since 8.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the relevant token in

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -30,6 +30,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
      * additional check. The method will be passed the parameter info and should return true
      * if the notice should be thrown or false otherwise.
      *
+     * @since 7.0.0
+     * @since 7.0.2 Visibility changed from `public` to `protected`.
      * @since 9.3.0 Optional `callback` key.
      *
      * @var array
@@ -80,6 +82,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -92,6 +96,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -155,6 +161,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -168,6 +176,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
      *
+     * @since 7.1.0
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -178,6 +188,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -196,6 +208,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the item name to be used for the creation of the error code.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo  Base information about the item.
      * @param array $errorInfo Detail information about an item.
      *
@@ -210,6 +224,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the error message template for this sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     protected function getErrorMsgTemplate()
@@ -220,6 +236,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Filter the error data before it's passed to PHPCS.
+     *
+     * @since 7.1.0
      *
      * @param array $data      The error data array which was created.
      * @param array $itemInfo  Base information about the item this error message applies to.

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -24,6 +24,13 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
      * The array lists : version number with false (deprecated) or true (removed) and an alternative function.
      * If no alternative exists, it is NULL, i.e, the function should just not be used.
      *
+     * @since 5.5
+     * @since 5.6   Visibility changed from `protected` to `public`.
+     * @since 7.0.2 Visibility changed back from `public` to `protected`.
+     *              The earlier change was made to be in line with the upstream sniff,
+     *              but that sniff is no longer being extended.
+     * @since 7.0.8 Property renamed from `$forbiddenFunctions` to `$removedFunctions`.
+     *
      * @var array(string => array(string => bool|string|null))
      */
     protected $removedFunctions = array(
@@ -999,6 +1006,8 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.6
+     *
      * @return array
      */
     public function register()
@@ -1012,6 +1021,8 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -1057,6 +1068,8 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -1069,6 +1082,8 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 7.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -28,6 +28,8 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
      * The index is the location of the parameter in the parameter list, starting at 0 !
      * If's sufficient to list the last version in which the parameter was still required.
      *
+     * @since 7.0.3
+     *
      * @var array
      */
     protected $functionParameters = array(
@@ -149,6 +151,8 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.3
+     *
      * @return array
      */
     public function register()
@@ -161,6 +165,8 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -219,6 +225,8 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
     /**
      * Determine whether an error/warning should be thrown for an item based on collected information.
      *
+     * @since 7.1.0
+     *
      * @param array $errorInfo Detail information about an item.
      *
      * @return bool
@@ -231,6 +239,8 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
 
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
+     *
+     * @since 7.1.0
      *
      * @param array $itemInfo Base information about the item.
      *
@@ -245,6 +255,8 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
      *
+     * @since 7.1.0
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -255,6 +267,8 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -287,6 +301,8 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
     /**
      * Get the error message template for this sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     protected function getErrorMsgTemplate()
@@ -297,6 +313,8 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
 
     /**
      * Generates the error or warning for this item.
+     *
+     * @since 7.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the relevant token in

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -24,6 +24,8 @@ class NewGeneratorReturnSniff extends Sniff
     /**
      * Scope conditions within which a yield can exist.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     private $validConditions = array(
@@ -34,6 +36,8 @@ class NewGeneratorReturnSniff extends Sniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 8.2.0
      *
      * @return array
      */
@@ -71,6 +75,8 @@ class NewGeneratorReturnSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -24,6 +24,9 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not present) or true (present).
      * If's sufficient to list the first version where the ini directive appears.
      *
+     * @since 5.5
+     * @since 7.0.3 Support for 'alternative' has been added.
+     *
      * @var array(string)
      */
     protected $newIniDirectives = array(
@@ -662,6 +665,8 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     *
      * @return array
      */
     public function register()
@@ -671,6 +676,8 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -721,6 +728,8 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -734,6 +743,8 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
      *
+     * @since 7.1.0
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -744,6 +755,8 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -771,6 +784,8 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Get the error message template for this sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     protected function getErrorMsgTemplate()
@@ -781,6 +796,8 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
 
     /**
      * Allow for concrete child classes to filter the error message before it's passed to PHPCS.
+     *
+     * @since 7.1.0
      *
      * @param string $error     The error message which was created.
      * @param array  $itemInfo  Base information about the item this error message applies to.
@@ -800,6 +817,8 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
 
     /**
      * Allow for concrete child classes to filter the error data before it's passed to PHPCS.
+     *
+     * @since 7.1.0
      *
      * @param array $data      The error data array which was created.
      * @param array $itemInfo  Base information about the item this error message applies to.

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -24,6 +24,9 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
      * The array lists : version number with false (deprecated) and true (removed).
      * If's sufficient to list the first version where the ini directive was deprecated/removed.
      *
+     * @since 5.5
+     * @since 7.0.3 Support for 'alternative' has been added.
+     *
      * @var array(string)
      */
     protected $deprecatedIniDirectives = array(
@@ -284,6 +287,8 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     *
      * @return array
      */
     public function register()
@@ -293,6 +298,8 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -343,6 +350,8 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -355,6 +364,8 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -377,6 +388,8 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the error message template for this sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     protected function getErrorMsgTemplate()
@@ -387,6 +400,8 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Get the error message template for suggesting an alternative for a specific sniff.
+     *
+     * @since 7.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -24,6 +24,8 @@ class NewConstantArraysUsingConstSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.1.4
+     *
      * @return array
      */
     public function register()
@@ -33,6 +35,8 @@ class NewConstantArraysUsingConstSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -24,6 +24,8 @@ class NewConstantArraysUsingDefineSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -33,6 +35,8 @@ class NewConstantArraysUsingDefineSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -29,12 +29,16 @@ class NewConstantScalarExpressionsSniff extends Sniff
     /**
      * Error message.
      *
+     * @since 8.2.0
+     *
      * @var string
      */
     const ERROR_PHRASE = 'Constant scalar expressions are not allowed %s in PHP 5.5 or earlier.';
 
     /**
      * Partial error phrases to be used in combination with the error message constant.
+     *
+     * @since 8.2.0
      *
      * @var array
      */
@@ -49,6 +53,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
      * Tokens which were allowed to be used in these declarations prior to PHP 5.6.
      *
      * This list will be enriched in the setProperties() method.
+     *
+     * @since 8.2.0
      *
      * @var array
      */
@@ -82,6 +88,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.2.0
+     *
      * @return array
      */
     public function register()
@@ -102,6 +110,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
     /**
      * Make some adjustments to the $safeOperands property.
      *
+     * @since 8.2.0
+     *
      * @return void
      */
     public function setProperties()
@@ -114,6 +124,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 8.2.0
+     *
      * @return bool
      */
     protected function bowOutEarly()
@@ -124,6 +136,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -289,6 +303,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
     /**
      * Is a value declared and is the value declared valid pre-PHP 5.6 ?
      *
+     * @since 8.2.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
      *                                         stack passed in $tokens.
@@ -312,6 +328,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
 
     /**
      * Is a value declared and is the value declared constant as accepted in PHP 5.5 and lower ?
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param array                 $tokens       The token stack of the current file.
@@ -457,6 +475,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
     /**
      * Throw an error if a scalar expression is found.
      *
+     * @since 8.2.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the token to link the error to.
      * @param string                $type      Type of usage found.
@@ -491,6 +511,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
      *
      * Checks whether a certain part of a declaration needs to be skipped over or
      * if it is the real end of the declaration.
+     *
+     * @since 8.2.0
      *
      * @param array $tokens      Token stack of the current file.
      * @param int   $endPtr      The token to examine as a candidate end pointer.

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -31,12 +31,16 @@ class NewHeredocSniff extends NewConstantScalarExpressionsSniff
     /**
      * Error message.
      *
+     * @since 8.2.0
+     *
      * @var string
      */
     const ERROR_PHRASE = 'Initializing %s using the Heredoc syntax was not supported in PHP 5.2 or earlier';
 
     /**
      * Partial error phrases to be used in combination with the error message constant.
+     *
+     * @since 8.2.0
      *
      * @var array
      */
@@ -51,6 +55,8 @@ class NewHeredocSniff extends NewConstantScalarExpressionsSniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 8.2.0
+     *
      * @return bool
      */
     protected function bowOutEarly()
@@ -61,6 +67,8 @@ class NewHeredocSniff extends NewConstantScalarExpressionsSniff
 
     /**
      * Is a value declared and does the declared value not contain an heredoc ?
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -25,6 +25,8 @@ class InternalInterfacesSniff extends Sniff
      *
      * The array lists : the error message to use.
      *
+     * @since 7.0.3
+     *
      * @var array(string => string)
      */
     protected $internalInterfaces = array(
@@ -36,6 +38,8 @@ class InternalInterfacesSniff extends Sniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.3
      *
      * @return array
      */
@@ -56,6 +60,8 @@ class InternalInterfacesSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -26,6 +26,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not present) or true (present).
      * If's sufficient to list the first version where the interface appears.
      *
+     * @since 7.0.3
+     *
      * @var array(string => array(string => bool))
      */
     protected $newInterfaces = array(
@@ -99,6 +101,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
     /**
      * A list of methods which cannot be used in combination with particular interfaces.
      *
+     * @since 7.0.3
+     *
      * @var array(string => array(string => string))
      */
     protected $unsupportedMethods = array(
@@ -110,6 +114,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.3
      *
      * @return array
      */
@@ -139,6 +145,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -184,6 +192,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      *
      * - Detect classes implementing the new interfaces.
      * - Detect classes implementing the new interfaces with unsupported functions.
+     *
+     * @since 7.1.4 Split off from the `process()` method.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -250,6 +260,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      *
      * - Detect new interfaces when used as a type hint.
      *
+     * @since 7.1.4
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
      *                                         the stack passed in $tokens.
@@ -283,6 +295,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      *
      * - Detect new interfaces when used as a return type declaration.
      *
+     * @since 8.2.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
      *                                         the stack passed in $tokens.
@@ -315,6 +329,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -327,6 +343,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 7.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -25,6 +25,8 @@ class CaseSensitiveKeywordsSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.1.4
+     *
      * @return array
      */
     public function register()
@@ -38,6 +40,8 @@ class CaseSensitiveKeywordsSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -28,6 +28,8 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
     /**
      * List of tokens which can not be used as class, interface, trait names or as part of a namespace.
      *
+     * @since 7.0.8
+     *
      * @var array
      */
     protected $forbiddenTokens = array(
@@ -38,6 +40,8 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
 
     /**
      * T_STRING keywords to recognize as forbidden names.
+     *
+     * @since 7.0.8
      *
      * @var array
      */
@@ -60,6 +64,8 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
      * Using any of these keywords to name a class, interface, trait or namespace
      * is highly discouraged since they may be used in future versions of PHP.
      *
+     * @since 7.0.8
+     *
      * @var array
      */
     protected $softReservedNames = array(
@@ -76,6 +82,8 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
      * word.
      * Set from the `register()` method.
      *
+     * @since 7.0.8
+     *
      * @var array
      */
     private $allForbiddenNames = array();
@@ -83,6 +91,8 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.8
      *
      * @return array
      */
@@ -105,6 +115,8 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.8
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -23,6 +23,8 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
     /**
      * List of tokens to register.
      *
+     * @since 5.5
+     *
      * @var array
      */
     protected $targetedTokens = array(
@@ -52,6 +54,8 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
      * as its own token and for PHPCS versions which change the token to
      * T_STRING when used in a method call.
      *
+     * @since 5.5
+     *
      * @var array
      */
     protected $targetedStringTokens = array(
@@ -76,6 +80,8 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     *
      * @return array
      */
     public function register()
@@ -88,6 +94,8 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -24,6 +24,8 @@ class ForbiddenNamesSniff extends Sniff
      * A list of keywords that can not be used as function, class and namespace name or constant name.
      * Mentions since which version it's not allowed.
      *
+     * @since 5.5
+     *
      * @var array(string => string)
      */
     protected $invalidNames = array(
@@ -104,6 +106,8 @@ class ForbiddenNamesSniff extends Sniff
     /**
      * A list of keywords that can follow use statements.
      *
+     * @since 7.0.1
+     *
      * @var array(string => string)
      */
     protected $validUseNames = array(
@@ -114,12 +118,16 @@ class ForbiddenNamesSniff extends Sniff
     /**
      * Scope modifiers and other keywords allowed in trait use statements.
      *
+     * @since 7.1.4
+     *
      * @var array
      */
     private $allowedModifiers = array();
 
     /**
      * Targeted tokens.
+     *
+     * @since 5.5
      *
      * @var array
      */
@@ -139,6 +147,8 @@ class ForbiddenNamesSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     *
      * @return array
      */
     public function register()
@@ -157,6 +167,8 @@ class ForbiddenNamesSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -180,6 +192,8 @@ class ForbiddenNamesSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -336,6 +350,8 @@ class ForbiddenNamesSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
+     * @since 5.5
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
      *                                         stack passed in $tokens.
@@ -385,6 +401,8 @@ class ForbiddenNamesSniff extends Sniff
     /**
      * Add the error message.
      *
+     * @since 7.1.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
      *                                         stack passed in $tokens.
@@ -404,6 +422,8 @@ class ForbiddenNamesSniff extends Sniff
     /**
      * Check if the current token code is for a token which can be considered
      * the end of a (partial) use statement.
+     *
+     * @since 7.0.8
      *
      * @param int $token The current token information.
      *

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -33,6 +33,9 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
      * The callback function should return `true` if the condition is met and the
      * error should *not* be thrown.
      *
+     * @since 5.5
+     * @since 7.0.3 Support for 'condition' has been added.
+     *
      * @var array(string => array(string => bool|string))
      */
     protected $newKeywords = array(
@@ -144,6 +147,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
      *
      * Will be set up from the register() method.
      *
+     * @since 7.0.5
+     *
      * @var array(string => string)
      */
     protected $translateContentToToken = array();
@@ -151,6 +156,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 5.5
      *
      * @return array
      */
@@ -182,6 +189,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -283,6 +292,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -295,6 +306,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
 
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
+     *
+     * @since 7.1.0
      *
      * @return array
      */
@@ -310,6 +323,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -327,6 +342,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
 
     /**
      * Allow for concrete child classes to filter the error data before it's passed to PHPCS.
+     *
+     * @since 7.1.0
      *
      * @param array $data      The error data array which was created.
      * @param array $itemInfo  Base information about the item this error message applies to.
@@ -346,6 +363,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
      *
      * A double quoted identifier will have the opening quote on position 3
      * in the string: `<<<"ID"`.
+     *
+     * @since 8.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -25,6 +25,8 @@ class NewEmptyNonVariableSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.4
+     *
      * @return array
      */
     public function register()
@@ -34,6 +36,8 @@ class NewEmptyNonVariableSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -25,6 +25,8 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not present) or true (present).
      * If's sufficient to list the first version where the keyword appears.
      *
+     * @since 5.6
+     *
      * @var array(string => array(string => bool|string))
      */
     protected $newConstructs = array(
@@ -44,6 +46,8 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.6
+     *
      * @return array
      */
     public function register()
@@ -58,6 +62,8 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.6
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -80,6 +86,8 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -93,6 +101,8 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
      *
+     * @since 7.1.0
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -103,6 +113,8 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -120,6 +132,8 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
 
     /**
      * Allow for concrete child classes to filter the error data before it's passed to PHPCS.
+     *
+     * @since 7.1.0
      *
      * @param array $data      The error data array which was created.
      * @param array $itemInfo  Base information about the item this error message applies to.

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -28,6 +28,8 @@ class AssignmentOrderSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 9.0.0
+     *
      * @return array
      */
     public function register()
@@ -41,6 +43,8 @@ class AssignmentOrderSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -25,12 +25,16 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
     /**
      * List of tokens to disregard when determining whether the list() is empty.
      *
+     * @since 7.0.3
+     *
      * @var array
      */
     protected $ignoreTokens = array();
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.0
      *
      * @return array
      */
@@ -51,6 +55,8 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -24,6 +24,8 @@ class NewKeyedListSniff extends Sniff
     /**
      * Tokens which represent the start of a list construct.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     protected $sniffTargets =  array(
@@ -33,6 +35,8 @@ class NewKeyedListSniff extends Sniff
 
     /**
      * The token(s) within the list construct which is being targeted.
+     *
+     * @since 9.0.0
      *
      * @var array
      */
@@ -46,6 +50,8 @@ class NewKeyedListSniff extends Sniff
      *
      * Set by the setUpAllTargets() method which is called from within register().
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     protected $allTargets;
@@ -53,6 +59,8 @@ class NewKeyedListSniff extends Sniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 9.0.0
      *
      * @return array
      */
@@ -66,6 +74,8 @@ class NewKeyedListSniff extends Sniff
     /**
      * Prepare the $allTargets array only once.
      *
+     * @since 9.0.0
+     *
      * @return void
      */
     public function setUpAllTargets()
@@ -76,6 +86,8 @@ class NewKeyedListSniff extends Sniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 9.0.0
+     *
      * @return bool
      */
     protected function bowOutEarly()
@@ -85,6 +97,8 @@ class NewKeyedListSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -139,6 +153,8 @@ class NewKeyedListSniff extends Sniff
     /**
      * Examine the contents of a list construct to determine whether an error needs to be thrown.
      *
+     * @since 9.0.0
+     *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $opener    The position of the list open token.
      * @param int                   $closer    The position of the list close token.
@@ -162,6 +178,8 @@ class NewKeyedListSniff extends Sniff
      * Check whether a certain target token exists within a list construct.
      *
      * Skips past nested list constructs, so these can be examined based on their own token.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $start     The position of the list open token or a token

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -23,6 +23,8 @@ class NewListReferenceAssignmentSniff extends NewKeyedListSniff
     /**
      * The token(s) within the list construct which is being targeted.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     protected $targetsInList = array(
@@ -31,6 +33,8 @@ class NewListReferenceAssignmentSniff extends NewKeyedListSniff
 
     /**
      * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 9.0.0
      *
      * @return bool
      */
@@ -41,6 +45,8 @@ class NewListReferenceAssignmentSniff extends NewKeyedListSniff
 
     /**
      * Examine the contents of a list construct to determine whether an error needs to be thrown.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $opener    The position of the list open token.

--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -26,6 +26,8 @@ class NewShortListSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 9.0.0
+     *
      * @return array
      */
     public function register()
@@ -35,6 +37,8 @@ class NewShortListSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -33,6 +33,8 @@ class NewDirectCallsToCloneSniff extends Sniff
     /**
      * Tokens which indicate class internal use.
      *
+     * @since 9.3.2
+     *
      * @var array
      */
     protected $classInternal = array(

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -27,12 +27,16 @@ class RemovedAlternativePHPTagsSniff extends Sniff
     /**
      * Whether ASP tags are enabled or not.
      *
+     * @since 7.0.4
+     *
      * @var bool
      */
     private $aspTags = false;
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.4
      *
      * @return array
      */
@@ -53,6 +57,8 @@ class RemovedAlternativePHPTagsSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token
@@ -131,6 +137,8 @@ class RemovedAlternativePHPTagsSniff extends Sniff
 
     /**
      * Get a snippet from a HTML token.
+     *
+     * @since 7.0.4
      *
      * @param string $content The content of the HTML token.
      * @param string $startAt Partial string to use as a starting point for the snippet.

--- a/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/ValidIntegersSniff.php
@@ -22,12 +22,16 @@ class ValidIntegersSniff extends Sniff
     /**
      * Whether PHPCS is run on a PHP < 5.4.
      *
+     * @since 7.0.3
+     *
      * @var bool
      */
     protected $isLowPHPVersion = false;
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.3
      *
      * @return array
      */
@@ -44,6 +48,8 @@ class ValidIntegersSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -107,6 +113,8 @@ class ValidIntegersSniff extends Sniff
     /**
      * Could the current token potentially be a binary integer ?
      *
+     * @since 7.0.3
+     *
      * @param array $tokens   Token stack.
      * @param int   $stackPtr The current position in the token stack.
      *
@@ -133,6 +141,8 @@ class ValidIntegersSniff extends Sniff
     /**
      * Is the current token an invalid binary integer ?
      *
+     * @since 7.0.3
+     *
      * @param array $tokens   Token stack.
      * @param int   $stackPtr The current position in the token stack.
      *
@@ -154,6 +164,8 @@ class ValidIntegersSniff extends Sniff
 
     /**
      * Retrieve the content of the tokens which together look like a binary integer.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param array                 $tokens    Token stack.
@@ -180,6 +192,8 @@ class ValidIntegersSniff extends Sniff
     /**
      * Is the current token an invalid octal integer ?
      *
+     * @since 7.0.3
+     *
      * @param array $tokens   Token stack.
      * @param int   $stackPtr The current position in the token stack.
      *
@@ -198,6 +212,8 @@ class ValidIntegersSniff extends Sniff
 
     /**
      * Is the current token a hexidecimal numeric string ?
+     *
+     * @since 7.0.3
      *
      * @param array $tokens   Token stack.
      * @param int   $stackPtr The current position in the token stack.

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -29,6 +29,8 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
      * in how it returns the statement end. This is just a simple way to bypass
      * the inconsistency for our purposes.}}
      *
+     * @since 8.2.0
+     *
      * @var array
      */
     private $inclusiveStopPoints = array(
@@ -40,6 +42,9 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.0.0
+     * @since 8.2.0 Now registers all bitshift tokens, not just bitshift right (`T_SR`).
      *
      * @return array
      */
@@ -55,6 +60,8 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -25,6 +25,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not present) or true (present).
      * If's sufficient to list the first version where the operator appears.
      *
+     * @since 5.6
+     *
      * @var array(string => array(string => bool|string))
      */
     protected $newOperators = array(
@@ -61,6 +63,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
      *
      * The array lists an alternative token to listen for.
      *
+     * @since 7.0.3
+     *
      * @var array(string => int)
      */
     protected $newOperatorsPHPCSCompat = array(
@@ -85,6 +89,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
      *
      * {@internal 'before' was chosen rather than 'after' as that allowed for a 1-on-1
      * translation list with the current tokens.}}
+     *
+     * @since 7.0.3
      *
      * @var array(string => array(string => string))
      */
@@ -114,6 +120,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.6
+     *
      * @return array
      */
     public function register()
@@ -132,6 +140,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.6
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -177,6 +187,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -190,6 +202,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
      *
+     * @since 7.1.0
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -200,6 +214,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 7.1.0
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -218,6 +234,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
     /**
      * Filter the error data before it's passed to PHPCS.
      *
+     * @since 7.1.0
+     *
      * @param array $data      The error data array which was created.
      * @param array $itemInfo  Base information about the item this error message applies to.
      * @param array $errorInfo Detail information about an item this error message applies to.
@@ -233,6 +251,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
 
     /**
      * Callback function to determine whether a T_EQUAL token is really a T_COALESCE_EQUAL token.
+     *
+     * @since 7.1.2
      *
      * @param array $tokens   The token stack.
      * @param int   $stackPtr The current position in the token stack.
@@ -260,6 +280,8 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
 
     /**
      * Callback function to determine whether a T_INLINE_THEN token is really a T_COALESCE token.
+     *
+     * @since 7.1.2
      *
      * @param array $tokens   The token stack.
      * @param int   $stackPtr The current position in the token stack.

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -25,6 +25,8 @@ class NewShortTernarySniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -34,6 +36,8 @@ class NewShortTernarySniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -25,6 +25,8 @@ class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
     /**
      * Functions to check for.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -34,6 +36,8 @@ class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 9.0.0
      *
      * @return bool
      */
@@ -45,6 +49,8 @@ class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Process the parameters of a matched function.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -22,6 +22,8 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
     /**
      * Functions to check for.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -31,6 +33,8 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
     /**
      * Tokens which, for the purposes of this sniff, indicate that there is
      * a variable element to the value passed.
+     *
+     * @since 9.0.0
      *
      * @var array
      */
@@ -47,6 +51,8 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 9.0.0
+     *
      * @return bool
      */
     protected function bowOutEarly()
@@ -57,6 +63,8 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Process the parameters of a matched function.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -22,6 +22,8 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
     /**
      * Functions to check for.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -31,6 +33,8 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 9.0.0
      *
      * @return bool
      */
@@ -44,6 +48,8 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Process the parameters of a matched function.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -24,6 +24,8 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not present) or true (present).
      * If's sufficient to list the first version where the hash algorithm appears.
      *
+     * @since 7.0.7
+     *
      * @var array(string => array(string => bool))
      */
     protected $newAlgorithms = array(
@@ -106,6 +108,8 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.7
+     *
      * @return array
      */
     public function register()
@@ -116,6 +120,8 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.7
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -146,6 +152,8 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -158,6 +166,8 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 7.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -25,6 +25,8 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
     /**
      * Functions to check for.
      *
+     * @since 9.0.0
+     *
      * @var array Function name => 1-based parameter offset of the affected parameters => parameter name.
      */
     protected $targetFunctions = array(
@@ -72,6 +74,8 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 9.0.0
+     *
      * @return bool
      */
     protected function bowOutEarly()
@@ -81,6 +85,8 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Process the parameters of a matched function.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -22,6 +22,8 @@ class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
     /**
      * Functions to check for.
      *
+     * @since 8.2.0
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -41,6 +43,8 @@ class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
      * The key should be the modifier (case-sensitive!).
      * The value should be the PHP version in which the modifier was introduced.
      *
+     * @since 8.2.0
+     *
      * @var array
      */
     protected $newModifiers = array(
@@ -54,6 +58,8 @@ class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 8.2.0
+     *
      * @return bool
      */
     protected function bowOutEarly()
@@ -66,6 +72,8 @@ class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
 
     /**
      * Examine the regex modifier string.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -22,6 +22,8 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
     /**
      * Functions to check for.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -30,6 +32,8 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * List of new format character codes added to pack().
+     *
+     * @since 9.0.0
      *
      * @var array Regex pattern => Version array.
      */
@@ -52,6 +56,8 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 9.0.0
+     *
      * @return bool
      */
     protected function bowOutEarly()
@@ -62,6 +68,8 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Process the parameters of a matched function.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -27,6 +27,8 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
      * The array lists : version number with false (deprecated) and true (removed).
      * If's sufficient to list the first version where the hash algorithm was deprecated/removed.
      *
+     * @since 7.0.7
+     *
      * @var array(string => array(string => bool))
      */
     protected $removedAlgorithms = array(
@@ -41,6 +43,8 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     *
      * @return array
      */
     public function register()
@@ -51,6 +55,8 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -80,6 +86,8 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -92,6 +100,8 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Get the error message template for this sniff.
+     *
+     * @since 7.1.0
      *
      * @return string
      */

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -28,6 +28,8 @@ class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
     /**
      * Functions to check for.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -37,6 +39,8 @@ class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 9.0.0
      *
      * @return bool
      */
@@ -48,6 +52,8 @@ class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Process the parameters of a matched function.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -27,6 +27,9 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
      *
      * Key is the function name, value the parameter position of the options parameter.
      *
+     * @since 7.0.5
+     * @since 8.2.0 Renamed from `$functions` to `$targetFunctions`.
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -41,6 +44,8 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 8.2.0
+     *
      * @return bool
      */
     protected function bowOutEarly()
@@ -53,6 +58,10 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Process the parameters of a matched function.
+     *
+     * @since 7.0.5
+     * @since 8.2.0 Renamed from `process()` to `processParameters()` and removed
+     *              logic superfluous now the sniff extends the abstract.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -25,6 +25,8 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
     /**
      * Functions to check for.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -36,6 +38,8 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * List of the non-cryptographic hashes.
+     *
+     * @since 9.0.0
      *
      * @var array
      */
@@ -54,6 +58,8 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 9.0.0
+     *
      * @return bool
      */
     protected function bowOutEarly()
@@ -64,6 +70,8 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Process the parameters of a matched function.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -26,6 +26,9 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
     /**
      * Functions to check for.
      *
+     * @since 7.0.1
+     * @since 8.2.0 Renamed from `$functions` to `$targetFunctions`.
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -35,6 +38,8 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Regex bracket delimiters.
+     *
+     * @since 7.0.5 This array was originally contained within the `process()` method.
      *
      * @var array
      */
@@ -48,6 +53,10 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Process the parameters of a matched function.
+     *
+     * @since 5.6
+     * @since 8.2.0 Renamed from `process()` to `processParameters()` and removed
+     *              logic superfluous now the sniff extends the abstract.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.
@@ -107,6 +116,8 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
+     * @since 8.2.0
+     *
      * @return bool
      */
     protected function bowOutEarly()
@@ -117,6 +128,8 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Analyse a potential regex pattern for use of the /e modifier.
+     *
+     * @since 7.1.2 This logic was originally contained within the `process()` method.
      *
      * @param array                 $pattern      Array containing the start and end token
      *                                            pointer of the potential regex pattern and
@@ -181,6 +194,8 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Examine the regex modifier string.
+     *
+     * @since 8.2.0 Split off from the `processRegexPattern()` method.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -26,6 +26,8 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
     /**
      * Functions to check for.
      *
+     * @since 9.0.0
+     *
      * @var array
      */
     protected $targetFunctions = array(
@@ -35,6 +37,8 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 9.0.0
      *
      * @return bool
      */
@@ -46,6 +50,8 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
 
     /**
      * Process the parameters of a matched function.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                   $stackPtr     The position of the current token in the stack.

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -28,6 +28,8 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
      * Near duplicate of Tokens::$assignmentTokens + Tokens::$equalityTokens.
      * Copied in for PHPCS cross-version compatibility.
      *
+     * @since 8.1.0
+     *
      * @var array
      */
     private $assignOrCompare = array(
@@ -61,6 +63,8 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     *
      * @return array
      */
     public function register()
@@ -73,6 +77,8 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token
@@ -149,6 +155,8 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
     /**
      * Determine whether a parameter is passed by reference.
+     *
+     * @since 7.0.6 Split off from the `process()` method.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param array                 $parameter    Information on the current parameter

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -38,6 +38,8 @@ class NewArrayStringDereferencingSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.1.4
+     *
      * @return array
      */
     public function register()
@@ -51,6 +53,8 @@ class NewArrayStringDereferencingSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -29,6 +29,8 @@ class NewArrayUnpackingSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 9.2.0
+     *
      * @return array
      */
     public function register()
@@ -41,6 +43,8 @@ class NewArrayUnpackingSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -38,6 +38,8 @@ class NewClassMemberAccessSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.2.0
+     *
      * @return array
      */
     public function register()
@@ -50,6 +52,8 @@ class NewClassMemberAccessSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -26,6 +26,8 @@ class NewDynamicAccessToStaticSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.1.0
+     *
      * @return array
      */
     public function register()
@@ -37,6 +39,8 @@ class NewDynamicAccessToStaticSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -31,6 +31,8 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 9.0.0
+     *
      * @return array
      */
     public function register()
@@ -51,6 +53,8 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -78,6 +82,8 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
 
     /**
      * Detect indented and/or non-stand alone closing markers.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -165,6 +171,8 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
 
     /**
      * Detect heredoc/nowdoc identifiers at the start of lines in the heredoc/nowdoc body.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -36,6 +36,8 @@ class NewFunctionArrayDereferencingSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -45,6 +47,8 @@ class NewFunctionArrayDereferencingSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -24,6 +24,8 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.2.0
+     *
      * @return array
      */
     public function register()
@@ -39,6 +41,8 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -24,6 +24,8 @@ class NewShortArraySniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -37,6 +39,8 @@ class NewShortArraySniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -25,6 +25,8 @@ class RemovedNewReferenceSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     *
      * @return array
      */
     public function register()
@@ -34,6 +36,8 @@ class RemovedNewReferenceSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -26,6 +26,8 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
      * The array lists : version number with false (not present) or true (present).
      * If's sufficient to list the first version where the keyword appears.
      *
+     * @since 8.0.1
+     *
      * @var array(string => array(string => bool|string))
      */
     protected $newTypeCasts = array(
@@ -44,6 +46,8 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 8.0.1
      *
      * @return array
      */
@@ -76,6 +80,8 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.0.1
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -129,6 +135,8 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 8.0.1
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -142,6 +150,8 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
      *
+     * @since 8.0.1
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -152,6 +162,8 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
 
     /**
      * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @since 8.0.1
      *
      * @param array $itemArray Version and other information about the item.
      * @param array $itemInfo  Base information about the item.
@@ -170,6 +182,8 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
     /**
      * Filter the error message before it's passed to PHPCS.
      *
+     * @since 8.0.1
+     *
      * @param string $error     The error message which was created.
      * @param array  $itemInfo  Base information about the item this error message applies to.
      * @param array  $errorInfo Detail information about an item this error message applies to.
@@ -184,6 +198,8 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
 
     /**
      * Filter the error data before it's passed to PHPCS.
+     *
+     * @since 8.0.1
      *
      * @param array $data      The error data array which was created.
      * @param array $itemInfo  Base information about the item this error message applies to.

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -24,6 +24,8 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
      * The array lists : version number with false (deprecated) or true (removed) and an alternative function.
      * If no alternative exists, it is NULL, i.e, the function should just not be used.
      *
+     * @since 8.0.1
+     *
      * @var array(string => array(string => bool|string))
      */
     protected $deprecatedTypeCasts = array(
@@ -43,6 +45,8 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 8.0.1
+     *
      * @return array
      */
     public function register()
@@ -58,6 +62,8 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 8.0.1
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -87,6 +93,8 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
     /**
      * Get an array of the non-PHP-version array keys used in a sub-array.
      *
+     * @since 8.0.1
+     *
      * @return array
      */
     protected function getNonVersionArrayKeys()
@@ -96,6 +104,8 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
+     *
+     * @since 8.0.1
      *
      * @param array $itemInfo Base information about the item.
      *
@@ -110,6 +120,8 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the error message template for this sniff.
      *
+     * @since 8.0.1
+     *
      * @return string
      */
     protected function getErrorMsgTemplate()
@@ -120,6 +132,8 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Filter the error data before it's passed to PHPCS.
+     *
+     * @since 8.0.1
      *
      * @param array $data      The error data array which was created.
      * @param array $itemInfo  Base information about the item this error message applies to.

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -24,6 +24,8 @@ class NewGroupUseDeclarationsSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -38,6 +40,8 @@ class NewGroupUseDeclarationsSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -27,6 +27,8 @@ class NewUseConstFunctionSniff extends Sniff
     /**
      * A list of keywords that can follow use statements.
      *
+     * @since 7.1.4
+     *
      * @var array(string => string)
      */
     protected $validUseNames = array(
@@ -36,6 +38,8 @@ class NewUseConstFunctionSniff extends Sniff
 
     /**
      * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 7.1.4
      *
      * @return array
      */
@@ -47,6 +51,8 @@ class NewUseConstFunctionSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.1.4
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -25,6 +25,8 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.0.0
+     *
      * @return array
      */
     public function register()
@@ -34,6 +36,8 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -24,6 +24,8 @@ class NewUniformVariableSyntaxSniff extends Sniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 7.1.2
+     *
      * @return array
      */
     public function register()
@@ -33,6 +35,8 @@ class NewUniformVariableSyntaxSniff extends Sniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 7.1.2
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -27,6 +27,9 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
      * The array lists : version number with false (deprecated) and true (removed).
      * If's sufficient to list the first version where the variable was deprecated/removed.
      *
+     * @since 5.5
+     * @since 7.0
+     *
      * @var array(string => array(string => bool|string))
      */
     protected $removedGlobalVariables = array(
@@ -82,6 +85,9 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
     /**
      * Returns an array of tokens this test wants to listen for.
      *
+     * @since 5.5
+     * @since 7.0
+     *
      * @return array
      */
     public function register()
@@ -92,6 +98,9 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 5.5
+     * @since 7.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -143,6 +152,8 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
+     * @since 7.1.0
+     *
      * @param array $itemInfo Base information about the item.
      *
      * @return array Version and other information about the item.
@@ -156,6 +167,8 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
     /**
      * Get the error message template for this sniff.
      *
+     * @since 7.1.0
+     *
      * @return string
      */
     protected function getErrorMsgTemplate()
@@ -166,6 +179,8 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Filter the error message before it's passed to PHPCS.
+     *
+     * @since 8.1.0
      *
      * @param string $error     The error message which was created.
      * @param array  $itemInfo  Base information about the item this error message applies to.
@@ -183,6 +198,8 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
     /**
      * Run some additional checks for the `$php_errormsg` variable.
+     *
+     * @since 8.1.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -37,6 +37,8 @@ class BaseSniffTest extends PHPUnit_TestCase
      *
      * Used by PHPCS 2.x.
      *
+     * @since 5.5
+     *
      * @var \PHP_CodeSniffer
      */
     protected static $phpcs = null;
@@ -44,12 +46,16 @@ class BaseSniffTest extends PHPUnit_TestCase
     /**
      * An array of PHPCS results by filename and PHP version.
      *
+     * @since 7.0.4
+     *
      * @var array
      */
     public static $sniffFiles = array();
 
     /**
      * Sets up this unit test.
+     *
+     * @since 7.0.4
      *
      * @return void
      */
@@ -61,6 +67,8 @@ class BaseSniffTest extends PHPUnit_TestCase
 
     /**
      * Sets up this unit test.
+     *
+     * @since 5.5
      *
      * @return void
      */
@@ -88,6 +96,8 @@ class BaseSniffTest extends PHPUnit_TestCase
     /**
      * Tear down after each test.
      *
+     * @since 5.5
+     *
      * @return void
      */
     public function tearDown()
@@ -99,6 +109,8 @@ class BaseSniffTest extends PHPUnit_TestCase
     /**
      * Tear down after each test.
      *
+     * @since 7.0.4
+     *
      * @return void
      */
     public static function tearDownAfterClass()
@@ -108,6 +120,8 @@ class BaseSniffTest extends PHPUnit_TestCase
 
     /**
      * Get the sniff code for the current sniff being tested.
+     *
+     * @since 7.1.3
      *
      * @return string
      */
@@ -123,6 +137,11 @@ class BaseSniffTest extends PHPUnit_TestCase
 
     /**
      * Sniff a file and return resulting file object.
+     *
+     * @since 5.5
+     * @since 9.0.0 Signature change. The `$filename` parameter was renamed to
+     *              `$pathToFile` and now expects an absolute path instead of
+     *              a relative one.
      *
      * @param string $pathToFile       Absolute path to the file to sniff.
      *                                 Allows for passing __FILE__ from the unit test
@@ -176,6 +195,8 @@ class BaseSniffTest extends PHPUnit_TestCase
     /**
      * Assert a PHPCS error on a particular line number.
      *
+     * @since 5.5
+     *
      * @param \PHP_CodeSniffer_File $file            Codesniffer file object.
      * @param int                   $lineNumber      Line number.
      * @param string                $expectedMessage Expected error message (assertContains).
@@ -192,6 +213,8 @@ class BaseSniffTest extends PHPUnit_TestCase
     /**
      * Assert a PHPCS warning on a particular line number.
      *
+     * @since 5.5
+     *
      * @param \PHP_CodeSniffer_File $file            Codesniffer file object.
      * @param int                   $lineNumber      Line number.
      * @param string                $expectedMessage Expected message (assertContains).
@@ -207,6 +230,8 @@ class BaseSniffTest extends PHPUnit_TestCase
 
     /**
      * Assert a PHPCS error or warning on a particular line number.
+     *
+     * @since 7.0.3
      *
      * @param array  $issues          Array of issues of a particular type.
      * @param string $type            The type of issues, either 'error' or 'warning'.
@@ -241,6 +266,8 @@ class BaseSniffTest extends PHPUnit_TestCase
 
     /**
      * Assert no violation (warning or error) on a given line number.
+     *
+     * @since 5.5
      *
      * @param \PHP_CodeSniffer_File $file       Codesniffer File object.
      * @param mixed                 $lineNumber Line number.
@@ -287,6 +314,8 @@ class BaseSniffTest extends PHPUnit_TestCase
      *
      * This is useful for debugging sniffs on a file.
      *
+     * @since 5.5
+     *
      * @param \PHP_CodeSniffer_File $file Codesniffer file object.
      *
      * @return array
@@ -304,6 +333,8 @@ class BaseSniffTest extends PHPUnit_TestCase
     /**
      * Gather all error messages by line number from phpcs file result.
      *
+     * @since 5.5
+     *
      * @param \PHP_CodeSniffer_File $file Codesniffer File object.
      *
      * @return array
@@ -318,6 +349,8 @@ class BaseSniffTest extends PHPUnit_TestCase
     /**
      * Gather all warning messages by line number from phpcs file result.
      *
+     * @since 5.5
+     *
      * @param \PHP_CodeSniffer_File $file Codesniffer File object.
      *
      * @return array
@@ -331,6 +364,8 @@ class BaseSniffTest extends PHPUnit_TestCase
 
     /**
      * Gather all messages or a particular type by line number.
+     *
+     * @since 7.0.3
      *
      * @param array $issuesArray Array of a particular type of issues,
      *                           i.e. errors or warnings.

--- a/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
+++ b/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
@@ -24,12 +24,16 @@ abstract class CoreMethodTestFrame extends PHPUnit_TestCase
     /**
      * The \PHP_CodeSniffer_File object containing parsed contents of this file.
      *
+     * @since 7.0.3
+     *
      * @var \PHP_CodeSniffer_File
      */
     protected $phpcsFile;
 
     /**
      * A wrapper for the abstract PHPCompatibility sniff.
+     *
+     * @since 7.0.3
      *
      * @var \PHPCompatibility\Sniff
      */
@@ -38,6 +42,8 @@ abstract class CoreMethodTestFrame extends PHPUnit_TestCase
 
     /**
      * Sets up this unit test.
+     *
+     * @since 7.0.3
      *
      * @return void
      */
@@ -81,6 +87,8 @@ abstract class CoreMethodTestFrame extends PHPUnit_TestCase
     /**
      * Clean up after finished test.
      *
+     * @since 7.0.3
+     *
      * @return void
      */
     public function tearDown()
@@ -91,6 +99,9 @@ abstract class CoreMethodTestFrame extends PHPUnit_TestCase
 
     /**
      * Get the token pointer for a target token based on a specific comment found on the line before.
+     *
+     * @since 7.1.3
+     * @since 8.1.0 New `$tokenContent` parameter.
      *
      * @param string    $commentString The comment to look for.
      * @param int|array $tokenType     The type of token(s) to look for.

--- a/PHPCompatibility/Util/Tests/TestHelperPHPCompatibility.php
+++ b/PHPCompatibility/Util/Tests/TestHelperPHPCompatibility.php
@@ -21,6 +21,8 @@ class TestHelperPHPCompatibility extends Sniff
     /**
      * Dummy method to bypass the abstract method implementation requirements.
      *
+     * @since 7.0.3
+     *
      * @return void
      */
     public function register()
@@ -29,6 +31,8 @@ class TestHelperPHPCompatibility extends Sniff
 
     /**
      * Dummy method to bypass the abstract method implementation requirements.
+     *
+     * @since 7.0.3
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in
@@ -42,6 +46,8 @@ class TestHelperPHPCompatibility extends Sniff
 
     /**
      * Wrapper to make the protected parent::isNumber() method testable.
+     *
+     * @since 8.2.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
      * @param int                   $start       Start of the snippet (inclusive), i.e. this
@@ -59,6 +65,8 @@ class TestHelperPHPCompatibility extends Sniff
 
     /**
      * Wrapper to make the protected parent::isNumericCalculation() method testable.
+     *
+     * @since 9.0.0
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $start     Start of the snippet (inclusive), i.e. this


### PR DESCRIPTION
Includes annotating significant changes to methods/properties.

Based on trace-back through the file history.

Note: this is only done for the sniff related files and for method in abstract classes, not for the sniff test files which are not user-facing.

Related to #734