### PR TITLE
NewHTMLEntitiesEncodingDefault: also detect get_html_translation_table()

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
@@ -40,9 +40,10 @@ class NewHTMLEntitiesEncodingDefaultSniff extends AbstractFunctionCallParameterS
      * @var array
      */
     protected $targetFunctions = array(
-        'html_entity_decode' => 3,
-        'htmlentities'       => 3,
-        'htmlspecialchars'   => 3,
+        'html_entity_decode'         => 3,
+        'htmlentities'               => 3,
+        'htmlspecialchars'           => 3,
+        'get_html_translation_table' => 3,
     );
 
 

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.inc
@@ -4,8 +4,10 @@
 echo htmlentities( $string, ENT_QUOTES, 'UTF-8' );
 echo htmlspecialchars( $string, ENT_COMPAT, $encoding, false );
 echo html_entity_decode( $string, ENT_COMPAT, $encoding );
+echo get_html_translation_table( $table, ENT_COMPAT, $encoding );
 
 // Not OK - error.
 echo htmlentities( $string, $flags );
 echo htmlspecialchars($string);
 echo HTML_entity_decode( $string, ENT_COMPAT );
+echo get_html_translation_table( $table );

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
@@ -53,9 +53,10 @@ class NewHTMLEntitiesEncodingDefaultUnitTest extends BaseSniffTest
     public function dataNewHTMLEntitiesEncodingDefault()
     {
         return array(
-            array(9, 'htmlentities'),
-            array(10, 'htmlspecialchars'),
-            array(11, 'HTML_entity_decode'),
+            array(10, 'htmlentities'),
+            array(11, 'htmlspecialchars'),
+            array(12, 'HTML_entity_decode'),
+            array(13, 'get_html_translation_table'),
         );
     }
 
@@ -69,8 +70,8 @@ class NewHTMLEntitiesEncodingDefaultUnitTest extends BaseSniffTest
     {
         $file = $this->sniffFile(__FILE__, '5.3-5.4');
 
-        // No errors expected on the first 7 lines.
-        for ($line = 1; $line <= 7; $line++) {
+        // No errors expected on the first 8 lines.
+        for ($line = 1; $line <= 8; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }


### PR DESCRIPTION
Per the changelog of `get_html_translation_table()`, this function is also affected by the changed default encoding.

Ref: https://www.php.net/manual/en/function.get-html-translation-table.php#refsect1-function.get-html-translation-table-changelog

Includes updated unit tests.