### PR TITLE
Various sniffs: use Collections::functionDeclarationTokensBC()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -40,13 +40,7 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
      */
     public function register()
     {
-        $targets  = array(
-            \T_FUNCTION,
-            \T_CLOSURE,
-        );
-        $targets += Collections::arrowFunctionTokensBC();
-
-        return $targets;
+        return Collections::functionDeclarationTokensBC();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -39,13 +39,7 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
      */
     public function register()
     {
-        $targets  = array(
-            \T_FUNCTION,
-            \T_CLOSURE,
-        );
-        $targets += Collections::arrowFunctionTokensBC();
-
-        return $targets;
+        return Collections::functionDeclarationTokensBC();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -44,13 +44,7 @@ class NewNullableTypesSniff extends Sniff
      */
     public function register()
     {
-        $targets  = array(
-            \T_FUNCTION,
-            \T_CLOSURE,
-        );
-        $targets += Collections::arrowFunctionTokensBC();
-
-        return $targets;
+        return Collections::functionDeclarationTokensBC();
     }
 
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -133,13 +133,7 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        $targets  = array(
-            \T_FUNCTION,
-            \T_CLOSURE,
-        );
-        $targets += Collections::arrowFunctionTokensBC();
-
-        return $targets;
+        return Collections::functionDeclarationTokensBC();
     }
 
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -121,13 +121,7 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        $targets  = array(
-            \T_FUNCTION,
-            \T_CLOSURE,
-        );
-        $targets += Collections::arrowFunctionTokensBC();
-
-        return $targets;
+        return Collections::functionDeclarationTokensBC();
     }
 
 


### PR DESCRIPTION
PHPCSUtils 1.0.0-alpha3 introduced a number of new token group properties and methods, including the `Collections::functionDeclarationTokensBC()` method which returns all tokens which can be used to declare functions, i.e. `T_FUNCTION`, `T_CLOSURE`, `T_FN` (if it exists) and `T_STRING` for when arrow functions have not been backfilled yet.

This implements the use of this method in various sniffs which have already previously been reviewed & updated for PHPCSUtils.