### PR TITLE
NewListReferenceAssignment: bug fix and decouple the sniff using PHPCSUtils

### DIFF
--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.inc
@@ -35,3 +35,7 @@ list(
 
 foreach ($array as list(&$a, &$b)) {}
 foreach ($array as [&$a, $b]) {}
+
+// Test handling of tokenizer issue in older PHPCS versions.
+if (true) {}
+[$id1, &$name1] = $data;

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
@@ -58,6 +58,7 @@ class NewListReferenceAssignmentUnitTest extends BaseSniffTest
             array(33), // x2.
             array(36), // x2.
             array(37),
+            array(41),
         );
     }
 


### PR DESCRIPTION
## NewListReferenceAssignment: add unit test for tokenizer issue in older PHPCS versions

## NewListReferenceAssignment: use PHPCSUtils / refactor the sniff

As PHPCS has an issue with sniffs extending other sniffs, it is better for sniffs to be stand-alone.

PHPCSUtils contains the `Lists::getAssignments()` method. Using that method takes all the heavy lifting away from this sniff, so it is now easy to refactor the sniff to be stand-alone without having lots of duplicate code.

