### PR TITLE
PHP 8.0: RemovedMbStrrposEncodingThirdParam - handle removed support

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -24,10 +24,11 @@ use PHP_CodeSniffer_Tokens as Tokens;
  * Between PHP 5.2 and PHP 7.3, this was a deprecation in documentation only.
  * As of PHP 7.4, a deprecation warning will be thrown if an encoding is passed as the 3rd
  * argument.
- * As of PHP 8, the argument is expected to change to accept an integer only.
+ * As of PHP 8, an explicit 0 offset should be passed with the encoding as the fourth argument.
  *
  * PHP version 5.2
  * PHP version 7.4
+ * PHP version 8.0
  *
  * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.mbstring
  * @link https://wiki.php.net/rfc/deprecations_php_7_4#mb_strrpos_with_encoding_as_3rd_argument
@@ -133,17 +134,20 @@ class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParame
             return;
         }
 
-        $error = 'Passing the encoding to mb_strrpos() as third parameter is soft deprecated since PHP 5.2';
-        if ($this->supportsAbove('7.4') === true) {
+        $error   = 'Passing the encoding to mb_strrpos() as third parameter is soft deprecated since PHP 5.2';
+        $isError = false;
+        $code    = 'Deprecated';
+
+        if ($this->supportsAbove('8.0') === true) {
+            $error  .= ', hard deprecated since PHP 7.4 and removed since PHP 8.0';
+            $isError = true;
+            $code    = 'Removed';
+        } elseif ($this->supportsAbove('7.4') === true) {
             $error .= ' and hard deprecated since PHP 7.4';
         }
 
         $error .= '. Use an explicit 0 as the offset in the third parameter.';
 
-        $phpcsFile->addWarning(
-            $error,
-            $targetParam['start'],
-            'Deprecated'
-        );
+        $this->addMessage($phpcsFile, $error, $targetParam['start'], $isError, $code);
     }
 }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
@@ -40,9 +40,13 @@ class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTest
         $error = 'Passing the encoding to mb_strrpos() as third parameter is soft deprecated since PHP 5.2';
         $this->assertWarning($file, $line, $error);
 
-        $file   = $this->sniffFile(__FILE__, '7.4');
-        $error .= ' and hard deprecated since PHP 7.4.';
-        $this->assertWarning($file, $line, $error);
+        $file    = $this->sniffFile(__FILE__, '7.4');
+        $error74 = $error . ' and hard deprecated since PHP 7.4.';
+        $this->assertWarning($file, $line, $error74);
+
+        $file    = $this->sniffFile(__FILE__, '8.0');
+        $error80 = $error . ', hard deprecated since PHP 7.4 and removed since PHP 8.0';
+        $this->assertError($file, $line, $error80);
     }
 
     /**


### PR DESCRIPTION
> The legacy behaviour of passing the encoding as the third argument instead of an offset for the `mb_strrpos` function has been removed, provide an explicit 0 offset with the encoding as the fourth argument.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L285-L286
* https://github.com/php/php-src/commit/fdf45debdf49e636d007ca43270cac57061304cd

Includes adjusted unit tests.

Related to #809