### PR TITLE
ForbiddenToStringParameters: use PHPCSUtils x 2

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -12,7 +12,6 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
 
@@ -60,13 +59,13 @@ class ForbiddenToStringParametersSniff extends Sniff
             return;
         }
 
-        $functionName = $phpcsFile->getDeclarationName($stackPtr);
+        $functionName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
         if (strtolower($functionName) !== '__tostring') {
             // Not the right function.
             return;
         }
 
-        if (Scopes::validDirectScope($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) === false) {
+        if (Scopes::isOOMethod($phpcsFile, $stackPtr) === false) {
             // Function, not method.
             return;
         }


### PR DESCRIPTION
* Switch out the call to `validDirectScope()` for one to the `isOOMethod()` method, which does the same (and makes the code more descriptive).
* Switch out the call to the PHPCS native `File::getDeclarationname()` for one to the `FunctionDeclarations::getName()` method which has improved parse/tokenizer error handling.