### PR TITLE
Verified extension: Classes/Objects [1]

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -1336,12 +1336,12 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
 
         'call_user_method' => array(
-            '5.3' => false,
+            '4.1' => false,
             '7.0' => true,
             'alternative' => 'call_user_func()',
         ),
         'call_user_method_array' => array(
-            '5.3' => false,
+            '4.1' => false,
             '7.0' => true,
             'alternative' => 'call_user_func_array()',
         ),
@@ -1964,6 +1964,10 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         'png2wbmp' => array(
             '7.2' => false,
             'alternative' => 'imagecreatefrompng() or imagewbmp()',
+        ),
+        '__autoload' => array(
+            '7.2' => false,
+            'alternative' => 'SPL autoload',
         ),
         'create_function' => array(
             '7.2' => false,

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -585,3 +585,5 @@ msession_set();
 msession_timeout();
 msession_uniq();
 msession_unlock();
+
+__autoload($class);

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -169,6 +169,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('jpeg2wbmp', '7.2', 'imagecreatefromjpeg() and imagewbmp()', array(144), '7.1'),
             array('png2wbmp', '7.2', 'imagecreatefrompng() or imagewbmp()', array(145), '7.1'),
             array('create_function', '7.2', 'an anonymous function', array(146), '7.1'),
+            array('__autoload', '7.2', 'SPL autoload', array(589), '7.1'),
             array('each', '7.2', 'a foreach loop', array(147), '7.1'),
             array('gmp_random', '7.2', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
             array('read_exif_data', '7.2', 'exif_read_data()', array(149), '7.1'),
@@ -792,8 +793,8 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
     public function dataDeprecatedRemovedFunctionWithAlternative()
     {
         return array(
-            array('call_user_method', '5.3', '7.0', 'call_user_func()', array(3), '5.2'),
-            array('call_user_method_array', '5.3', '7.0', 'call_user_func_array()', array(4), '5.2'),
+            array('call_user_method', '4.1', '7.0', 'call_user_func()', array(3), '4.0'),
+            array('call_user_method_array', '4.1', '7.0', 'call_user_func_array()', array(4), '4.0'),
             array('ereg', '5.3', '7.0', 'preg_match()', array(7), '5.2'),
             array('ereg_replace', '5.3', '7.0', 'preg_replace()', array(8), '5.2'),
             array('eregi', '5.3', '7.0', 'preg_match() (with the i modifier)', array(9), '5.2'),
@@ -905,7 +906,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '5.0'); // Low version below the first deprecation.
+        $file = $this->sniffFile(__FILE__, '4.0'); // Low version below the first deprecation.
         $this->assertNoViolation($file);
     }
 }


### PR DESCRIPTION
Note: there is a separate sniff which detects an `__autoload()` function being declared. Adding the function name to the `RemovedFunctions` sniff will warn about direct calls to that function.

Ref: https://www.php.net/manual/en/book.classobj.php