### PR TITLE
PHPUnit: enforce use of `@covers` tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ composer.phar
 composer.lock
 .phpcs.xml
 phpcs.xml
+/build/
 phpunit.xml
 .phpunit.result.cache
 *~

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,15 @@
     "post-update-cmd" : [
       "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
     ],
+    "test": [
+      "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+    ],
+    "coverage": [
+      "@php ./vendor/phpunit/phpunit/phpunit"
+    ],
+    "coverage-local": [
+      "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/logs"
+    ],
     "check-complete": [
       "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./PHPCompatibility"
     ],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
         colors="true"
         verbose="false"
         convertWarningsToExceptions="true"
+        forceCoversAnnotation="true"
     >
     <testsuites>
         <testsuite name="PHPCompatibility Utilities Tests">
@@ -18,7 +19,7 @@
     </testsuites>
 
     <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+        <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
             <file>./PHPCompatibility/Sniff.php</file>
             <directory>./PHPCompatibility/Sniffs/</directory>
         </whitelist>


### PR DESCRIPTION
... and more code coverage tweaks.

* Only record code coverage when there is a `@covers` tag.
* Add three convenience scripts to Composer:
    1. `test`: to run the tests without generating code coverage (faster).
    2. `coverage`: to run the tests with code coverage.
    3. `coverage-local`: to run the tests and generate human readable test and coverage reports.
* Ignore the `build` directory generated by PHPUnit when code coverage is generated locally, for committing.
* Document that uncovered files don't need to be processed by PHPUnit (= default setting).