### PR TITLE
Documentation: improve use of `@internal` tags

### DIFF
--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -21,11 +21,11 @@
  * {@internal The PHPCS file have been reorganized in PHPCS 3.x, quite
  * a few "old" classes have been split and spread out over several "new"
  * classes. In other words, this will only work for a limited number
- * of classes.}}
+ * of classes.}
  *
  * {@internal The `class_exists` wrappers are needed to play nice with other
  * external PHPCS standards creating cross-version compatibility in the same
- * manner.}}
+ * manner.}
  */
 if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
     if (interface_exists('\PHP_CodeSniffer_Sniff') === false) {
@@ -54,7 +54,7 @@ if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
      *
      * {@internal When `installed_paths` is set via the ruleset, this autoloader
      * is needed to run the sniffs.
-     * Upstream issue: {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/1591} }}
+     * Upstream issue: {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/1591} }
      *
      * @since 8.0.0
      */

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -145,7 +145,7 @@ class PHPCSHelper
      * that, this method can be removed and calls to it replaced with
      * `$phpcsFile->findStartOfStatement($start, $ignore)` calls.
      *
-     * Last synced with PHPCS version: PHPCS 3.3.2 at commit 6ad28354c04b364c3c71a34e4a18b629cc3b231e}}
+     * Last synced with PHPCS version: PHPCS 3.3.2 at commit 6ad28354c04b364c3c71a34e4a18b629cc3b231e}
      *
      * @since 9.1.0
      *
@@ -226,7 +226,7 @@ class PHPCSHelper
      * that, this method can be removed and calls to it replaced with
      * `$phpcsFile->findEndOfStatement($start, $ignore)` calls.
      *
-     * Last synced with PHPCS version: PHPCS 3.3.0-alpha at commit f5d899dcb5c534a1c3cca34668624517856ba823}}
+     * Last synced with PHPCS version: PHPCS 3.3.0-alpha at commit f5d899dcb5c534a1c3cca34668624517856ba823}
      *
      * @since 8.2.0
      *
@@ -327,7 +327,7 @@ class PHPCSHelper
      * that, this method can be removed and calls to it replaced with
      * `$phpcsFile->findExtendedClassName($stackPtr)` calls.
      *
-     * Last synced with PHPCS version: PHPCS 3.1.0-alpha at commit a9efcc9b0703f3f9f4a900623d4e97128a6aafc6}}
+     * Last synced with PHPCS version: PHPCS 3.1.0-alpha at commit a9efcc9b0703f3f9f4a900623d4e97128a6aafc6}
      *
      * @since 7.1.4
      * @since 8.2.0 Moved from the `Sniff` class to this class.
@@ -395,7 +395,7 @@ class PHPCSHelper
      * in PHPCS 2.8.0, so only defer to upstream for higher versions.
      * Once the minimum supported PHPCS version for this sniff library goes beyond
      * that, this method can be removed and calls to it replaced with
-     * `$phpcsFile->findImplementedInterfaceNames($stackPtr)` calls.}}
+     * `$phpcsFile->findImplementedInterfaceNames($stackPtr)` calls.}
      *
      * @since 7.0.3
      * @since 8.2.0 Moved from the `Sniff` class to this class.
@@ -480,7 +480,7 @@ class PHPCSHelper
      * {@internal Duplicate of same method as contained in the `\PHP_CodeSniffer_File`
      * class.
      *
-     * Last synced with PHPCS version: PHPCS 3.3.0-alpha at commit 53a28408d345044c0360c2c1b4a2aaebf4a3b8c9}}
+     * Last synced with PHPCS version: PHPCS 3.3.0-alpha at commit 53a28408d345044c0360c2c1b4a2aaebf4a3b8c9}
      *
      * @since 7.0.3
      * @since 8.2.0 Moved from the `Sniff` class to this class.

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -415,9 +415,9 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      * {@internal Classes listed here do not need to be added to the $newClasses
      *            property as well.
      *            This list is automatically added to the $newClasses property
-     *            in the `register()` method.}}
+     *            in the `register()` method.}
      *
-     * {@internal Helper to update this list: https://3v4l.org/MhlUp}}
+     * {@internal Helper to update this list: https://3v4l.org/MhlUp}
      *
      * @since 7.1.4
      *

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -28,7 +28,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * (since PHPCompatibility 7.0.2).
  *
  * {@internal This sniff is a candidate for removal once all functions from all
- * deprecated/removed extensions have been added to the RemovedFunctions sniff.}}
+ * deprecated/removed extensions have been added to the RemovedFunctions sniff.}
  *
  * PHP version All
  *

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer_File as File;
 /**
  * Detect the use of superglobals as parameters for functions, support for which was removed in PHP 5.4.
  *
- * {@internal List of superglobals is maintained in the parent class.}}
+ * {@internal List of superglobals is maintained in the parent class.}
  *
  * PHP version 5.4
  *

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -150,7 +150,7 @@ class NewExceptionsFromToStringSniff extends Sniff
          * Check whether the function has a docblock and if so, whether it contains a @throws tag.
          *
          * {@internal This can be partially replaced by the findCommentAboveFunction()
-         *            utility function in due time.}}
+         *            utility function in due time.}
          */
         $commentEnd = $phpcsFile->findPrevious($this->docblockIgnoreTokens, ($stackPtr - 1), null, true);
         if ($commentEnd === false || $tokens[$commentEnd]['code'] !== \T_DOC_COMMENT_CLOSE_TAG) {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -33,7 +33,7 @@ class NewNullableTypesSniff extends Sniff
      *
      * {@internal Not sniffing for T_NULLABLE which was introduced in PHPCS 2.7.2
      * as in that case we can't distinguish between parameter type hints and
-     * return type hints for the error message.}}
+     * return type hints for the error message.}
      *
      * @since 7.0.7
      *

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -29,7 +29,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  *            the logic in this sniff is largely the same as used upstream.
  *            Extending the upstream sniff instead of including it via the ruleset, however,
  *            prevents hard to debug issues of errors not being reported from the upstream sniff
- *            if this library is used in combination with other rulesets.}}
+ *            if this library is used in combination with other rulesets.}
  *
  * @link https://www.php.net/manual/en/language.oop5.magic.php
  *

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -238,7 +238,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                          * higher than the number of named parameters.
                          *
                          * {@internal Note: This does not take calculations into account!
-                         *  Should be exceptionally rare and can - if needs be - be addressed at a later stage.}}
+                         *  Should be exceptionally rare and can - if needs be - be addressed at a later stage.}
                          */
                         case 'func_get_arg':
                             $number = $phpcsFile->findNext(\T_LNUMBER, $paramOne['start'], ($paramOne['end'] + 1));
@@ -260,7 +260,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                  * In that case, we can ignore it.
                  *
                  * {@internal Note: This does not take offset calculations into account!
-                 *  Should be exceptionally rare and can - if needs be - be addressed at a later stage.}}
+                 *  Should be exceptionally rare and can - if needs be - be addressed at a later stage.}
                  */
                 if ($prev !== false && $tokens[$prev]['code'] === \T_OPEN_PARENTHESIS) {
 

--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -24,7 +24,7 @@ use PHP_CodeSniffer_File as File;
  * {@internal Due to an issue with the Tokenizer, this sniff will not work correctly
  *            on PHP 5.3 in combination with PHPCS < 2.6.0 when short_open_tag is `On`.
  *            As this is causing "Undefined offset" notices, there is nothing we can
- *            do to work-around this.}}
+ *            do to work-around this.}
  *
  * PHP version 7.4
  *

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer_File as File;
  * Check for use of alternative PHP tags, support for which was removed in PHP 7.0.
  *
  * {@internal Based on `Generic.PHP.DisallowAlternativePHPTags` by Juliette Reinders Folmer
- * (with permission) which was merged into PHPCS 2.7.0.}}
+ * (with permission) which was merged into PHPCS 2.7.0.}
  *
  * PHP version 7.0
  *

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -32,7 +32,7 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
      *
      * {@internal The PHPCS `findEndOfStatement()` method is not completely consistent
      * in how it returns the statement end. This is just a simple way to bypass
-     * the inconsistency for our purposes.}}
+     * the inconsistency for our purposes.}
      *
      * @since 8.2.0
      *

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -98,7 +98,7 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
      * PHP and PHPCS versions.
      *
      * {@internal 'before' was chosen rather than 'after' as that allowed for a 1-on-1
-     * translation list with the current tokens.}}
+     * translation list with the current tokens.}
      *
      * @since 7.0.3
      *

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer_File as File;
  * deprecated in favour of default_charset."
  *
  * {@internal It is unclear which mbstring functions should be targetted, so for now,
- * only the iconv function is handled.}}
+ * only the iconv function is handled.}
  *
  * PHP version 5.6
  *

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -21,7 +21,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * and removed as of PHP 7.0.
  *
  * {@internal If and when this sniff would need to start checking for other modifiers, a minor
- * refactor will be needed as all references to the `e` modifier are currently hard-coded.}}
+ * refactor will be needed as all references to the `e` modifier are currently hard-coded.}
  *
  * PHP version 5.5
  * PHP version 7.0

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -32,7 +32,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://www.php.net/manual/en/language.types.array.php#example-63
  *
  * {@internal The reason for splitting the logic of this sniff into different methods is
- *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}}
+ *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}
  *
  * @since 7.1.4
  * @since 9.3.0 Now also detects dereferencing using curly braces.

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -33,7 +33,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *
  * {@internal The reason for splitting the logic of this sniff into different methods is
- *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}}
+ *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}
  *
  * @since 8.2.0
  * @since 9.3.0 Now also detects class member access on instantiation using curly braces.

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -31,7 +31,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *
  * {@internal The reason for splitting the logic of this sniff into different methods is
- *            to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.}}
+ *            to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.}
  *
  * @since 7.0.0
  * @since 9.3.0 Now also detects dereferencing using curly braces.

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -286,7 +286,7 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
      *
      * {@internal Note: the first braces for array access to a constant, for some unknown reason,
      *            can never be curlies, but have to be square brackets.
-     *            Subsequent braces can be curlies.}}
+     *            Subsequent braces can be curlies.}
      *
      * @since 9.3.0
      *

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -159,7 +159,7 @@ class LowPHPCSSniff extends Sniff
          * it should be. A patch for that is included in the same upstream PR.
          *
          * If/when the upstream PR has been merged and the minimum supported/recommended version
-         * of PHPCompatibility would go beyond that, the below code should be adjusted.}}
+         * of PHPCompatibility would go beyond that, the below code should be adjusted.}
          */
         $reportWidth = PHPCSHelper::getCommandLineData($phpcsFile, 'reportWidth');
         if (empty($reportWidth)) {

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -154,7 +154,7 @@ class LowPHPSniff extends Sniff
          * it should be. A patch for that is included in the same upstream PR.
          *
          * If/when the upstream PR has been merged and the minimum supported/recommended version
-         * of PHPCompatibility would go beyond that, the below code should be adjusted.}}
+         * of PHPCompatibility would go beyond that, the below code should be adjusted.}
          */
         $reportWidth = PHPCSHelper::getCommandLineData($phpcsFile, 'reportWidth');
         if (empty($reportWidth)) {

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -39,7 +39,7 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * - `get_defined_vars()` always doesn't show value of variable `$this`.
  * - Always show true `$this` value in magic method `__call()`.
  *   {@internal This could possibly be covered. Similar logic as "outside object context",
- *   but with function name check and supportsBelow('7.0').}}
+ *   but with function name check and supportsBelow('7.0').}
  *
  * PHP version 7.1
  *

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -62,7 +62,7 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
      * openers/closers when run on PHP 5.3 or lower.
      * In a 'normal' situation you won't often find classes, interfaces and traits all
      * mixed in one file anyway, so this issue for which this is a work-around,
-     * should not cause real world issues anyway.}}
+     * should not cause real world issues anyway.}
      *
      * @param bool   $isTrait     Whether to load the class/interface test file or the trait test file.
      * @param string $testVersion Value of 'testVersion' to set on PHPCS object.

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -62,7 +62,7 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
      * openers/closers when run on PHP 5.3 or lower.
      * In a 'normal' situation you won't often find classes, interfaces and traits all
      * mixed in one file anyway, so this issue for which this is a work-around,
-     * should not cause real world issues anyway.}}
+     * should not cause real world issues anyway.}
      *
      * @param bool   $isTrait     Whether to load the class/interface test file or the trait test file.
      * @param string $testVersion Value of 'testVersion' to set on PHPCS object.

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -52,7 +52,7 @@ class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
      * Set up skip condition based on used PHP version.
      *
      * {@internal The data providers are run before the setUpClass method is run, so
-     * we can't use that method for this skip condition.}}
+     * we can't use that method for this skip condition.}
      *
      * @return bool True if PHPCS is running on PHP 7.3 or higher. False otherwise.
      */

--- a/PHPCompatibility/Util/Tests/Core/IsNumberUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsNumberUnitTest.php
@@ -63,7 +63,7 @@ class IsNumberUnitTest extends CoreMethodTestFrame
      * {@internal Case I13 is not tested here on purpose as the result depends on the
      * `testVersion` which we don't use in the utility tests.
      * For a `testVersion` with a minimum of PHP 7.0, the result will be false.
-     * For a `testVersion` which includes any PHP 5 version, the result will be true.}}
+     * For a `testVersion` which includes any PHP 5 version, the result will be true.}
      *
      * @return array
      */


### PR DESCRIPTION
For the use of `@internal` tags with comments for dev internal information, it used to be recommended to use `{@internal ... }}` (not the double curlies at the end) format to help IDEs parse these correctly.

This format has since been superseded as the parsing of docblocks in IDEs has improved a lot since then.

The current recommendation is to just use a single curly at the end.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#55-internal