### PR TITLE
PHP 8.0: RemovedPHP4StyleConstructors - handle removed support in PHP 8

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -16,10 +16,11 @@ use PHP_CodeSniffer_Tokens as Tokens;
 use PHPCSUtils\Utils\Namespaces;
 
 /**
- * Detect declarations of PHP 4 style constructors which are deprecated as of PHP 7.0.0.
+ * Detect declarations of PHP 4 style constructors which are deprecated as of PHP 7.0.0
+ * and for which support has been removed in PHP 8.0.0.
  *
  * PHP 4 style constructors - methods that have the same name as the class they are defined in -
- * are deprecated as of PHP 7.0.0, and will be removed in the future.
+ * are deprecated as of PHP 7.0.0, and have been removed in PHP 8.0.
  * PHP 7 will emit `E_DEPRECATED` if a PHP 4 constructor is the only constructor defined
  * within a class. Classes that implement a `__construct()` method are unaffected.
  *
@@ -27,6 +28,7 @@ use PHPCSUtils\Utils\Namespaces;
  * are not recognized as constructors anyway and therefore outside the scope of this sniff.
  *
  * PHP version 7.0
+ * PHP version 8.0
  *
  * @link https://www.php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors
  * @link https://wiki.php.net/rfc/remove_php4_constructors
@@ -144,11 +146,17 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
         }
 
         if ($newConstructorFound === false && $oldConstructorFound === true) {
-            $phpcsFile->addWarning(
-                'Use of deprecated PHP4 style class constructor is not supported since PHP 7.',
-                $oldConstructorPos,
-                'Found'
-            );
+            $error   = 'Declaration of a PHP4 style class constructor is deprecated since PHP 7.0';
+            $code    = 'Deprecated';
+            $isError = false;
+
+            if ($this->supportsAbove('8.0') === true) {
+                $error  .= ' and removed since PHP 8.0';
+                $code    = 'Removed';
+                $isError = true;
+            }
+
+            $this->addMessage($phpcsFile, $error, $oldConstructorPos, $isError, $code);
         }
     }
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
@@ -37,7 +37,10 @@ class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
     public function testIsDeprecated($line)
     {
         $file = $this->sniffFile(__FILE__, '7.0');
-        $this->assertWarning($file, $line, 'Use of deprecated PHP4 style class constructor is not supported since PHP 7');
+        $this->assertWarning($file, $line, 'Declaration of a PHP4 style class constructor is deprecated since PHP 7.0');
+
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Declaration of a PHP4 style class constructor is deprecated since PHP 7.0 and removed since PHP 8.0');
     }
 
     /**


### PR DESCRIPTION
> Methods with the same name as the class are no longer interpreted as
constructors. The __construct() method should be used instead.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L24
* https://github.com/php/php-src/commit/682b54f68748715f85e9ac4a267477d9ac61918a

This commit changes the existing sniff to throw an `error` instead of a `warning` if the `testVersion` includes PHP 8 and adjusts the error message to reflect this.

Note: the error code has also been adjusted. Previously, it would be `Found`, now it will be `Deprecated` or `Removed`, depending on the `testVersion` set and whether a warning or error is being thrown.
:point_right: _This needs a changelog entry._

Includes adjusted unit tests.

Related to #809