### PR TITLE
PHP 8.0: new `PHPCompatibility.FunctionDeclarations.NewTrailingComma` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Detect trailing comma's in function declarations as allowed since PHP 8.
+ *
+ * PHP version 8.0
+ *
+ * @link https://wiki.php.net/rfc/trailing_comma_in_parameter_list
+ *
+ * @since 10.0.0
+ */
+class NewTrailingCommaSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return Collections::functionDeclarationTokensBC();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset(Collections::arrowFunctionTokensBC()[$tokens[$stackPtr]['code']]) === true) {
+            $arrowInfo = FunctionDeclarations::getArrowFunctionOpenClose($phpcsFile, $stackPtr);
+            if ($arrowInfo === false) {
+                // Not an arrow function.
+                return;
+            }
+
+            $closer = $arrowInfo['parenthesis_closer'];
+        } else {
+            if (isset($tokens[$stackPtr]['parenthesis_closer']) === false) {
+                // Live coding or parse error.
+                return;
+            }
+
+            $closer = $tokens[$stackPtr]['parenthesis_closer'];
+        }
+
+        $lastInParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), null, true);
+
+        if ($tokens[$lastInParenthesis]['code'] !== \T_COMMA) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Trailing comma\'s are not allowed in function declaration parameter lists in PHP 7.4 or earlier',
+            $lastInParenthesis,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.inc
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Allowed pre-PHP 8.0.
+ */
+function Foo7(
+    $foo,
+    $bar
+) {
+    return $foo + $bar;
+}
+
+$closure = function ($foo, $bar) {
+    return $foo + $bar;
+};
+
+$arrow = fn($foo, $bar) => $foo + $bar;
+
+class LotsOfParams7 {
+    private function __construct(
+        ?string $scheme,
+        ?string $user,
+        ?string $pass,
+        ?string $host,
+        ?int $port,
+        string $path,
+        ?string $query,
+        ?string $fragment // <-- ARGH!
+    ) {
+        // Do something.
+    }
+}
+
+/*
+ * PHP 8.0 trailing comma's in function declarations.
+ */
+function Foo8(
+    $foo,
+    $bar,
+) {
+    return $foo + $bar;
+}
+
+$closure = function ($foo, $bar,) {
+    return $foo + $bar;
+};
+
+$arrow = fn($foo, $bar,) => $foo + $bar;
+
+class LotsOfParams8 {
+    private function __construct(
+        ?string $scheme,
+        ?string $user,
+        ?string $pass,
+        ?string $host,
+        ?int $port,
+        string $path,
+        ?string $query,
+        ?string $fragment, // Trailing comment.
+    ) {
+        // Do something.
+    }
+}
+
+/*
+ * Still not allowed.
+ */
+
+// Free-standing comma.
+$c = function(,) {}; // Parse error, but throw an error anyway.
+
+// Multiple trailing comma's.
+$a = fn($foo, $bar,,) => $bar; // Parse error, but throw an error anyway.
+
+// Leading comma.
+function Leading(, $foo, $bar) {} // Parse error, but not our concern.
+
+// Live coding.
+// Intentional parse error. This has to be the last test in the file.
+function Unfinished( $foo, $bar,

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewTrailingComma sniff.
+ *
+ * @group newTrailingComma
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewTrailingCommaSniff
+ *
+ * @since 10.0.0
+ */
+class NewTrailingCommaUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test correctly identifying trailing comma's in function declarations.
+     *
+     * @dataProvider dataTrailingComma
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testTrailingComma($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, "Trailing comma's are not allowed in function declaration parameter lists in PHP 7.4 or earlier");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testTrailingComma()
+     *
+     * @return array
+     */
+    public function dataTrailingComma()
+    {
+        return array(
+            array(39),
+            array(44),
+            array(48),
+            array(59),
+            array(70),
+            array(73),
+        );
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        // No errors expected on the first 33 lines.
+        $data = array();
+        for ($line = 1; $line <= 33; $line++) {
+            $data[] = array($line);
+        }
+
+        $data[] = array(76);
+        $data[] = array(80);
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
PHP 8.0 will allow trailing comma's in parameter lists for function declarations.

> Allow a single optional trailing comma in parameter lists. This includes parameter lists for functions, methods and closures.

Refs:
* https://wiki.php.net/rfc/trailing_comma_in_parameter_list
* https://github.com/php/php-src/commit/f545ee2c6cc63bae79cc5618f2019e3d9bc2dfa5

This new sniff detects those.

I've tested and confirmed that arrow functions are included in this change.

Includes unit tests.

Related to #809