### PR TITLE
RemovedExtensions: PHP 5.0 Crack

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -45,6 +45,23 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
      * @var array(string => array(string => bool|string|null))
      */
     protected $removedFunctions = array(
+        'crack_check' => array(
+            '5.0'       => true,
+            'extension' => 'crack',
+        ),
+        'crack_closedict' => array(
+            '5.0'       => true,
+            'extension' => 'crack',
+        ),
+        'crack_getlastmessage' => array(
+            '5.0'       => true,
+            'extension' => 'crack',
+        ),
+        'crack_opendict' => array(
+            '5.0'       => true,
+            'extension' => 'crack',
+        ),
+
         'php_check_syntax' => array(
             '5.0.5' => true,
             'alternative' => null,

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -44,6 +44,11 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
      * @var array(string)
      */
     protected $deprecatedIniDirectives = array(
+        'crack.default_dictionary' => array(
+            '5.0'       => true,
+            'extension' => 'crack',
+        ),
+
         'fbsql.batchSize' => array(
             '5.1'         => true,
             'alternative' => 'fbsql.batchsize',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -587,3 +587,9 @@ msession_uniq();
 msession_unlock();
 
 __autoload($class);
+
+// PHP 5.0 Crack extension.
+crack_check();
+crack_closedict();
+crack_getlastmessage();
+crack_opendict();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -239,6 +239,11 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
     public function dataRemovedFunction()
     {
         return array(
+            array('crack_check', '5.0', array(592), '4.4'),
+            array('crack_closedict', '5.0', array(593), '4.4'),
+            array('crack_getlastmessage', '5.0', array(594), '4.4'),
+            array('crack_opendict', '5.0', array(595), '4.4'),
+
             array('m_checkstatus', '5.1', array(417), '5.0'),
             array('m_completeauthorizations', '5.1', array(418), '5.0'),
             array('m_connect', '5.1', array(419), '5.0'),

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -252,3 +252,6 @@ $test = ini_get('mime_magic.magicfile');
 
 ini_set('hwapi.allow_persistent', 0);
 $test = ini_get('hwapi.allow_persistent');
+
+ini_set('crack.default_dictionary', 0);
+$test = ini_get('crack.default_dictionary');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -243,6 +243,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
     public function dataRemovedDirectives()
     {
         return array(
+            array('crack.default_dictionary', '5.0', array(256, 257), '4.4'),
+
             array('hwapi.allow_persistent', '5.2', array(253, 254), '5.1'),
 
             array('ifx.allow_persistent', '5.2.1', array(92, 93), '5.2', '5.3'),
@@ -344,7 +346,7 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '5.0'); // Low version below the first deprecation.
+        $file = $this->sniffFile(__FILE__, '4.4'); // Low version below the first deprecation.
         $this->assertNoViolation($file);
     }
 }


### PR DESCRIPTION
Add all functions and ini directives from the extension to the `RemovedFunctions` and `RemovedIniDirectives` sniffs.

Based on: https://web.archive.org/web/20090218171604/http://us.php.net/manual/en/book.crack.php

Related to #1022