### PR TITLE
NewIconvMbstringCharsetDefault: use PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -183,8 +183,8 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
         if ($tokens[$firstNonEmpty]['code'] === \T_ARRAY
             || $tokens[$firstNonEmpty]['code'] === \T_OPEN_SHORT_ARRAY
         ) {
-            $hasInputCharset  = preg_match('`([\'"])input-charset\1\s*=>`', $targetParam['raw']);
-            $hasOutputCharset = preg_match('`([\'"])output-charset\1\s*=>`', $targetParam['raw']);
+            $hasInputCharset  = preg_match('`([\'"])input-charset\1\s*=>`', $targetParam['clean']);
+            $hasOutputCharset = preg_match('`([\'"])output-charset\1\s*=>`', $targetParam['clean']);
             if ($hasInputCharset === 1 && $hasOutputCharset === 1) {
                 // Both input as well as output charset are set.
                 return;

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -183,6 +183,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
         if ($tokens[$firstNonEmpty]['code'] === \T_ARRAY
             || $tokens[$firstNonEmpty]['code'] === \T_OPEN_SHORT_ARRAY
         ) {
+            // Note: the item names are treated case-sensitively in PHP, so match on exact case.
             $hasInputCharset  = preg_match('`([\'"])input-charset\1\s*=>`', $targetParam['clean']);
             $hasOutputCharset = preg_match('`([\'"])output-charset\1\s*=>`', $targetParam['clean']);
             if ($hasInputCharset === 1 && $hasOutputCharset === 1) {

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
@@ -108,3 +108,13 @@ $a = iconv_mime_encode(
         'line-length'      => 80,
     ]
 ); // Error: 'input-charset' not set.
+
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    [
+        'Input-CharSet'    => 'ISO-8859-1',
+        'output-charset'   => 'UTF-8',
+        'line-length'      => 80,
+    ]
+); // Error: 'input-charset' not set (because case-sensitive).

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -109,17 +109,43 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
     /**
      * Test the special handling of calls to iconv_mime_encode().
      *
+     * @dataProvider dataIconvMimeEncode
+     *
+     * @param int    $line    Line number where the error should occur.
+     * @param string $missing The preferences which are missing.
+     * @param string $type    Whether an error or a warning is expected. Defaults to 'error'.
+     *
      * @return void
      */
-    public function testIconvMimeEncode()
+    public function testIconvMimeEncode($line, $missing, $type = 'error')
     {
         $file  = $this->sniffFile(__FILE__, '5.4-7.0');
         $error = 'The default value of the %s parameter index for iconv_mime_encode() was changed from ISO-8859-1 to UTF-8 in PHP 5.6';
+        $error = sprintf($error, $missing);
 
-        $this->assertError($file, 91, sprintf($error, '$preferences[\'input/output-charset\']'));
-        $this->assertWarning($file, 92, sprintf($error, '$preferences[\'input/output-charset\']'));
-        $this->assertError($file, 96, sprintf($error, '$preferences[\'output-charset\']'));
-        $this->assertError($file, 106, sprintf($error, '$preferences[\'input-charset\']'));
+        if ($type === 'error') {
+            $this->assertError($file, $line, $error);
+        } else {
+            $this->assertWarning($file, $line, $error);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIconvMimeEncode()
+     *
+     * @return array
+     */
+    public function dataIconvMimeEncode()
+    {
+        return array(
+            array(91, '$preferences[\'input/output-charset\']'),
+            array(92, '$preferences[\'input/output-charset\']', 'warning'),
+            array(96, '$preferences[\'output-charset\']'),
+            array(106, '$preferences[\'input-charset\']'),
+            array(115, '$preferences[\'input-charset\']'),
+        );
     }
 
 


### PR DESCRIPTION
### NewIconvMbstringCharsetDefault: improve efficiency

The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

Using the `clean` index will allow for the regexes to be faster if the parameter contains comments.

### NewIconvMbstringCharsetDefault: add test safeguarding case-sensitivity

Per the documentation, the item names in preferences are treated case-sensitively.

This commit:
* Adds a unit test to make sure the sniff does so as well;
* Makes a note of this in the code inline;
* Reworks the `testIconvMimeEncode()` method to use a data provider as the number of assertions in the method was getting higher than I'd like them to be.

Ref: https://www.php.net/manual/en/function.iconv-mime-encode.php

