### PR TITLE
NewNegativeStringOffset: cleaner error output

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -115,13 +115,13 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
             }
 
             $phpcsFile->addError(
-                'Negative string offsets were not supported for the $%s parameter in %s() in PHP 7.0 or lower. Found %s',
+                'Negative string offsets were not supported for the $%s parameter in %s() in PHP 7.0 or lower. Found: %s',
                 $targetParam['start'],
                 'Found',
                 array(
                     $name,
                     $functionName,
-                    $targetParam['raw'],
+                    $targetParam['clean'],
                 )
             );
         }


### PR DESCRIPTION
The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

Using the `clean` index will allow for "cleaner" code snippets in the error messages.

Tested via an existing unit test.

Includes minor textual improvement to the error message text.