### PR TITLE
NewConstantArraysUsingConst: fix false positives on older PHPCS versions

### DIFF
--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.inc
@@ -41,3 +41,7 @@ const MULTI_A = 1,
     MULTI_F = array(
         ['c', 'd'],
     );
+
+// Constant array dereferencing.
+const DEREF = OTHER['key'];
+const DEREF = 'string'[2];

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
@@ -94,6 +94,8 @@ class NewConstantArraysUsingConstUnitTest extends BaseSniffTest
             array(38),
             array(40),
             array(42),
+            array(46),
+            array(47),
         );
     }
 


### PR DESCRIPTION
The second of the new unit tests would fail on older PHPCS versions without the "is short array" check due to upstream tokenizer issues.

Note: I'm not using the `Collections::$arrayTokensBC` property as constant declarations with an array value are not affected by the tokenizer bugs where a short array could be incorrectly tokenized as `T_OPEN/CLOSE_SQUARE_BRACKET` in older PHPCS versions.