### PR TITLE
ForbiddenBreakContinueVariableArguments: fix handling of PHP 7.4 numeric literals and non-decimals

### DIFF
--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ControlStructures;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCSUtils\Utils\Numbers;
 
 /**
  * Detects using 0 and variable numeric arguments on `break` and `continue` statements.
@@ -93,9 +94,12 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
                 $errorType = 'variableArgument';
                 break;
 
-            } elseif ($tokens[$curToken]['type'] === 'T_LNUMBER' && $tokens[$curToken]['content'] === '0') {
-                $errorType = 'zeroArgument';
-                break;
+            } elseif ($tokens[$curToken]['code'] === \T_LNUMBER) {
+                $numberInfo = Numbers::getCompleteNumber($phpcsFile, $curToken);
+                if ($numberInfo['decimal'] === '0') {
+                    $errorType = 'zeroArgument';
+                    break;
+                }
             }
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -49,6 +49,18 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
     );
 
     /**
+     * Tokens indicating this is definitely a variable argument.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $varArgTokens = array(
+        \T_VARIABLE => \T_VARIABLE,
+        \T_CLOSURE  => \T_CLOSURE,
+    );
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 5.5
@@ -81,7 +93,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
         $nextSemicolonToken = $phpcsFile->findNext(array(\T_SEMICOLON, \T_CLOSE_TAG), ($stackPtr), null, false);
         $errorType          = '';
         for ($curToken = $stackPtr + 1; $curToken < $nextSemicolonToken; $curToken++) {
-            if ($tokens[$curToken]['type'] === 'T_STRING') {
+            if ($tokens[$curToken]['code'] === \T_STRING) {
                 // If the next non-whitespace token after the string
                 // is an opening parenthesis then it's a function call.
                 $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, $curToken + 1, null, true);
@@ -89,12 +101,15 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
                     $errorType = 'variableArgument';
                     break;
                 }
+            }
 
-            } elseif (\in_array($tokens[$curToken]['type'], array('T_VARIABLE', 'T_FUNCTION', 'T_CLOSURE'), true)) {
+            if (isset($this->varArgTokens[$tokens[$curToken]['code']]) === true) {
                 $errorType = 'variableArgument';
                 break;
 
-            } elseif ($tokens[$curToken]['code'] === \T_LNUMBER) {
+            }
+
+            if ($tokens[$curToken]['code'] === \T_LNUMBER) {
                 $numberInfo = Numbers::getCompleteNumber($phpcsFile, $curToken);
                 if ($numberInfo['decimal'] === '0') {
                     $errorType = 'zeroArgument';

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.inc
@@ -126,3 +126,41 @@ for ($x=0;$x<5;$x++):
     continue ?> <?php
     print 0;
 endfor;
+
+// Break/continue with non-decimal zero value.
+for ($y = 0; $y < 8; $y++) {
+   if ($y == 1) {
+       break 0x0; // Bad: zero.
+   }
+
+   if ($y == 2) {
+       break 0x1;
+   }
+
+   if ($y == 3) {
+       continue 00; // Bad: zero.
+   }
+
+   if ($y == 4) {
+       continue 01;
+   }
+
+   if ($y == 5) {
+       continue 0b0; // Bad: zero.
+   }
+
+   if ($y == 6) {
+       continue 0b1;
+   }
+}
+
+// Break/continue with PHP 7.4 numeric literals.
+for ($y = 0; $y < 8; $y++) {
+   if ($y == 3) {
+       continue 0_0; // Bad: zero.
+   }
+
+   if ($y == 4) {
+       continue 0_1;
+   }
+}

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.inc
@@ -86,11 +86,11 @@ for ($i = 0; $i < 20; $i++) {
 
         // Bad: Break/continue with a closure.
         if ($i == 10) {
-            break function () { return 1; }; // Bad.
+            break function () { return 1; }(); // Bad.
         }
 
         if ($i < 11) {
-            continue function () { return 1; }; // Bad.
+            continue function () { return 1; }(); // Bad.
         }
 
         // Bad: Break/continue with a namespaced function call.

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Tests\ControlStructures;
 
 use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Test the ForbiddenBreakContinueVariableArguments sniff.
@@ -64,7 +65,7 @@ class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
      */
     public function dataBreakAndContinueVariableArgument()
     {
-        return array(
+        $data = array(
             array(53, self::ERROR_TYPE_VARIABLE),
             array(57, self::ERROR_TYPE_VARIABLE),
             array(62, self::ERROR_TYPE_VARIABLE),
@@ -81,7 +82,16 @@ class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
             array(111, self::ERROR_TYPE_ZERO),
             array(118, self::ERROR_TYPE_ZERO),
             array(122, self::ERROR_TYPE_VARIABLE),
+            array(133, self::ERROR_TYPE_ZERO),
+            array(141, self::ERROR_TYPE_ZERO),
+            array(149, self::ERROR_TYPE_ZERO),
         );
+
+        if (version_compare(Helper::getVersion(), '3.5.3', '!=')) {
+            $data[] = array(160, self::ERROR_TYPE_ZERO);
+        }
+
+        return $data;
     }
 
 
@@ -121,6 +131,10 @@ class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
             array(44),
             array(48),
             array(126),
+            array(137),
+            array(145),
+            array(153),
+            array(164),
         );
     }
 


### PR DESCRIPTION
## ForbiddenBreakContinueVariableArguments: fix handling of PHP 7.4 numeric literals and non-decimals

While uncommon, passing a non-decimal integer as the argument to `continue`/`break` is actually supported by PHP, so should be correctly handled by the sniff.

Along the same lines, PHP 7.4 numeric literals with underscores should also be handled correctly by the sniff.

Includes unit tests.

## ForbiddenBreakContinueVariableArguments: minor tweaks

* Minor efficiency tweak by setting the "variable argument tokens" as a class property and using `isset()`.
* While the `T_FUNCTION` token may have been necessary in the past when the `T_CLOSURE` token wasn't backfilled (yet), it is no longer needed.
    A function declaration on the same line as `continue` would be a parse error, so not our concern as the function can't be called from within the same statement.
    And by the same logic, PHP 7.4 arrow functions don't need to be detected here either.
* Minor readability tweak by exchanging the `elseif`s for `if`s.

