### PR TITLE
NewPasswordAlgoConstantValues: cleaner error output

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -114,7 +114,7 @@ class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParameterSn
                     'NotAlgoConstant',
                     array(
                         $functionName,
-                        $targetParam['raw'],
+                        $targetParam['clean'],
                     )
                 );
 

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
@@ -22,5 +22,5 @@ $hash = password_hash( $password, +1, $options );
 $hash = password_needs_rehash( $password, 2, $options );
 $hash = password_hash( $password, 3, $options );
 $hash = password_hash( $password, '2y', $options );
-$hash = password_HASH( $password, "argon{$type}", $options );
+$hash = password_HASH( $password, "argon{$type}" /*comment*/, $options );
 $hash = password_needs_rehash( $password, 'argon2id', $options );


### PR DESCRIPTION
The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

Using the `clean` index will allow for "cleaner" code snippets in the error messages.

Tested via adjusting an existing unit test.