### PR TITLE
NewFopenModes: cleaner error output

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -91,13 +91,13 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
                 $errors['cplusFound'] = array(
                     'c+',
                     '5.2.5',
-                    $targetParam['raw'],
+                    $targetParam['clean'],
                 );
             } elseif (strpos($tokens[$i]['content'], 'c') !== false && $this->supportsBelow('5.2.5')) {
                 $errors['cFound'] = array(
                     'c',
                     '5.2.5',
-                    $targetParam['raw'],
+                    $targetParam['clean'],
                 );
             }
 
@@ -105,7 +105,7 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
                 $errors['eFound'] = array(
                     'e',
                     '7.0.15',
-                    $targetParam['raw'],
+                    $targetParam['clean'],
                 );
             }
         }
@@ -116,7 +116,7 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
 
         foreach ($errors as $errorCode => $errorData) {
             $phpcsFile->addError(
-                'Passing "%s" as the $mode to fopen() is not supported in PHP %s or lower. Found %s',
+                'Passing "%s" as the $mode to fopen() is not supported in PHP %s or lower. Found: %s',
                 $targetParam['start'],
                 $errorCode,
                 $errorData

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.inc
@@ -9,7 +9,7 @@ $handle = fopen("/home/rasmus/file.gif", 'a' . $additional_modes);
 $handle = fopen("/home/rasmus/file.txt", "re"); // PHP 7.0.16+
 $handle = fopen("/home/rasmus/file.gif", 'c+'); // PHP 5.2.6+
 $handle = fopen("/home/rasmus/file.gif", 'c'); // PHP 5.2.6+
-$handle = fopen("/home/rasmus/file.gif", 'c'.'e'); // PHP 5.2.6+ and PHP 7.0.16+
+$handle = fopen("/home/rasmus/file.gif", 'c'./*comment*/'e'); // PHP 5.2.6+ and PHP 7.0.16+
 
 // Issue #1043 - ignore function calls, constants etc.
 $handle = fopen("/home/rasmus/file.gif", setFormat('c+'));


### PR DESCRIPTION
The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

Using the `clean` index will allow for "cleaner" code snippets in the error messages.

Tested via adjusting an existing unit test.

Includes minor textual improvement to the error message text.