### PR TITLE
NewLateStaticBinding: bug fix (false negatives)

### DIFF
--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.inc
@@ -1,19 +1,27 @@
 <?php
 
 class LateStatic {
-    private $bar;
+    private static $bar;
 
     public function test() {
         self::foo(); // Ok.
         static::foo(); // Late static binding.
         echo static::$bar; // Late static binding.
+        $name = static::class; // Late static binding.
+        
+        $obj = new static; // Late static binding.
+        $obj = new static(); // Late static binding.
+
+        $foo = $foo instanceof static ? 'foo' : 'bar'; // Late static binding.
+
+        return $foo instanceof static; // Late static binding.
     }
 
     public static function foo() {} // Ok.
 }
 
 static function testing() { // Ok.
-    static $var; //Ok.
+    static $var; // Ok.
 }
 
 static::testing(); // Bad. Outside class scope.

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
@@ -55,6 +55,11 @@ class NewLateStaticBindingUnitTest extends BaseSniffTest
         return array(
             array(8),
             array(9),
+            array(10),
+            array(12),
+            array(13),
+            array(15),
+            array(17),
         );
     }
 
@@ -84,7 +89,7 @@ class NewLateStaticBindingUnitTest extends BaseSniffTest
     public function dataLateStaticBindingOutsideClassScope()
     {
         return array(
-            array(19),
+            array(27),
         );
     }
 
@@ -114,10 +119,12 @@ class NewLateStaticBindingUnitTest extends BaseSniffTest
     public function dataNoFalsePositives()
     {
         return array(
+            array(4),
+            array(6),
             array(7),
-            array(12),
-            array(15),
-            array(16),
+            array(20),
+            array(23),
+            array(24),
         );
     }
 


### PR DESCRIPTION
The `NewLateStaticBinding` sniff was underreporting for `instanceof static` and `new static`. Fixed now.

Includes unit tests.