### PR TITLE
PHP 8.0: RemovedMagicAutoload - handle removed support for __autoload()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -16,11 +16,12 @@ use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\Scopes;
 
 /**
- * Detect declaration of the magic `__autoload()` method.
+ * Detect declaration of the magic `__autoload()` function.
  *
- * This method has been deprecated in PHP 7.2 in favour of `spl_autoload_register()`.
+ * This functionality has been deprecated in PHP 7.2 and removed in PHP 8.0 in favour of `spl_autoload_register()`.
  *
  * PHP version 7.2
+ * PHP version 8.0
  *
  * @link https://www.php.net/manual/en/migration72.deprecated.php#migration72.deprecated.__autoload-method
  * @link https://wiki.php.net/rfc/deprecations_php_7_2#autoload
@@ -89,6 +90,16 @@ class RemovedMagicAutoloadSniff extends Sniff
             return;
         }
 
-        $phpcsFile->addWarning('Use of __autoload() function is deprecated since PHP 7.2', $stackPtr, 'Found');
+        $error   = 'Specifying an autoloader using an __autoload() function is deprecated since PHP 7.2';
+        $code    = 'Deprecated';
+        $isError = false;
+
+        if ($this->supportsAbove('8.0') === true) {
+            $error  .= ' and no longer supported since PHP 8.0';
+            $code    = 'Removed';
+            $isError = true;
+        }
+
+        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
     }
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -52,28 +52,31 @@ class RemovedMagicAutoloadUnitTest extends BaseSniffTest
     }
 
     /**
-     * Test __autoload deprecation.
+     * Test detection of __autoload declarations for which support has been deprecated/removed.
      *
-     * @dataProvider dataIsDeprecated
+     * @dataProvider dataRemovedMagicAutoload
      *
      * @param int $line The line number where the error should occur.
      *
      * @return void
      */
-    public function testIsDeprecated($line)
+    public function testRemovedMagicAutoload($line)
     {
         $file = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE, '7.2');
-        $this->assertWarning($file, $line, 'Use of __autoload() function is deprecated since PHP 7.2');
+        $this->assertWarning($file, $line, 'Specifying an autoloader using an __autoload() function is deprecated since PHP 7.2');
+
+        $file = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE, '8.0');
+        $this->assertError($file, $line, 'Specifying an autoloader using an __autoload() function is deprecated since PHP 7.2 and no longer supported since PHP 8.0');
     }
 
     /**
-     * dataIsDeprecated
+     * Data provider.
      *
-     * @see testIsDeprecated()
+     * @see testRemovedMagicAutoload()
      *
      * @return array
      */
-    public function dataIsDeprecated()
+    public function dataRemovedMagicAutoload()
     {
         return array(
             array(3),


### PR DESCRIPTION
> Removed ability to specify an autoloader using an __autoload() function.
spl_autoload_register() should be used instead.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L35-L36
* https://github.com/php/php-src/commit/0dfd918ee7a3520836b875b8c24f0a5f98fbee15

Includes adjusted error message and unit tests.

Note: the error code has also been adjusted. Previously, it would be `Found`, now it will be `Deprecated` or `Removed`, depending on the `testVersion` set and whether a warning or error is being thrown.
:point_right: _This needs a changelog entry._

Related to #809