### PR TITLE
NewTypedProperties: minor tweaks to the unit tests

### DIFF
--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -35,7 +35,7 @@ class PHP74Example {
     public ?string $nullableStr = null;
 
     // The type applies to all properties in one declaration
-    public float $x, $y;
+    public float $a, $b;
 
     // Additional tests not from the RFC.
     public int $x = 10,
@@ -51,7 +51,6 @@ class PHP74Example {
     private static self $instance;
 
     // Note: The RFC does not explicitely mention this syntax.
-    // @todo This needs verification once the alpha is out.
     static bool $bool = true;
 
     // Test reversed keyword order.

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -61,11 +61,11 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             array(41),
             array(49),
             array(51),
-            array(55),
-            array(58),
+            array(54),
+            array(57),
+            array(62),
             array(63),
             array(64),
-            array(65),
         );
     }
 
@@ -111,9 +111,9 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
     public function dataInvalidPropertyType()
     {
         return array(
-            array(63, 'void'),
+            array(62, 'void'),
+            array(63, 'callable'),
             array(64, 'callable'),
-            array(65, 'callable'),
         );
     }
 


### PR DESCRIPTION
* Replace duplicate property declaration with different variables.
* Remove `@todo` note. This has been verified and found to be supported.