### PR TITLE
PHP 7.2: New `PHPCompatibility.ParameterValues.ForbiddenSessionModuleNameUser` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCSUtils\Utils\TextStrings;
+
+/**
+ * Detect: Passing "user" to `session_module_name()` is no longer allowed as of PHP 7.2.
+ * This will now result in a (recoverable) fatal error being thrown.
+ *
+ * Previously, passing "user" would result in it being silently ignored.
+ *
+ * PHP version 7.2
+ *
+ * @link https://www.php.net/manual/en/function.session-module-name.php#refsect1-function.session-module-name-changelog
+ *
+ * @since 10.0.0
+ */
+class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'session_module_name' => true,
+    );
+
+    /**
+     * Tokens which we are looking for in the parameter.
+     *
+     * This property is set in the register() method.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $targetTokens = array();
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        // Only set the $targetTokens property once.
+        $this->targetTokens  = Tokens::$emptyTokens;
+        $this->targetTokens += Tokens::$heredocTokens;
+        $this->targetTokens += Tokens::$stringTokens;
+
+        return parent::register();
+    }
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('7.2') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[1]) === false) {
+            return;
+        }
+
+        $param = $parameters[1];
+
+        $firstNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, $param['start'], ($param['end'] + 1), true);
+        $hasNonTextToken = $phpcsFile->findNext($this->targetTokens, $firstNonEmpty, ($param['end'] + 1), true);
+        if ($hasNonTextToken !== false) {
+            // Non text string token found.
+            return;
+        }
+
+        $content   = TextStrings::getCompleteTextString($phpcsFile, $firstNonEmpty);
+        $contentLC = \strtolower($content);
+
+        if ($contentLC !== 'user') {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Passing "user" as the $module to session_module_name() is not allowed since PHP 7.2.',
+            $firstNonEmpty,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.inc
@@ -1,0 +1,21 @@
+<?php
+/*
+ * Test session_module_name() PHP 7.2 change in accepted values.
+ */
+
+// OK.
+session_module_name($module);
+session_module_name();
+session_module_name('user' . $something);
+session_module_name(<<<EOD
+user-nonsense
+EOD
+);
+
+// Not OK.
+session_module_name('user');
+session_module_name("USER");
+session_module_name(<<<'EOD'
+user
+EOD
+);

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the ForbiddenSessionModuleNameUser sniff.
+ *
+ * @group forbiddenSessionModuleNameUser
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\ForbiddenSessionModuleNameUserSniff
+ *
+ * @since 10.0.0
+ */
+class ForbiddenSessionModuleNameUserUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testForbiddenSessionModuleNameUser
+     *
+     * @dataProvider dataForbiddenSessionModuleNameUser
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testForbiddenSessionModuleNameUser($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.2');
+        $this->assertError($file, $line, 'Passing "user" as the $module to session_module_name() is not allowed since PHP 7.2.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenSessionModuleNameUser()
+     *
+     * @return array
+     */
+    public function dataForbiddenSessionModuleNameUser()
+    {
+        return array(
+            array(16),
+            array(17),
+            array(18),
+        );
+    }
+
+
+    /**
+     * Verify there are no false positives on valid code.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '7.2');
+
+        // No errors expected on the first 14 lines.
+        for ($line = 1; $line <= 14; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION

From: https://www.php.net/manual/en/function.session-module-name.php#refsect1-function.session-module-name-changelog

> It is now explicitly forbidden to set the module name to "user". Formerly, this has been silently ignored.

This sniff addresses that change.

Includes unit tests.