### PR TITLE
RemovedGetDefinedFunctionsExcludeDisabledFalse: minor tweak for consistency

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
@@ -74,10 +74,10 @@ class RemovedGetDefinedFunctionsExcludeDisabledFalseSniff extends AbstractFuncti
             return;
         }
 
-        $phpcsFile->addError(
+        $phpcsFile->addWarning(
             'Explicitly passing "false" as the value for $exclude_disabled to get_defined_functions() is deprecated since PHP 8.0.',
             $parameters[1]['start'],
-            'Found'
+            'Deprecated'
         );
     }
 }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.php
@@ -20,7 +20,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedGetDefinedFunctionsExcludeDisabledFalseSniff
  *
- * @since x.x.x
+ * @since 10.0.0
  */
 class RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest extends BaseSniffTest
 {
@@ -37,7 +37,7 @@ class RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest extends BaseSniffTe
     public function testRemovedGetDefinedFunctionsExcludeDisabledFalse($line)
     {
         $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertError($file, $line, 'Explicitly passing "false" as the value for $exclude_disabled to get_defined_functions() is deprecated since PHP 8.0.');
+        $this->assertWarning($file, $line, 'Explicitly passing "false" as the value for $exclude_disabled to get_defined_functions() is deprecated since PHP 8.0.');
     }
 
     /**


### PR DESCRIPTION
Oops... just saw this after PR #1150 was merged ...

The feature is - at this time - only deprecated. Everywhere else, we throw a "warning" for deprecations and an "error" for removals/new features, so this should have been set to throw a "warning" for now.

Also, as at some point in the future, the feature is expected to be removed, let's change the error code to `Deprecated` to allow for a second `Removed` error code once the feature is removed.
Again, that is in line with how it's done in most places in the code base (though a cross-sniff consistency check at some point wouldn't be amiss).
Having different error codes for Deprecated/Removed allows for ignoring deprecations, while still getting the errors when the feature actually gets removed.