### PR TITLE
RemovedExtensions: PHP 7.4 wddx

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -1669,28 +1669,34 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             'extension'   => 'recode',
         ),
         'wddx_add_vars' => array(
-            '7.4' => true,
+            '7.4'         => true,
             'alternative' => null,
+            'extension'   => 'wddx',
         ),
         'wddx_deserialize' => array(
-            '7.4' => true,
+            '7.4'         => true,
             'alternative' => null,
+            'extension'   => 'wddx',
         ),
         'wddx_packet_end' => array(
-            '7.4' => true,
+            '7.4'         => true,
             'alternative' => null,
+            'extension'   => 'wddx',
         ),
         'wddx_packet_start' => array(
-            '7.4' => true,
+            '7.4'         => true,
             'alternative' => null,
+            'extension'   => 'wddx',
         ),
         'wddx_serialize_value' => array(
-            '7.4' => true,
+            '7.4'         => true,
             'alternative' => null,
+            'extension'   => 'wddx',
         ),
         'wddx_serialize_vars' => array(
-            '7.4' => true,
+            '7.4'         => true,
             'alternative' => null,
+            'extension'   => 'wddx',
         ),
     );
 


### PR DESCRIPTION
Add the `extension` key to the relevant array entries in the `RemovedFunctions` sniff.

Ref: https://www.php.net/manual/en/book.wddx.php

Related to #1022