### PR TITLE
PHP 8.0: RemovedImplodeFlexibleParamOrder - handle removed support

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -16,9 +16,10 @@ use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Passing the `$glue` and `$pieces` parameters to `implode()` in reverse order has
- * been deprecated in PHP 7.4.
+ * been deprecated in PHP 7.4 and removed in PHP 8.0.
  *
  * PHP version 7.4
+ * PHP version 8.0
  *
  * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.implode-reverse-parameters
  * @link https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix
@@ -306,15 +307,11 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
         $errorCode = 'Deprecated';
         $data      = array($functionName);
 
-        /*
-        Support for the deprecated behaviour is expected to be removed in PHP 8.0.
-        Once this has been implemented, this section should be uncommented.
         if ($this->supportsAbove('8.0') === true) {
             $message  .= ' and is removed since PHP 8.0';
             $isError   = true;
             $errorCode = 'Removed';
         }
-        */
 
         $message .= '; $glue should be the first parameter and $pieces the second';
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
@@ -39,6 +39,9 @@ class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTest
     {
         $file = $this->sniffFile(__FILE__, '7.4');
         $this->assertWarning($file, $line, 'Passing the $glue and $pieces parameters in reverse order to ' . $function . ' has been deprecated since PHP 7.4; $glue should be the first parameter and $pieces the second');
+
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Passing the $glue and $pieces parameters in reverse order to ' . $function . ' has been deprecated since PHP 7.4 and is removed since PHP 8.0; $glue should be the first parameter and $pieces the second');
     }
 
     /**


### PR DESCRIPTION
> Calling implode() with parameters in a reverse order ($pieces, $glue) is no
longer supported.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L384-L385
* https://github.com/php/php-src/commit/beee92a887e8036a84dcb34f00bdca550eeee420

Includes adjusted error message and unit tests.

Related to #809