### PR TITLE
NewShortArray: prevent false positives on short lists and fix false negatives

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -12,6 +12,8 @@ namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Arrays;
 
 /**
  * Detect use of short array syntax which is available since PHP 5.4.
@@ -36,10 +38,7 @@ class NewShortArraySniff extends Sniff
      */
     public function register()
     {
-        return array(
-            \T_OPEN_SHORT_ARRAY,
-            \T_CLOSE_SHORT_ARRAY,
-        );
+        return Collections::$shortArrayTokensBC;
     }
 
 
@@ -60,15 +59,19 @@ class NewShortArraySniff extends Sniff
             return;
         }
 
+        if (Arrays::isShortArray($phpcsFile, $stackPtr) === false) {
+            return;
+        }
+
         $tokens = $phpcsFile->getTokens();
         $token  = $tokens[$stackPtr];
 
         $error = '%s is not supported in PHP 5.3 or lower';
         $data  = array();
 
-        if ($token['type'] === 'T_OPEN_SHORT_ARRAY') {
+        if ($token['code'] === \T_OPEN_SHORT_ARRAY || $token['code'] === \T_OPEN_SQUARE_BRACKET) {
             $data[] = 'Short array syntax (open)';
-        } elseif ($token['type'] === 'T_CLOSE_SHORT_ARRAY') {
+        } elseif ($token['code'] === \T_CLOSE_SHORT_ARRAY || $token['code'] === \T_CLOSE_SQUARE_BRACKET) {
             $data[] = 'Short array syntax (close)';
         }
 

--- a/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.inc
@@ -17,3 +17,9 @@ $arr[] = [
     'A',
     'B'
 ];
+
+// Direct array dereferencing (tokenizer bug in older PHPCS versions).
+echo [ 1,2,3 ][0]; // Error x1 (not 2).
+
+// Short list, not short array.
+[$a, $b] = $array;

--- a/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
@@ -56,6 +56,7 @@ class NewShortArrayUnitTest extends BaseSniffTest
             array(13, 13),
             array(14, 14),
             array(16, 19),
+            array(22, 22),
         );
     }
 
@@ -88,6 +89,7 @@ class NewShortArrayUnitTest extends BaseSniffTest
             array(5),
             array(6),
             array(7),
+            array(25),
         );
     }
 


### PR DESCRIPTION
* Prevent false positives on short lists as those are handled by a different sniff.
* Fix false negatives: report on short arrays which are incorrectly tokenized as `T_OPEN/CLOSE_SQUARE_BRACKET` on older PHPCS versions.

Includes unit tests.