### PR TITLE
RemovedTernaryAssociativity: use BCTokens::assignmentTokens()

### DIFF
--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -12,8 +12,8 @@ namespace PHPCompatibility\Sniffs\Operators;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
 use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\Operators;
 
 /**
@@ -115,7 +115,7 @@ class RemovedTernaryAssociativitySniff extends Sniff
             }
 
             // Check for operators with lower operator precedence.
-            if (isset(Tokens::$assignmentTokens[$tokens[$i]['code']])
+            if (isset(BCTokens::assignmentTokens()[$tokens[$i]['code']])
                 || isset($this->tokensWithLowerPrecedence[$tokens[$i]['code']])
             ) {
                 break;


### PR DESCRIPTION
The assignment tokens array has changed between PHPCS 2.6.0 and current. The `BCTokens::assignmentTokens()` method backfills the changes back to PHPCS 2.6.0 (in as far as possible as the tokens involved may or may not be available depending on the PHPCS and the PHP version used).