### PR TITLE
NewExtensions: PHP 7.4 FFI

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -397,16 +397,19 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         ),
 
         'FFI' => array(
-            '7.3' => false,
-            '7.4' => true,
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'ffi',
         ),
         'FFI\CData' => array(
-            '7.3' => false,
-            '7.4' => true,
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'ffi',
         ),
         'FFI\CType' => array(
-            '7.3' => false,
-            '7.4' => true,
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'ffi',
         ),
         'ReflectionReference' => array(
             '7.3' => false,
@@ -600,12 +603,14 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         ),
 
         'FFI\Exception' => array(
-            '7.3' => false,
-            '7.4' => true,
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'ffi',
         ),
         'FFI\ParserException' => array(
-            '7.3' => false,
-            '7.4' => true,
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'ffi',
         ),
     );
 

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -661,12 +661,14 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
         ),
 
         'ffi.enable' => array(
-            '7.3' => false,
-            '7.4' => true,
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'ffi',
         ),
         'ffi.preload' => array(
-            '7.3' => false,
-            '7.4' => true,
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'ffi',
         ),
         'opcache.cache_id' => array(
             '7.3' => false,


### PR DESCRIPTION
Add the `extension` key to the relevant array entries in the `NewClasses`, `NewConstants`, `NewFunctions`, `NewInterfaces` and `NewIniDirectives` sniffs.

Ref: https://www.php.net/manual/en/book.ffi.php

Related to #1023.