### PR TITLE
NewKeyedList: bug fix & simplify with PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -12,7 +12,7 @@ namespace PHPCompatibility\Sniffs\Lists;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
-use PHP_CodeSniffer_Tokens as Tokens;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Utils\Lists;
 
 /**
@@ -24,45 +24,10 @@ use PHPCSUtils\Utils\Lists;
  * @link https://www.php.net/manual/en/function.list.php
  *
  * @since 9.0.0
+ * @since 10.0.0 Complete rewrite.
  */
 class NewKeyedListSniff extends Sniff
 {
-    /**
-     * Tokens which represent the start of a list construct.
-     *
-     * @since 9.0.0
-     *
-     * @var array
-     */
-    protected $sniffTargets =  array(
-        \T_LIST                => \T_LIST,
-        \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
-        \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
-    );
-
-    /**
-     * The token(s) within the list construct which is being targeted.
-     *
-     * @since 9.0.0
-     *
-     * @var array
-     */
-    protected $targetsInList = array(
-        \T_DOUBLE_ARROW => \T_DOUBLE_ARROW,
-    );
-
-    /**
-     * All tokens needed to walk through the list construct and
-     * determine whether the target token is contained within.
-     *
-     * Set by the setUpAllTargets() method which is called from within register().
-     *
-     * @since 9.0.0
-     *
-     * @var array
-     */
-    protected $allTargets;
-
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -73,33 +38,11 @@ class NewKeyedListSniff extends Sniff
      */
     public function register()
     {
-        $this->setUpAllTargets();
-
-        return $this->sniffTargets;
-    }
-
-    /**
-     * Prepare the $allTargets array only once.
-     *
-     * @since 9.0.0
-     *
-     * @return void
-     */
-    public function setUpAllTargets()
-    {
-        $this->allTargets = $this->sniffTargets + $this->targetsInList;
-    }
-
-    /**
-     * Do a version check to determine if this sniff needs to run at all.
-     *
-     * @since 9.0.0
-     *
-     * @return bool
-     */
-    protected function bowOutEarly()
-    {
-        return ($this->supportsBelow('7.0') === false);
+        return array(
+            \T_LIST                => \T_LIST,
+            \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
+        );
     }
 
     /**
@@ -115,115 +58,27 @@ class NewKeyedListSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->bowOutEarly() === true) {
+        if ($this->supportsBelow('7.0') === false) {
             return;
         }
 
-        $tokens = $phpcsFile->getTokens();
-
-        if ($tokens[$stackPtr]['code'] !== \T_LIST
-            && Lists::isShortList($phpcsFile, $stackPtr) === false
-        ) {
-            // Short array, not short list.
+        try {
+            $assignments = Lists::getAssignments($phpcsFile, $stackPtr);
+        } catch (RuntimeException $e) {
+            // Parse error, live coding or short array, not short list.
             return;
         }
 
-        if ($tokens[$stackPtr]['code'] === \T_LIST) {
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-            if ($nextNonEmpty === false
-                || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
-                || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
-            ) {
-                // Parse error or live coding.
-                return;
-            }
-
-            $opener = $nextNonEmpty;
-            $closer = $tokens[$nextNonEmpty]['parenthesis_closer'];
-        } else {
-            // Short list syntax.
-            $opener = $stackPtr;
-
-            if (isset($tokens[$stackPtr]['bracket_closer'])) {
-                $closer = $tokens[$stackPtr]['bracket_closer'];
-            }
-        }
-
-        if (isset($opener, $closer) === false) {
-            return;
-        }
-
-        $this->examineList($phpcsFile, $opener, $closer);
-    }
-
-
-    /**
-     * Examine the contents of a list construct to determine whether an error needs to be thrown.
-     *
-     * @since 9.0.0
-     *
-     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                   $opener    The position of the list open token.
-     * @param int                   $closer    The position of the list close token.
-     *
-     * @return void
-     */
-    protected function examineList(File $phpcsFile, $opener, $closer)
-    {
-        $start = $opener;
-        while (($start = $this->hasTargetInList($phpcsFile, $start, $closer)) !== false) {
-            $phpcsFile->addError(
-                'Specifying keys in list constructs is not supported in PHP 7.0 or earlier.',
-                $start,
-                'Found'
-            );
-        }
-    }
-
-
-    /**
-     * Check whether a certain target token exists within a list construct.
-     *
-     * Skips past nested list constructs, so these can be examined based on their own token.
-     *
-     * @since 9.0.0
-     *
-     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                   $start     The position of the list open token or a token
-     *                                         within the list to start (resume) the examination from.
-     * @param int                   $closer    The position of the list close token.
-     *
-     * @return int|bool Stack pointer to the target token if encountered. False otherwise.
-     */
-    protected function hasTargetInList(File $phpcsFile, $start, $closer)
-    {
-        $tokens = $phpcsFile->getTokens();
-
-        for ($i = ($start + 1); $i < $closer; $i++) {
-            if (isset($this->allTargets[$tokens[$i]['code']]) === false) {
+        foreach ($assignments as $assign) {
+            if (isset($assign['key_token']) === false) {
                 continue;
             }
 
-            if (isset($this->targetsInList[$tokens[$i]['code']]) === true) {
-                return $i;
-            }
-
-            // Skip past nested list constructs.
-            if ($tokens[$i]['code'] === \T_LIST) {
-                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
-                if ($nextNonEmpty !== false
-                    && $tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS
-                    && isset($tokens[$nextNonEmpty]['parenthesis_closer']) === true
-                ) {
-                    $i = $tokens[$nextNonEmpty]['parenthesis_closer'];
-                }
-            } elseif ($tokens[$i]['code'] === \T_OPEN_SHORT_ARRAY
-                && isset($tokens[$i]['bracket_closer'])
-            ) {
-                $i = $tokens[$i]['bracket_closer'];
-            }
+            $phpcsFile->addError(
+                'Specifying keys in list constructs is not supported in PHP 7.0 or earlier.',
+                $assign['key_token'],
+                'Found'
+            );
         }
-
-        return false;
     }
 }

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -35,8 +35,9 @@ class NewKeyedListSniff extends Sniff
      * @var array
      */
     protected $sniffTargets =  array(
-        \T_LIST             => \T_LIST,
-        \T_OPEN_SHORT_ARRAY => \T_OPEN_SHORT_ARRAY,
+        \T_LIST                => \T_LIST,
+        \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
+        \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
     );
 
     /**
@@ -120,7 +121,7 @@ class NewKeyedListSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY
+        if ($tokens[$stackPtr]['code'] !== \T_LIST
             && Lists::isShortList($phpcsFile, $stackPtr) === false
         ) {
             // Short array, not short list.

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.inc
@@ -49,6 +49,10 @@ list(
 		list($x2, $y2),
 ) = $points;
 
+// Test handling of tokenizer issue in older PHPCS versions.
+if (true) {}
+["id" => $id1, "name" => &$name1] = $data;
+
 /*
  * Invalid syntaxes.
  */

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
@@ -68,8 +68,9 @@ class NewKeyedListUnitTest extends BaseSniffTest
             array(42), // x2.
             array(46),
             array(48),
-            array(58),
+            array(54),
             array(62),
+            array(66),
         );
     }
 


### PR DESCRIPTION
### NewKeyedList: BC fix for tokenizer issue in older PHPCS versions

Short lists are sometimes tokenized as `T_OPEN/CLOSE_SQUARE_BRACKET`. The `Lists::isShortList()` method handles these correctly for BC.

Includes unit tests.

### NewKeyedList: use PHPCSUtils / refactor the sniff

PHPCSUtils contains the `Lists::getAssignments()` method. Using that method takes all the heavy lifting away from this sniff.

This refactor is possible now the `NewListReferenceAssignment` sniff has become stand-alone and no longer extends this sniff. (PR #1147)