### PR TITLE
NewLateStaticBinding: use PHPCSUtils\Utils\Conditions::hasCondition()

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -13,6 +13,8 @@ namespace PHPCompatibility\Sniffs\Classes;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\Conditions;
 
 /**
  * Detect use of late static binding as introduced in PHP 5.3.
@@ -98,7 +100,7 @@ class NewLateStaticBindingSniff extends Sniff
                 break;
         }
 
-        $inClass = $this->inClassScope($phpcsFile, $stackPtr, false);
+        $inClass = Conditions::hasCondition($phpcsFile, $stackPtr, BCTokens::ooScopeTokens());
 
         if ($inClass === true && $this->supportsBelow('5.2') === true) {
             $phpcsFile->addError(


### PR DESCRIPTION
Switch out the use of the `Sniff::inClassScope()` method for the `Conditions::hasCondition()` method in combination with the `BCTokens::ooScopeTokens()` method.