### PR TITLE
RemovedNamespacedAssert: bug fix - handling of nested function declarations / use PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -12,7 +12,9 @@ namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer_File as File;
+use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Namespaces;
+use PHPCSUtils\Utils\Scopes;
 
 /**
  * Detect declaration of a namespaced function called `assert()`.
@@ -34,20 +36,6 @@ use PHPCSUtils\Utils\Namespaces;
  */
 class RemovedNamespacedAssertSniff extends Sniff
 {
-    /**
-     * Scopes in which an `assert` function can be declared without issue.
-     *
-     * @since 9.0.0
-     *
-     * @var array
-     */
-    private $scopes = array(
-        \T_CLASS,
-        \T_ANON_CLASS,
-        \T_INTERFACE,
-        \T_TRAIT,
-        \T_CLOSURE,
-    );
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -78,13 +66,13 @@ class RemovedNamespacedAssertSniff extends Sniff
             return;
         }
 
-        $funcName = $phpcsFile->getDeclarationName($stackPtr);
+        $funcName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
 
         if (strtolower($funcName) !== 'assert') {
             return;
         }
 
-        if ($phpcsFile->hasCondition($stackPtr, $this->scopes) === true) {
+        if (Scopes::isOOMethod($phpcsFile, $stackPtr) === true) {
             return;
         }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.1.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.1.inc
@@ -21,3 +21,13 @@ fooanonclass(new class {
 namespace ScopedNS {
 	function assert($something) {}
 }
+
+class nested {
+    public function hasNested($something) {
+        function assert($something) {}
+    }
+}
+
+$cl = function() {
+    function assert($something) {}
+};

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.2.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.2.inc
@@ -19,3 +19,13 @@ trait footrait {
 fooanonclass(new class {
     private function assert($something) {}
 });
+
+class nested {
+    public function hasNested($something) {
+        function assert($something) {}
+    }
+}
+
+$cl = function() {
+    function assert($something) {}
+};

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -67,6 +67,8 @@ class RemovedNamespacedAssertUnitTest extends BaseSniffTest
         return array(
             array(self::TEST_FILE, 22),
             array(self::TEST_FILE_NAMESPACED, 5),
+            array(self::TEST_FILE_NAMESPACED, 25),
+            array(self::TEST_FILE_NAMESPACED, 30),
         );
     }
 
@@ -101,6 +103,8 @@ class RemovedNamespacedAssertUnitTest extends BaseSniffTest
             array(self::TEST_FILE, 10),
             array(self::TEST_FILE, 14),
             array(self::TEST_FILE, 18),
+            array(self::TEST_FILE, 27),
+            array(self::TEST_FILE, 32),
             array(self::TEST_FILE_NAMESPACED, 8),
             array(self::TEST_FILE_NAMESPACED, 12),
             array(self::TEST_FILE_NAMESPACED, 16),


### PR DESCRIPTION
A function called `assert()` declared nested in a class method or closure in a namespaced file will still be defined in that namespace and is therefore deprecated.

POC:
* https://3v4l.org/fKBkf
* https://3v4l.org/mMXLv

This fixes the handling of those.

Includes switching out the PHPCS native `File::getDeclarationName()` method for the PHPCSUtils `FunctionDeclarations::getName()` method.

Includes unit tests.