### PR TITLE
NewExtensions: PHP 7.0 CSPRNG

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -1232,12 +1232,14 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
         ),
 
         'random_bytes' => array(
-            '5.6' => false,
-            '7.0' => true,
+            '5.6'       => false,
+            '7.0'       => true,
+            'extension' => 'csprng',
         ),
         'random_int' => array(
-            '5.6' => false,
-            '7.0' => true,
+            '5.6'       => false,
+            '7.0'       => true,
+            'extension' => 'csprng',
         ),
         'error_clear_last' => array(
             '5.6' => false,


### PR DESCRIPTION
Add the `extension` key to the relevant array entries in the `NewClasses`, `NewConstants`, `NewFunctions`, `NewInterfaces` and `NewIniDirectives` sniffs.

Ref: https://www.php.net/manual/en/book.csprng.php

Related to #1023.