### PR TITLE
NewListInForeach: add some extra unit tests

### DIFF
--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -75,6 +75,13 @@ class NewListInForeachSniff extends Sniff
             return;
         }
 
+        /*
+         * @internal No need to check for short array vs short list as if this token is found after the `as`
+         * in a `foreach`, it will always be a short list.
+         * Also not affected by any known tokenizer bugs which would tokenize the open bracket as
+         * `T_OPEN_SQUARE_BRACKET`.
+         */
+
         $phpcsFile->addError(
             'Unpacking nested arrays with list() in a foreach is not supported in PHP 5.4 or earlier.',
             $hasList,

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.inc
@@ -13,7 +13,14 @@ foreach ([1, 2, 3, 4, 5] as $user) {
  */
 foreach ($data as list($id, $name)) {}
 
-// Make sure it's also detected when using PHP 7.1 syntax.
+// Make sure it's also detected when using PHP 7.1 short list syntax.
 foreach ( $data as [ $id, $name ] ) {}
 foreach ($data as list("id" => $id, "name" => $name)) {}
 foreach ($data as ['id' => $id, 'name' => $name]) {}
+
+// Check correctly recognizing nested short lists in foreach.
+foreach ($data as [$id, [$name, $address]]) {}
+foreach ($data as $key => [$id, [$name, $address]]) {}
+
+// Make sure there's no false positives on incorrectly tokenized short array tokens in older PHPCS versions.
+foreach ( $data as $this->prop['key'] ) {}

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
@@ -54,6 +54,8 @@ class NewListInForeachUnitTest extends BaseSniffTest
             array(17),
             array(18),
             array(19),
+            array(22),
+            array(23),
         );
     }
 
@@ -85,6 +87,7 @@ class NewListInForeachUnitTest extends BaseSniffTest
         return array(
             array(6),
             array(7),
+            array(26),
         );
     }
 


### PR DESCRIPTION
... to verify that this sniff is not subseptible to the short array vs short list issue, nor to the incorrect tokenizing of short lists as `T_OPEN_SQUARE_BRACKET` and annotate the findings in the sniff.