### PR TITLE
NewPackFormat: use PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
 
 /**
  * Check for valid values for the `$format` passed to `pack()`.
@@ -102,9 +103,7 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
                 return;
             }
 
-            if ($tokens[$i]['code'] !== \T_CONSTANT_ENCAPSED_STRING
-                && $tokens[$i]['code'] !== \T_DOUBLE_QUOTED_STRING
-            ) {
+            if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === false) {
                 continue;
             }
 
@@ -121,13 +120,13 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
                 foreach ($versionArray as $version => $present) {
                     if ($present === false && $this->supportsBelow($version) === true) {
                         $phpcsFile->addError(
-                            'Passing the $format(s) "%s" to pack() is not supported in PHP %s or lower. Found %s',
+                            'Passing the $format(s) "%s" to pack() is not supported in PHP %s or lower. Found: %s',
                             $targetParam['start'],
                             'NewFormatFound',
                             array(
                                 $matches[1],
                                 $version,
-                                $targetParam['raw'],
+                                $targetParam['clean'],
                             )
                         );
                         continue 2;

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
@@ -17,7 +17,7 @@ $binarydata = pack("n{$s}vGc*", 0x1234, 0x5678, 65, 66);
 
 $binarydata = pack("ZJE*", 0x1234, 0x5678, 65, 66); // Error x 3.
 
-$binarydata = pack('nv' . 'Pc*', 0x1234, 0x5678, 65, 66); // Testing multi-token.
+$binarydata = pack('nv' . /*comment*/ 'Pc*', 0x1234, 0x5678, 65, 66); // Testing multi-token.
 
 // Issue #1043 - OK, text in brackets, not the actual format.
 $binarydata = pack($foo['test'], 0x1234, 0x5678, 65, 66);


### PR DESCRIPTION
1. Use the PHPCS native `Tokens::$stringTokens`

This PHPCS native property has been around from before PHPCS 2.6.0, so let's use it.

2. Cleaner error output

The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

Using the `clean` index will allow for "cleaner" code snippets in the error messages.

Tested via adjusting an existing unit test.

Includes minor textual improvement to the error message text.