### PR TITLE
PHP 7.2: New `PHPCompatibility.ParameterValues.RemovedAssertStringAssertion` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+
+/**
+ * Detect the use of assertions passed as a string.
+ *
+ * > Usage of a string as the assertion became deprecated. It now emits an E_DEPRECATED
+ * > notice when both assert.active and zend.assertions are set to 1.
+ *
+ * PHP version 7.2
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_7_2#assert_with_string_argument
+ * @link https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-changelog
+ *
+ * @since 10.0.0
+ */
+class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'assert' => true,
+    );
+
+    /**
+     * Target tokens.
+     *
+     * If there is anything but any of these tokens in the parameter, we bow out as undetermined.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $targetTokens = array();
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        // Set $targetTokens only once.
+        $this->targetTokens                   = Tokens::$emptyTokens;
+        $this->targetTokens                  += Tokens::$stringTokens + Tokens::$heredocTokens;
+        $this->targetTokens[\T_STRING_CONCAT] = \T_STRING_CONCAT;
+
+        return parent::register();
+    }
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('7.2') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[1]) === false) {
+            return;
+        }
+
+        $targetParam = $parameters[1];
+        $hasOther    = $phpcsFile->findNext($this->targetTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+        if ($hasOther !== false) {
+            // Some other token was found, unclear whether this is really a text string. Bow out.
+            return;
+        }
+
+        $error = 'Using a string as the assertion passed to assert() is deprecated since PHP 7.2. Found: %s';
+        $data  = array($targetParam['clean']);
+
+        $phpcsFile->addWarning($error, $targetParam['start'], 'Found', $data);
+    }
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
@@ -17,12 +17,19 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 /**
  * Detect the use of assertions passed as a string.
  *
+ * PHP 7.2:
  * > Usage of a string as the assertion became deprecated. It now emits an E_DEPRECATED
  * > notice when both assert.active and zend.assertions are set to 1.
  *
+ * PHP 8.0:
+ * > assert() will no longer evaluate string arguments, instead they will be treated
+ * > like any other argument. `assert($a == $b)` should be used instead of `assert('$a == $b')`.
+ *
  * PHP version 7.2
+ * PHP version 8.0
  *
  * @link https://wiki.php.net/rfc/deprecations_php_7_2#assert_with_string_argument
+ * @link https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L350-L354
  * @link https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-changelog
  *
  * @since 10.0.0
@@ -107,9 +114,18 @@ class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSni
             return;
         }
 
-        $error = 'Using a string as the assertion passed to assert() is deprecated since PHP 7.2. Found: %s';
-        $data  = array($targetParam['clean']);
+        $error   = 'Using a string as the assertion passed to assert() is deprecated since PHP 7.2%s. Found: %s';
+        $isError = false;
+        $data    = array(
+            '',
+            $targetParam['clean'],
+        );
 
-        $phpcsFile->addWarning($error, $targetParam['start'], 'Found', $data);
+        if ($this->supportsAbove('8.0') === true) {
+            $data[0] = ' and removed since PHP 8.0';
+            $isError = true;
+        }
+
+        $this->addMessage($phpcsFile, $error, $targetParam['start'], $isError, 'Found', $data);
     }
 }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.inc
@@ -1,0 +1,28 @@
+<?php
+
+// Incorrect call. Ignore.
+assert();
+
+// OK in all versions.
+assert(false);
+assert(true);
+
+// Undetermined. Ignore.
+assert($assertion);
+
+// Expression, PHP 7+, not our concern.
+assert(true == false);
+assert((bool) ($input));
+
+// Deprecated as of PHP 7.2.
+assert('mysql_query("")');
+assert("2 < 1" /* just a demo */, 'Two is less than one');
+assert(<<<'EOT'
+    is_string($result) &&
+    (strlen($result) > 0);
+EOT
+);
+assert(
+    'is_int($int)'
+    . '&& $int > 10'
+);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.php
@@ -37,9 +37,12 @@ class RemovedAssertStringAssertionUnitTest extends BaseSniffTest
     public function testRemovedAssertStringAssertion($line)
     {
         $file  = $this->sniffFile(__FILE__, '7.2');
-        $error = 'Using a string as the assertion passed to assert() is deprecated since PHP 7.2.';
-
+        $error = 'Using a string as the assertion passed to assert() is deprecated since PHP 7.2';
         $this->assertWarning($file, $line, $error);
+
+        $file  = $this->sniffFile(__FILE__, '8.0');
+        $error = 'Using a string as the assertion passed to assert() is deprecated since PHP 7.2 and removed since PHP 8.0';
+        $this->assertError($file, $line, $error);
     }
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedAssertStringAssertion sniff.
+ *
+ * @group removedAssertStringAssertion
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedAssertStringAssertionSniff
+ *
+ * @since 10.0.0
+ */
+class RemovedAssertStringAssertionUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test the sniff correctly detects assertions passed as strings.
+     *
+     * @dataProvider dataRemovedAssertStringAssertion
+     *
+     * @param int $line Line number where the warning should occur.
+     *
+     * @return void
+     */
+    public function testRemovedAssertStringAssertion($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '7.2');
+        $error = 'Using a string as the assertion passed to assert() is deprecated since PHP 7.2.';
+
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedAssertStringAssertion()
+     *
+     * @return array
+     */
+    public function dataRemovedAssertStringAssertion()
+    {
+        return array(
+            array(18),
+            array(19),
+            array(20),
+            array(25),
+        );
+    }
+
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '7.2');
+
+        // No errors expected on the first 16 lines.
+        for ($line = 1; $line <= 16; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Usage of a string as the assertion became deprecated. It now emits an E_DEPRECATED
> notice when both assert.active and zend.assertions are set to 1.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_2#assert_with_string_argument
* https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-changelog

This sniff addresses that change.

Includes unit tests.

Partially addresses #908

---

### PHP 8.0: RemovedAssertStringAssertion: account for support being completely removed

> `assert()` will no longer evaluate string arguments, instead they will be
> treated like any other argument. `assert($a == $b)` should be used instead of
`assert('$a == $b')`.

Ref:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L350-L354

Includes adjusted unit tests.