### PR TITLE
PHP 7.0: New NewNestedStaticAccess sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Syntax;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * (Nested) Static property and constant fetches as well as method calls can be applied to
+ * any dereferencable expression since PHP 7.0.
+ *
+ * PHP version 7.0
+ *
+ * @link https://wiki.php.net/rfc/uniform_variable_syntax
+ *
+ * @since 10.0.0
+ */
+class NewNestedStaticAccessSniff extends Sniff
+{
+
+    /**
+     * Access operators.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $accessOperators = array(
+        \T_OBJECT_OPERATOR => true,
+        \T_DOUBLE_COLON    => true,
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(\T_DOUBLE_COLON);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.6') === false) {
+            return;
+        }
+
+        $tokens       = $phpcsFile->getTokens();
+        $prev         = $stackPtr;
+        $seenBrackets = false;
+        $prevOperator = false;
+
+        do {
+            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+
+            if ($prev === false) {
+                return;
+            }
+
+            if ($tokens[$prev]['code'] === \T_CLOSE_SQUARE_BRACKET
+                || $tokens[$prev]['code'] === \T_CLOSE_CURLY_BRACKET
+            ) {
+                if (isset($tokens[$prev]['bracket_opener']) === false) {
+                    // Parse error.
+                    return;
+                }
+
+                $prev         = $tokens[$prev]['bracket_opener'];
+                $seenBrackets = true;
+                continue;
+            }
+
+            if ($tokens[$prev]['code'] === \T_CLOSE_PARENTHESIS) {
+                if (isset($tokens[$prev]['parenthesis_opener']) === false) {
+                    // Parse error.
+                    return;
+                }
+
+                $prev         = $tokens[$prev]['parenthesis_opener'];
+                $seenBrackets = true;
+                continue;
+            }
+
+            // Now this should either be a T_STRING or a T_VARIABLE.
+            if ($tokens[$prev]['code'] !== \T_STRING && $tokens[$prev]['code'] !== \T_VARIABLE) {
+                // Not sure what's happening, but this is outside the scope of this sniff.
+                return;
+            }
+
+            // OK, we have the start of the access, let see if it's nested.
+            $prevOperator = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+            break;
+
+        } while (true);
+
+        if ($prevOperator === false
+            || isset($this->accessOperators[$tokens[$prevOperator]['code']]) === false
+        ) {
+            return;
+        }
+
+        // Ignore the one form of nested static access which is still not supported: ?::CONST::?.
+        if ($seenBrackets === false
+            && $tokens[$prev]['code'] === \T_STRING
+            && $tokens[$prevOperator]['code'] === \T_DOUBLE_COLON
+        ) {
+            return;
+        }
+
+        // This is nested static access.
+        $phpcsFile->addError(
+            'Nested access to static properties, constants and methods was not supported in PHP 5.6 or earlier.',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.inc
@@ -1,0 +1,35 @@
+<?php
+
+// Non-nested static access is valid cross version.
+echo $foo['bar']::$baz;
+
+// PHP 7.0: new nested static access to properties, constants and method calls.
+echo $foo::$bar::$baz;
+echo $foo::$bar::BAZ;
+echo $foo->bar()::baz();
+echo $instance->prop::MY_CONSTANT;
+echo $bar::$foo['bar']::$baz;
+echo $bar::$foo{'bar'}::$baz;
+echo $bar::foo()['bar']::$baz;
+echo $bar::foo(){'bar'}::$baz;
+echo Foo::$boo::$baz;
+echo self::$boo::$baz;
+echo self::MY_CONSTANT[0]::$baz;
+echo Foo::MY_CONSTANT[0]::$baz;
+echo Bar::$bar::BAZ;
+
+// Test code style independent sniffing.
+echo $obj  ->   /* comment */ $var()
+	 :: $bar; // Bad.
+
+// PHP 7.0 change, but outside the scope of this sniff
+// (dereferencing operations can now be applied to arbitrary parenthesis-expressions).
+echo ($foo::$bar)::$baz;
+echo ($foo->bar())::baz();
+
+// Parse error in any PHP version. Outside the scope of this sniff.
+echo $bar::($foo['bar'])::$baz;
+
+// Still not supported.
+self::MY_CONSTANT::$baz;
+Foo::MY_CONSTANT::$baz;

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewNestedStaticAccess sniff.
+ *
+ * @group newNestedStaticAccess
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewNestedStaticAccessSniff
+ *
+ * @since 10.0.0
+ */
+class NewNestedStaticAccessUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNestedStaticAccess
+     *
+     * @dataProvider dataNestedStaticAccess
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNestedStaticAccess($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertError($file, $line, 'Nested access to static properties, constants and methods was not supported in PHP 5.6 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNestedStaticAccess()
+     *
+     * @return array
+     */
+    public function dataNestedStaticAccess()
+    {
+        return array(
+            array(7),
+            array(8),
+            array(9),
+            array(10),
+            array(11),
+            array(12),
+            array(13),
+            array(14),
+            array(15),
+            array(16),
+            array(17),
+            array(18),
+            array(19),
+            array(23),
+        );
+    }
+
+
+    /**
+     * Verify the sniff doesn't throw false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(4),
+            array(27),
+            array(28),
+            array(31),
+            array(34),
+            array(35),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
This sniff only covers a small part of the changes in the PHP 7.0 Uniform Variable Syntax RFC, but it's at least another part which is covered.

> ```php
> // support nested ::
> $foo['bar']::$baz
> $foo::$bar::$baz
> $foo->bar()::baz()
> ```
>
> Static property fetches and method calls can now be applied to any dereferencable expression. E.g. `$foo['bar']::$baz`, `$foo::$bar::$baz` and `$foo->bar()::baz()` are all valid now.

Ref: https://wiki.php.net/rfc/uniform_variable_syntax

The sniff implementation as is being pulled now is supported by various tests run on 3v4l:
https://3v4l.org/up9e3
https://3v4l.org/7tZcL
https://3v4l.org/5uuFR
https://3v4l.org/grUNF
https://3v4l.org/mtWn9
https://3v4l.org/PAtnX
https://3v4l.org/qujtp
https://3v4l.org/Rrteo
https://3v4l.org/GQA2P
https://3v4l.org/2XCUZ
https://3v4l.org/d3vcp

Includes unit tests.

The sniff has been run over a number of large PHP projects to see if any false positives could be found, but didn't find any, though I'm not giving out any guarantees at this point.

Fixes #946