### PR TITLE
NewClasses: minor bug fix - move two classes

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -380,6 +380,14 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '7.1' => true,
         ),
 
+        'ReflectionReference' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
+        'WeakReference' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
     );
 
     /**
@@ -559,15 +567,6 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         'JsonException' => array(
             '7.2' => false,
             '7.3' => true,
-        ),
-
-        'ReflectionReference' => array(
-            '7.3' => false,
-            '7.4' => true,
-        ),
-        'WeakReference' => array(
-            '7.3' => false,
-            '7.4' => true,
         ),
     );
 

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -150,6 +150,8 @@ class NewClassesUnitTest extends BaseSniffTest
             array('ReflectionType', '5.6', array(308), '7.0'),
             array('ReflectionGenerator', '5.6', array(309), '7.0'),
             array('ReflectionClassConstant', '7.0', array(306), '7.1'),
+            array('ReflectionReference', '7.3', array(344), '7.4'),
+            array('WeakReference', '7.3', array(345), '7.4'),
 
             array('DATETIME', '5.1', array(146), '5.2'),
             array('datetime', '5.1', array(147, 320), '5.2'),
@@ -193,8 +195,6 @@ class NewClassesUnitTest extends BaseSniffTest
             array('SodiumException', '7.1', array(342), '7.2'),
             array('CompileError', '7.2', array(249), '7.3'),
             array('JsonException', '7.2', array(250, 339), '7.3'),
-            array('ReflectionReference', '7.3', array(344), '7.4'),
-            array('WeakReference', '7.3', array(345), '7.4'),
         );
     }
 


### PR DESCRIPTION
The two new PHP 7.4 classes had inadvertently been added to the `$newExceptions` array, while they should have been added to the `$newClasses` aray.