### PR TITLE
PHP 8.0: NewMagicClassConstant: detect ::class on objects

### DIFF
--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.inc
@@ -7,13 +7,46 @@ namespace foo {
 }
 
 namespace MyNameSpace {
-	class xyz {}
+    class xyz {}
 
-	remove_filter('theme_filter', [\namespace\xyz::class, 'methodName'], 30);
+    remove_filter('theme_filter', [\MyNameSpace\xyz::class, 'methodName'], 30);
 }
 
 /*
  * False positives check.
  */
 echo bar::classProp; // Not the keyword.
-new class {} // Anonymous class, not the keyword.
+$anon = new class {}; // Anonymous class, not the keyword.
+
+/*
+ * Differentiate between Name::class (PHP 5.5) and $obj::class (PHP 8.0)
+ */
+class Foo {
+    public function test() {
+        // PHP 5.5+.
+        if (class_exists(Name::class)) {}
+        if (class_exists(Vendor\Name::CLASS)) {}
+        if (class_exists(namespace\Name::class)) {}
+        if (class_exists(self::class)) {}
+        if (class_exists(parent::class)) {}
+        if (class_exists(static::class)) {}
+
+        // PHP 8.0+, but only if the result of the expression is an object.
+        if (class_exists($obj::class)) {}
+        var_dump((new stdClass)::Class);
+        var_dump((new MyClass($paramA, $paramB))::class);
+        if (class_exists($array['object']::class)) {}
+        if (class_exists($obj->otherObjectSavedAsProperty::class)) {}
+    }
+}
+
+/*
+ * Syntaxes which are not supported in any version.
+ * PHPCompatibility shouldn't throw an error for these, but it's darn hard to figure out if it's
+ * a supported or non-supported syntax.
+ * As it would be a fatal error anyway, don't bother differentiating for now.
+ */
+$name = ($string = 'text')::class; // Using ::class on a string literal.
+$name = (1+1)::class; // Using ::class on a literal.
+const A = [0]::class; // Using ::class on a literal.
+$name = ClassName::CONSTANT_NAME::class; // Objects can not be set as the value for a constant.

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -26,7 +26,7 @@ class NewMagicClassConstantUnitTest extends BaseSniffTest
 {
 
     /**
-     * testNewMagicClassConstant
+     * Test correctly identifying the magic class constant.
      *
      * @dataProvider dataNewMagicClassConstant
      *
@@ -38,10 +38,13 @@ class NewMagicClassConstantUnitTest extends BaseSniffTest
     {
         $file = $this->sniffFile(__FILE__, '5.4');
         $this->assertError($file, $line, 'The magic class constant ClassName::class was not available in PHP 5.4 or earlier');
+
+        $file = $this->sniffFile(__FILE__, '5.5');
+        $this->assertNoViolation($file, $line);
     }
 
     /**
-     * Data provider dataNewMagicClassConstant.
+     * Data provider.
      *
      * @see testNewMagicClassConstant()
      *
@@ -52,12 +55,18 @@ class NewMagicClassConstantUnitTest extends BaseSniffTest
         return array(
             array(6),
             array(12),
+            array(27),
+            array(28),
+            array(29),
+            array(30),
+            array(31),
+            array(32),
         );
     }
 
 
     /**
-     * testNoFalsePositives
+     * Verify that no false positives are thrown for valid code.
      *
      * @dataProvider dataNoFalsePositives
      *
@@ -90,13 +99,53 @@ class NewMagicClassConstantUnitTest extends BaseSniffTest
 
 
     /**
+     * Test correctly identifying the magic class constant when used on instantiated objects.
+     *
+     * @dataProvider dataNewMagicClassConstantOnObject
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewMagicClassConstantOnObject($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, 'Using the magic class constant ::class with dynamic class names is not supported in PHP 7.4 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewMagicClassConstantOnObject()
+     *
+     * @return array
+     */
+    public function dataNewMagicClassConstantOnObject()
+    {
+        return array(
+            array(35),
+            array(36),
+            array(37),
+            array(38),
+            array(39),
+
+            // Still not supported, but throwing an error anyhow.
+            array(49),
+            array(50),
+            array(51),
+            array(52),
+        );
+    }
+
+
+    /**
      * Verify no notices are thrown at all.
      *
      * @return void
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '5.5');
+        $file = $this->sniffFile(__FILE__, '8.0');
         $this->assertNoViolation($file);
     }
 }


### PR DESCRIPTION
> It is now possible to fetch the class name of an object using `$object::class`. The result is the same as `get_class($object)`.

Refs:
* https://wiki.php.net/rfc/class_name_literal_on_object
* https://github.com/php/php-src/pull/5065
* https://github.com/php/php-src/commit/d933591674ddcda342e80f32ca77dee1ada23fd7

This adjusts the existing `PHPCompatibility.Constants.NewMagicClassConstant` sniff to differentiate between `::class` being used on class names/`self`/`parent`/`static`, as allowed per PHP 5.5 and `::class` being used on objects, as allowed per PHP 8.0.

Note: there are a number of syntaxes which are still not allowed (and which don't make any sense anyhow). These would cause a fatal error when used in PHP.

Differentiating between what is allowed and what isn't, is pretty hard though and realistically beyond the capabilities of a static analysis tool as `$var` in `$var::class` could be either an object or a literal, with the first being allowed, while the second isn't.

So I have taken the executive decision that, for now, everything which wasn't yet explicitly allowed per PHP 5.5 will throw an error for PHP < 8, independently of whether it is now supported or still forbidden.

In a way, this is no different from how the sniff behaved before, as previously, using `::class` on any context would throw an error for PHP < 5.5, independently of whether the used syntax was actually supported in PHP 5.5+.

Includes unit tests.

Includes minor fixes to the existing unit tests.

Related to #809