### PR TITLE
New `PHPCompatibility.FunctionDeclarations.AbstractPrivateMethods` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
@@ -8,7 +8,7 @@
  * @link      https://github.com/PHPCompatibility/PHPCompatibility
  */
 
-namespace PHPCompatibility\Sniffs\Classes;
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
@@ -17,19 +17,26 @@ use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
 
 /**
- * Abstract private methods are not allowed since PHP 5.1.
+ * Abstract private methods are not allowed since PHP 5.1, though they are allowed in traits since PHP 8.0.
  *
  * Abstract private methods were supported between PHP 5.0.0 and PHP 5.0.4, but
  * were then disallowed on the grounds that the behaviours of `private` and `abstract`
  * are mutually exclusive.
  *
+ * As of PHP 8.0, traits are allowed to declare abstract private methods.
+ *
  * PHP version 5.1
+ * PHP version 8.0
  *
  * @link https://www.php.net/manual/en/migration51.oop.php#migration51.oop-methods
+ * @link https://wiki.php.net/rfc/abstract_trait_method_validation
  *
  * @since 9.2.0
+ * @since 10.0.0 The sniff has been renamed from `PHPCompatibility.Classes.ForbiddenAbstractPrivateMethods`
+ *               to `PHPCompatibility.FunctionDeclarations.AbstractPrivateMethods` and now
+ *               includes detection of the PHP 8 change.
  */
-class ForbiddenAbstractPrivateMethodsSniff extends Sniff
+class AbstractPrivateMethodsSniff extends Sniff
 {
 
     /**
@@ -48,6 +55,7 @@ class ForbiddenAbstractPrivateMethodsSniff extends Sniff
      * Processes this test, when one of its tokens is encountered.
      *
      * @since 9.2.0
+     * @since 10.0.0 New error message for abstract private methods in traits.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token
@@ -61,16 +69,32 @@ class ForbiddenAbstractPrivateMethodsSniff extends Sniff
             return;
         }
 
-        if (Scopes::validDirectScope($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) === false) {
+        $tokens   = $phpcsFile->getTokens();
+        $scopePtr = Scopes::validDirectScope($phpcsFile, $stackPtr, BCTokens::ooScopeTokens());
+        if ($scopePtr === false) {
             // Function, not method.
             return;
         }
 
         $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
         if ($properties['scope'] !== 'private' || $properties['is_abstract'] !== true) {
+            // Not an abstract private method.
             return;
         }
 
+        if ($tokens[$scopePtr]['code'] === \T_TRAIT) {
+            if ($this->supportsBelow('7.4') === true) {
+                $phpcsFile->addError(
+                    'Traits cannot declare "abstract private" methods in PHP 7.4 or below',
+                    $stackPtr,
+                    'InTrait'
+                );
+            }
+
+            return;
+        }
+
+        // Not a trait.
         $phpcsFile->addError(
             'Abstract methods cannot be declared as private since PHP 5.1',
             $stackPtr,

--- a/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.inc
@@ -23,13 +23,7 @@ $anon = new class() {
 };
 
 // PHP 5.1: abstract functions can not be private.
-abstract class CrossVersionValid
-{
-    abstract private function privateOverload();
-    static private abstract function privateStaticOverload();
-}
-
-trait CrossVersionValidTrait
+abstract class CrossVersionInValid
 {
     abstract private function privateOverload();
     static private abstract function privateStaticOverload();
@@ -39,3 +33,12 @@ $anon = new class() {
     abstract private function privateOverload();
     static private abstract function privateStaticOverload();
 };
+
+/*
+ * PHP 8.0: abstract private methods in traits.
+ */
+trait CrossVersionInValidTrait
+{
+    abstract private function privateOverload();
+    static private abstract function privateStaticOverload();
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.php
@@ -8,25 +8,26 @@
  * @link      https://github.com/PHPCompatibility/PHPCompatibility
  */
 
-namespace PHPCompatibility\Tests\Classes;
+namespace PHPCompatibility\Tests\FunctionDeclarations;
 
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Test the ForbiddenAbstractPrivateMethods sniff.
+ * Test the AbstractPrivateMethods sniff.
  *
- * @group newForbiddenAbstractPrivateMethods
- * @group classes
+ * @group abstractPrivateMethods
+ * @group functiondeclarations
  *
- * @covers \PHPCompatibility\Sniffs\Classes\ForbiddenAbstractPrivateMethodsSniff
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\AbstractPrivateMethodsSniff
  *
  * @since 9.2.0
+ * @since 10.0.0 Moved from `Classes` to `FunctionDeclarations`.
  */
-class ForbiddenAbstractPrivateMethodsUnitTest extends BaseSniffTest
+class AbstractPrivateMethodsUnitTest extends BaseSniffTest
 {
 
     /**
-     * testForbiddenAbstractPrivateMethods.
+     * Verify that the sniff throws an error for non-trait abstract private methods for PHP 5.1+.
      *
      * @dataProvider dataForbiddenAbstractPrivateMethods
      *
@@ -52,16 +53,49 @@ class ForbiddenAbstractPrivateMethodsUnitTest extends BaseSniffTest
         return array(
             array(28),
             array(29),
+            array(33),
             array(34),
-            array(35),
-            array(39),
-            array(40),
         );
     }
 
 
     /**
-     * testNoFalsePositives.
+     * Verify that the sniff throws an error for abstract private methods in traits for PHP 7.4
+     * and doesn't for PHP 8.0.
+     *
+     * @dataProvider dataNewTraitAbstractPrivateMethods
+     *
+     * @param int $line The line number where a warning is expected.
+     *
+     * @return void
+     */
+    public function testNewTraitAbstractPrivateMethods($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, 'Traits cannot declare "abstract private" methods in PHP 7.4 or below');
+
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewTraitAbstractPrivateMethods()
+     *
+     * @return array
+     */
+    public function dataNewTraitAbstractPrivateMethods()
+    {
+        return array(
+            array(42),
+            array(43),
+        );
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
      *
      * @dataProvider dataNoFalsePositives
      *
@@ -72,6 +106,9 @@ class ForbiddenAbstractPrivateMethodsUnitTest extends BaseSniffTest
     public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.1');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(__FILE__, '7.4');
         $this->assertNoViolation($file, $line);
     }
 


### PR DESCRIPTION
---
:point_right: **Open questions** - please answer these before considering merging this PR:
* For now, I've added a new `NewTraitAbstractPrivateMethods` sniff. Should this check be added to the existing `ForbiddenAbstractPrivateMethods` sniff instead ? The logic in the sniffs is > 90% the same.
    And if so, should the existing sniff be renamed to better cover both changes ?
* If this would remain two separate sniffs:
    Currently the `ForbiddenAbstractPrivateMethods` is in the `Classes` category, while I've elected to place the `ForbiddenAbstractPrivateMethods` in the `FunctionDeclarations` category.
    - Should they both be in the same category ?
    - And so, which category should this be ?
        IMO `FunctionDeclarations` seems more logical and if we'd choose to make a change in this for the existing sniff, now would be the time considering the next release is a major.

---

**Updated PR description** - this addresses the above points:

This sniff replaces the `PHPCompatibility.Classes.ForbiddenAbstractPrivateMethods` sniff.

The new sniff addresses both the PHP 5.1 change which forbade `abstract private` methods, as well as the PHP 8.0 change where "abstract private" methods are now allowed in traits.

> Traits can now define abstract private methods.

Refs:
* https://wiki.php.net/rfc/abstract_trait_method_validation
* https://github.com/php/php-src/commit/f74e30c07c2a94921fbfb7b8936324707505bd75

Includes unit tests.

Related to #809

---
<details>
  <summary>Old (superseded) PR description</summary>

## PHP 8.0: new `PHPCompatibility.FunctionDeclarations.NewTraitAbstractPrivateMethods` sniff

PHP 8.0 will allow "abstract private" methods in traits

> Traits can now define abstract private methods.

Refs:
* https://wiki.php.net/rfc/abstract_trait_method_validation
* php/php-src@f74e30c

This new sniff detects those.

Includes unit tests.

## ForbiddenAbstractPrivateMethods: bow out for abstract private methods in traits

... as this is now checked via the new `PHPCompatibility.FunctionDeclarations.NewTraitAbstractPrivateMethods` sniff and would otherwise cause duplicate and - if PHP 8 is supported - incorrect errors.


</details>

---


