### PR TITLE
NewExtensions: PHP 5.1 XMLReader

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -151,8 +151,9 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '5.1' => true,
         ),
         'XMLReader' => array(
-            '5.0' => false,
-            '5.1' => true,
+            '5.0'       => false,
+            '5.1'       => true,
+            'extension' => 'xmlreader',
         ),
 
         'SplFileInfo' => array(


### PR DESCRIPTION
Add the `extension` array key where relevant.

Ref: https://www.php.net/manual/en/book.xmlreader.php

Related to #1023