### PR TITLE
Verified extension: FBSQL (FrontBase)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -117,6 +117,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '5.0'       => true,
             'extension' => 'simplexml',
         ),
+        'fbsql_set_password' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
 
         'interface_exists' => array(
             '5.0.1' => false,
@@ -308,6 +312,14 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '5.0'       => false,
             '5.1'       => true,
             'extension' => 'libxml',
+        ),
+        'fbsql_rows_fetched' => array(
+            '5.0' => false,
+            '5.1' => true,
+        ),
+        'fbsql_set_characterset' => array(
+            '5.0' => false,
+            '5.1' => true,
         ),
 
         'date_sun_info' => array(

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -784,3 +784,6 @@ xmlwriter_write_dtd();
 xmlwriter_write_element_ns();
 xmlwriter_write_element();
 xmlwriter_write_pi();
+fbsql_rows_fetched();
+fbsql_set_characterset();
+fbsql_set_password();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -79,6 +79,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('simplexml_import_dom', '4.4', array(747), '5.0'),
             array('simplexml_load_file', '4.4', array(748), '5.0'),
             array('simplexml_load_string', '4.4', array(749), '5.0'),
+            array('fbsql_set_password', '4.4', array(789), '5.0'),
 
             array('interface_exists', '5.0.1', array(737), '5.1', '5.0'),
 
@@ -117,6 +118,8 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('libxml_get_last_error', '5.0', array(744), '5.1'),
             array('libxml_set_streams_context', '5.0', array(745), '5.1'),
             array('libxml_use_internal_errors', '5.0', array(746), '5.1'),
+            array('fbsql_rows_fetched', '5.0', array(787), '5.1'),
+            array('fbsql_set_characterset', '5.0', array(788), '5.1'),
 
             array('date_sun_info', '5.1.1', array(557), '5.2', '5.1'),
             array('hash_algos', '5.1.1', array(521), '5.2', '5.1'),


### PR DESCRIPTION
In PR #1090, everything to do with the removal of the extension in PHP 5.3 was addressed.

What's left is that a few functions were introduced in PHP >= 5.0. This adds those to the list.

Ref: https://www.php.net/manual/en/book.fbsql.php