### PR TITLE
NewExtensions: PHP 5.3 MySQLnd

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -314,20 +314,39 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             'extension' => 'mysqli',
         ),
         'mysqlnd.collect_memory_statistics' => array(
-            '5.2' => false,
-            '5.3' => true,
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'mysqlnd',
         ),
         'mysqlnd.collect_statistics' => array(
-            '5.2' => false,
-            '5.3' => true,
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'mysqlnd',
         ),
         'mysqlnd.debug' => array(
-            '5.2' => false,
-            '5.3' => true,
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'mysqlnd',
+        ),
+        'mysqlnd.log_mask' => array(
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'mysqlnd',
+        ),
+        'mysqlnd.net_read_timeout' => array(
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'mysqlnd',
+        ),
+        'mysqlnd.net_cmd_buffer_size' => array(
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'mysqlnd',
         ),
         'mysqlnd.net_read_buffer_size' => array(
-            '5.2' => false,
-            '5.3' => true,
+            '5.2'       => false,
+            '5.3'       => true,
+            'extension' => 'mysqlnd',
         ),
         'odbc.default_cursortype' => array(
             '5.2' => false,
@@ -365,6 +384,12 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '5.3' => true,
         ),
 
+        'mysqlnd.mempool_default_size' => array(
+            '5.3.2'     => false,
+            '5.3.3'     => true,
+            'extension' => 'mysqlnd',
+        ),
+
         'curl.cainfo' => array(
             '5.3.6' => false,
             '5.3.7' => true,
@@ -393,18 +418,6 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '5.4' => true,
         ),
         'enable_post_data_reading' => array(
-            '5.3' => false,
-            '5.4' => true,
-        ),
-        'mysqlnd.mempool_default_size' => array(
-            '5.3' => false,
-            '5.4' => true,
-        ),
-        'mysqlnd.net_cmd_buffer_size' => array(
-            '5.3' => false,
-            '5.4' => true,
-        ),
-        'mysqlnd.net_read_timeout' => array(
             '5.3' => false,
             '5.4' => true,
         ),
@@ -458,10 +471,6 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '5.3' => false,
             '5.4' => true,
         ),
-        'mysqlnd.log_mask' => array(
-            '5.3' => false,
-            '5.4' => true,
-        ),
 
         'intl.use_exceptions' => array(
             '5.4'       => false,
@@ -469,12 +478,14 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             'extension' => 'intl',
         ),
         'mysqlnd.sha256_server_public_key' => array(
-            '5.4' => false,
-            '5.5' => true,
+            '5.4'       => false,
+            '5.5'       => true,
+            'extension' => 'mysqlnd',
         ),
         'mysqlnd.trace_alloc' => array(
-            '5.4' => false,
-            '5.5' => true,
+            '5.4'       => false,
+            '5.5'       => true,
+            'extension' => 'mysqlnd',
         ),
         'sys_temp_dir' => array(
             '5.4' => false,
@@ -658,6 +669,11 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
         'openssl.capath' => array(
             '5.5' => false,
             '5.6' => true,
+        ),
+        'mysqlnd.fetch_data_copy' => array(
+            '5.5'       => false,
+            '5.6'       => true,
+            'extension' => 'mysqlnd',
         ),
 
         'assert.exception' => array(

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -493,3 +493,6 @@ $test = ini_get('pdo_odbc.db2_instance_name');
 
 ini_set('mysqli.reconnect', 1);
 $test = ini_get('mysqli.reconnect');
+
+ini_set('mysqlnd.fetch_data_copy', 1);
+$test = ini_get('mysqlnd.fetch_data_copy');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -139,11 +139,16 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('mysqlnd.collect_statistics', '5.3', array(236, 237), '5.2'),
             array('mysqlnd.debug', '5.3', array(239, 240), '5.2'),
             array('mysqlnd.net_read_buffer_size', '5.3', array(242, 243), '5.2'),
+            array('mysqlnd.log_mask', '5.3', array(263, 264), '5.2'),
+            array('mysqlnd.net_read_timeout', '5.3', array(272, 273), '5.2'),
+            array('mysqlnd.net_cmd_buffer_size', '5.3', array(269, 270), '5.2'),
             array('odbc.default_cursortype', '5.3', array(245, 246), '5.2'),
             array('phar.readonly', '5.3', array(473, 474), '5.2'),
             array('phar.require_hash', '5.3', array(476, 477), '5.2'),
             array('phar.extract_list', '5.3', array(479, 480), '5.2'),
             array('zend.enable_gc', '5.3', array(248, 249), '5.2'),
+
+            array('mysqlnd.mempool_default_size', '5.4', array(266, 267), '5.3.2', '5.3'),
 
             array('curl.cainfo', '5.4', array(251, 252), '5.3.6', '5.3'),
 
@@ -164,10 +169,6 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('enable_post_data_reading', '5.4', array(71, 72), '5.3'),
             array('windows_show_crt_warning', '5.4', array(74, 75), '5.3'),
             array('session.upload_progress.prefix', '5.4', array(257, 258), '5.3'),
-            array('mysqlnd.log_mask', '5.4', array(263, 264), '5.3'),
-            array('mysqlnd.mempool_default_size', '5.4', array(266, 267), '5.3'),
-            array('mysqlnd.net_cmd_buffer_size', '5.4', array(269, 270), '5.3'),
-            array('mysqlnd.net_read_timeout', '5.4', array(272, 273), '5.3'),
             array('phar.cache_list', '5.4', array(275, 276), '5.3'),
 
             array('intl.use_exceptions', '5.5', array(77, 78), '5.4'),
@@ -211,6 +212,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('mysqli.rollback_on_cached_plink', '5.6', array(290, 291), '5.5'),
             array('openssl.cafile', '5.6', array(482, 483), '5.5'),
             array('openssl.capath', '5.6', array(485, 486), '5.5'),
+            array('mysqlnd.fetch_data_copy', '5.6', array(497, 498), '5.5'),
 
             array('phpdbg.path', '7.0', array(467, 468), '5.6.2', '5.6'),
 


### PR DESCRIPTION
* Added the `extension` index key.
* Fixed some version nrs.
* Added missing ini directive.

Ref: https://www.php.net/manual/en/book.mysqlnd.php

Related to #1023