### PR TITLE
NewGeneratorReturn: use PHPCSUtils + prevent false positive for arrow functions

### DIFF
--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Generators;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\Conditions;
 
 /**
  * As of PHP 7.0, a `return` statement can be used within a generator for a final expression to be returned.
@@ -104,20 +105,8 @@ class NewGeneratorReturnSniff extends Sniff
             return;
         }
 
-        if (empty($tokens[$stackPtr]['conditions']) === true) {
-            return;
-        }
-
-        // Walk the condition from inner to outer to see if we can find a valid function/closure scope.
-        $conditions = array_reverse($tokens[$stackPtr]['conditions'], true);
-        foreach ($conditions as $ptr => $type) {
-            if (isset($this->validConditions[$type]) === true) {
-                $function = $ptr;
-                break;
-            }
-        }
-
-        if (isset($function) === false) {
+        $function = Conditions::getLastCondition($phpcsFile, $stackPtr, $this->validConditions);
+        if ($function === false) {
             // Yield outside function scope, fatal error, but not our concern.
             return;
         }

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Generators;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Utils\Conditions;
 
@@ -102,6 +103,19 @@ class NewGeneratorReturnSniff extends Sniff
         if ($tokens[$stackPtr]['code'] === \T_STRING
             && $tokens[$stackPtr]['content'] !== 'yield'
         ) {
+            return;
+        }
+
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($prevNonEmpty !== false
+            && ($tokens[$prevNonEmpty]['type'] === 'T_FN_ARROW'
+            || $tokens[$prevNonEmpty]['code'] === \T_DOUBLE_ARROW)
+        ) {
+            /*
+             * Yield in an arrow function, which can only contain one expression.
+             * And as `yield` can not be used within an array declaration or a foreach expression,
+             * just checking for the double arrow should be sufficient.
+             */
             return;
         }
 

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.inc
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.inc
@@ -79,7 +79,7 @@ function xrange($start, $limit, $step = 1) {
             yield $i;
         }
     }
-    
+
     return 100; // Not OK.
 }
 
@@ -106,9 +106,15 @@ function nestedClosureReturn() {
 	$a = function() {
 		return 10; // OK.
 	};
-	
+
 	$a();
 
 	yield 20;
 }
 
+function notAGeneratorNestedArrowGenerator($a) {
+    $arrow1 = fn($i) => yield $i++;
+    $arrow2 = fn($array) => yield from $array;
+
+    return $arrow1($a); // OK.
+}

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -90,6 +90,7 @@ class NewGeneratorReturnUnitTest extends BaseSniffTest
             array(21),
             array(53),
             array(107),
+            array(119),
         );
     }
 


### PR DESCRIPTION
## NewGeneratorReturn: use Conditions::getLastCondition()

... to retrieve a valid scope instead of walking the conditions ourselves.

## NewGeneratorReturn: prevent false positives for `yield` in PHP 7.4 arrow functions

:exclamation:  [**_Critical look warranted - more realistic test code where arrow functions with yield are used within a function would be helpful to test with_**]

As arrow functions can only contain one expression, they can never have both a `yield` as well as a `return`, so just bow out in that case.

Includes unit test.

