### PR TITLE
ForbiddenGetClassNull: improve comment tolerance

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -71,7 +71,7 @@ class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        if ($parameters[1]['raw'] !== 'null') {
+        if ($parameters[1]['clean'] !== 'null') {
             return;
         }
 

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.inc
@@ -9,3 +9,6 @@ get_class();
 
 // Not OK.
 get_class(null);
+get_class(
+    null // Comment.
+);

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
@@ -41,7 +41,7 @@ class ForbiddenGetClassNullUnitTest extends BaseSniffTest
     }
 
     /**
-     * dataGetClassNull
+     * Data provider.
      *
      * @see testGetClassNull()
      *
@@ -51,6 +51,7 @@ class ForbiddenGetClassNullUnitTest extends BaseSniffTest
     {
         return array(
             array(11),
+            array(12),
         );
     }
 


### PR DESCRIPTION
The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

This allows for more reliable results for the sniff.

Includes unit test.