### PR TITLE
PHP 7.4: New NewArrowFunction sniff

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewArrowFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewArrowFunctionSniff.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHP_CodeSniffer_File as File;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * The arrow function syntax for short functions is available since PHP 7.4.
+ *
+ * PHP version 7.4
+ *
+ * @link https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.arrow-functions
+ * @link https://wiki.php.net/rfc/arrow_functions_v2
+ *
+ * @since 10.0.0
+ */
+class NewArrowFunctionSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return Collections::arrowFunctionTokensBC();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.3') === false) {
+            return;
+        }
+
+        if (FunctionDeclarations::isArrowFunction($phpcsFile, $stackPtr) === false) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Arrow functions are not available in PHP 7.3 or earlier.',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewArrowFunctionUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewArrowFunctionUnitTest.inc
@@ -1,0 +1,37 @@
+<?php
+
+// OK: fn, but not an arrow function.
+$a = Foo::fn($param);
+$a = MyClass::FN;
+$a = MyClass::Fn[$a];
+$a = $obj->fn($param);
+$a = $obj->FN($param);
+$a = MyNS\Sub\Fn($param);
+$a = namespace\fn($param);
+
+class Foo {
+    const FN = 'a';
+
+    public static function fn($param) {
+    }
+
+    public function bar() {
+        $this->fn = 'a';
+    }
+}
+
+// PHP 7.4 arrow functions.
+$nums = array_map(fn($n) => $n * $factor, [1, 2, 3, 4]);
+
+$fn1 = Fn($x) => $x + $y;
+
+$fn = fn($c) => $callable($factory($c), $c);
+
+$result = Collection::from([1, 2])
+    ->map(fn($v) => $v * 2)
+    ->reduce(fn($tmp, $v) => $tmp + $v, 0);
+
+$result = array_map(
+    static fn(int $number) : ?int => $number + 1,
+    $numbers
+);

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewArrowFunctionUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewArrowFunctionUnitTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New Arrow Function Sniff tests
+ *
+ * @group newArrowFunction
+ * @group functionDeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewArrowFunctionSniff
+ *
+ * @since 10.0.0
+ */
+class NewArrowFunctionUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test recognizing arrow functions correctly.
+     *
+     * @dataProvider dataNewArrowFunction
+     *
+     * @param array $line The line number on which the error should occur.
+     *
+     * @return void
+     */
+    public function testNewArrowFunction($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertError($file, $line, 'Arrow functions are not available in PHP 7.3 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewArrowFunction()
+     *
+     * @return array
+     */
+    public function dataNewArrowFunction()
+    {
+        return array(
+            array(24),
+            array(26),
+            array(28),
+            array(31),
+            array(32),
+            array(35),
+        );
+    }
+
+
+    /**
+     * Verify there are no false positives for a PHP version on which this sniff throws errors.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = array();
+
+        // No issues expected on the first 21 lines.
+        for ($i = 1; $i <= 21; $i++) {
+            $data[] = array($i);
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
New sniff to detect PHP 7.4 arrow functions.

> Arrow functions
>
> Arrow functions provide a shorthand syntax for defining functions with implicit by-value scope binding.
> ```php
> <?php
> $factor = 10;
> $nums = array_map(fn($n) => $n * $factor, [1, 2, 3, 4]);
> // $nums = array(10, 20, 30, 40);
> ?>

Refs:
* https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.arrow-functions
 * https://wiki.php.net/rfc/arrow_functions_v2

Related to #808