### PR TITLE
ForbiddenAbstractPrivateMethods: use PHPCSUtils\Utils\FunctionDeclarations::getProperties()

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/ForbiddenAbstractPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenAbstractPrivateMethodsSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Classes;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
 
 /**
@@ -65,7 +66,7 @@ class ForbiddenAbstractPrivateMethodsSniff extends Sniff
             return;
         }
 
-        $properties = $phpcsFile->getMethodProperties($stackPtr);
+        $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
         if ($properties['scope'] !== 'private' || $properties['is_abstract'] !== true) {
             return;
         }


### PR DESCRIPTION
Switch over from using the PHPCS native `File::getMethodProperties()` method to using the improved version in PHPCSUtils.

The version in PHPCSUtils:
* Contains all the improvements made to the method between PHPCS 2.6.0 and now, which makes those improvements available when running on older PHPCS versions.
* Has improved defensive coding, including improved handling of PHPCS annotations.