### PR TITLE
DiscouragedSwitchContinue: fix handling of PHP 7.4 numeric literals and non-decimals + T_POW

### DIFF
--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ControlStructures;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\Numbers;
 
 /**
@@ -87,7 +88,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
      */
     public function register()
     {
-        $this->acceptedLevelTokens += Tokens::$arithmeticTokens;
+        $this->acceptedLevelTokens += BCTokens::arithmeticTokens();
         $this->acceptedLevelTokens += Tokens::$emptyTokens;
 
         return array(\T_SWITCH);

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.inc
@@ -189,3 +189,37 @@ while ($foo)
             }
         }
     }
+
+/*
+ * Test with PHP 7.4 numeric literals with underscore and non-decimal continue values.
+ * The chances of these ever being encountered in the wild are slim to none, but the sniff
+ * should handle them correctly.
+ */
+switch ($foo) {
+    case $bar:
+        switch ($ten) {
+            case 'normal_decimal_ten':
+                continue 10;
+            case 'decimal_ten':
+                continue 1_0;
+            case 'hex_sixteen':
+                continue 0x10;
+            case 'hex_sixteen_php74':
+                continue 0x1_0;
+            case 'octal_one':
+                continue 01; // Warning.
+            case 'octal_one_php74':
+                continue 0_1; // Warning.
+            case 'octal_ten':
+                continue 012;
+            case 'octal_ten_php74':
+                continue 0_12;
+            case 'binary_two':
+                continue 0b1_0; // Warning.
+            case 'binary_ten':
+                continue 0b1010;
+            case 'binary_ten_php74':
+                continue 0b10_10;
+        }
+        break;
+}

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Tests\ControlStructures;
 
 use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Test the DiscouragedSwitchContinue sniff.
@@ -49,7 +50,7 @@ class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
      */
     public function dataDiscouragedSwitchContinue()
     {
-        return array(
+        $data = array(
             array(16),
             array(24),
             array(28),
@@ -66,6 +67,7 @@ class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
             array(120),
             array(149),
             array(174),
+            array(210),
 
             /*
             @todo: False negatives. Unscoped control structure within case.
@@ -75,6 +77,13 @@ class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
             array(184),
             */
         );
+
+        if (version_compare(Helper::getVersion(), '3.5.3', '!=')) {
+            $data[] = array(212);
+            $data[] = array(218);
+        }
+
+        return $data;
     }
 
 
@@ -129,6 +138,15 @@ class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
             array(164),
             array(176),
             array(188),
+            array(188),
+            array(202),
+            array(204),
+            array(206),
+            array(208),
+            array(214),
+            array(216),
+            array(220),
+            array(222),
         );
     }
 


### PR DESCRIPTION
## DiscouragedSwitchContinue: fix handling of PHP 7.4 numeric literals and non-decimals

While uncommon, passing a non-decimal integer as the argument to `continue` is actually supported by PHP, so should be correctly handled by the sniff.

Along the same lines, PHP 7.4 numeric literals with underscores should also be handled correctly by the sniff.

Includes unit tests.

## DiscouragedSwitchContinue: allow for T_POW

The `T_POW` token did not exist in the `$arithmeticTokens` array until PHPCS 2.9.0.

This allows for recognizing it in older PHPCS versions.

