### PR TITLE
PHP 8.0: New `PHPCompatibility.ParameterValues.RemovedGetDefinedFunctionsExcludeDisabledFalse` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * Detect: Passing `false` to `get_defined_functions()` is deprecated as of PHP 8.0.
+ *
+ * > Calling `get_defined_functions()` with `$exclude_disabled` explicitly set to `false`
+ * > is deprecated. `get_defined_functions()` will never include disabled functions.
+ *
+ * PHP version 8.0
+ *
+ * @link https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L514-L516
+ *
+ * @since 10.0.0
+ */
+class RemovedGetDefinedFunctionsExcludeDisabledFalseSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'get_defined_functions' => true,
+    );
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('8.0') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[1]) === false) {
+            return;
+        }
+
+        if ($parameters[1]['clean'] !== 'false') {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Explicitly passing "false" as the value for $exclude_disabled to get_defined_functions() is deprecated since PHP 8.0.',
+            $parameters[1]['start'],
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.inc
@@ -1,0 +1,11 @@
+<?php
+/*
+ * Test get_defined_functions() PHP 8.0 change in accepted values.
+ */
+
+// OK.
+get_defined_functions();
+get_defined_functions($exclude_disabled);
+
+// Not OK.
+get_defined_functions(false);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedGetDefinedFunctionsExcludeDisabledFalse sniff.
+ *
+ * @group removedGetDefinedFunctionsExcludeDisabledFalse
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedGetDefinedFunctionsExcludeDisabledFalseSniff
+ *
+ * @since x.x.x
+ */
+class RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testRemovedGetDefinedFunctionsExcludeDisabledFalse
+     *
+     * @dataProvider dataRemovedGetDefinedFunctionsExcludeDisabledFalse
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedGetDefinedFunctionsExcludeDisabledFalse($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Explicitly passing "false" as the value for $exclude_disabled to get_defined_functions() is deprecated since PHP 8.0.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedGetDefinedFunctionsExcludeDisabledFalse()
+     *
+     * @return array
+     */
+    public function dataRemovedGetDefinedFunctionsExcludeDisabledFalse()
+    {
+        return array(
+            array(11),
+        );
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+
+        // No errors expected on the first 9 lines.
+        for ($line = 1; $line <= 9; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Calling `get_defined_functions()` with `$exclude_disabled` explicitly set to
>  `false` is deprecated. `get_defined_functions()` will never include disabled functions.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L514-L516
* https://github.com/php/php-src/pull/5473
* https://github.com/php/php-src/commit/53eee290b6f5ca531aef19885a392c939013ce36

This sniff addresses that change.

Includes unit tests.

Related to #809