### PR TITLE
Verified extension: OpenSSL

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -354,6 +354,19 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '5.2.1' => true,
         ),
 
+        'openssl_pkcs12_export_to_file' => array(
+            '5.2.1' => false,
+            '5.2.2' => true,
+        ),
+        'openssl_pkcs12_export' => array(
+            '5.2.1' => false,
+            '5.2.2' => true,
+        ),
+        'openssl_pkcs12_read' => array(
+            '5.2.1' => false,
+            '5.2.2' => true,
+        ),
+
         'php_ini_loaded_file' => array(
             '5.2.3' => false,
             '5.2.4' => true,
@@ -672,6 +685,35 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
         'intl_is_failure' => array(
             '5.2' => false,
             '5.3' => true,
+        ),
+        'openssl_decrypt' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'openssl_dh_compute_key' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'openssl_digest' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'openssl_encrypt' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'openssl_get_cipher_methods' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'openssl_get_md_methods' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+
+        'openssl_cipher_iv_length' => array(
+            '5.3.2' => false,
+            '5.3.3' => true,
         ),
 
         'hex2bin' => array(
@@ -1491,6 +1533,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.0' => false,
             '7.1' => true,
         ),
+        'openssl_get_curve_names' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
 
         'hash_hkdf' => array(
             '7.1.1'     => false,
@@ -2028,6 +2074,11 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.2'       => true,
             'extension' => 'sodium',
         ),
+        'openssl_pkcs7_read' => array(
+            '7.1' => false,
+            '7.2' => true,
+        ),
+
         // Introduced in 7.2.14 and 7.3.1 simultanously.
         'oci_set_call_timeout' => array(
             '7.2.13' => false,

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -617,6 +617,14 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '5.5' => false,
             '5.6' => true,
         ),
+        'openssl.cafile' => array(
+            '5.5' => false,
+            '5.6' => true,
+        ),
+        'openssl.capath' => array(
+            '5.5' => false,
+            '5.6' => true,
+        ),
 
         'assert.exception' => array(
             '5.6' => false,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -527,3 +527,16 @@ hash_update_file();
 hash_update_stream();
 hash_update();
 hash();
+
+openssl_cipher_iv_length();
+openssl_decrypt();
+openssl_dh_compute_key();
+openssl_digest();
+openssl_encrypt();
+openssl_get_cipher_methods();
+openssl_get_curve_names();
+openssl_get_md_methods();
+openssl_pkcs12_export_to_file();
+openssl_pkcs12_export();
+openssl_pkcs12_read();
+openssl_pkcs7_read();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -135,6 +135,10 @@ class NewFunctionsUnitTest extends BaseSniffTest
 
             array('sys_get_temp_dir', '5.2.0', array(17), '5.3', '5.2'),
 
+            array('openssl_pkcs12_export_to_file', '5.2.1', array(539), '5.3', '5.2'),
+            array('openssl_pkcs12_export', '5.2.1', array(540), '5.3', '5.2'),
+            array('openssl_pkcs12_read', '5.2.1', array(541), '5.3', '5.2'),
+
             array('php_ini_loaded_file', '5.2.3', array(509), '5.3', '5.2'),
 
             array('array_replace', '5.2', array(65), '5.3'),
@@ -215,6 +219,14 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('intl_get_error_message', '5.2', array(140), '5.3'),
             array('intl_is_failure', '5.2', array(141), '5.3'),
             array('mysqli_get_cache_stats', '5.2', array(142), '5.3'),
+            array('openssl_decrypt', '5.2', array(532), '5.3'),
+            array('openssl_dh_compute_key', '5.2', array(533), '5.3'),
+            array('openssl_digest', '5.2', array(534), '5.3'),
+            array('openssl_encrypt', '5.2', array(535), '5.3'),
+            array('openssl_get_cipher_methods', '5.2', array(536), '5.3'),
+            array('openssl_get_md_methods', '5.2', array(538), '5.3'),
+
+            array('openssl_cipher_iv_length', '5.3.2', array(531), '5.4', '5.3'),
 
             array('hex2bin', '5.3', array(144), '5.4'),
             array('http_response_code', '5.3', array(145), '5.4'),
@@ -418,6 +430,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('sapi_windows_cp_get', '7.0', array(463), '7.1'),
             array('sapi_windows_cp_is_utf8', '7.0', array(464), '7.1'),
             array('sapi_windows_cp_conv', '7.0', array(465), '7.1'),
+            array('openssl_get_curve_names', '7.0', array(537), '7.1'),
 
             array('hash_hkdf', '7.1.1', array(466), '7.2', '7.1'),
             array('oci_register_taf_callback', '7.1.6', array(322), '7.2', '7.1'),
@@ -532,6 +545,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('sodium_pad', '7.1', array(417), '7.2'),
             array('sodium_unpad', '7.1', array(418), '7.2'),
             array('spl_object_id', '7.1', array(419), '7.2'),
+            array('openssl_pkcs7_read', '7.1', array(542), '7.2'),
 
             array('pg_lo_truncate', '5.5', array(420), '5.6'),
 

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -478,3 +478,9 @@ $test = ini_get('phar.require_hash');
 
 ini_set('phar.extract_list', 1);
 $test = ini_get('phar.extract_list');
+
+ini_set('openssl.cafile', 1);
+$test = ini_get('openssl.cafile');
+
+ini_set('openssl.capath', 1);
+$test = ini_get('openssl.capath');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -206,6 +206,8 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('session.use_strict_mode', '5.6', array(287, 288), '5.5.1', '5.5'),
 
             array('mysqli.rollback_on_cached_plink', '5.6', array(290, 291), '5.5'),
+            array('openssl.cafile', '5.6', array(482, 483), '5.5'),
+            array('openssl.capath', '5.6', array(485, 486), '5.5'),
 
             array('phpdbg.path', '7.0', array(467, 468), '5.6.2', '5.6'),
 


### PR DESCRIPTION
Add various functions and ini directives which were added to PHP after PHP 5 to the lists in the respective sniffs.