### PR TITLE
NewExtensions: PHP 5.3 Phar

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -234,16 +234,19 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '5.3' => true,
         ),
         'Phar' => array(
-            '5.2' => false,
-            '5.3' => true,
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'phar',
         ),
         'PharData' => array(
-            '5.2' => false,
-            '5.3' => true,
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'phar',
         ),
         'PharFileInfo' => array(
-            '5.2' => false,
-            '5.3' => true,
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'phar',
         ),
         'FilesystemIterator' => array(
             '5.2' => false,
@@ -532,8 +535,9 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         ),
 
         'PharException' => array(
-            '5.2' => false,
-            '5.3' => true,
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'phar',
         ),
 
         'SNMPException' => array(

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -301,6 +301,21 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '5.2' => false,
             '5.3' => true,
         ),
+        'phar.readonly' => array(
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'phar',
+        ),
+        'phar.require_hash' => array(
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'phar',
+        ),
+        'phar.extract_list' => array(
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'phar',
+        ),
         'request_order' => array(
             '5.2' => false,
             '5.3' => true,
@@ -362,8 +377,9 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '5.4' => true,
         ),
         'phar.cache_list' => array(
-            '5.3' => false,
-            '5.4' => true,
+            '5.3'       => false,
+            '5.4'       => true,
+            'extension' => 'phar',
         ),
         'session.upload_progress.enabled' => array(
             '5.3' => false,

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -140,6 +140,9 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             '5.4'         => true,
             'alternative' => 'zend.script_encoding',
         ),
+        'phar.extract_list' => array(
+            '5.4' => true,
+        ),
         'register_globals' => array(
             '5.3' => false,
             '5.4' => true,

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -469,3 +469,12 @@ $test = ini_get('phpdbg.path');
 
 ini_set('phpdbg.eol', 1);
 $test = ini_get('phpdbg.eol');
+
+ini_set('phar.readonly', 1);
+$test = ini_get('phar.readonly');
+
+ini_set('phar.require_hash', 1);
+$test = ini_get('phar.require_hash');
+
+ini_set('phar.extract_list', 1);
+$test = ini_get('phar.extract_list');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -137,6 +137,9 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('mysqlnd.debug', '5.3', array(239, 240), '5.2'),
             array('mysqlnd.net_read_buffer_size', '5.3', array(242, 243), '5.2'),
             array('odbc.default_cursortype', '5.3', array(245, 246), '5.2'),
+            array('phar.readonly', '5.3', array(473, 474), '5.2'),
+            array('phar.require_hash', '5.3', array(476, 477), '5.2'),
+            array('phar.extract_list', '5.3', array(479, 480), '5.2'),
             array('zend.enable_gc', '5.3', array(248, 249), '5.2'),
 
             array('curl.cainfo', '5.4', array(251, 252), '5.3.6', '5.3'),

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -240,3 +240,6 @@ $a = ini_get('allow_url_include');
 
 ini_set('opcache.load_comments', 'On');
 $a = ini_get('opcache.load_comments');
+
+ini_set('phar.extract_list', 1);
+$test = ini_get('phar.extract_list');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -257,6 +257,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
 
             array('zend.ze1_compatibility_mode', '5.3', array(36, 37), '5.2'),
 
+            array('phar.extract_list', '5.4', array(244, 245), '5.3'),
+
             array('asp_tags', '7.0', array(83, 84), '5.6'),
             array('xsl.security_prefs', '7.0', array(86, 87), '5.6'),
             array('opcache.load_comments', '7.0', array(241, 242), '5.6'),


### PR DESCRIPTION
* Added missing ini directives from introduction.
* Added `phar.extract_list` to removed ini directives list.
    Version is a little unclear - Phar 2.0, but as another ini was introduced in Phar 2.0 and that one is listed as PHP 5.4, I've put this one on PHP 5.4 too.

Ref: https://www.php.net/manual/en/book.phar.php