### PR TITLE
PHP 8.0: RemovedTypeCasts - handle removed support for (unset) cast

### DIFF
--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -40,6 +40,7 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
     protected $deprecatedTypeCasts = array(
         'T_UNSET_CAST' => array(
             '7.2'         => false,
+            '8.0'         => true,
             'alternative' => 'unset()',
             'description' => 'unset',
         ),

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
@@ -65,8 +65,62 @@ class RemovedTypeCastsUnitTest extends BaseSniffTest
     public function dataDeprecatedTypeCastWithAlternative()
     {
         return array(
-            array('The unset cast', '7.2', 'unset()', array(8, 11, 12), '7.1'),
             array('The real cast', '7.4', '(float)', array(15, 16), '7.3'),
+        );
+    }
+
+
+    /**
+     * testDeprecatedRemovedTypeCastWithAlternative
+     *
+     * @dataProvider dataDeprecatedRemovedTypeCastWithAlternative
+     *
+     * @param string $castDescription   The type of type cast.
+     * @param string $deprecatedIn      The PHP version in which the function was deprecated.
+     * @param string $removedIn         The PHP version in which the extension was removed.
+     * @param string $alternative       An alternative type cast.
+     * @param array  $lines             The line numbers in the test file which apply to this function.
+     * @param string $okVersion         A PHP version in which the function was still valid.
+     * @param string $deprecatedVersion Optional PHP version to test deprecation message with -
+     *                                  if different from the $deprecatedIn version.
+     * @param string $removedVersion    Optional PHP version to test removal message with -
+     *                                  if different from the $removedIn version.
+     *
+     * @return void
+     */
+    public function testDeprecatedRemovedTypeCastWithAlternative($castDescription, $deprecatedIn, $removedIn, $alternative, $lines, $okVersion, $deprecatedVersion = null, $removedVersion = null)
+    {
+        $file = $this->sniffFile(__FILE__, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        $errorVersion = (isset($deprecatedVersion)) ? $deprecatedVersion : $deprecatedIn;
+        $file         = $this->sniffFile(__FILE__, $errorVersion);
+        $error        = "{$castDescription} is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead";
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, $error);
+        }
+
+        $errorVersion = (isset($removedVersion)) ? $removedVersion : $removedIn;
+        $file         = $this->sniffFile(__FILE__, $errorVersion);
+        $error        = "{$castDescription} is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}; Use {$alternative} instead";
+        foreach ($lines as $line) {
+            $this->assertError($file, $line, $error);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDeprecatedRemovedTypeCastWithAlternative()
+     *
+     * @return array
+     */
+    public function dataDeprecatedRemovedTypeCastWithAlternative()
+    {
+        return array(
+            array('The unset cast', '7.2', '8.0', 'unset()', array(8, 11, 12), '7.1'),
         );
     }
 


### PR DESCRIPTION
> Removed (unset) cast.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L27
* https://github.com/php/php-src/commit/d74d3922ce6f9ea07c1226b0cb2a94fc333f7a02

Includes adjusted unit tests.

Related to #809