### PR TITLE
NewNullableTypes: use PHPCSUtils + add support for PHP 7.4 arrow functions

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -13,6 +13,8 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
@@ -36,15 +38,19 @@ class NewNullableTypesSniff extends Sniff
      * return type hints for the error message.}
      *
      * @since 7.0.7
+     * @since 10.0.0 Allows for PHP 7.4+ arrow functions.
      *
      * @return array
      */
     public function register()
     {
-        return array(
+        $targets  = array(
             \T_FUNCTION,
             \T_CLOSURE,
         );
+        $targets += Collections::arrowFunctionTokensBC();
+
+        return $targets;
     }
 
 
@@ -65,35 +71,40 @@ class NewNullableTypesSniff extends Sniff
             return;
         }
 
-        /*
-         * Check parameter type declarations.
-         */
-        $params = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
-        if (empty($params) === false) {
-            foreach ($params as $param) {
-                if ($param['nullable_type'] === true) {
-                    $phpcsFile->addError(
-                        'Nullable type declarations are not supported in PHP 7.0 or earlier. Found: %s',
-                        $param['token'],
-                        'typeDeclarationFound',
-                        array($param['type_hint'])
-                    );
+        try {
+            /*
+             * Check parameter type declarations.
+             */
+            $params = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+            if (empty($params) === false) {
+                foreach ($params as $param) {
+                    if ($param['nullable_type'] === true) {
+                        $phpcsFile->addError(
+                            'Nullable type declarations are not supported in PHP 7.0 or earlier. Found: %s',
+                            $param['token'],
+                            'typeDeclarationFound',
+                            array($param['type_hint'])
+                        );
+                    }
                 }
             }
-        }
 
-        /*
-         * Check return type declarations.
-         */
-        $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
-        if ($properties['nullable_return_type'] === true) {
-            $nullPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($properties['return_type_token'] - 1), null, true);
-            $phpcsFile->addError(
-                'Nullable return types are not supported in PHP 7.0 or earlier. Found: %s',
-                $nullPtr,
-                'returnTypeFound',
-                array($properties['return_type'])
-            );
+            /*
+             * Check return type declarations.
+             */
+            $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
+            if ($properties['nullable_return_type'] === true) {
+                $nullPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($properties['return_type_token'] - 1), null, true);
+                $phpcsFile->addError(
+                    'Nullable return types are not supported in PHP 7.0 or earlier. Found: %s',
+                    $nullPtr,
+                    'returnTypeFound',
+                    array($properties['return_type'])
+                );
+            }
+        } catch (RuntimeException $e) {
+            // Most likely a T_STRING which wasn't an arrow function.
+            return;
         }
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -44,7 +44,6 @@ class NewNullableTypesSniff extends Sniff
         return array(
             \T_FUNCTION,
             \T_CLOSURE,
-            \T_RETURN_TYPE,
         );
     }
 
@@ -66,40 +65,11 @@ class NewNullableTypesSniff extends Sniff
             return;
         }
 
-        $tokens    = $phpcsFile->getTokens();
-        $tokenCode = $tokens[$stackPtr]['code'];
-
-        if ($tokenCode === \T_FUNCTION || $tokenCode === \T_CLOSURE) {
-            $this->processFunctionDeclaration($phpcsFile, $stackPtr);
-
-            // Deal with older PHPCS version which don't recognize return type hints
-            // as well as newer PHPCS versions (3.3.0+) where the tokenization has changed.
-            $returnTypeHint = $this->getReturnTypeHintToken($phpcsFile, $stackPtr);
-            if ($returnTypeHint !== false) {
-                $this->processReturnType($phpcsFile, $returnTypeHint);
-            }
-        } else {
-            $this->processReturnType($phpcsFile, $stackPtr);
-        }
-    }
-
-
-    /**
-     * Process this test for function tokens.
-     *
-     * @since 7.0.7
-     *
-     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                   $stackPtr  The position of the current token
-     *                                         in the stack passed in $tokens.
-     *
-     * @return void
-     */
-    protected function processFunctionDeclaration(File $phpcsFile, $stackPtr)
-    {
+        /*
+         * Check parameter type declarations.
+         */
         $params = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
-
-        if (empty($params) === false && \is_array($params)) {
+        if (empty($params) === false) {
             foreach ($params as $param) {
                 if ($param['nullable_type'] === true) {
                     $phpcsFile->addError(
@@ -111,53 +81,18 @@ class NewNullableTypesSniff extends Sniff
                 }
             }
         }
-    }
 
-
-    /**
-     * Process this test for return type tokens.
-     *
-     * @since 7.0.7
-     *
-     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                   $stackPtr  The position of the current token
-     *                                         in the stack passed in $tokens.
-     *
-     * @return void
-     */
-    protected function processReturnType(File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
-
-        if (isset($tokens[($stackPtr - 1)]['code']) === false) {
-            return;
-        }
-
-        $previous = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-
-        // Deal with namespaced class names.
-        if ($tokens[$previous]['code'] === \T_NS_SEPARATOR) {
-            $validTokens                  = Tokens::$emptyTokens;
-            $validTokens[\T_STRING]       = true;
-            $validTokens[\T_NS_SEPARATOR] = true;
-
-            $stackPtr--;
-
-            while (isset($validTokens[$tokens[($stackPtr - 1)]['code']]) === true) {
-                $stackPtr--;
-            }
-
-            $previous = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        }
-
-        // T_NULLABLE token was introduced in PHPCS 2.8.0. Before that it identified as T_INLINE_THEN.
-        if ((\defined('T_NULLABLE') === true && $tokens[$previous]['type'] === 'T_NULLABLE')
-            || (\defined('T_NULLABLE') === false && $tokens[$previous]['code'] === \T_INLINE_THEN)
-        ) {
+        /*
+         * Check return type declarations.
+         */
+        $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
+        if ($properties['nullable_return_type'] === true) {
+            $nullPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($properties['return_type_token'] - 1), null, true);
             $phpcsFile->addError(
-                'Nullable return types are not supported in PHP 7.0 or earlier.',
-                $stackPtr,
-                'returnTypeFound'
+                'Nullable return types are not supported in PHP 7.0 or earlier. Found: %s',
+                $nullPtr,
+                'returnTypeFound',
+                array($properties['return_type'])
             );
         }
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.inc
@@ -81,3 +81,6 @@ function testTypeDeclarationsInterspersedWithComments(
 	Baz
 {
 }
+
+// PHP 7.4 arrow functions with nullable types.
+$arrow = fn(?int $a): ?\bool => $a > 10;

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
@@ -20,7 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group typeDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewNullableTypesSniff
- * @covers \PHPCompatibility\Sniff::getReturnTypeHintToken
  *
  * @since 7.0.7
  */

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
@@ -63,6 +63,7 @@ class NewNullableTypesUnitTest extends BaseSniffTest
 
             array(63),
             array(77),
+            array(86),
         );
     }
 
@@ -107,6 +108,7 @@ class NewNullableTypesUnitTest extends BaseSniffTest
             array(64),
             array(68),
             array(74),
+            array(86),
         );
     }
 


### PR DESCRIPTION
## NewNullableTypes: use FunctionDeclarations::getProperties()

The return value  of the PHPCS native `File::getMethodProperties()` method contains a `nullable_return_type` index key since PHPCS 3.3.0.

PHPCSUtils backports this functionality back to PHPCS 2.6.0.

This now allows us to remove the sniffing for the `T_RETURN_TYPE` token and the custom token walking for the analysis of a function return type declaration, which greatly simplifies the sniff.

## NewNullableTypes: add support for PHP 7.4 arrow functions

... which may use nullable types as well.

