### PR TITLE
NewClasses: remove classes which only exist in PECL

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -850,14 +850,6 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '5.6' => false,
             '7.0' => true,
         ),
-        'UI\Exception\InvalidArgumentException' => array(
-            '5.6' => false,
-            '7.0' => true,
-        ),
-        'UI\Exception\RuntimeException' => array(
-            '5.6' => false,
-            '7.0' => true,
-        ),
 
         'ArgumentCountError' => array(
             '7.0' => false,

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -185,18 +185,18 @@ function(myNameSpace\IntlTimeZone $a) {} // Ok.
  */
 throw new DomainException($msg);
 throw new ReflectionException($msg);
-throw new UI\Exception\RuntimeException($msg);
+
 
 class MyException extends Exception {}
 class MyException extends UnexpectedValueException {}
-class MyException extends UI\Exception\InvalidArgumentException {}
+
 
 ErrorException::static_method();
 LengthException::static_method();
 OverflowException::CLASS_CONSTANT;
 UnderflowException::CLASS_CONSTANT;
 PDOException::$static_property;
-UI\Exception\RuntimeException::$static_property;
+
 
 new class extends BadFunctionCallException {}
 new class extends mysqli_sql_exception {}
@@ -207,7 +207,7 @@ class MyExceptionHandler {
     function ExceptionTypeHint( BadMethodCallException $e ) {}
     function ExceptionTypeHint( RangeException $e ) {}
     function ExceptionTypeHint( ArithmeticError $e ) {}
-    function ExceptionTypeHint( UI\Exception\InvalidArgumentException $e ) {}
+
 }
 
 // New exceptions as type hints in anonymous functions.
@@ -243,8 +243,8 @@ try {
 } catch (DivisionByZeroError $e) {
 } catch (ParseError $e) {
 } catch (TypeError $e) {
-} catch (UI\Exception\InvalidArgumentException $e) {
-} catch (UI\Exception\RuntimeException $e) {
+
+
 } catch (ArgumentCountError $e) {
 } catch (CompileError $e) {
 } catch (JsonException $e) {
@@ -319,7 +319,7 @@ function DateTimeReturnTypeHint( $a ) : DateTime {}
 function DateTimeNullableReturnTypeHint( $a ) : ?DateTime {}
 function GlobalNSLcDateTimeReturnTypeHint( $a ) : \datetime {}
 function GlobalNSDateTimeNullableReturnTypeHint( $a ) : ?\DateTime {}
-function UIExceptionReturnTypeHint( $e ): UI\Exception\InvalidArgumentException {}
+
 
 // Test against false positives for return type declarations.
 function NsDateTimeReturnTypeHint( $a ) : \SomeNamespace\DateTime {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -231,8 +231,6 @@ class NewClassesUnitTest extends BaseSniffTest
             array('ParseError', '5.6', array(244), '7.0'),
             array('TypeError', '5.6', array(245), '7.0'),
             array('ClosedGeneratorException', '5.6', array(341), '7.0'),
-            array('UI\Exception\InvalidArgumentException', '5.6', array(192, 210, 246, 322), '7.0'),
-            array('UI\Exception\RuntimeException', '5.6', array(188, 199, 247), '7.0'),
             array('ArgumentCountError', '7.0', array(248), '7.1'),
             array('HashContext', '7.1', array(350), '7.2'),
             array('SodiumException', '7.1', array(342), '7.2'),


### PR DESCRIPTION
The UI extension is not bundled with PHP, but a PECL only extension. These exceptions shouldn't be included in scans with PHPCompatibility.

Ref: https://www.php.net/manual/en/book.ui.php