### PR TITLE
NonStaticMagicMethods: use PHPCSUtils & simplify the sniff

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -162,7 +162,9 @@ class NonStaticMagicMethodsSniff extends Sniff
         $methodProperties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
         $errorCodeBase    = $this->stringToErrorCode($methodNameLc);
 
-        if (isset($this->magicMethods[$methodNameLc]['visibility']) && $this->magicMethods[$methodNameLc]['visibility'] !== $methodProperties['scope']) {
+        if (isset($this->magicMethods[$methodNameLc]['visibility'])
+            && $this->magicMethods[$methodNameLc]['visibility'] !== $methodProperties['scope']
+        ) {
             $error     = 'Visibility for magic method %s must be %s. Found: %s';
             $errorCode = $errorCodeBase . 'MethodVisibility';
             $data      = array(
@@ -174,7 +176,9 @@ class NonStaticMagicMethodsSniff extends Sniff
             $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
         }
 
-        if (isset($this->magicMethods[$methodNameLc]['static']) && $this->magicMethods[$methodNameLc]['static'] !== $methodProperties['is_static']) {
+        if (isset($this->magicMethods[$methodNameLc]['static'])
+            && $this->magicMethods[$methodNameLc]['static'] !== $methodProperties['is_static']
+        ) {
             $error     = 'Magic method %s cannot be defined as static.';
             $errorCode = $errorCodeBase . 'MethodStatic';
             $data      = array($methodName);

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
+use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
 
 /**
@@ -150,7 +151,7 @@ class NonStaticMagicMethodsSniff extends Sniff
             return;
         }
 
-        $methodName   = $phpcsFile->getDeclarationName($stackPtr);
+        $methodName   = FunctionDeclarations::getName($phpcsFile, $stackPtr);
         $methodNameLc = strtolower($methodName);
 
         if (isset($this->magicMethods[$methodNameLc]) === false) {
@@ -158,7 +159,7 @@ class NonStaticMagicMethodsSniff extends Sniff
             return;
         }
 
-        $methodProperties = $phpcsFile->getMethodProperties($stackPtr);
+        $methodProperties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
         $errorCodeBase    = $this->stringToErrorCode($methodNameLc);
 
         if (isset($this->magicMethods[$methodNameLc]['visibility']) && $this->magicMethods[$methodNameLc]['visibility'] !== $methodProperties['scope']) {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
@@ -271,3 +271,9 @@ trait WrongStaticTrait
     public static function __serialize() {}
     static public function __unserialize($data) {}
 }
+
+class Nested {
+    public function something() {
+        function __get() {} // This is a global function, not a method.
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -367,6 +367,9 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             array(243),
             array(244),
             array(245),
+
+            // Nested function.
+            array(277),
         );
     }
 


### PR DESCRIPTION
## NonStaticMagicMethods: add extra unit test

... to verify & safeguard that functions nested in methods will not give false positives.

## NonStaticMagicMethods: simplify the logic

Until now, the sniff started from a class/interface/trait token and would walk the whole scope to find all the method declarations contained therein.

This changes the entry-point for the sniff to `T_FUNCTION` combined with a quick "is this an OO method ?" check at the start of the sniff, which allows for removing all the token walking logic from the sniff, making the sniff a little faster.

Note: this commit will be easiest to review with the "ignore whitespace changes" option turned on.

## NonStaticMagicMethods: use PHPCSUtils FunctionDeclarations methods

## NonStaticMagicMethods: minor code readability improvement 