### PR TITLE
Verified extension: PHP Options/Info

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -94,10 +94,6 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '5.1' => false,
             '5.2' => true,
         ),
-        'sys_get_temp_dir' => array(
-            '5.1' => false,
-            '5.2' => true,
-        ),
         'timezone_abbreviations_list' => array(
             '5.1' => false,
             '5.2' => true,
@@ -283,6 +279,16 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
         'zip_read' => array(
             '5.1' => false,
             '5.2' => true,
+        ),
+
+        'sys_get_temp_dir' => array(
+            '5.2.0' => false,
+            '5.2.1' => true,
+        ),
+
+        'php_ini_loaded_file' => array(
+            '5.2.3' => false,
+            '5.2.4' => true,
         ),
 
         'array_replace' => array(
@@ -2037,6 +2043,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.3' => true,
         ),
         'socket_wsaprotocol_info_release' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
+        'gc_status' => array(
             '7.2' => false,
             '7.3' => true,
         ),

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -903,7 +903,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'zend_logo_guid' => array(
             '5.5' => true,
-            'alternative' => null,
+            'alternative' => 'text string "PHPE9568F35-D428-11d2-A769-00AA001ACF42"',
         ),
         'datefmt_set_timezone_id' => array(
             '5.5' => false,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -504,3 +504,6 @@ phpdbg_exec();
 phpdbg_get_executable();
 phpdbg_prompt();
 phpdbg_start_oplog();
+
+gc_status();
+php_ini_loaded_file();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -69,7 +69,6 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('error_get_last', '5.1', array(14), '5.2'),
             array('image_type_to_extension', '5.1', array(15), '5.2'),
             array('memory_get_peak_usage', '5.1', array(16), '5.2'),
-            array('sys_get_temp_dir', '5.1', array(17), '5.2'),
             array('timezone_abbreviations_list', '5.1', array(18), '5.2'),
             array('timezone_identifiers_list', '5.1', array(19), '5.2'),
             array('timezone_name_from_abbr', '5.1', array(20), '5.2'),
@@ -116,6 +115,10 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('zip_entry_read', '5.1', array(61), '5.2'),
             array('zip_open', '5.1', array(62), '5.2'),
             array('zip_read', '5.1', array(63), '5.2'),
+
+            array('sys_get_temp_dir', '5.2.0', array(17), '5.3', '5.2'),
+
+            array('php_ini_loaded_file', '5.2.3', array(509), '5.3', '5.2'),
 
             array('array_replace', '5.2', array(65), '5.3'),
             array('array_replace_recursive', '5.2', array(66), '5.3'),
@@ -538,6 +541,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('socket_wsaprotocol_info_export', '7.2', array(458), '7.3'),
             array('socket_wsaprotocol_info_import', '7.2', array(459), '7.3'),
             array('socket_wsaprotocol_info_release', '7.2', array(460), '7.3'),
+            array('gc_status', '7.2', array(508), '7.3'),
 
             array('ldap_add_ext', '7.2', array(469), '7.3'),
             array('ldap_bind_ext', '7.2', array(470), '7.3'),

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -402,7 +402,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('php_logo_guid', '5.5', array(32), '5.4'),
             array('php_egg_logo_guid', '5.5', array(33), '5.4'),
             array('php_real_logo_guid', '5.5', array(34), '5.4'),
-            array('zend_logo_guid', '5.5', array(35), '5.4'),
             array('imagepsbbox', '7.0', array(90), '5.6'),
             array('imagepsencodefont', '7.0', array(91), '5.6'),
             array('imagepsextendfont', '7.0', array(92), '5.6'),
@@ -517,6 +516,8 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
     public function dataRemovedFunctionWithAlternative()
     {
         return array(
+            array('zend_logo_guid', '5.5', 'text string "PHPE9568F35-D428-11d2-A769-00AA001ACF42"', array(35), '5.4'),
+
             array('recode_file', '7.4', 'the iconv or mbstring extension', array(236), '7.3'),
             array('recode_string', '7.4', 'the iconv or mbstring extension', array(237), '7.3'),
             array('recode', '7.4', 'the iconv or mbstring extension', array(238), '7.3'),


### PR DESCRIPTION
* Added missing new functions:
    - `gc_status()` - introduced in PHP 7.3.
        Ref: https://www.php.net/manual/en/function.gc-status.php
    - `php_ini_loaded_file()` - introduced in PHP 5.2.4.
        Ref: https://www.php.net/manual/en/function.php-ini-loaded-file.php
* Minor version nr precision fix for `sys_get_temp_dir()`
    Ref: https://www.php.net/manual/en/function.sys-get-temp-dir.php
* Added alternative for removed function `zend_logo_guid()`
    Ref: https://www.php.net/manual/en/function.zend-logo-guid.php