### PR TITLE
Lists/AssignmentOrder: bug fix + refactor using PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -44,6 +44,7 @@ class AssignmentOrderSniff extends Sniff
         return array(
             \T_LIST,
             \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET,
         );
     }
 
@@ -69,7 +70,7 @@ class AssignmentOrderSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY
+        if ($tokens[$stackPtr]['code'] !== \T_LIST
             && Lists::isShortList($phpcsFile, $stackPtr) === false
         ) {
             // Short array, not short list.
@@ -115,6 +116,8 @@ class AssignmentOrderSniff extends Sniff
         $stopPoints = array(\T_COMMA);
         if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY) {
             $stopPoints[] = \T_CLOSE_SHORT_ARRAY;
+        } elseif ($tokens[$stackPtr]['code'] === \T_OPEN_SQUARE_BRACKET) {
+            $stopPoints[] = \T_CLOSE_SQUARE_BRACKET;
         } else {
             $stopPoints[] = \T_CLOSE_PARENTHESIS;
         }

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -68,39 +68,15 @@ class AssignmentOrderSniff extends Sniff
             return;
         }
 
+        $openClose = Lists::getOpenClose($phpcsFile, $stackPtr);
+        if ($openClose === false) {
+            // Parse error, live coding, real square brackets or short array, not short list.
+            return;
+        }
+
+        $opener = $openClose['opener'];
+        $closer = $openClose['closer'];
         $tokens = $phpcsFile->getTokens();
-
-        if ($tokens[$stackPtr]['code'] !== \T_LIST
-            && Lists::isShortList($phpcsFile, $stackPtr) === false
-        ) {
-            // Short array, not short list.
-            return;
-        }
-
-        if ($tokens[$stackPtr]['code'] === \T_LIST) {
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-            if ($nextNonEmpty === false
-                || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
-                || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
-            ) {
-                // Parse error or live coding.
-                return;
-            }
-
-            $opener = $nextNonEmpty;
-            $closer = $tokens[$nextNonEmpty]['parenthesis_closer'];
-        } else {
-            // Short list syntax.
-            $opener = $stackPtr;
-
-            if (isset($tokens[$stackPtr]['bracket_closer'])) {
-                $closer = $tokens[$stackPtr]['bracket_closer'];
-            }
-        }
-
-        if (isset($opener, $closer) === false) {
-            return;
-        }
 
         /*
          * OK, so we have the opener & closer, now we need to check all the variables in the

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
@@ -43,3 +43,7 @@ list($b => $a, $a => $b, 'field' => $c) = ['name' => 1, 'id' => 2, 'field' => 3]
 
 // Don't get confused when some of the entries are empty.
 list( , $a, , $b, , $a, ,) = array[1, 2, 3, 4, 5, 6, 7, 8];
+
+// Test handling of specific tokenizer issue.
+if (true) {}
+[$a, [$b, $a]] = array(1, array(2, 3));

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
@@ -47,3 +47,6 @@ list( , $a, , $b, , $a, ,) = array[1, 2, 3, 4, 5, 6, 7, 8];
 // Test handling of specific tokenizer issue.
 if (true) {}
 [$a, [$b, $a]] = array(1, array(2, 3));
+
+// Test handling of list vars with differing whitespace.
+list( $a [ 'key' ], $b [ 'key' ], list($a['key'], $b['key'])) = $array;

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -66,6 +66,7 @@ class AssignmentOrderUnitTest extends BaseSniffTest
             array(38),
             array(45),
             array(49),
+            array(52),
         );
     }
 

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -65,6 +65,7 @@ class AssignmentOrderUnitTest extends BaseSniffTest
             array(37),
             array(38),
             array(45),
+            array(49),
         );
     }
 


### PR DESCRIPTION
## AssignmentOrder: BC fix for tokenizer issues in older PHPCS versions

Short lists are sometimes tokenized as `T_OPEN/CLOSE_SQUARE_BRACKET`. The `Lists::isShortList()` method handles these correctly for BC.

Includes unit tests.

## AssignmentOrder: use `Lists::getOpenClose()`

## AssignmentOrder: use `Lists::getAssignments()` / refactor the sniff

PHPCSUtils contains the `Lists::getAssignments()` method. Using that method takes all the heavy lifting away from this sniff, so we can now refactor the sniff to be much simpler.

