### PR TITLE
NewArrayReduceInitialType: cleaner error output

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -99,17 +99,17 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
         $error = 'Passing a non-integer as the value for $initial to array_reduce() is not supported in PHP 5.2 or lower.';
         if ($phpcsFile->findNext($this->variableValueTokens, $targetParam['start'], ($targetParam['end'] + 1)) === false) {
             $phpcsFile->addError(
-                $error . ' Found %s',
+                $error . ' Found: %s',
                 $targetParam['start'],
                 'InvalidTypeFound',
-                array($targetParam['raw'])
+                array($targetParam['clean'])
             );
         } else {
             $phpcsFile->addWarning(
-                $error . ' Variable value found. Found %s',
+                $error . ' Variable value found. Found: %s',
                 $targetParam['start'],
                 'VariableFound',
-                array($targetParam['raw'])
+                array($targetParam['clean'])
             );
         }
     }

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.inc
@@ -16,7 +16,7 @@ array_reduce( $array, $callback, null ); // Will be typecast by PHP.
 array_reduce( $array, $callback, array() );
 
 // Not OK - warning.
-array_reduce( $array, $callback, $initial );
+array_reduce( $array, $callback, $initial /*initial*/ );
 array_reduce( $array, $callback, $this->initial );
 array_reduce( $array, $callback, self::INITIAL );
 array_reduce( $array, $callback, 15 * $initial );


### PR DESCRIPTION
The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

Using the `clean` index will allow for "cleaner" code snippets in the error messages.

Tested via adjusting an existing unit test.

Includes minor textual improvement to the error message text.