### PR TITLE
NewUniformVariableSyntax: bug fix - false negative when used with hierarchy keywords

### DIFF
--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -93,16 +93,6 @@ class NewUniformVariableSyntaxSniff extends Sniff
                     return;
                 }
             }
-
-            // Now let's also prevent false positives when used with self and static which still work fine.
-            $classToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true, null, true);
-            if ($classToken !== false) {
-                if ($tokens[$classToken]['code'] === \T_STATIC || $tokens[$classToken]['code'] === \T_SELF) {
-                    return;
-                } elseif ($tokens[$classToken]['code'] === \T_STRING && $tokens[$classToken]['content'] === 'self') {
-                    return;
-                }
-            }
         }
 
         $phpcsFile->addError(

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.inc
@@ -26,10 +26,13 @@ echo myClass::hello();
 echo ${$obj->getName()};
 echo $obj->{$obj->$hello}();
 echo $obj->{myClass::$foo}();
-echo new self::$transport[$cap_string]();
-class fooBar {
+
+// Uh oh, these were false negatives. Reporting them now.
+class fooBar extends Bar{
     function foo() {
+        echo new self::$transport[$cap_string]();
         echo static::$transport[$cap_string]();
+        echo parent::$transport[$cap_string]();
     }
 }
 

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
@@ -55,8 +55,11 @@ class NewUniformVariableSyntaxUnitTest extends BaseSniffTest
             array(6),
             array(7),
             array(8),
-            array(37),
-            array(38),
+            array(33),
+            array(34),
+            array(35),
+            array(40),
+            array(41),
         );
     }
 
@@ -103,9 +106,8 @@ class NewUniformVariableSyntaxUnitTest extends BaseSniffTest
             array(26),
             array(27),
             array(28),
-            array(29),
-            array(32),
             array(42),
+            array(45),
         );
     }
 


### PR DESCRIPTION
I ran some tests as I thought it was strange that `T_PARENT` wasn't accounted for and I intended to replace the check for the `T_SELF` and `T_STATIC` token with one using `Collections::$OOHierarchyKeywords`.

My findings were contrary to what was documented in-line: function calls with the hierarchy keywords, double colon and then a variable are also affected by the change in PHP 7.0.

I tried to find in the history of the sniff why I made an exception for this previously and also looked over the RFC, but I haven't been able to determine why the exception was previously made, so I'm removing it now.

Proof of false negative: https://3v4l.org/umg8a

Includes adjusted unit tests.