### PR TITLE
RemovedSetlocaleString: fix false positive

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -78,6 +78,13 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
         $targetParam = $parameters[1];
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
+            if ($tokens[$i]['code'] === \T_STRING
+                || $tokens[$i]['code'] === \T_VARIABLE
+            ) {
+                // Variable, constant, function call. Ignore as undetermined.
+                return;
+            }
+
             if ($tokens[$i]['code'] !== \T_CONSTANT_ENCAPSED_STRING
                 && $tokens[$i]['code'] !== \T_DOUBLE_QUOTED_STRING
             ) {

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.inc
@@ -8,3 +8,7 @@ setlocale($category, $lang); // Can't be determined.
 // Not OK.
 setlocale('LC_ALL', 'nl_NL');
 setlocale('LC_'.$category, $lang);
+
+// Issue #1043 - ignore function calls, constants etc.
+setlocale(getMyLocale('text'), 'nl_NL');
+setlocale($array['LC_ALL'], 'nl_NL');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
@@ -62,16 +62,38 @@ class RemovedSetlocaleStringUnitTest extends BaseSniffTest
     /**
      * testNoFalsePositives
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = array();
 
         // No errors expected on the first 7 lines.
         for ($line = 1; $line <= 7; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = array($line);
         }
+
+        $data[] = array(13);
+        $data[] = array(14);
+
+        return $data;
     }
 
 


### PR DESCRIPTION
Let's just bow out as soon as a variable or `T_STRING` is encountered as the results of the sniff will be unreliable in that case anyway.

Includes unit test.

Related to #1043