### PR TITLE
Travis/QA: check that all sniffs are feature complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,11 @@ jobs:
         # Check the code-style consistency of the xml files.
         - diff -B ./PHPCompatibility/ruleset.xml <(xmllint --format "./PHPCompatibility/ruleset.xml")
 
+        # Check that the sniffs available are feature complete.
+        # For now, just check that all sniffs have unit tests.
+        # At a later stage the documentation check can be activated.
+        - composer check-complete
+
     #### QUICK TEST STAGE ####
     # This is a much quicker test which only runs the unit tests and linting against the low/high
     # supported PHP/PHPCS combinations.
@@ -179,9 +184,16 @@ before_install:
     if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then
       composer require --no-update php-coveralls/php-coveralls:${COVERALLS_VERSION}
     fi
-  # --no-dev makes sure the Travis provided version of PHPUnit is used whenever possible for better stability.
   # --prefer-dist will allow for optimal use of the travis caching ability.
-  - composer install --no-dev --prefer-dist --no-suggest
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Sniff" ]]; then
+      composer install --prefer-dist --no-suggest
+    else
+      # Remove devtools as it would block testing on old PHPCS versions (< 3.0).
+      composer remove --dev phpcsstandards/phpcsdevtools --no-update
+      # --no-dev makes sure the Travis provided version of PHPUnit is used whenever possible for better stability.
+      composer install --no-dev --prefer-dist --no-suggest
+    fi
 
 before_script:
   - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then mkdir -p build/logs; fi

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "squizlabs/php_codesniffer" : "^2.3 || ^3.0.2"
   },
   "require-dev" : {
-    "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+    "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0",
+    "phpcsstandards/phpcsdevtools": "^1.0"
   },
   "conflict": {
     "squizlabs/php_codesniffer": "2.6.2"
@@ -38,7 +39,17 @@
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "scripts" : {
-    "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..",
-    "post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
+    "post-install-cmd": [
+      "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
+    ],
+    "post-update-cmd" : [
+      "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
+    ],
+    "check-complete": [
+      "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./PHPCompatibility"
+    ],
+    "check-complete-strict": [
+      "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./PHPCompatibility"
+    ]
   }
 }


### PR DESCRIPTION
The new `phpcsstandards/phpcsdevtools` package includes a script which can check whether sniffs are feature complete, i.e. whether all sniffs have unit tests and documentation.

By adding this check to the Travis script, we prevent untested and/or undocumented sniffs from entering the repo.

For now, the documentation check is silenced.

P.S.: the `PHPCSDevTools` package contains a few more goodies, have a look at the [readme](https://github.com/PHPCSStandards/PHPCSDevTools) for more information.