### PR TITLE
RemovedExtensions: PHP 5.2 HW API (Hyperwave)

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -46,6 +46,30 @@ class RemovedClassesSniff extends AbstractRemovedFeatureSniff
      * @var array(string => array(string => bool))
      */
     protected $removedClasses = array(
+        'HW_API' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
+        'HW_API_Object' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
+        'HW_API_Attribute' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
+        'HW_API_Error' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
+        'HW_API_Content' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
+        'HW_API_Reason' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
 
         'SWFAction' => array(
             '5.3'       => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -303,6 +303,23 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             'extension' => 'fam',
         ),
 
+        'hwapi_attribute_new' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
+        'hwapi_content_new' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
+        'hwapi_hgcsp' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
+        'hwapi_object_new' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
+
         'ncurses_addch' => array(
             '5.3'       => true,
             'extension' => 'ncurses',

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -70,6 +70,11 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             '5.1' => true,
         ),
 
+        'hwapi.allow_persistent' => array(
+            '5.2'       => true,
+            'extension' => 'hwapi',
+        ),
+
         'ifx.allow_persistent' => array(
             '5.2.1' => true,
         ),

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
@@ -55,3 +55,10 @@ class TypeHints {
 echo \SWFText::$property;
 echo \SWFTextField::method_call();
 echo \SWFVideoStream::CLASS_CONSTANT;
+
+$closure = function() : HW_API {};
+$closure = function() : \HW_API_Object {};
+$closure = function() : ?\HW_API_Attribute {};
+$closure = function() : ?HW_API_Error {};
+$obj = new HW_API_Content;
+echo HW_API_Reason::$property;

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
@@ -64,6 +64,13 @@ class RemovedClassesUnitTest extends BaseSniffTest
     public function dataRemovedClass()
     {
         return array(
+            array('HW_API', '5.2', array(59), '5.1'),
+            array('HW_API_Object', '5.2', array(60), '5.1'),
+            array('HW_API_Attribute', '5.2', array(61), '5.1'),
+            array('HW_API_Error', '5.2', array(62), '5.1'),
+            array('HW_API_Content', '5.2', array(63), '5.1'),
+            array('HW_API_Reason', '5.2', array(64), '5.1'),
+
             array('SWFAction', '5.3', array(32, 33, 34, 35), '5.2'),
             array('SWFBitmap', '5.3', array(37), '5.2'),
             array('SWFButton', '5.3', array(38), '5.2'),

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -521,3 +521,9 @@ fam_open();
 fam_pending();
 fam_resume_monitor();
 fam_suspend_monitor();
+
+// PHP 5.2 HWAPI extension.
+hwapi_attribute_new();
+hwapi_content_new();
+hwapi_hgcsp();
+hwapi_object_new();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -297,6 +297,11 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('fam_resume_monitor', '5.1', array(522), '5.0'),
             array('fam_suspend_monitor', '5.1', array(523), '5.0'),
 
+            array('hwapi_attribute_new', '5.2', array(526), '5.1'),
+            array('hwapi_content_new', '5.2', array(527), '5.1'),
+            array('hwapi_hgcsp', '5.2', array(528), '5.1'),
+            array('hwapi_object_new', '5.2', array(529), '5.1'),
+
             array('ncurses_addch', '5.3', array(255), '5.2'),
             array('ncurses_addchnstr', '5.3', array(256), '5.2'),
             array('ncurses_addchstr', '5.3', array(257), '5.2'),

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -249,3 +249,6 @@ $test = ini_get('mime_magic.debug');
 
 ini_set('mime_magic.magicfile', 'path');
 $test = ini_get('mime_magic.magicfile');
+
+ini_set('hwapi.allow_persistent', 0);
+$test = ini_get('hwapi.allow_persistent');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -243,6 +243,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
     public function dataRemovedDirectives()
     {
         return array(
+            array('hwapi.allow_persistent', '5.2', array(253, 254), '5.1'),
+
             array('ifx.allow_persistent', '5.2.1', array(92, 93), '5.2', '5.3'),
             array('ifx.blobinfile', '5.2.1', array(95, 96), '5.2', '5.3'),
             array('ifx.byteasvarchar', '5.2.1', array(98, 99), '5.2', '5.3'),


### PR DESCRIPTION
Add all classes, functions and ini directives from the extension to the respective `RemovedClasses`,`RemovedFunctions` and `RemovedIniDirectives` sniffs.

Ref: https://www.php.net/manual/en/book.hwapi.php

Related to #1022