### PR TITLE
PHP 8.0: RemovedOrphanedParent - handle removed support

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -15,12 +15,13 @@ use PHP_CodeSniffer_File as File;
 use PHPCSUtils\Utils\Conditions;
 
 /**
- * Using `parent` inside a class without parent is deprecated since PHP 7.4.
+ * Using `parent` inside a class without parent is deprecated since PHP 7.4 and removed in PHP 8.0.
  *
- * This will throw a compile-time error in the future. Currently an error will only
+ * This will throw a compile-time error in PHP 8.0. In PHP 7.4 an error will only
  * be generated if/when the parent is accessed at run-time.
  *
  * PHP version 7.4
+ * PHP version 8.0
  *
  * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.parent
  *
@@ -90,10 +91,16 @@ class RemovedOrphanedParentSniff extends Sniff
             return;
         }
 
-        $phpcsFile->addError(
-            'Using "parent" inside a class without parent is deprecated since PHP 7.4',
-            $stackPtr,
-            'Deprecated'
-        );
+        $error   = 'Using "parent" inside a class without parent is deprecated since PHP 7.4';
+        $code    = 'Deprecated';
+        $isError = false;
+
+        if ($this->supportsAbove('8.0') === true) {
+            $error  .= ' and removed since PHP 8.0';
+            $code    = 'Removed';
+            $isError = true;
+        }
+
+        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
     }
 }

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -37,7 +37,10 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
     public function testRemovedOrphanedParent($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
-        $this->assertError($file, $line, 'Using "parent" inside a class without parent is deprecated since PHP 7.4');
+        $this->assertWarning($file, $line, 'Using "parent" inside a class without parent is deprecated since PHP 7.4');
+
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Using "parent" inside a class without parent is deprecated since PHP 7.4 and removed since PHP 8.0');
     }
 
     /**


### PR DESCRIPTION
> Using "parent" inside a class that has no parent will now result in a
fatal compile-time error.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L55-L56
* https://github.com/php/php-src/commit/5c24f8042d46f3dfbe8eb122a64792758fff5271

Includes adjusted error message and unit tests.

Related to #809