### PR TITLE
NewPackFormat: fix false positive

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -95,6 +95,13 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
         $targetParam = $parameters[1];
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
+            if ($tokens[$i]['code'] === \T_STRING
+                || $tokens[$i]['code'] === \T_VARIABLE
+            ) {
+                // Variable, constant, function call. Ignore as undetermined.
+                return;
+            }
+
             if ($tokens[$i]['code'] !== \T_CONSTANT_ENCAPSED_STRING
                 && $tokens[$i]['code'] !== \T_DOUBLE_QUOTED_STRING
             ) {

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
@@ -16,3 +16,9 @@ $binarydata = pack('nvcgG*', 0x1234, 0x5678, 65, 66);
 $binarydata = pack("n{$s}vGc*", 0x1234, 0x5678, 65, 66);
 
 $binarydata = pack("ZJE*", 0x1234, 0x5678, 65, 66); // Error x 3.
+
+$binarydata = pack('nv' . 'Pc*', 0x1234, 0x5678, 65, 66); // Testing multi-token.
+
+// Issue #1043 - OK, text in brackets, not the actual format.
+$binarydata = pack($foo['test'], 0x1234, 0x5678, 65, 66);
+$binarydata = pack($obj->getModes('type'), 0x1234, 0x5678, 65, 66);

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -75,6 +75,7 @@ class NewPackFormatUnitTest extends BaseSniffTest
             array(18, 'Z', '5.4', '7.1'), // OK version set to beyond last error.
             array(18, 'J', '5.6', '7.1', '5.6.2'), // OK version set to beyond last error.
             array(18, 'E', '7.0', '7.1', '7.0.14'),
+            array(20, 'P', '5.6', '7.0', '5.6.2'),
         );
     }
 
@@ -82,16 +83,38 @@ class NewPackFormatUnitTest extends BaseSniffTest
     /**
      * testNoFalsePositives
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = array();
 
         // No errors expected on the first 6 lines.
         for ($line = 1; $line <= 6; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = array($line);
         }
+
+        $data[] = array(23);
+        $data[] = array(24);
+
+        return $data;
     }
 
 


### PR DESCRIPTION
Let's just bow out as soon as a variable or `T_STRING` is encountered as the results of the sniff will be unreliable in that case anyway.

Includes unit test.

Fixes #1043