### PR TITLE
PHP 7.0: New `PHPCompatibility.ParameterValues.NewAssertCustomException` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewAssertCustomExceptionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewAssertCustomExceptionSniff.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHP_CodeSniffer_File as File;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+
+/**
+ * Assert() supports custom exceptions as $description since PHP 7.0.
+ *
+ * > assert() is now a language construct and not a function. Assertion can now be
+ * > an expression. The second parameter is now interpreted either as an exception
+ * > (if a Throwable object is given), or as the description supported from PHP 5.4.8 onwards.
+ *
+ * PHP version 7.0
+ *
+ * @link https://wiki.php.net/rfc/expectations
+ * @link https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-changelog
+ *
+ * @since 10.0.0
+ */
+class NewAssertCustomExceptionSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'assert' => true,
+    );
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('5.6') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[2]) === false) {
+            return;
+        }
+
+        /*
+         * Examine the description parameter.
+         *
+         * Note: this could still generate false positives if a non-Throwable object is instantiated which
+         * has a __toString() method to generate the $description, but chances of code like that being used
+         * are slim.
+         */
+        $targetParam = $parameters[2];
+        $hasNew      = $phpcsFile->findNext(\T_NEW, $targetParam['start'], ($targetParam['end'] + 1));
+        if ($hasNew === false) {
+            // Undetermined. Bow out.
+            return;
+        }
+
+        $hasStringCast = $phpcsFile->findNext(\T_STRING_CAST, $targetParam['start'], ($targetParam['end'] + 1));
+        if ($hasStringCast !== false && $hasStringCast < $hasNew) {
+            // Cast to string, not an issue.
+            return;
+        }
+
+        $error = 'Passing a Throwable object as the second parameter to assert() is not supported in PHP 5.6 or earlier. Found: %s';
+        $data  = array($targetParam['clean']);
+
+        $phpcsFile->addError($error, $targetParam['start'], 'CustomExceptionFound', $data);
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.inc
@@ -1,0 +1,19 @@
+<?php
+
+// OK, no second param.
+assert('mysql_query("")');
+
+// OK, second param string.
+assert("2 < 1", 'Two is less than one');
+assert(false, 'Unexpected condition');
+
+// Undetermined. Ignore.
+assert($assertion, $errorMsg);
+
+// Ok: Custom error message via __toString()
+assert(false, (string) new CustomError('True is not false!'));
+
+// PHP 7.0+ custom exception.
+class CustomError extends AssertionError {}
+assert(false, new CustomError('True is not false!'));
+assert(false, new CustomError((string) $otherObj));

--- a/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewAssertCustomException sniff.
+ *
+ * @group newAssertCustomException
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewAssertCustomExceptionSniff
+ *
+ * @since 10.0.0
+ */
+class NewAssertCustomExceptionUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test the sniff correctly detects an custom exception being passed as the description.
+     *
+     * @dataProvider dataNewAssertCustomException
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testNewAssertCustomException($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '5.6');
+        $error = 'Passing a Throwable object as the second parameter to assert() is not supported in PHP 5.6 or earlier.';
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewAssertCustomException()
+     *
+     * @return array
+     */
+    public function dataNewAssertCustomException()
+    {
+        return array(
+            array(18),
+            array(19),
+        );
+    }
+
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+
+        // No errors expected on the first 15 lines.
+        for ($line = 1; $line <= 15; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> assert() is now a language construct and not a function. Assertion can now be
> an expression. The second parameter is now interpreted either as an exception
> (if a Throwable object is given), or as the description supported from PHP 5.4.8 onwards.

Refs:
* https://wiki.php.net/rfc/expectations
* https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-changelog

This sniff addresses that change.

Includes unit tests.

Partially addressed #908