### PR TITLE
Make `testVersion` config variable less case-sensitive

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -114,7 +114,8 @@ abstract class Sniff implements PHPCS_Sniff
      * would be treated as invalid, and ignored.
      *
      * @since 7.0.0
-     * @since 7.1.3 Now allows for partial ranges such as `5.2-`.
+     * @since 7.1.3  Now allows for partial ranges such as `5.2-`.
+     * @since 10.0.0 Will allow for "testVersion" config in lowercase.
      *
      * @return array $arrTestVersions will hold an array containing min/max version
      *               of PHP that we are checking against (see above).  If only a
@@ -129,6 +130,11 @@ abstract class Sniff implements PHPCS_Sniff
 
         $default     = array(null, null);
         $testVersion = trim(PHPCSHelper::getConfigData('testVersion'));
+
+        // Case-sensitivity tolerance.
+        if (empty($testVersion) === true) {
+            $testVersion = trim(PHPCSHelper::getConfigData('testversion'));
+        }
 
         if (empty($testVersion) === false && isset($arrTestVersions[$testVersion]) === false) {
 

--- a/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
@@ -56,6 +56,7 @@ class FunctionsUnitTest extends PHPUnit_TestCase
 
         // Only really needed for the testVersion related tests, but doesn't harm the other test in this file.
         PHPCSHelper::setConfigData('testVersion', null, true);
+        PHPCSHelper::setConfigData('testversion', null, true);
     }
 
 
@@ -77,10 +78,34 @@ class FunctionsUnitTest extends PHPUnit_TestCase
             PHPCSHelper::setConfigData('testVersion', $testVersion, true);
         }
 
-        $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'GetTestVersion'));
+        $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'getTestVersion'));
 
         // Verify that the caching of the function results is working correctly.
-        $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'GetTestVersion'));
+        $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'getTestVersion'));
+    }
+
+    /**
+     * testGetTestVersionCaseLowercase
+     *
+     * @dataProvider dataGetTestVersion
+     *
+     * @covers \PHPCompatibility\Sniff::getTestVersion
+     *
+     * @param string $testVersion The testVersion as normally set via the command line or ruleset.
+     * @param string $expected    The expected testVersion array.
+     *
+     * @return void
+     */
+    public function testGetTestVersionCaseLowercase($testVersion, $expected)
+    {
+        if (isset($testVersion)) {
+            PHPCSHelper::setConfigData('testversion', $testVersion, true);
+        }
+
+        $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'getTestVersion'));
+
+        // Verify that the caching of the function results is working correctly.
+        $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'getTestVersion'));
     }
 
     /**


### PR DESCRIPTION
PHPCS treats anything passed on the command-line as case-insensitive, i.e. `--standard=phpcompatibility` works just as well as `--standard=PHPCompatibility`.

PHPCompatibility, however, would treat the config variable `testVersion` in a case-sensitive manner and would not recognize it when passed as `testversion`.

This fix changes how PHPCompatibility handles `testVersion` to be less case-sensitive.

Complete case-insensitivity would have to be build into PHPCS itself, but for now, allowing the config when it's fully lowercase should help.

Includes unit tests.