### PR TITLE
RemovedPHP4StyleConstructors: use PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -13,8 +13,9 @@ namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
 use PHPCSUtils\Utils\FunctionDeclarations;
-use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Namespaces;
+use PHPCSUtils\Utils\NamingConventions;
+use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
  * Detect declarations of PHP 4 style constructors which are deprecated as of PHP 7.0.0
@@ -102,7 +103,6 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
         }
 
         $nextFunc            = $class['scope_opener'];
-        $classNameLc         = strtolower($className);
         $newConstructorFound = false;
         $oldConstructorFound = false;
         $oldConstructorPos   = -1;
@@ -125,13 +125,11 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
                 continue;
             }
 
-            $funcNameLc = strtolower($funcName);
-
-            if ($funcNameLc === '__construct') {
+            if (strtolower($funcName) === '__construct') {
                 $newConstructorFound = true;
             }
 
-            if ($funcNameLc === $classNameLc) {
+            if (NamingConventions::isEqual($funcName, $className) === true) {
                 $oldConstructorFound = true;
                 $oldConstructorPos   = $nextFunc;
             }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.inc
@@ -81,5 +81,11 @@ class bar {
     }
 }
 
+// Class vs function name PHP case-sensitivity quirks.
+class FooBÃÈ {
+    function fOOBÃÈ() {}
+    function FooBãè() {} // OK - not PHP 4-type constructor - POC: https://3v4l.org/YOc2R.
+}
+
 // Must be last test: testing class without scope closer.
 class Something {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
@@ -57,6 +57,7 @@ class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
             array(18),
             array(33),
             array(66),
+            array(86),
         );
     }
 
@@ -96,6 +97,7 @@ class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
             array(51),
             array(53),
             array(65),
+            array(87),
         );
     }
 


### PR DESCRIPTION
### RemovedPHP4StyleConstructors: further implementation of PHPCSUtils

Switch out some custom code for the PHPCSUtils `FunctionDeclarations/ObjectDeclarations::getName()` method.

### RemovedPHP4StyleConstructors: improve handling of PHP case-(in)sensitivity quirks

PHP is case-insensitive for namespace, class, interface, trait and function names, but _only for the characters in those names within the ASCII range_.

Lovely quirky behaviour...

Either way, the `NamingConventions::isEqual()` method takes this into account and handles the comparison correctly based on how PHP itself handles this.

Includes unit test.

