### PR TITLE
NewExtensions: PHP 5.5 Password hashing

### DIFF
--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -1847,16 +1847,19 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
         ),
         // Core/Password Hashing:
         'PASSWORD_BCRYPT' => array(
-            '5.4' => false,
-            '5.5' => true,
+            '5.4'       => false,
+            '5.5'       => true,
+            'extension' => 'password',
         ),
         'PASSWORD_DEFAULT' => array(
-            '5.4' => false,
-            '5.5' => true,
+            '5.4'       => false,
+            '5.5'       => true,
+            'extension' => 'password',
         ),
         'PASSWORD_BCRYPT_DEFAULT_COST' => array(
-            '5.4' => false,
-            '5.5' => true,
+            '5.4'       => false,
+            '5.5'       => true,
+            'extension' => 'password',
         ),
 
 
@@ -2607,20 +2610,24 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
 
         // Core/Password Hashing:
         'PASSWORD_ARGON2I' => array(
-            '7.1' => false,
-            '7.2' => true,
+            '7.1'       => false,
+            '7.2'       => true,
+            'extension' => 'password',
         ),
         'PASSWORD_ARGON2_DEFAULT_MEMORY_COST' => array(
-            '7.1' => false,
-            '7.2' => true,
+            '7.1'       => false,
+            '7.2'       => true,
+            'extension' => 'password',
         ),
         'PASSWORD_ARGON2_DEFAULT_TIME_COST' => array(
-            '7.1' => false,
-            '7.2' => true,
+            '7.1'       => false,
+            '7.2'       => true,
+            'extension' => 'password',
         ),
         'PASSWORD_ARGON2_DEFAULT_THREADS' => array(
-            '7.1' => false,
-            '7.2' => true,
+            '7.1'       => false,
+            '7.2'       => true,
+            'extension' => 'password',
         ),
 
         // Fileinfo:
@@ -3496,8 +3503,9 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
             '7.3' => true,
         ),
         'PASSWORD_ARGON2ID' => array(
-            '7.2' => false,
-            '7.3' => true,
+            '7.2'       => false,
+            '7.3'       => true,
+            'extension' => 'password',
         ),
         'STREAM_CRYPTO_PROTO_SSLv3' => array(
             '7.2' => false,
@@ -3554,8 +3562,9 @@ class NewConstantsSniff extends AbstractNewFeatureSniff
             '7.4' => true,
         ),
         'PASSWORD_ARGON2_PROVIDER' => array(
-            '7.3' => false,
-            '7.4' => true,
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'password',
         ),
         'PHP_WINDOWS_EVENT_CTRL_C' => array(
             '7.3' => false,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -710,20 +710,24 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '5.5' => true,
         ),
         'password_get_info' => array(
-            '5.4' => false,
-            '5.5' => true,
+            '5.4'       => false,
+            '5.5'       => true,
+            'extension' => 'password',
         ),
         'password_hash' => array(
-            '5.4' => false,
-            '5.5' => true,
+            '5.4'       => false,
+            '5.5'       => true,
+            'extension' => 'password',
         ),
         'password_needs_rehash' => array(
-            '5.4' => false,
-            '5.5' => true,
+            '5.4'       => false,
+            '5.5'       => true,
+            'extension' => 'password',
         ),
         'password_verify' => array(
-            '5.4' => false,
-            '5.5' => true,
+            '5.4'       => false,
+            '5.5'       => true,
+            'extension' => 'password',
         ),
         'hash_pbkdf2' => array(
             '5.4' => false,
@@ -1900,8 +1904,9 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.4' => true,
         ),
         'password_algos' => array(
-            '7.3' => false,
-            '7.4' => true,
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'password',
         ),
         'pcntl_unshare' => array(
             '7.3' => false,


### PR DESCRIPTION
Add the `extension` key to the relevant array entries in the `NewClasses`, `NewConstants`, `NewFunctions`, `NewInterfaces` and `NewIniDirectives` sniffs.

Ref: https://www.php.net/manual/en/book.password.php

Related to #1023.