### PR TITLE
NewClosure: use PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
 
 /**
@@ -249,7 +250,7 @@ class NewClosureSniff extends Sniff
         }
 
         $tokens   = $phpcsFile->getTokens();
-        $classRef = $phpcsFile->findNext(array(\T_SELF, \T_PARENT, \T_STATIC), $startToken, $endToken);
+        $classRef = $phpcsFile->findNext(Collections::$OOHierarchyKeywords, $startToken, $endToken);
 
         if ($classRef === false || $tokens[$classRef]['code'] !== \T_STATIC) {
             return $classRef;

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -13,6 +13,8 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\Conditions;
 
 /**
  * Detect closures and verify that the features used are supported.
@@ -161,7 +163,7 @@ class NewClosureSniff extends Sniff
                 /*
                  * Closures only have access to $this if used within a class context.
                  */
-                elseif ($this->inClassScope($phpcsFile, $stackPtr, false) === false) {
+                elseif (Conditions::hasCondition($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) === false) {
                     $phpcsFile->addWarning(
                         'Closures / anonymous functions only have access to $this if used within a class or when bound to an object using bindTo(). Please verify.',
                         $thisFound,


### PR DESCRIPTION
## NewClosure: use PHPCSUtils\Utils\Conditions::hasCondition()

Switch out the use of the `Sniff::inClassScope()` method for the `Conditions::hasCondition()` method in combination with the `BCTokens::ooScopeTokens()` method.

## NewClosure: use Collections::$OOHierarchyKeywords 