### PR TITLE
PHP 8.0: NewReturnTypeDeclarations: allow for "static" return type

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -22,6 +22,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * Return type declarations are available since PHP 7.0.
  * - Since PHP 7.1, the `iterable` and `void` pseudo-types are available.
  * - Since PHP 7.2, the generic `object` type is available.
+ * - Since PHP 8.0, `static` is allowed to be used as a return type.
  *
  * PHP version 7.0+
  *
@@ -31,6 +32,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * @link https://wiki.php.net/rfc/iterable
  * @link https://wiki.php.net/rfc/void_return_type
  * @link https://wiki.php.net/rfc/object-typehint
+ * @link https://wiki.php.net/rfc/static_return_type
  *
  * @since 7.0.0
  * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
@@ -99,6 +101,11 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
         'object' => array(
             '7.1' => false,
             '7.2' => true,
+        ),
+
+        'static' => array(
+            '7.4' => false,
+            '8.0' => true,
         ),
     );
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -41,3 +41,10 @@ function fooInterspersedWithComments($a) :
 // PHP 7.4 arrow functions.
 $arrow = fn($a) => $a * 10;
 $arrow = fn($a) : int => $a * 10;
+
+// PHP 8.0+
+class Foo {
+    public function fooStatic($a): static {
+        $closure = function ($a): ?static {};
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -78,6 +78,9 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             array('callable', '5.6', 22, '7.0'),
 
             array('object', '7.1', 29, '7.2'),
+
+            array('static', '7.4', 47, '8.0'),
+            array('static', '7.4', 48, '8.0'),
         );
     }
 


### PR DESCRIPTION
As of PHP 8.0, `static` can be used as a return type for function declarations.

Refs:
* https://wiki.php.net/rfc/static_return_type
* https://github.com/php/php-src/pull/5062
* https://github.com/php/php-src/commit/43443857b74503246ee4ca25859b302ed0ebc078

Includes unit tests.

Related to #809