### PR TITLE
NewFopenModes: fix false positive

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -76,6 +76,13 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
         $errors      = array();
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
+            if ($tokens[$i]['code'] === \T_STRING
+                || $tokens[$i]['code'] === \T_VARIABLE
+            ) {
+                // Variable, constant, function call. Ignore as undetermined.
+                return;
+            }
+
             if ($tokens[$i]['code'] !== \T_CONSTANT_ENCAPSED_STRING) {
                 continue;
             }

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.inc
@@ -10,3 +10,7 @@ $handle = fopen("/home/rasmus/file.txt", "re"); // PHP 7.0.16+
 $handle = fopen("/home/rasmus/file.gif", 'c+'); // PHP 5.2.6+
 $handle = fopen("/home/rasmus/file.gif", 'c'); // PHP 5.2.6+
 $handle = fopen("/home/rasmus/file.gif", 'c'.'e'); // PHP 5.2.6+ and PHP 7.0.16+
+
+// Issue #1043 - ignore function calls, constants etc.
+$handle = fopen("/home/rasmus/file.gif", setFormat('c+'));
+$handle = fopen("/home/rasmus/file.txt", $array["re"]);

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
@@ -96,11 +96,17 @@ class NewFopenModesUnitTest extends BaseSniffTest
      */
     public function dataNoFalsePositives()
     {
-        return array(
-            array(4),
-            array(5),
-            array(6),
-        );
+        $data = array();
+
+        // No errors expected on the first 6 lines.
+        for ($line = 1; $line <= 6; $line++) {
+            $data[] = array($line);
+        }
+
+        $data[] = array(15);
+        $data[] = array(16);
+
+        return $data;
     }
 
 


### PR DESCRIPTION
Let's just bow out as soon as a variable or `T_STRING` is encountered as the results of the sniff will be unreliable in that case anyway.

Includes unit test.

Related to #1043