### PR TITLE
ForbiddenParameterShadowSuperGlobals: add support for PHP 7.4 arrow functions

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -13,11 +13,10 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\Variables;
 
 /**
  * Detect the use of superglobals as parameters for functions, support for which was removed in PHP 5.4.
- *
- * {@internal List of superglobals is maintained in the parent class.}
  *
  * PHP version 5.4
  *
@@ -67,7 +66,7 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
         }
 
         foreach ($parameters as $param) {
-            if (isset($this->superglobals[$param['name']]) === true) {
+            if (Variables::isSuperglobalName($param['name']) === true) {
                 $error     = 'Parameter shadowing super global (%s) causes fatal error since PHP 5.4';
                 $errorCode = $this->stringToErrorCode(substr($param['name'], 1)) . 'Found';
                 $data      = array($param['name']);

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.inc
@@ -9,7 +9,7 @@ function testingE( $_FILES ) {}
 function testingF( $_COOKIE ) {}
 function testingG( $_SESSION ) {}
 function testingH( $_REQUEST ) {}
-function testingI( $_ENV ) {}
+class Foo { function testingI( $_ENV ) {} }
 
 // This should be ok.
 function testingJ( $globals ) {}
@@ -20,3 +20,6 @@ function testingL( $POST ) {}
 function ( $GLOBALS ) {}
 function( $_SERVER ) {}
 function($_GET) {}
+
+// Arrow functions: these should be flagged.
+$arrow = fn( $_ENV ) => $_ENV['key'];

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
@@ -39,7 +39,7 @@ class ForbiddenParameterShadowSuperGlobalsUnitTest extends BaseSniffTest
     public function testParameterShadowSuperGlobal($superglobal, $line)
     {
         $file = $this->sniffFile(__FILE__, '5.4');
-        $this->assertError($file, $line, "Parameter shadowing super global ({$superglobal}) causes fatal error since PHP 5.4");
+        $this->assertError($file, $line, "Parameter shadowing super global ({$superglobal}) causes a fatal error since PHP 5.4");
     }
 
     /**
@@ -64,6 +64,7 @@ class ForbiddenParameterShadowSuperGlobalsUnitTest extends BaseSniffTest
             array('$GLOBALS', 20),
             array('$_SERVER', 21),
             array('$_GET', 22),
+            array('$_ENV', 25),
         );
     }
 


### PR DESCRIPTION
## ForbiddenParameterShadowSuperGlobals: use Variables::isSuperglobalName()

... to determine whether a parameter shadows a super global.

## ForbiddenParameterShadowSuperGlobals: add support for PHP 7.4 arrow functions

Shadowing superglobals is also forbidden in arrow function declarations.

Includes unit test.

Additionally:
* Ensure methods are treated the same as global functions by adjusting an existing unit test.
* Minor grammatical fix for the error message.

