### PR TITLE
NewArrayUnpacking: bug fix / cross version compatibility and short lists

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Syntax;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCSUtils\Utils\GetTokensAsString;
 
 /**
  * Using the spread operator for unpacking arrays in array expressions is available since PHP 7.4.
@@ -130,7 +131,7 @@ class NewArrayUnpackingSniff extends Sniff
 
             // Ok, found one.
             $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
-            $snippet      = trim($phpcsFile->getTokensAsString($i, (($nextNonEmpty - $i) + 1)));
+            $snippet      = GetTokensAsString::compact($phpcsFile, $i, $nextNonEmpty, true);
             $phpcsFile->addError(
                 'Array unpacking within array declarations using the spread operator is not supported in PHP 7.3 or earlier. Found: %s',
                 $i,

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.inc
@@ -37,6 +37,9 @@ $arr8 = [...arrGen()];
 // Unpacking array by reference is not supported in PHP 7.4, but not our concern, throw an error anyway.
 $arr2 = [...&$arr1];
 
+// Short list, not short array. Parse error. Ignore.
+[$a, ...$b] = $array;
+
 // Intentional parse error. This has to be the last test in the file.
 $arr5 = array(
     ...$arr1,

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
@@ -63,8 +63,6 @@ class NewArrayUnpackingUnitTest extends BaseSniffTest
             array(34),
             array(35),
             array(38),
-            array(42),
-            array(43),
         );
     }
 
@@ -72,15 +70,40 @@ class NewArrayUnpackingUnitTest extends BaseSniffTest
     /**
      * Verify the sniff doesn't throw false positives.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param array $line The line number on which the error should occur.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file, $line);
+    }
 
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = array();
         for ($line = 1; $line < 7; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = array($line);
         }
+
+        // Short list.
+        $data[] = array(41);
+
+        // Don't report for live coding.
+        $data[] = array(45);
+        $data[] = array(46);
+
+        return $data;
     }
 
 


### PR DESCRIPTION
## NewArrayUnpacking: use `GetTokensAsString::compact()`

... to get a cleaner code snippet to show in the error message. (multi-space whitespace compacted to one space, comments removed)

## NewArrayUnpacking: bug fix / cross version compatibility and short lists

Use the `Arrays::getOpenClose()` method to retrieve the array open/close brackets and include `T_OPEN_SQUARE_BRACKET` for listening.

This fixes two bugs:
1. The spread operator when used in _short list_ structures would previously trigger an error.
    This will no longer be the case.
    The spread operator is not supported in _list_ structures, so that would be a parse error anyway.
    Ignoring those is in line with the behaviour in most sniffs.
2. Short array tokens were sometimes tokenized as plain square brackets and some plain square brackets were sometimes tokenized as short array in older PHPCS versions.
    Short arrays will now consistently be recognized correctly.

Note: This also changes the behaviour of the sniff during live coding.
Previously, if code was unfinished, the sniff would still trigger errors for encountered spread operators.
Now it no longer will.
IMO this is an acceptable behaviour change as most sniffs stay silent in case of live coding/parse errors. This sniff now just falls in line with that.

Includes minor simplification of some of the conditions.
Includes additional unit test for short list.
Includes changing the "no false positives" test to use a data provider.

