### PR TITLE
PHP 8.0: new `PHPCompatibility.FunctionDeclarations.RemovedOptionalBeforeRequiredParam` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Declaring a required function parameter after an optional parameter is deprecated since PHP 8.0.
+ *
+ * > Declaring a required parameter after an optional one is deprecated. As an
+ * > exception, declaring a parameter of the form "Type $param = null" before
+ * > a required one continues to be allowed, because this pattern was sometimes
+ * > used to achieve nullable types in older PHP versions.
+ *
+ * PHP version 8.0
+ *
+ * @link https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L145-L151
+ *
+ * @since 10.0.0
+ */
+class RemovedOptionalBeforeRequiredParamSniff extends Sniff
+{
+
+    /**
+     * Tokens allowed in the default value.
+     *
+     * This property will be enriched in the register() method.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $allowedInDefault = [
+        \T_NULL => \T_NULL,
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $this->allowedInDefault += Tokens::$emptyTokens;
+
+        return Collections::functionDeclarationTokensBC();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('8.0') === false) {
+            return;
+        }
+
+        try {
+            // Get all parameters from the function signature.
+            $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+            if (empty($parameters)) {
+                return;
+            }
+        } catch (RuntimeException $e) {
+            // Most likely a T_STRING which wasn't an arrow function.
+            return;
+        }
+
+        $error = 'Declaring a required parameter after an optional one is deprecated since PHP 8.0. Parameter %s is optional, while parameter %s is required.';
+
+        $paramCount    = \count($parameters);
+        $lastKey       = ($paramCount - 1);
+        $firstOptional = null;
+
+        foreach ($parameters as $key => $param) {
+            // Handle optional parameters.
+            if (isset($param['default']) === true) {
+                if ($key === $lastKey) {
+                    // This is the last parameter and it's optional, no further checking needed.
+                    break;
+                }
+
+                if (isset($firstOptional) === false) {
+                    // Check if it's typed and has a null default value, in which case we can ignore it.
+                    if ($param['type_hint'] !== '') {
+                        $hasNull    = $phpcsFile->findNext(\T_NULL, $param['default_token'], $param['comma_token']);
+                        $hasNonNull = $phpcsFile->findNext(
+                            $this->allowedInDefault,
+                            $param['default_token'],
+                            $param['comma_token'],
+                            true
+                        );
+
+                        if ($hasNull !== false && $hasNonNull === false) {
+                            continue;
+                        }
+                    }
+
+                    // Non-null default value. This is an optional param we need to take into account.
+                    $firstOptional = $param['name'];
+                }
+
+                continue;
+            }
+
+            // Found a required parameter.
+            if (isset($firstOptional) === false) {
+                // No optional params found yet.
+                continue;
+            }
+
+            // Found a required parameter with an optional param before it.
+            $data = [
+                $firstOptional,
+                $param['name'],
+            ];
+
+            $phpcsFile->addWarning($error, $param['token'], 'Deprecated', $data);
+        }
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * OK on all versions.
+ */
+function requiredBeforeOptional($a, $b, $c = null, $d = true) {}
+function requiredBeforeOptionalWithTypes(?int $a, string $b, callable $c = null, bool $d = /*comment*/ true) {}
+function nullableTypedOptionalBeforeRequired(Foo $a = /* comment */ null, ?int $b = null, $c, $d) {}
+
+/*
+ * Deprecated in PHP 8.
+ */
+function optionalBeforeRequired($a = [], $b, $c) {}
+function nonNullTypedOptionalBeforeRequired(int $a = 1, bool $b) {}
+
+$closure = function ($a = 10 * DAY_IN_SECONDS, $b) {};
+$arrow = fn(?bool $a = true, ?bool $b): string => $a ? (string) $b : '';
+
+// Parse error, nothing in default, not our concern. Throw error anyway.
+$closure = function ($a = /*comment*/, $b) {};
+
+// Intentional parse error. This has to be the last test in the file.
+$closure = function( $a = [], $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedOptionalBeforeRequiredParam sniff.
+ *
+ * @group removedOptionalBeforeRequiredParam
+ * @group functiondeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\RemovedOptionalBeforeRequiredParamSniff
+ *
+ * @since 10.0.0
+ */
+class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify that the sniff throws a warning for optional parameters before required.
+     *
+     * @dataProvider dataRemovedOptionalBeforeRequiredParam
+     *
+     * @param int $line The line number where a warning is expected.
+     *
+     * @return void
+     */
+    public function testRemovedOptionalBeforeRequiredParam($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertWarning($file, $line, 'Declaring a required parameter after an optional one is deprecated since PHP 8.0');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedOptionalBeforeRequiredParam()
+     *
+     * @return array
+     */
+    public function dataRemovedOptionalBeforeRequiredParam()
+    {
+        return array(
+            array(13), // Warning x 2.
+            array(14),
+            array(16),
+            array(17),
+            array(20),
+        );
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = array();
+        // No errors expected on the first 9 lines.
+        for ($line = 1; $line <= 9; $line++) {
+            $cases[] = array($line);
+        }
+
+        // Add parse error test case.
+        $cases[] = array(23);
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
PHP 8.0 will deprecate required function parameters being placed after optional ones.

> Declaring a required parameter after an optional one is deprecated. As an
>  exception, declaring a parameter of the form "Type $param = null" before
>  a required one continues to be allowed, because this pattern was sometimes
>  used to achieve nullable types in older PHP versions.
> ```php
>     function test($a = [], $b) {}       // Deprecated
>     function test(Foo $a = null, $b) {} // Allowed
> ```

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L145-L151
* https://github.com/php/php-src/commit/3b08f53c97b2aa1bdd132d0f715e9db20fefad5d

This new sniff detects this.

Includes unit tests.

Related to #809