### PR TITLE
NewParamTypeDeclarations: bug fix (nested functions) + support arrow functions

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -70,5 +70,13 @@ class Bar {
     function baz() {
         $c = function (self $a) {}; // Ok.
         function foo(self $a) {} // Invalid - not within class scope.
+        $arrow = fn(parent $a) => $a->prop; // Ok.
     }
 }
+
+// PHP 7.4 arrow functions.
+$arrow = fn(int $a) => $a * 10;
+$arrow = fn(\FQN\ClassName $b) => $b::method();
+$arrow = fn(callable $a) => $a();
+$arrow = fn(integer $a) => $a . 'test';
+$arrow = fn($a) => $a * 10; // OK.

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -65,3 +65,10 @@ function foo(parent $a) {} // Invalid - not within a class.
 namespace test {
     function foo(parent $a) {} // Invalid - not within a class.
 }
+
+class Bar {
+    function baz() {
+        $c = function (self $a) {}; // Ok.
+        function foo(self $a) {} // Invalid - not within class scope.
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -83,6 +83,9 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             array('parent', '5.1', 66, '5.2', false),
             array('self', '5.1', 71, '5.2'),
             array('self', '5.1', 72, '5.2', false),
+            array('parent', '5.1', 73, '5.2', false),
+            array('int', '5.6', 78, '7.0'),
+            array('callable', '5.3', 80, '5.4'),
         );
     }
 
@@ -117,6 +120,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             array('boolean', 'bool', 20),
             array('integer', 'int', 21),
             array('static', 'self', 25),
+            array('integer', 'int', 81),
         );
     }
 
@@ -182,6 +186,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
     {
         return array(
             array(71),
+            array(73),
         );
     }
 
@@ -246,6 +251,11 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             array(66),
             array(71),
             array(72),
+            array(73),
+            array(78),
+            array(79),
+            array(80),
+            array(81),
         );
     }
 
@@ -277,6 +287,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
         return array(
             array(48),
             array(49),
+            array(82),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -81,6 +81,8 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             array('object', '7.1', 60, '7.2'),
             array('parent', '5.1', 63, '5.2', false),
             array('parent', '5.1', 66, '5.2', false),
+            array('self', '5.1', 71, '5.2'),
+            array('self', '5.1', 72, '5.2', false),
         );
     }
 
@@ -125,7 +127,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
      * @dataProvider dataInvalidSelfTypeDeclaration
      *
      * @param int    $line Line number on which to expect an error.
-     * @param string $type The invalid type which should eb expected.
+     * @param string $type The invalid type which should be expected.
      *
      * @return void
      */
@@ -149,6 +151,37 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             array(44, 'self'),
             array(63, 'parent'),
             array(66, 'parent'),
+            array(72, 'self'),
+        );
+    }
+
+
+    /**
+     * testInvalidSelfTypeDeclaration
+     *
+     * @dataProvider dataInvalidSelfTypeDeclarationNoFalsePositives
+     *
+     * @param int $line Line number on which to expect an error.
+     *
+     * @return void
+     */
+    public function testInvalidSelfTypeDeclarationNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidSelfTypeDeclarationNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataInvalidSelfTypeDeclarationNoFalsePositives()
+    {
+        return array(
+            array(71),
         );
     }
 
@@ -211,6 +244,8 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             array(60),
             array(63),
             array(66),
+            array(71),
+            array(72),
         );
     }
 


### PR DESCRIPTION
## NewParamTypeDeclarations: bug fix - throw error for nested function declarations

This fixes a bug where the sniff was underreporting for `self`/`parent` type declarations used in nested functions within class methods.

```php
class Bar {
    function baz() {
        function foo(self $a) {} // Invalid - not within class scope.
    }
}
```

Includes unit test.

## NewParamTypeDeclarations: add support for PHP 7.4 arrow functions

Analyze the parameter type declarations in arrow function declarations too.

Includes unit test.

