### PR TITLE
PHP 5.3: New `PHPCompatibility.Namespaces.ReservedNames` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Namespaces;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHPCSUtils\Utils\Namespaces;
+
+/**
+ * The namespace name PHP is reserved by PHP.
+ *
+ * > The Namespace name PHP, and compound names starting with this name (like PHP\Classes) are reserved
+ * > for internal language use and should not be used in the userspace code.
+ *
+ * PHP version 5.3
+ *
+ * @link https://www.php.net/manual/en/language.namespaces.rationale.php
+ *
+ * @since 10.0.0
+ */
+class ReservedNamesSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            \T_NAMESPACE,
+        );
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('5.3') === false) {
+            // Namespaces were introduced in PHP 5.3.
+            return;
+        }
+
+        $name = Namespaces::getDeclaredName($phpcsFile, $stackPtr);
+        if (empty($name)) {
+            // Use of namespace operator, global namespace or parse error/live coding.
+            return;
+        }
+
+        $nameParts = explode('\\', $name);
+        $firstPart = strtolower($nameParts[0]);
+        if ($firstPart !== 'php') {
+            return;
+        }
+
+        $phpcsFile->addWarning(
+            'Namespace name "%s" is discouraged; PHP has reserved the namespace name "PHP" and compound names starting with "PHP" for internal language use.',
+            $stackPtr,
+            'Found',
+            array($name)
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
@@ -1,0 +1,18 @@
+<?php
+
+// OK.
+namespace MyPHPApp;
+namespace My\PHP\App;
+namespace {
+    // Do something.
+}
+
+// Warning.
+namespace PHP;
+namespace PHP\App;
+namespace PHP\Classes {
+    // Do something.
+}
+
+// Intentional parse error. This has to be the last test in the file.
+namespace PHP\Cli

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Namespaces;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the ReservedNames sniff.
+ *
+ * @group reservedNames
+ * @group namespaces
+ *
+ * @covers \PHPCompatibility\Sniffs\Namespaces\ReservedNamesSniff
+ *
+ * @since 10.0.0
+ */
+class ReservedNamesUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify correctly detecting reserved namespace names.
+     *
+     * @dataProvider dataReservedNames
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testReservedNames($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertWarning($file, $line, ' is discouraged; PHP has reserved the namespace name "PHP" and compound names starting with "PHP" for internal language use.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testReservedNames()
+     *
+     * @return array
+     */
+    public function dataReservedNames()
+    {
+        return array(
+            array(11),
+            array(12),
+            array(13),
+        );
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(4),
+            array(5),
+            array(6),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.2');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> The Namespace name PHP, and compound names starting with this name (like PHP\Classes) are reserved for internal language use and should not be used in the userspace code.

Source: https://www.php.net/manual/en/language.namespaces.rationale.php

This PR introduces a new `PHPCompatibility.Namespaces.ReservedNames` sniff to detect use of namespace names reserved by PHP, in userland code.

The sniff will throw a `warning` when a reserved namespace name is detected.

This sniff is along the same lines as the `PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames` sniff which does the same for reserved function names to prevent code being introduced in userland code which has a high risk of being incompatible with future PHP versions.

Includes unit tests.

Fixes #1025