### PR TITLE
RemovedPredefinedGlobalVariables: various bug fixes

### DIFF
--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Variables;
 use PHPCompatibility\AbstractRemovedFeatureSniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
 
@@ -227,10 +228,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
         /*
          * If the variable is detected within the scope of a function/closure, limit the checking.
          */
-        $function = $phpcsFile->getCondition($stackPtr, \T_CLOSURE);
-        if ($function === false) {
-            $function = $phpcsFile->getCondition($stackPtr, \T_FUNCTION);
-        }
+        $function = Conditions::getLastCondition($phpcsFile, $stackPtr, array(\T_CLOSURE, \T_FUNCTION));
 
         // It could also be a function param, which is not in the function scope.
         if ($function === false && isset($tokens[$stackPtr]['nested_parenthesis']) === true) {

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -278,6 +278,29 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
                     }
                 }
             }
+
+            // Has this variable been imported via a closure `use` ?
+            if ($tokens[$function]['code'] === \T_CLOSURE
+                && isset($tokens[$function]['parenthesis_closer'])
+            ) {
+                $hasUse = $phpcsFile->findNext(
+                    Tokens::$emptyTokens,
+                    ($tokens[$function]['parenthesis_closer'] + 1),
+                    null,
+                    true
+                );
+
+                if ($hasUse !== false && $tokens[$hasUse]['code'] === \T_USE) {
+                    $useParameters = FunctionDeclarations::getParameters($phpcsFile, $hasUse);
+                    if (\is_array($useParameters) === true && empty($useParameters) === false) {
+                        foreach ($useParameters as $param) {
+                            if ($param['name'] === '$php_errormsg') {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         $skipPast = array(

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -141,11 +141,9 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
         }
 
         // Check for static usage of class properties shadowing the removed global variables.
-        if ($this->inClassScope($phpcsFile, $stackPtr, false) === true) {
-            $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-            if ($prevToken !== false && $tokens[$prevToken]['code'] === \T_DOUBLE_COLON) {
-                return;
-            }
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        if ($prevToken !== false && $tokens[$prevToken]['code'] === \T_DOUBLE_COLON) {
+            return;
         }
 
         // Do some additional checks for the $php_errormsg variable.

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.inc
@@ -171,3 +171,11 @@ echo $php_errormsg; // OK - uses the value from the assignment on line 37.
 // Use of a static class property outside class context works perfectly fine.
 echo $a::$HTTP_ENV_VARS; // OK.
 echo TestClass::$HTTP_POST_FILES; // OK.
+
+function nesting() {
+    $php_errormsg = error_get_last(); // OK.
+
+    function nested() {
+        echo $php_errormsg; // Bad.
+    }
+}

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.inc
@@ -124,7 +124,7 @@ $a = function ( $php_errormsg ) // OK, param.
 };
 
 $f = function () use (&$php_errormsg) { // Bad.
-	echo $php_errormsg; // Bad.
+	echo $php_errormsg; // OK, uses imported var. Error will be on imported var, not here.
 };
 
 $php_errormsg = error_get_last(); // OK.
@@ -148,7 +148,7 @@ function something_else()
 	}
 
 	$f = function () use (&$php_errormsg) { // OK, uses the value from the above assignment.
-		echo $php_errormsg; // OK, but for now gives false positive.
+		echo $php_errormsg; // OK, uses imported var.
 	};
 
 	$a = function ()

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.inc
@@ -23,7 +23,7 @@ class TestClass {
     var $HTTP_SERVER_VARS;
     private $HTTP_COOKIE_VARS;
     protected $HTTP_SESSION_VARS;
-    public $HTTP_POST_FILES;
+    public static $HTTP_POST_FILES;
     var $HTTP_RAW_POST_DATA;
 
     function testing() {
@@ -167,3 +167,7 @@ trait ABC {
 }
 
 echo $php_errormsg; // OK - uses the value from the assignment on line 37.
+
+// Use of a static class property outside class context works perfectly fine.
+echo $a::$HTTP_ENV_VARS; // OK.
+echo TestClass::$HTTP_POST_FILES; // OK.

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -212,6 +212,9 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
             array(165),
             array(169),
 
+            // Static property use outside class context.
+            array(172),
+            array(173),
         );
     }
 

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -122,6 +122,7 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
             array(141),
             array(151), // False positive!
             array(156),
+            array(179),
         );
     }
 
@@ -215,6 +216,8 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
             // Static property use outside class context.
             array(172),
             array(173),
+
+            array(176),
         );
     }
 

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -117,10 +117,8 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
             array(110),
             array(111),
             array(126),
-            array(127),
             array(140),
             array(141),
-            array(151), // False positive!
             array(156),
             array(179),
         );
@@ -201,6 +199,7 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
             array(118),
             array(121),
             array(123),
+            array(127),
             array(130),
             array(132),
             array(133),
@@ -210,6 +209,7 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
             array(146),
             array(147),
             array(150),
+            array(151),
             array(165),
             array(169),
 


### PR DESCRIPTION
## RemovedPredefinedGlobalVariables: bug fix - static property use outside class context

Using a (public) static class property which shadows one of the removed superglobals outside of the class's context is perfectly fine and will not throw an error in PHP.

Includes unit test.

## RemovedPredefinedGlobalVariables: use `Conditions::getLastCondition()` / bug fix

Previously, when `$php_errormsg` was used, the "outermost" function scope would be examined to see if this was the deprecated/removed PHP global.
This was incorrect as functions are closed scopes, so one should always examine the "innermost" function scope.

Fixed now.

Includes unit test.

## RemovedPredefinedGlobalVariables: use `Parentheses::lastOwnerIn()`

... to retrieve the owner of the last set of parentheses the token lives in.

## RemovedPredefinedGlobalVariables: bug fix for variables imported via closure `use`

This was a known bug but would previously have required a lot of custom code to work out.

Now, using the `FunctionDeclarations::getParameters()` which supports getting the parameters from a closure `use` import, checking this has become a lot easier.

If a closure imports the `$php_errormsg` variable in a `use` statement, the use of this variable within the closure will be regarded as ok. The use of the variable in the `use` itself will still check the surrounding scope for the variable being declared.

Includes adjusting the unit tests for the fixed bug.

