### PR TITLE
NewUseConstFunction: only check import `use` statements

### DIFF
--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\UseDeclarations;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCSUtils\Utils\UseStatements;
 
 /**
  * Detect importing constants and functions via a `use` statement.
@@ -71,6 +72,10 @@ class NewUseConstFunctionSniff extends Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.5') !== true) {
+            return;
+        }
+
+        if (UseStatements::isImportUse($phpcsFile, $stackPtr) === false) {
             return;
         }
 

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.inc
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.inc
@@ -8,63 +8,28 @@ namespace FooBar;
     use Foobar as Baz;
     use Foobar as Baz, Bay as BarFoo;
 
+/*
+ * Not import use statements.
+ */
 class Foobar {
     use Baz;
 }
 
 class Foobar {
     use BazTrait {
-        oldfunction as Baz
+        oldfunction as Baz;
     }
 }
 
-class Foobar {
-    use BazTrait {
-        oldfunction as public Baz
-    }
-}
-
-class Foobar {
-    use BazTrait {
-        oldfunction as protected Baz
-    }
-}
-
-class Foobar {
-    use BazTrait {
-        oldfunction as private Baz
-    }
-}
-
-class Foobar {
-    use BazTrait {
-        oldfunction as final Baz
-    }
-}
+$closure = function($a) use ($b) {};
 
 /*
  * PHP 5.6: Use statements using `const` and `function`
  */
 use const Baz;
-use const FOOBAR as Baz;
+use Const FOOBAR as Baz;
 use function Baz;
-use function FooBar as Baz;
-
-class Foobar {
-    use const Baz;
-}
-
-class Foobar {
-    use function Baz;
-}
-
-trait Foobar {
-    use const Baz;
-}
-
-trait Foobar {
-    use function Baz;
-}
+use FUNCTION FooBar as Baz;
 
 /*
  * Incorrect use, but covered by ForbiddenNames sniff, should not be reported here.
@@ -72,3 +37,15 @@ trait Foobar {
 use const as Baz;
 use function as Baz;
 use const, function, somethingElse;
+
+/*
+ * Not supported by PHP, so the sniff should ignore these.
+ */
+class Foobar {
+    use const Baz;
+    use function Bar;
+}
+
+// Live coding.
+// Intentional parse error. This should be the last test in the file.
+use function

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
@@ -50,14 +50,10 @@ class NewUseConstFunctionUnitTest extends BaseSniffTest
     public function dataNewUseConstFunction()
     {
         return array(
-            array(48),
-            array(49),
-            array(50),
-            array(51),
-            array(54),
-            array(58),
-            array(62),
-            array(66),
+            array(29),
+            array(30),
+            array(31),
+            array(32),
         );
     }
 
@@ -90,15 +86,15 @@ class NewUseConstFunctionUnitTest extends BaseSniffTest
             array(7),
             array(8),
             array(9),
-            array(12),
-            array(16),
-            array(22),
-            array(28),
-            array(34),
-            array(40),
-            array(72),
-            array(73),
-            array(74),
+            array(15),
+            array(19),
+            array(24),
+            array(37),
+            array(38),
+            array(39),
+            array(45),
+            array(46),
+            array(51),
         );
     }
 


### PR DESCRIPTION
## NewUseConstFunction: improve unit tests

* There were unintentional parse errors in the unit tests (for the trait `use` statements).
* Trait `use` statements cannot use the `const` or `function` keywords in PHP.
* Add a test simulating live coding/parse error.
* Adjust two tests to test the case-insensitive checking of the keywords.

## NewUseConstFunction: only check import `use` statements

... as trait or closure `use` statements cannot use `function` or `const` anyway.

