### PR TITLE
ForbiddenParametersWithSameName: bug fix + arrow functions support

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -78,10 +78,10 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
 
         $paramNames = array();
         foreach ($parameters as $param) {
-            $paramNames[] = $param['name'];
+            $paramNames[$param['name']] = true;
         }
 
-        if (\count($paramNames) !== \count(array_unique($paramNames))) {
+        if (\count($parameters) !== \count($paramNames)) {
             $phpcsFile->addError(
                 'Functions can not have multiple parameters with the same name since PHP 7.0',
                 $stackPtr,

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -65,13 +65,6 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
             return;
         }
 
-        $tokens = $phpcsFile->getTokens();
-        $token  = $tokens[$stackPtr];
-        // Skip function without body.
-        if (isset($token['scope_opener']) === false) {
-            return;
-        }
-
         // Get all parameters from method signature.
         try {
             $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.inc
@@ -10,5 +10,13 @@ function varsAreCaseSensitive( $a, $A ) {}
 
 $arrow = fn ($a, $b, $a) => $a * $b; // PHP 7.4 arrow function.
 
+interface Foo {
+    public function bar( $a, $a );
+}
+
+abstract class Foo {
+    abstract public function bar( $a, $a );
+}
+
 // Don't throw errors during live code review.
 function foobar($a,$a

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.inc
@@ -8,5 +8,7 @@ function ($a, $b, $unused, $unused) {}; // Anonymous function with params of sam
 
 function varsAreCaseSensitive( $a, $A ) {}
 
+$arrow = fn ($a, $b, $a) => $a * $b; // PHP 7.4 arrow function.
+
 // Don't throw errors during live code review.
 function foobar($a,$a

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
@@ -52,6 +52,7 @@ class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTest
         return array(
             array(3),
             array(7),
+            array(11),
         );
     }
 
@@ -83,7 +84,7 @@ class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTest
         return array(
             array(5),
             array(9),
-            array(10),
+            array(14),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
@@ -53,6 +53,8 @@ class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTest
             array(3),
             array(7),
             array(11),
+            array(14),
+            array(18),
         );
     }
 
@@ -84,7 +86,7 @@ class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTest
         return array(
             array(5),
             array(9),
-            array(14),
+            array(22),
         );
     }
 


### PR DESCRIPTION
## ForbiddenParametersWithSameName: add support for PHP 7.4 arrow functions

Parameters with the same name are also forbidden in arrow function declarations.

Includes unit test.

## ForbiddenParametersWithSameName: bug fix - false negative for functions without body

Methods declared in interfaces or as an abstract method in an abstract class will also generate a fatal error.

The parse error protection used previously was a little overzealous as it would also prevent notices from being thrown for the above mentioned cases.
Parse errors are handled in the `FunctionDeclarations::getParameters()` method anyhow.

Fixed now by removing the superfluous check.

Includes unit tests.

## ForbiddenParametersWithSameName: minor efficiency tweak

No need for the `array_unique()` function call.

