### PR TITLE
RemovedExtensions: PHP 5.1 PfPro

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -68,24 +68,24 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
 
         'pfpro_cleanup' => array(
-            '5.1' => true,
-            'alternative' => null,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'pfpro_init' => array(
-            '5.1' => true,
-            'alternative' => null,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'pfpro_process_raw' => array(
-            '5.1' => true,
-            'alternative' => null,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'pfpro_process' => array(
-            '5.1' => true,
-            'alternative' => null,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'pfpro_version' => array(
-            '5.1' => true,
-            'alternative' => null,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'm_checkstatus' => array(
             '5.1'       => true,

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -58,25 +58,32 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             'extension'   => 'fbsql',
         ),
         'pfpro.defaulthost' => array(
-            '5.1' => true,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'pfpro.defaultport' => array(
-            '5.1' => true,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'pfpro.defaulttimeout' => array(
-            '5.1' => true,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'pfpro.proxyaddress' => array(
-            '5.1' => true,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'pfpro.proxyport' => array(
-            '5.1' => true,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'pfpro.proxylogon' => array(
-            '5.1' => true,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'pfpro.proxypassword' => array(
-            '5.1' => true,
+            '5.1'       => true,
+            'extension' => 'pfpro',
         ),
         'ingres.allow_persistent' => array(
             '5.1'       => true,

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -244,6 +244,11 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('crack_getlastmessage', '5.0', array(594), '4.4'),
             array('crack_opendict', '5.0', array(595), '4.4'),
 
+            array('pfpro_cleanup', '5.1', array(221), '5.0'),
+            array('pfpro_init', '5.1', array(222), '5.0'),
+            array('pfpro_process_raw', '5.1', array(223), '5.0'),
+            array('pfpro_process', '5.1', array(224), '5.0'),
+            array('pfpro_version', '5.1', array(225), '5.0'),
             array('m_checkstatus', '5.1', array(417), '5.0'),
             array('m_completeauthorizations', '5.1', array(418), '5.0'),
             array('m_connect', '5.1', array(419), '5.0'),
@@ -1020,12 +1025,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('fbird_set_event_handler', '7.4', array(1032), '7.3'),
             array('fbird_trans', '7.4', array(1033), '7.3'),
             array('fbird_wait_event', '7.4', array(1034), '7.3'),
-
-            array('pfpro_cleanup', '5.1', array(221), '5.0'),
-            array('pfpro_init', '5.1', array(222), '5.0'),
-            array('pfpro_process_raw', '5.1', array(223), '5.0'),
-            array('pfpro_process', '5.1', array(224), '5.0'),
-            array('pfpro_version', '5.1', array(225), '5.0'),
 
             array('wddx_add_vars', '7.4', array(228), '7.3'),
             array('wddx_deserialize', '7.4', array(229), '7.3'),


### PR DESCRIPTION
Added the `extension` array index key to the relevant entries.

Ref: https://web.archive.org/web/20070226211109/http://www.php.net/manual/en/ref.pfpro.php

Related to #1022