### PR TITLE
RemovedExtensions: PHP 7.4 Recode

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -1617,16 +1617,19 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             'alternative' => 'ldap_search()',
         ),
         'recode_file' => array(
-            '7.4' => true,
+            '7.4'         => true,
             'alternative' => 'the iconv or mbstring extension',
+            'extension'   => 'recode',
         ),
         'recode_string' => array(
-            '7.4' => true,
+            '7.4'         => true,
             'alternative' => 'the iconv or mbstring extension',
+            'extension'   => 'recode',
         ),
         'recode' => array(
-            '7.4' => true,
+            '7.4'         => true,
             'alternative' => 'the iconv or mbstring extension',
+            'extension'   => 'recode',
         ),
         'wddx_add_vars' => array(
             '7.4' => true,


### PR DESCRIPTION
Add the `extension` key to the relevant array entries in the `RemovedConstants`, `RemovedFunctions` and `RemovedIniDirectives` sniffs.

Ref: https://www.php.net/manual/en/book.recode.php

Related to #1022.