### PR TITLE
Update suggested version of Composer PHPCS plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Installation in a Composer project (method 1)
 
        Just add the Composer plugin you prefer to the `require-dev` section of your `composer.json` file.
 
-       * [DealerDirect/phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.5.0"
+       * [DealerDirect/phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.6.0"
        * [higidi/composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin)
        * [SimplyAdmire/ComposerPlugins](https://github.com/SimplyAdmire/ComposerPlugins). This plugin *might* still work, but appears to be abandoned.
     - As a last alternative in case you use a custom ruleset, _and only if you use PHP CodeSniffer version 2.6.0 or higher_, you can tell PHP CodeSniffer the path to the PHPCompatibility standard by adding the following snippet to your custom ruleset:

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "squizlabs/php_codesniffer": "2.6.2"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "scripts" : {


### PR DESCRIPTION
The DealerDirect Composer plugin has just released version `0.6.0`.
As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats ^0.3 as >=0.3.0 <0.4.0.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.6.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-