### PR TITLE
RemovedMagicAutoload: use PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -12,6 +12,8 @@ namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\Scopes;
 
@@ -35,16 +37,14 @@ class RemovedMagicAutoloadSniff extends Sniff
     /**
      * Scopes to look for when testing using validDirectScope.
      *
+     * {@internal More tokens are added on register().}
+     *
      * @since 8.1.0
      *
      * @var array
      */
     private $checkForScopes = array(
-        \T_CLASS      => \T_CLASS,
-        \T_ANON_CLASS => \T_ANON_CLASS,
-        \T_INTERFACE  => \T_INTERFACE,
-        \T_TRAIT      => \T_TRAIT,
-        \T_NAMESPACE  => \T_NAMESPACE,
+        \T_NAMESPACE => \T_NAMESPACE,
     );
 
     /**
@@ -56,6 +56,8 @@ class RemovedMagicAutoloadSniff extends Sniff
      */
     public function register()
     {
+        $this->checkForScopes += BCTokens::ooScopeTokens();
+
         return array(\T_FUNCTION);
     }
 
@@ -76,7 +78,7 @@ class RemovedMagicAutoloadSniff extends Sniff
             return;
         }
 
-        $funcName = $phpcsFile->getDeclarationName($stackPtr);
+        $funcName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
 
         if (strtolower($funcName) !== '__autoload') {
             return;

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.1.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.1.inc
@@ -25,3 +25,12 @@ fooanonclass(new class {
         echo 'I am the autoloader in an anonymous class (which makes no sense) - I am deprecated from PHP 7.2 onwards';
     }
 });
+
+class Nested {
+    public function test() {
+        // Nested function becomes available in the global namespace.
+        function __autoload($someclass) {
+            echo 'I am the autoloader - I am deprecated from PHP 7.2 onwards';
+        }
+    }
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -80,6 +80,7 @@ class RemovedMagicAutoloadUnitTest extends BaseSniffTest
     {
         return array(
             array(3),
+            array(32),
         );
     }
 


### PR DESCRIPTION
### RemovedMagicAutoload: add extra unit test

... to verify & safeguard that functions nested in methods will not give false negatives (they currently don't).

### RemovedMagicAutoload: use PHPCSUtils x 2

* Use the backport for the `$ooScopeTokens` property: `BCTokens::ooScopeTokens()`.
* Switch out the PHPCS native `File::getDeclarationName()` method for the PHPCSUtils `FunctionDeclarations::getName()` method.

