### PR TITLE
Verified extension: mysql

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -1098,6 +1098,11 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '5.2.2' => true,
         ),
 
+        'mysql_set_charset' => array(
+            '5.2.2' => false,
+            '5.2.3' => true,
+        ),
+
         'php_ini_loaded_file' => array(
             '5.2.3' => false,
             '5.2.4' => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -827,3 +827,4 @@ sqlite_udf_decode_binary();
 sqlite_udf_encode_binary();
 sqlite_unbuffered_query();
 sqlite_valid();
+mysql_set_charset();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -294,6 +294,8 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('openssl_pkcs12_export', '5.2.1', array(540), '5.3', '5.2'),
             array('openssl_pkcs12_read', '5.2.1', array(541), '5.3', '5.2'),
 
+            array('mysql_set_charset', '5.2.2', array(830), '5.3', '5.2'),
+
             array('php_ini_loaded_file', '5.2.3', array(509), '5.3', '5.2'),
             array('stream_is_local', '5.2.3', array(705), '5.3', '5.2'),
 


### PR DESCRIPTION
While this extension has been removed in PHP 7.0 (PR #1102), it has also had some feature additions before that time.

Ref: https://www.php.net/manual/en/book.mysql.php