### PR TITLE
PHP 5.4: New `PHPCompatibility.ParameterValues.ChangedObStartEraseFlags` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * Detect incompatible use of the third parameter for `ob_start()`.
+ *
+ * > The third parameter of ob_start() changed from a boolean parameter called erase
+ * > (which, if set to FALSE, would prevent the output buffer from being deleted until
+ * > the script finished executing) to an integer parameter called flags.
+ * > Unfortunately, this results in an API compatibility break for code written prior to
+ * > PHP 5.4.0 that uses the third parameter.
+ *
+ * PHP version 5.4
+ *
+ * @link https://www.php.net/manual/en/function.ob-start.php#refsect1-function.ob-start-changelog
+ *
+ * @since 10.0.0
+ */
+class ChangedObStartEraseFlagsSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'ob_start' => true,
+    );
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return false;
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[3]) === false) {
+            return;
+        }
+
+        $targetParam  = $parameters[3];
+        $cleanValueLc = \strtolower($targetParam['clean']);
+
+        $error = 'The third parameter of ob_start() changed from the boolean $erase to the integer $flags in PHP 5.4. Found: %s';
+        $data  = array($targetParam['clean']);
+
+        if ($cleanValueLc === 'true' || $cleanValueLc === 'false') {
+            if ($this->supportsAbove('5.4') === true) {
+                $phpcsFile->addError($error, $targetParam['start'], 'BooleanFound', $data);
+            }
+
+            return;
+        }
+
+        if ((preg_match('`PHP_OUTPUT_HANDLER_(CLEANABLE|FLUSHABLE|REMOVABLE|STDFLAGS)`', $targetParam['clean']) === 1
+            || $this->isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], true) !== false)
+            && $this->supportsBelow('5.3') === true
+        ) {
+            $phpcsFile->addError($error, $targetParam['start'], 'IntegerFound', $data);
+        }
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.inc
@@ -1,0 +1,23 @@
+<?php
+
+// OK.
+ob_start($output_callback);
+ob_start($output_callback, $chunk_size);
+
+// Undetermined. Ignore.
+ob_start($output_callback, $chunk_size, $flags);
+ob_start($output_callback, $chunk_size, CUSTOM_CONSTANT);
+ob_start($output_callback, $chunk_size, My::do_erase());
+
+// Not OK - error PHP < 5.4.
+ob_start($output_callback, $chunk_size, true);
+ob_start($output_callback, $chunk_size, false);
+
+// Not OK - error PHP >= 5.4.
+ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_CLEANABLE);
+ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_FLUSHABLE);
+ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_REMOVABLE);
+ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS);
+ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS | PHP_OUTPUT_HANDLER_FLUSHABLE);
+ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS ^ PHP_OUTPUT_HANDLER_FLUSHABLE);
+ob_start($output_callback, $chunk_size, 10);

--- a/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the ChangedObStartEraseFlags sniff.
+ *
+ * @group changedObStartEraseFlags
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\ChangedObStartEraseFlagsSniff
+ *
+ * @since 10.0.0
+ */
+class ChangedObStartEraseFlagsUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test the sniff correctly detecting boolean parameter values being passed.
+     *
+     * @dataProvider dataChangedObStartEraseFlagsBoolean
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testChangedObStartEraseFlagsBoolean($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '5.4');
+        $error = 'The third parameter of ob_start() changed from the boolean $erase to the integer $flags in PHP 5.4.';
+
+        $this->assertError($file, $line, $error);
+
+        $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testChangedObStartEraseFlagsBoolean()
+     *
+     * @return array
+     */
+    public function dataChangedObStartEraseFlagsBoolean()
+    {
+        return array(
+            array(13),
+            array(14),
+        );
+    }
+
+
+    /**
+     * Test the sniff correctly detecting integer parameter values being passed.
+     *
+     * @dataProvider dataChangedObStartEraseFlagsInt
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testChangedObStartEraseFlagsInt($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '5.3');
+        $error = 'The third parameter of ob_start() changed from the boolean $erase to the integer $flags in PHP 5.4.';
+
+        $this->assertError($file, $line, $error);
+
+        $file = $this->sniffFile(__FILE__, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testChangedObStartEraseFlagsInt()
+     *
+     * @return array
+     */
+    public function dataChangedObStartEraseFlagsInt()
+    {
+        return array(
+            array(17),
+            array(18),
+            array(19),
+            array(20),
+            array(21),
+            array(22),
+            array(23),
+        );
+    }
+
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '5.3-5.4');
+
+        // No errors expected on the first 11 lines.
+        for ($line = 1; $line <= 11; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /*
+     * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors
+     * about both for above as well as below a certain version.
+     */
+}


### PR DESCRIPTION
From: https://www.php.net/manual/en/function.ob-start.php#refsect1-function.ob-start-changelog

> The third parameter of ob_start() changed from a boolean parameter called erase
> (which, if set to FALSE, would prevent the output buffer from being deleted until
> the script finished executing) to an integer parameter called flags.
> Unfortunately, this results in an API compatibility break for code written prior to
> PHP 5.4.0 that uses the third parameter.

This sniff addresses that change.

Includes unit tests.