### PR TITLE
ReservedFunctionNames: bug fixes and enhancements via PHPCSUtils

### DIFF
--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -40,12 +40,6 @@ if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
     if (class_exists('\PHP_CodeSniffer_Exception') === false) {
         class_alias('PHP_CodeSniffer\Exceptions\RuntimeException', '\PHP_CodeSniffer_Exception');
     }
-    if (class_exists('\PHP_CodeSniffer_Standards_AbstractScopeSniff') === false) {
-        class_alias('PHP_CodeSniffer\Sniffs\AbstractScopeSniff', '\PHP_CodeSniffer_Standards_AbstractScopeSniff');
-    }
-    if (class_exists('\Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff') === false) {
-        class_alias('PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff', '\Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff');
-    }
 
     define('PHPCOMPATIBILITY_PHPCS_ALIASES_SET', true);
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -153,7 +153,7 @@ class ReservedFunctionNamesSniff extends PHPCS_CamelCapsFunctionNameSniff
             $magicPart = strtolower(substr($functionName, 2));
             if (isset($this->magicFunctions[$magicPart]) === false) {
                 $phpcsFile->addWarning(
-                    'Function name "%s" is discouraged; PHP has reserved all method names with a double underscore prefix for future use.',
+                    'Function name "%s" is discouraged; PHP has reserved all function names with a double underscore prefix for future use.',
                     $stackPtr,
                     'FunctionDoubleUnderscore',
                     array($functionName)

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -43,7 +43,7 @@ function __my_function() {}
 
 interface Foo
 {
-    function __call() {}
+    function __call();
 }
 
 class Magic_Case_Test {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -134,3 +134,10 @@ class Deprecated {
      */
     public static function __deprecatedMethod() {}
 }
+
+// Verify that functions declared as return by reference are recognized correctly.
+function & __returnByRef() {} // Error.
+
+class Ref {
+    public function &__returnByRef() {} // Error.
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -150,3 +150,12 @@ class Nesting extends \SoapClient {
         function __getLastResponse() {} // Error.
     }
 }
+
+// PHP 7.4: allow for new (un)serialize magic methods.
+class Magic_Test_PHP74 {
+    function __serialize() {} // OK.
+    function __unserialize() {} // OK.
+}
+
+function __serialize() {} // Error.
+function __unserialize() {} // Error.

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -141,3 +141,12 @@ function & __returnByRef() {} // Error.
 class Ref {
     public function &__returnByRef() {} // Error.
 }
+
+// Verify that nested functions are correctly seen as declared in the global namespace.
+class Nesting extends \SoapClient {
+    public function thisIsOk() {
+        function __autoload($class) {} // OK.
+        function __isset() {} // Error.
+        function __getLastResponse() {} // Error.
+    }
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -78,6 +78,9 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
 
             array(107, 'method'),
             array(109, 'method'),
+
+            array(139, 'function'),
+            array(142, 'method'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -84,6 +84,9 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
 
             array(149, 'function'),
             array(150, 'function'),
+
+            array(160, 'function'),
+            array(161, 'function'),
         );
     }
 
@@ -166,6 +169,9 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
             array(135),
 
             array(148),
+
+            array(156),
+            array(157),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -26,18 +26,19 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
 {
 
     /**
-     * testReservedFunctionNames
+     * Test that double underscore prefixed functions/methods which aren't reserved names trigger an error.
      *
      * @dataProvider dataReservedFunctionNames
      *
-     * @param int $line The line number.
+     * @param int    $line The line number.
+     * @param string $type Either 'function' or 'method'.
      *
      * @return void
      */
-    public function testReservedFunctionNames($line)
+    public function testReservedFunctionNames($line, $type)
     {
         $file = $this->sniffFile(__FILE__);
-        $this->assertWarning($file, $line, ' is discouraged; PHP has reserved all method names with a double underscore prefix for future use.');
+        $this->assertWarning($file, $line, " is discouraged; PHP has reserved all $type names with a double underscore prefix for future use.");
     }
 
     /**
@@ -50,39 +51,39 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
     public function dataReservedFunctionNames()
     {
         return array(
-            array(20),
-            array(21),
-            array(22),
+            array(20, 'method'),
+            array(21, 'method'),
+            array(22, 'method'),
 
-            array(25),
-            array(26),
-            array(27),
-            array(28),
-            array(29),
-            array(30),
-            array(31),
-            array(32),
-            array(33),
-            array(34),
-            array(35),
-            array(37),
-            array(38),
-            array(39),
-            array(41),
-            array(42),
+            array(25, 'function'),
+            array(26, 'function'),
+            array(27, 'function'),
+            array(28, 'function'),
+            array(29, 'function'),
+            array(30, 'function'),
+            array(31, 'function'),
+            array(32, 'function'),
+            array(33, 'function'),
+            array(34, 'function'),
+            array(35, 'function'),
+            array(37, 'function'),
+            array(38, 'function'),
+            array(39, 'function'),
+            array(41, 'function'),
+            array(42, 'function'),
 
-            array(92),
-            array(93),
-            array(94),
+            array(92, 'method'),
+            array(93, 'method'),
+            array(94, 'method'),
 
-            array(107),
-            array(109),
+            array(107, 'method'),
+            array(109, 'method'),
         );
     }
 
 
     /**
-     * testNoFalsePositives
+     * Verify the sniff doesn't throw false positives.
      *
      * @dataProvider dataNoFalsePositives
      *

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -123,6 +123,7 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
             array(19),
 
             array(40),
+            array(46),
             array(50),
             array(51),
             array(52),

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -81,6 +81,9 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
 
             array(139, 'function'),
             array(142, 'method'),
+
+            array(149, 'function'),
+            array(150, 'function'),
         );
     }
 
@@ -161,6 +164,8 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
 
             array(124),
             array(135),
+
+            array(148),
         );
     }
 


### PR DESCRIPTION
## ReservedFunctionNames: add missing test case

The test case on line 46 was so far not being tested.
It also contained a parse error in test case file.

Fixed now.

## ReservedFunctionNames: fix the error message

The error message for (global) functions referred to `methods` which is confusing and semantically incorrect.

Fixed now.

Includes adjusting the unit test file to allow for the different error messages.

## ReservedFunctionNames: add test cases for return by reference

The sniff was so far not tested for correctly identifying and verifying the names of functions returning by reference.

It did already handle those correctly though.

## ReservedFunctionNames: add extra unit test with nested function declarations

Function declarations nested in a class method declare the function in the global namespace. This was previously handled incorrectly.

See: https://3v4l.org/R32Sl

## ReservedFunctionNames: add test cases for PHP 7.4 magic methods

The sniff was so far not tested for correctly disregarding the new PHP 7.4 `__(un)serialize()` magic methods.

These would throw a false positive before now.

## ReservedFunctionNames: refactor the sniff and use PHPCSUtils

Refactor the sniff to be stand-alone, independent of the PHPCS sniff.

The sniff only extended the PHPCS sniff for the properties containing the names of magic methods and such anyway and these can now be found, including helper methods, in the `PHPCSUtils\Utils\FunctionDeclarations` class, where the function name lists are also more complete.

