### PR TITLE
NewShortList: BC fix for tokenizer issues in older PHPCS versions

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -40,7 +40,10 @@ class NewShortListSniff extends Sniff
      */
     public function register()
     {
-        return array(\T_OPEN_SHORT_ARRAY);
+        return array(
+            \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET,
+        );
     }
 
     /**

--- a/PHPCompatibility/Tests/Lists/NewShortListUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewShortListUnitTest.inc
@@ -29,3 +29,7 @@ foreach ($data as [$id, $name]) {}
 
 // List does not contain variables.
 [42] = [1];
+
+// Test specific buggy tokenizer issue.
+if (true) {}
+[$id1, $name1] = $data[0];

--- a/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
@@ -57,6 +57,7 @@ class NewShortListUnitTest extends BaseSniffTest
             array(23),
             array(25), // x2.
             array(28),
+            array(35),
         );
     }
 


### PR DESCRIPTION
Short lists are sometimes tokenized as `T_OPEN/CLOSE_SQUARE_BRACKET`. The `Lists::isShortList()` method handles these correctly for BC.

Includes unit tests.