### PR TITLE
ForbiddenEmptyListAssignment: bug fix, improve tests & simplify with PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -51,8 +51,6 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
         // Only needs to be set up once.
         $this->ignoreTokens                       = Tokens::$emptyTokens;
         $this->ignoreTokens[\T_COMMA]             = \T_COMMA;
-        $this->ignoreTokens[\T_OPEN_PARENTHESIS]  = \T_OPEN_PARENTHESIS;
-        $this->ignoreTokens[\T_CLOSE_PARENTHESIS] = \T_CLOSE_PARENTHESIS;
 
         return array(
             \T_LIST,

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -55,6 +55,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
         return array(
             \T_LIST,
             \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET,
         );
     }
 
@@ -77,7 +78,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY) {
+        if ($tokens[$stackPtr]['code'] !== \T_LIST) {
             if (Lists::isShortList($phpcsFile, $stackPtr) === false) {
                 return;
             }

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.inc
@@ -1,9 +1,9 @@
 <?php
 
-list() = 5;
-list(, ,) = 5;
-list(/*comment*/) = 5;
-list( /*comment*/ /*another comment*/ ) = 5;
+list() = $infoArray;
+list(, ,) = $infoArray;
+list(/*comment*/) = $infoArray;
+list( /*comment*/ /*another comment*/ ) = $infoArray;
 list($x, list(), $y) = $a;
 
 /*
@@ -16,15 +16,15 @@ list($a[0], $a[1], $a[2]) = $infoArray;
 list( ${$drink} ) = $infoArray;
 
 // Invalid with short list syntax.
-[] = 5;
-[, ,] = 5;
-[/*comment*/] = 5;
-[ /*comment*/ /*another comment*/ ] = 5;
+[] = $infoArray;
+[, ,] = $infoArray;
+[/*comment*/] = $infoArray;
+[ /*comment*/ /*another comment*/ ] = $infoArray;
 [$x, [], $y] = $a;
 
 // Parse errors. Ignore.
-list(,(),) = 5;
-[,(),] = 5;
+list(,(),) = $infoArray;
+[,(),] = $infoArray;
 
 // Don't trigger on unfinished code during live code review.
 list(

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.inc
@@ -4,7 +4,6 @@ list() = 5;
 list(, ,) = 5;
 list(/*comment*/) = 5;
 list( /*comment*/ /*another comment*/ ) = 5;
-list(,(),) = 5;
 list($x, list(), $y) = $a;
 
 /*
@@ -21,8 +20,11 @@ list( ${$drink} ) = $infoArray;
 [, ,] = 5;
 [/*comment*/] = 5;
 [ /*comment*/ /*another comment*/ ] = 5;
-[,(),] = 5;
 [$x, [], $y] = $a;
+
+// Parse errors. Ignore.
+list(,(),) = 5;
+[,(),] = 5;
 
 // Don't trigger on unfinished code during live code review.
 list(

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.inc
@@ -22,6 +22,10 @@ list( ${$drink} ) = $infoArray;
 [ /*comment*/ /*another comment*/ ] = $infoArray;
 [$x, [], $y] = $a;
 
+// Test handling of tokenizer issue in older PHPCS versions.
+if (true) {}
+[,[],] = $infoArray;
+
 // Parse errors. Ignore.
 list(,(),) = $infoArray;
 [,(),] = $infoArray;

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
@@ -60,6 +60,7 @@ class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTest
             array(21),
             array(22),
             array(23),
+            array(27),
         );
     }
 
@@ -94,9 +95,9 @@ class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTest
             array(14),
             array(15),
             array(16),
-            array(26),
-            array(27),
             array(30),
+            array(31),
+            array(34),
         );
     }
 

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
@@ -55,13 +55,11 @@ class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTest
             array(5),
             array(6),
             array(7),
-            array(8),
+            array(19),
             array(20),
             array(21),
             array(22),
             array(23),
-            array(24),
-            array(25),
         );
     }
 
@@ -91,12 +89,14 @@ class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTest
     public function dataNoFalsePositives()
     {
         return array(
+            array(12),
             array(13),
             array(14),
             array(15),
             array(16),
-            array(17),
-            array(28),
+            array(26),
+            array(27),
+            array(30),
         );
     }
 


### PR DESCRIPTION
## ForbiddenEmptyListAssignment: ignore parse errors

Most sniffs bow out when parse errors are encountered. In this case, the sniff would still report an error.

This commit changes that behaviour to be in line with the rest of the sniffs.

Includes moving the relevant unit tests down and clearly annotating them as parse errors.

## ForbiddenEmptyListAssignment: make the test code more realistic

A list cannot destructure an integer.

## ForbiddenEmptyListAssignment: BC fix for tokenizer issues in older PHPCS versions

Short lists are sometimes tokenized as `T_OPEN/CLOSE_SQUARE_BRACKET`. The `Lists::isShortList()` method handles these correctly for BC.

This fixes some false negatives in older PHPCS versions.

Includes unit tests.

## ForbiddenEmptyListAssignment: use `Lists::getAssignments()`

The PHPCSUtils `Lists::getAssignments()` method will parse a list assignment into the individual list items being assigned to, giving us all the information we need to determine whether a list is empty or not.

This allows some code simplification.

