### PR TITLE
ForbiddenCallTimePassByReference: use PHPCSUtils x 2

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -13,6 +13,8 @@ namespace PHPCompatibility\Sniffs\Syntax;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -35,40 +37,13 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
     /**
      * Tokens that represent assignments or equality comparisons.
      *
-     * Near duplicate of Tokens::$assignmentTokens + Tokens::$equalityTokens.
-     * Copied in for PHPCS cross-version compatibility.
+     * Tokens are set via register(). Combines Tokens::$assignmentTokens + Tokens::$equalityTokens.
      *
      * @since 8.1.0
      *
      * @var array
      */
-    private $assignOrCompare = array(
-        // Equality tokens.
-        'T_IS_EQUAL'            => true,
-        'T_IS_NOT_EQUAL'        => true,
-        'T_IS_IDENTICAL'        => true,
-        'T_IS_NOT_IDENTICAL'    => true,
-        'T_IS_SMALLER_OR_EQUAL' => true,
-        'T_IS_GREATER_OR_EQUAL' => true,
-
-        // Assignment tokens.
-        'T_EQUAL'          => true,
-        'T_AND_EQUAL'      => true,
-        'T_OR_EQUAL'       => true,
-        'T_CONCAT_EQUAL'   => true,
-        'T_DIV_EQUAL'      => true,
-        'T_MINUS_EQUAL'    => true,
-        'T_POW_EQUAL'      => true,
-        'T_MOD_EQUAL'      => true,
-        'T_MUL_EQUAL'      => true,
-        'T_PLUS_EQUAL'     => true,
-        'T_XOR_EQUAL'      => true,
-        'T_DOUBLE_ARROW'   => true,
-        'T_SL_EQUAL'       => true,
-        'T_SR_EQUAL'       => true,
-        'T_COALESCE_EQUAL' => true,
-        'T_ZSR_EQUAL'      => true,
-    );
+    private $assignOrCompare = array();
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -79,6 +54,8 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
      */
     public function register()
     {
+        $this->assignOrCompare = BCTokens::assignmentTokens() + BCTokens::equalityTokens();
+
         return array(
             \T_STRING,
             \T_VARIABLE,
@@ -118,7 +95,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
             true
         );
 
-        if ($prevNonEmpty !== false && \in_array($tokens[$prevNonEmpty]['code'], array(\T_FUNCTION, \T_CLASS, \T_INTERFACE, \T_TRAIT), true)) {
+        if ($prevNonEmpty !== false && isset(Collections::$closedScopes[$tokens[$prevNonEmpty]['code']]) === true) {
             return;
         }
 
@@ -245,7 +222,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
             // Prevent false positive on assign by reference and compare with reference
             // within function call parameters.
-            if (isset($this->assignOrCompare[$tokens[$tokenBefore]['type']])) {
+            if (isset($this->assignOrCompare[$tokens[$tokenBefore]['code']])) {
                 continue;
             }
 


### PR DESCRIPTION
## ForbiddenCallTimePassByReference: use PHPCSUtils x 2

* Use the `BCTokens` class to get access to the latest version of the PHPCS native token arrays.
* Use `Collections::$closedScopes` for a preset of closed scope tokens.

## ForbiddenCallTimePassByReference: efficiency tweaks

* Remove some redundant conditions which would always be `true`.
* Skip over long arrays.

