### PR TITLE
NewProcOpenCmdArray: improve efficiency

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -100,7 +100,7 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
         }
 
         if ($this->supportsAbove('7.4') === true) {
-            if (strpos($targetParam['raw'], 'escapeshellarg(') === false) {
+            if (strpos($targetParam['clean'], 'escapeshellarg(') === false) {
                 // Efficiency: prevent needlessly walking the array.
                 return;
             }
@@ -122,10 +122,10 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
                     // @todo Potential future enhancement: check if it's a call to the PHP native function.
 
                     $phpcsFile->addWarning(
-                        'When passing proc_open() the $cmd parameter as an array, PHP will take care of any necessary argument escaping. Found: %s',
+                        'When passing the $cmd parameter to proc_open() as an array, PHP will take care of any necessary argument escaping. Found: %s',
                         $i,
                         'Invalid',
-                        array($item['raw'])
+                        array($item['clean'])
                     );
 
                     // Only throw one error per array item.

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.inc
@@ -21,7 +21,7 @@ $proc = proc_open(
         'php',
         '-r',
         'echo "Hello World\n";',
-    ),
+    ), // Not using escapeshellarg() as PHP will do the escaping.
     $descriptors,
     $pipes
 );
@@ -31,7 +31,7 @@ $proc = proc_open(['php', '-r', escapeshellarg($echo)], $descriptors, $pipes);
 $proc = proc_open(
     array(
         'phpcs',
-        '--standard=' . escapeshellarg($standard),
+        '--standard=' . escapeshellarg($standard), // Escaping.
         './path/to/' . escapeshellarg($file),
     ),
     $descriptors,

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
@@ -73,7 +73,7 @@ class NewProcOpenCmdArrayUnitTest extends BaseSniffTest
     public function testInvalidProcOpenCmdArray($line, $itemValue)
     {
         $file  = $this->sniffFile(__FILE__, '7.4');
-        $error = 'When passing proc_open() the $cmd parameter as an array, PHP will take care of any necessary argument escaping. Found: ' . $itemValue;
+        $error = 'When passing the $cmd parameter to proc_open() as an array, PHP will take care of any necessary argument escaping. Found: ' . $itemValue;
 
         $this->assertWarning($file, $line, $error);
     }


### PR DESCRIPTION
The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

Using the `clean` index will allow for the sniff to be faster if the parameter contains comments, as well as provide a cleaner error message.

Tested by adjusting two existing unit tests.

Includes minor textual improvement to the error message text.