### PR TITLE
PHP 7.4: Add detection of features from the new FFI extension detection

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -396,6 +396,18 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '7.1' => true,
         ),
 
+        'FFI' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
+        'FFI\CData' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
+        'FFI\CType' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
         'ReflectionReference' => array(
             '7.3' => false,
             '7.4' => true,
@@ -585,6 +597,15 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         'JsonException' => array(
             '7.2' => false,
             '7.3' => true,
+        ),
+
+        'FFI\Exception' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
+        'FFI\ParserException' => array(
+            '7.3' => false,
+            '7.4' => true,
         ),
     );
 

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -658,6 +658,14 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '7.3' => true,
         ),
 
+        'ffi.enable' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
+        'ffi.preload' => array(
+            '7.3' => false,
+            '7.4' => true,
+        ),
         'opcache.cache_id' => array(
             '7.3' => false,
             '7.4' => true,

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -343,3 +343,7 @@ function SodiumExceptionTypeHint( SodiumException $a ) {}
 $test = new com_exception();
 $test = new ReflectionReference;
 function DateTimeReturnTypeHint( $a ) : WeakReference {}
+FFI::load(__DIR__ . "/dummy.h");
+function FFITypeHints( FFI\CData $a, FFI\CType $b );
+try {
+} catch ( FFI\Exception | FFI\ParserException $e ) {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -152,6 +152,9 @@ class NewClassesUnitTest extends BaseSniffTest
             array('ReflectionType', '5.6', array(308), '7.0'),
             array('ReflectionGenerator', '5.6', array(309), '7.0'),
             array('ReflectionClassConstant', '7.0', array(306), '7.1'),
+            array('FFI', '7.3', array(346), '7.4'),
+            array('FFI\CData', '7.3', array(347), '7.4'),
+            array('FFI\CType', '7.3', array(347), '7.4'),
             array('ReflectionReference', '7.3', array(344), '7.4'),
             array('WeakReference', '7.3', array(345), '7.4'),
 
@@ -197,6 +200,8 @@ class NewClassesUnitTest extends BaseSniffTest
             array('SodiumException', '7.1', array(342), '7.2'),
             array('CompileError', '7.2', array(249), '7.3'),
             array('JsonException', '7.2', array(250, 339), '7.3'),
+            array('FFI\Exception', '7.3', array(349), '7.4'),
+            array('FFI\ParserException', '7.3', array(349), '7.4'),
         );
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -454,3 +454,9 @@ $test = ini_get('opcache.validate_root');
 
 ini_set('opcache.preload', 1);
 $test = ini_get('opcache.preload');
+
+ini_set('ffi.enable', 1);
+$test = ini_get('ffi.enable');
+
+ini_set('ffi.preload', 1);
+$test = ini_get('ffi.preload');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -231,6 +231,8 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('syslog.filter', '7.3', array(317, 318), '7.2'),
             array('session.cookie_samesite', '7.3', array(332, 333), '7.2'),
 
+            array('ffi.enable', '7.4', array(458, 459), '7.3'),
+            array('ffi.preload', '7.4', array(461, 462), '7.3'),
             array('opcache.cache_id', '7.4', array(341, 342), '7.3'),
             array('opcache.preload', '7.4', array(455, 456), '7.3'),
             array('zend.exception_ignore_args', '7.4', array(338, 339), '7.3'),


### PR DESCRIPTION
> FFI ¶
> 
> FFI is a new extension, which provides a simple way to call native functions, access native variables, and create/access data structures defined in C libraries.

* https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.ffi
* https://wiki.php.net/rfc/ffi

## Commits:

### NewIniDirectives: add FFI ini directives

Ref: https://www.php.net/manual/en/ffi.configuration.php

### NewClasses: add FFI classes

Ref: https://www.php.net/manual/en/book.ffi.php


