### PR TITLE
Unit tests: add support for PHPUnit 8.x and 9.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ composer.lock
 .phpcs.xml
 phpcs.xml
 phpunit.xml
+.phpunit.result.cache
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -165,7 +165,6 @@ before_install:
   - export XMLLINT_INDENT="    "
 
   # Toggle the PHPUnit versions if necessary, depending on the known Travis configurations.
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then export PHPUNIT_VERSION="^7.0"; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then export PHPUNIT_VERSION="~4.5"; fi
 
   # Set up test environment using Composer.

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,6 +167,9 @@ before_install:
   # Toggle the PHPUnit versions if necessary, depending on the known Travis configurations.
   - if [[ ${TRAVIS_PHP_VERSION:0:3} < "5.5" ]]; then export PHPUNIT_VERSION="~4.5"; fi
 
+  # Work around bug in Travis PHP 7.2 image which contains PHPUnit 9.x while PHPUnit 9.x needs PHP 7.3.
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then export PHPUNIT_VERSION="~8.5"; fi
+
   # Set up test environment using Composer.
   - composer require --no-update squizlabs/php_codesniffer:${PHPCS_VERSION}
   - |

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -35,11 +35,13 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
     /**
      * Set up the test file for some of these unit tests.
      *
+     * @before
+     *
      * @return void
      */
-    protected function setUp()
+    protected function setUpPHPCS()
     {
-        parent::setUp();
+        parent::setUpPHPCS();
 
         // Sniff file without testVersion for testing the version independent sniff features.
         $this->sniffResult = $this->sniffFile(__FILE__);

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -46,11 +46,13 @@ class InternalInterfacesUnitTest extends BaseSniffTest
     /**
      * Set up the test file for this unit test.
      *
+     * @before
+     *
      * @return void
      */
-    protected function setUp()
+    protected function setUpPHPCS()
     {
-        parent::setUp();
+        parent::setUpPHPCS();
 
         // Sniff file without testVersion as all checks run independently of testVersion being set.
         $this->sniffResult = $this->sniffFile(__FILE__);

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -36,16 +36,24 @@ class RemovedAlternativePHPTagsUnitTest extends BaseSniffTest
     /**
      * Set up skip condition.
      *
+     * @beforeClass
+     *
+     * @since 7.0.4
+     * @since 10.0.0 Renamed the method from `setUpBeforeClass()` to `setUpSkipCondition()` and
+     *               now using the `@beforeClass` annotation to allow for
+     *               PHPUnit cross-version compatibility.
+     *
      * @return void
      */
-    public static function setUpBeforeClass()
+    public static function setUpSkipCondition()
     {
+        // Run the parent `@beforeClass` method.
+        parent::resetSniffFiles();
+
         if (version_compare(\PHP_VERSION_ID, '70000', '<')) {
             // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.asp_tagsRemoved
             self::$aspTags = (bool) ini_get('asp_tags');
         }
-
-        parent::setUpBeforeClass();
     }
 
 

--- a/PHPCompatibility/Tests/Upgrade/LowPHPCSUnitTest.php
+++ b/PHPCompatibility/Tests/Upgrade/LowPHPCSUnitTest.php
@@ -45,11 +45,13 @@ class LowPHPCSUnitTest extends BaseSniffTest
     /**
      * Set up the test file for this unit test.
      *
+     * @before
+     *
      * @return void
      */
-    protected function setUp()
+    protected function setUpPHPCS()
     {
-        parent::setUp();
+        parent::setUpPHPCS();
 
         // Sniff file without testVersion as all checks run independently of testVersion being set.
         $this->sniffResult  = $this->sniffFile(__FILE__);

--- a/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
+++ b/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
@@ -44,11 +44,13 @@ class LowPHPUnitTest extends BaseSniffTest
     /**
      * Set up the test file for this unit test.
      *
+     * @before
+     *
      * @return void
      */
-    protected function setUp()
+    protected function setUpPHPCS()
     {
-        parent::setUp();
+        parent::setUpPHPCS();
 
         // Sniff file without testVersion as all checks run independently of testVersion being set.
         $this->sniffResult = $this->sniffFile(__FILE__);

--- a/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
@@ -128,15 +128,8 @@ class FunctionsUnitTest extends TestCase
      */
     public function testGetTestVersionInvalidRange($testVersion)
     {
-        if (method_exists($this, 'setExpectedException')) {
-            $this->setExpectedException(
-                'PHPUnit_Framework_Error_Warning',
-                sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion)
-            );
-        } else {
-            $this->expectException('PHPUnit\Framework\Error\Warning');
-            $this->expectExceptionMessage(sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion));
-        }
+        $message = sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion);
+        $this->phpWarningTestHelper($message);
 
         $this->testGetTestVersion($testVersion, array(null, null));
     }
@@ -171,15 +164,8 @@ class FunctionsUnitTest extends TestCase
      */
     public function testGetTestVersionInvalidVersion($testVersion)
     {
-        if (method_exists($this, 'setExpectedException')) {
-            $this->setExpectedException(
-                'PHPUnit_Framework_Error_Warning',
-                sprintf('Invalid testVersion setting: \'%s\'', trim($testVersion))
-            );
-        } else {
-            $this->expectException('PHPUnit\Framework\Error\Warning');
-            $this->expectExceptionMessage(sprintf('Invalid testVersion setting: \'%s\'', trim($testVersion)));
-        }
+        $message = sprintf('Invalid testVersion setting: \'%s\'', trim($testVersion));
+        $this->phpWarningTestHelper($message);
 
         $this->testGetTestVersion($testVersion, array(null, null));
     }
@@ -480,6 +466,38 @@ class FunctionsUnitTest extends TestCase
             array('"This is { $great}"', '"This is { }"'),
             array('"This is the return value of getName(): {getName()}"', '"This is the return value of getName(): {getName()}"'),
         );
+    }
+
+
+    /**
+     * Helper function for testing PHP warnings.
+     *
+     * @since 10.0.0
+     *
+     * @param string $message The warning message to expect.
+     *
+     * @return void
+     */
+    public function phpWarningTestHelper($message)
+    {
+        if (method_exists($this, 'expectWarning')) {
+            // PHPUnit 9.0+.
+            $this->expectWarning();
+            $this->expectWarningMessage($message);
+
+            return;
+        }
+
+        if (\method_exists($this, 'expectException') && class_exists('PHPUnit\Framework\Error\Warning')) {
+            // PHPUnit 5.7/6/7/8.
+            $this->expectException('PHPUnit\Framework\Error\Warning');
+            $this->expectExceptionMessage($message);
+
+            return;
+        }
+
+        // PHPUnit 4/5.7.
+        $this->setExpectedException('PHPUnit_Framework_Error_Warning', $message);
     }
 
 

--- a/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Util\Tests\Core;
 
-use PHPUnit_Framework_TestCase as PHPUnit_TestCase;
+use PHPUnit\Framework\TestCase;
 use PHPCompatibility\PHPCSHelper;
 use PHPCompatibility\Util\Tests\TestHelperPHPCompatibility;
 
@@ -22,7 +22,7 @@ use PHPCompatibility\Util\Tests\TestHelperPHPCompatibility;
  *
  * @since 7.0.6
  */
-class FunctionsUnitTest extends PHPUnit_TestCase
+class FunctionsUnitTest extends TestCase
 {
 
     /**
@@ -36,24 +36,24 @@ class FunctionsUnitTest extends PHPUnit_TestCase
     /**
      * Sets up this unit test.
      *
+     * @before
+     *
      * @return void
      */
-    protected function setUp()
+    protected function setUpHelper()
     {
-        parent::setUp();
-
         $this->helperClass = new TestHelperPHPCompatibility();
     }
 
     /**
      * Clean up after finished test.
      *
+     * @after
+     *
      * @return void
      */
-    protected function tearDown()
+    protected function resetTestVersion()
     {
-        parent::tearDown();
-
         // Only really needed for the testVersion related tests, but doesn't harm the other test in this file.
         PHPCSHelper::setConfigData('testVersion', null, true);
     }

--- a/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
+++ b/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Util\Tests;
 
-use PHPUnit_Framework_TestCase as PHPUnit_TestCase;
+use PHPUnit\Framework\TestCase;
 use PHPCompatibility\PHPCSHelper;
 use PHPCompatibility\Util\Tests\TestHelperPHPCompatibility;
 use PHP_CodeSniffer_File as File;
@@ -24,7 +24,7 @@ use PHP_CodeSniffer_File as File;
  * @since 7.0.5 Renamed from `BaseAbstractClassMethodTest` to `CoreMethodTestFrame`.
  * @since 7.1.2 No longer extends the `BaseSniffTest` class.
  */
-abstract class CoreMethodTestFrame extends PHPUnit_TestCase
+abstract class CoreMethodTestFrame extends TestCase
 {
 
     /**
@@ -49,14 +49,16 @@ abstract class CoreMethodTestFrame extends PHPUnit_TestCase
     /**
      * Sets up this unit test.
      *
+     * @before
+     *
      * @since 7.0.3
+     * @since 10.0.0 Renamed the method from `setUp()` to `setUpPHPCS()` and now using
+     *               the `@before` annotation to allow for PHPUnit cross-version compatibility.
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUpPHPCS()
     {
-        parent::setUp();
-
         $this->helperClass = new TestHelperPHPCompatibility();
 
         $FQClassName = \get_class($this);
@@ -93,11 +95,15 @@ abstract class CoreMethodTestFrame extends PHPUnit_TestCase
     /**
      * Clean up after finished test.
      *
+     * @after
+     *
      * @since 7.0.3
+     * @since 10.0.0 Renamed the method from `tearDown()` to `resetPHPCS()` and now using
+     *               the `@after` annotation to allow for PHPUnit cross-version compatibility.
      *
      * @return void
      */
-    public function tearDown()
+    public function resetPHPCS()
     {
         unset($this->phpcsFile, $this->helperClass);
     }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "squizlabs/php_codesniffer" : "^2.6 || ^3.0.2"
   },
   "require-dev" : {
-    "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0",
+    "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
     "phpcsstandards/phpcsdevtools": "^1.0"
   },
   "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "squizlabs/php_codesniffer" : "^2.6 || ^3.0.2"
   },
   "require-dev" : {
-    "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+    "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
     "phpcsstandards/phpcsdevtools": "^1.0"
   },
   "conflict": {

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -74,11 +74,10 @@ https://is.gd/PHPCompatibilityContrib
 
 
 // PHPUnit cross version compatibility.
-if (class_exists('PHPUnit\Runner\Version')
-    && version_compare(PHPUnit\Runner\Version::id(), '6.0', '>=')
-    && class_exists('PHPUnit_Framework_TestCase') === false
+if (class_exists('PHPUnit_Framework_TestCase') === true
+    && class_exists('PHPUnit\Framework\TestCase') === false
 ) {
-    class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+    class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
 }
 
 require_once __DIR__ . $ds . 'PHPCompatibility' . $ds . 'Tests' . $ds . 'BaseSniffTest.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.0/phpunit.xsd"
         bootstrap="./phpunit-bootstrap.php"
         backupGlobals="true"
         colors="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="phpunit-bootstrap.php" colors="true" backupGlobals="true">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
+        bootstrap="./phpunit-bootstrap.php"
+        backupGlobals="true"
+        colors="true"
+        verbose="false"
+        convertWarningsToExceptions="true"
+    >
     <testsuites>
         <testsuite name="PHPCompatibility Utilities Tests">
             <directory suffix="UnitTest.php">./PHPCompatibility/Util/Tests/</directory>


### PR DESCRIPTION
## Unit tests: add support for PHPUnit 8.x

In PHPUnit 8.x, the `setUpBeforeClass()`, `tearDownAfterClass()`, `setUp()` and `tearDown()` methods have received type declarations,with a return type `void`, making it neigh impossible to implement this in a cross-version manner as the `void` return type is not available until PHP 7.1.

However, PHPUnit also supports `@beforeClass`, `@afterClass`, `@before` and `@after` annotations to run arbitrary methods for setting things up/tearing things down. Those annotations have been around forever and are support all the way back to PHPUnit 4.x.

So instead of doing convoluted things with extending different classes for different PHPUnit versions or creating classes on the fly for this, by renaming the fixture related methods and using the PHPUnit annotations, the unit test suite becomes compatible with PHPUnit 4.x - 8.x without much effort.

Includes:
* Travis: Dropping the download of PHPUnit 7 for Travis images which contain PHPUnit 8.
* Composer: updating the `require-dev` section.
* `phpunit.xml.dist`: updating the configuration with a schema annotation.
* Test bootstrap: switching around the class aliasing from aliasing back to the PHPUnit 4.x testcase name, to aliasing forward. This will make it easier in the future to drop support for older PHPUnit versions.
* `BaseSniffTest`: add a switch for a deprecated PHPUnit method.

## Unit tests: add support for PHPUnit 9.x

In PHPUnit 9.x, the use of `expectException()` for PHP native error/warning/notice/deprecation messages has been deprecated and support will be removed in PHPUnit 10.x.

The dedicated `expectError()`, `expectWarning()`, `expectNotice()` and `expectDeprecation()` methods should be used instead and a warning will be thrown if `expectException()` is used for PHP native exceptions.

This adds a helper method for the one place in the PHPCompatibility test suite where we test that a PHP warning is being thrown handling the cross-version compatibility gracefully.

Includes:
* Composer: updating the `require-dev` section.
* `phpunit.xml.dist`: updating the schema annotation.

## Travis: work around bug in PHP 7.2 image

The current Travis PHP 7.2 image comes with PHPUnit 9.x, while PHPUnit 9.x has a minimum PHP requirement of PHP 7.3, so won't run on PHP 7.2.

This forces the use of PHPUnit 8.x on the PHP 7.2 image.

