### PR TITLE
NewExtensions: PHP 5.1 PDO

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -164,12 +164,14 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '5.1' => true,
         ),
         'PDO' => array(
-            '5.0' => false,
-            '5.1' => true,
+            '5.0'       => false,
+            '5.1'       => true,
+            'extension' => 'pdo',
         ),
         'PDOStatement' => array(
-            '5.0' => false,
-            '5.1' => true,
+            '5.0'       => false,
+            '5.1'       => true,
+            'extension' => 'pdo',
         ),
         'AppendIterator' => array(
             '5.0'       => false,
@@ -675,8 +677,9 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             'extension' => 'spl',
         ),
         'PDOException' => array(
-            '5.0' => false,
-            '5.1' => true,
+            '5.0'       => false,
+            '5.1'       => true,
+            'extension' => 'pdo',
         ),
         'RangeException' => array(
             '5.0'       => false,

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -173,6 +173,17 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '5.0' => false,
             '5.1' => true,
         ),
+        'pdo_odbc.connection_pooling' => array(
+            '5.0'       => false,
+            '5.1'       => true,
+            'extension' => 'pdo',
+        ),
+
+        'pdo_odbc.db2_instance_name' => array(
+            '5.1.0'     => false,
+            '5.1.1'     => true,
+            'extension' => 'pdo',
+        ),
 
         'mbstring.strict_detection' => array(
             '5.1.1' => false,

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -484,3 +484,9 @@ $test = ini_get('openssl.cafile');
 
 ini_set('openssl.capath', 1);
 $test = ini_get('openssl.capath');
+
+ini_set('pdo_odbc.connection_pooling', 1);
+$test = ini_get('pdo_odbc.connection_pooling');
+
+ini_set('pdo_odbc.db2_instance_name', 1);
+$test = ini_get('pdo_odbc.db2_instance_name');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -94,6 +94,9 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('detect_unicode', '5.1', array(164, 165), '5.0'),
             array('realpath_cache_size', '5.1', array(170, 171), '5.0'),
             array('realpath_cache_ttl', '5.1', array(173, 174), '5.0'),
+            array('pdo_odbc.connection_pooling', '5.1', array(488, 489), '5.0'),
+
+            array('pdo_odbc.db2_instance_name', '5.2', array(491, 492), '5.1.0', '5.1'),
 
             array('mbstring.strict_detection', '5.2', array(176, 177), '5.1.1', '5.1'),
             array('mssql.charset', '5.2', array(179, 180), '5.1.1', '5.1'),


### PR DESCRIPTION
* Add the `extension` index key.
* Add some missing ini directives.

Ref: https://www.php.net/manual/en/book.pdo.php

Related to #1023