### PR TITLE
Add missing information for error / warning handling

### DIFF
--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -530,7 +530,7 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
 
         $itemInfo = array(
             'name' => $constantName,
-            'removed' => "removed"
+            'removed' => "removed",
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -530,6 +530,7 @@ class RemovedConstantsSniff extends AbstractRemovedFeatureSniff
 
         $itemInfo = array(
             'name' => $constantName,
+            'removed' => "removed"
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -249,7 +249,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
             if (strpos($functionLc, $extension) === 0) {
                 $itemInfo = array(
                     'name'   => $extension,
-                    'removed' => 'removed'
+                    'removed' => 'removed',
                 );
                 $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
                 break;

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -249,6 +249,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
             if (strpos($functionLc, $extension) === 0) {
                 $itemInfo = array(
                     'name'   => $extension,
+                    'removed' => 'removed'
                 );
                 $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
                 break;

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -145,7 +145,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
                     'name'   => $function,
                     'nameLc' => $functionLc,
                     'offset' => $offset,
-                    'removed'=> 'removed'
+                    'removed'=> 'removed',
                 );
                 $this->handleFeature($phpcsFile, $openParenthesis, $itemInfo);
             }

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -145,7 +145,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
                     'name'   => $function,
                     'nameLc' => $functionLc,
                     'offset' => $offset,
-                    'removed'=> 'removed',
+                    'removed' => 'removed',
                 );
                 $this->handleFeature($phpcsFile, $openParenthesis, $itemInfo);
             }

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -145,6 +145,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
                     'name'   => $function,
                     'nameLc' => $functionLc,
                     'offset' => $offset,
+                    'removed'=> 'removed'
                 );
                 $this->handleFeature($phpcsFile, $openParenthesis, $itemInfo);
             }

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -1049,7 +1049,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         $itemInfo = array(
             'name'   => $function,
             'nameLc' => $functionLc,
-            'removed'=> 'removed',
+            'removed' => 'removed',
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -1049,6 +1049,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         $itemInfo = array(
             'name'   => $function,
             'nameLc' => $functionLc,
+            'removed'=> 'removed'
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -1049,7 +1049,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         $itemInfo = array(
             'name'   => $function,
             'nameLc' => $functionLc,
-            'removed'=> 'removed'
+            'removed'=> 'removed',
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -72,7 +72,7 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
 
         $itemInfo = array(
             'name' => $algo,
-            'removed' => 'removed'
+            'removed' => 'removed',
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -72,6 +72,7 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
 
         $itemInfo = array(
             'name' => $algo,
+            'removed' => 'removed'
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -79,6 +79,7 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
         $itemInfo = array(
             'name'        => $tokenType,
             'description' => $this->deprecatedTypeCasts[$tokenType]['description'],
+            'deprecated'  => 'deprecated'
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -79,7 +79,7 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
         $itemInfo = array(
             'name'        => $tokenType,
             'description' => $this->deprecatedTypeCasts[$tokenType]['description'],
-            'deprecated'  => 'deprecated'
+            'deprecated'  => 'deprecated',
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -135,6 +135,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
         // Still here, so throw an error/warning.
         $itemInfo = array(
             'name' => $varName,
+            'removed' => 'removed'
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -135,7 +135,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
         // Still here, so throw an error/warning.
         $itemInfo = array(
             'name' => $varName,
-            'removed' => 'removed'
+            'removed' => 'removed',
         );
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }


### PR DESCRIPTION
AbstractRemovedFeatureSniff  -> shouldThrowError is looking for information which are not set for Sniffs for Removed Feature so every Message is an warning. 