### PR TITLE
RemovedMbstringModifiers: fix false positive

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -94,19 +94,19 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
         }
 
         $optionsParam = $parameters[$this->targetFunctions[$functionNameLc]];
-
-        $stringToken = $phpcsFile->findNext(Tokens::$stringTokens, $optionsParam['start'], $optionsParam['end'] + 1);
-        if ($stringToken === false) {
-            // No string token found in the options parameter, so skip it (e.g. variable passed in).
-            return;
-        }
-
-        $options = '';
+        $options      = '';
 
         /*
          * Get the content of any string tokens in the options parameter and remove the quotes and variables.
          */
-        for ($i = $stringToken; $i <= $optionsParam['end']; $i++) {
+        for ($i = $optionsParam['start']; $i <= $optionsParam['end']; $i++) {
+            if ($tokens[$i]['code'] === \T_STRING
+                || $tokens[$i]['code'] === \T_VARIABLE
+            ) {
+                // Variable, constant, function call. Ignore as undetermined.
+                return;
+            }
+
             if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === false) {
                 continue;
             }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.inc
@@ -25,6 +25,10 @@ mb_ereg_replace( $pattern, $replace, $subject, "e$m" );
 mb_eregi_replace( $pattern, $replace, $subject, "me$i" );
 Mb_Regex_Set_Options( 'im' . "{$se}e" );
 
-// Verify the sniff also pick up on the function aliases.
+// Verify the sniff also picks up on the function aliases.
 mbereg_replace( $pattern, $replace, $subject, 'e' );
 mberegi_replace( $pattern, $replace, $subject, "me$i" );
+
+// Issue #1043 - ignore function calls, constants etc.
+mb_ereg_replace( $pattern, $replace, $subject, getOptions('type'));
+mb_eregi_replace( $pattern, $replace, $subject, CONSTANT_NAME['array_access'] );

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
@@ -100,6 +100,8 @@ class RemovedMbstringModifiersUnitTest extends BaseSniffTest
             array(19),
             array(20),
             array(21),
+            array(33),
+            array(34),
         );
     }
 


### PR DESCRIPTION
Let's just bow out as soon as a variable or `T_STRING` is encountered as the results of the sniff will be unreliable in that case anyway.

Includes unit test.

Related to #1043