### PR TITLE
Various sniffs: make function call check more stable

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -116,24 +116,40 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $ignore = array(
-            \T_DOUBLE_COLON    => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_FUNCTION        => true,
-            \T_CONST           => true,
-        );
-
-        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
-            // Not a call to a PHP function.
-            return;
-        }
-
         $function   = $tokens[$stackPtr]['content'];
         $functionLc = strtolower($function);
 
         if (isset($this->removedFunctionParameters[$functionLc]) === false) {
             return;
+        }
+
+        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextToken === false
+            || $tokens[$nextToken]['code'] !== \T_OPEN_PARENTHESIS
+            || isset($tokens[$nextToken]['parenthesis_owner']) === true
+        ) {
+            return;
+        }
+
+        $ignore = array(
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_NEW             => true,
+        );
+
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
+            // Not a call to a PHP function.
+            return;
+
+        } elseif ($tokens[$prevToken]['code'] === \T_NS_SEPARATOR) {
+            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
+            if ($tokens[$prevPrevToken]['code'] === \T_STRING
+                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
+            ) {
+                // Namespaced function.
+                return;
+            }
         }
 
         $parameters     = $this->getFunctionCallParameters($phpcsFile, $stackPtr);

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -245,3 +245,8 @@ money_format();
 ezmlm_hash();
 restore_include_path();
 
+// These calls should *not* trigger an error.
+$myobject -> php_check_syntax (); // Method, not the native PHP function.
+myNamespace \ /*comment*/ php_check_syntax(); // Namespaced function, not the native PHP function.
+namespace\php_check_syntax(); // Namespaced function, not the native PHP function.
+$obj = new php_check_syntax /*comment*/ (); // Class not method.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -566,11 +566,15 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array(134),
             array(135),
             array(136),
-            // array(137), // Not yet accounted for in the code, uncomment when fixed.
+            array(137),
             array(138),
             array(139),
             array(140),
             array(141),
+            array(249),
+            array(250),
+            array(251),
+            array(252),
         );
     }
 


### PR DESCRIPTION
Make the "is this a non-namespaced function call" check more stable by:
* Checking for parenthesis after the (potential) function call keyword and making sure that those parenthesis don't have an owner (like they would when it is a function declaration).
* Checking previous token via "previous non empty" instead of just disregarding whitespace.
* Make the namespace check more stable by checking the previous non-empty token before the namespace separator instead of the previous token and by checking for both `T_STRING` (`NS\call()`) as well as `T_NAMESPACE` (`namespace\call()`).

I've applied the same fix in a number of places where sniffs check for function calls.

This will be further improved upon once the repo switches over to PHPCSUtils which will have a utility function for this and (planned) an abstract sniff class to use.

Includes some unit tests in the `RemovedFunctions` sniff test case file.

Loosely related to #961