### PR TITLE
NewReturnTypeDeclarations: use PHPCSUtils + support arrow functions

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -37,3 +37,7 @@ function fooInterspersedWithComments($a) :
 	Baz
 {
 }
+
+// PHP 7.4 arrow functions.
+$arrow = fn($a) => $a * 10;
+$arrow = fn($a) : int => $a * 10;

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -70,6 +70,7 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             array('Class name', '5.6', 14, '7.0'),
             array('Class name', '5.6', 15, '7.0'),
             array('Class name', '5.6', 37, '7.0'),
+            array('int', '5.6', 43, '7.0'),
 
             array('iterable', '7.0', 18, '7.1'),
             array('void', '7.0', 19, '7.1'),
@@ -108,6 +109,7 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
         return array(
             array(25),
             array(26),
+            array(42),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -20,7 +20,6 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group typeDeclarations
  *
  * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewReturnTypeDeclarationsSniff
- * @covers \PHPCompatibility\Sniff::getReturnTypeHintToken
  *
  * @since 7.0.0
  */


### PR DESCRIPTION
## NewReturnTypeDeclarations: use FunctionDeclarations::getProperties()

The return value  of the PHPCS native `File::getMethodProperties()` method contains a `return_type` and a `return_type_token` index key since PHPCS 3.3.0.

PHPCSUtils backports this functionality back to PHPCS 2.6.0, as well as adding a `return_type_end_token` index to the return value.

This now allows us to remove the sniffing for the `T_RETURN_TYPE` token and simplify the sniff a little.

## NewReturnTypeDeclarations: add support for PHP 7.4 arrow functions

... which may use return types as well.

Includes unit tests.

