### PR TITLE
PHP 8.0: RemovedCurlyBraceArrayAccess - handle removed support

### DIFF
--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
@@ -37,7 +37,10 @@ class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTest
     public function testRemovedCurlyBraceArrayAccess($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
-        $this->assertWarning($file, $line, 'Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4.');
+        $this->assertWarning($file, $line, 'Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4');
+
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4 and removed in PHP 8.0');
     }
 
     /**


### PR DESCRIPTION
> Removed support for deprecated curly braces for offset access

Refs:
* https://wiki.php.net/rfc/deprecate_curly_braces_array_access
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L195-L196
* https://github.com/php/php-src/commit/c803499e2317a879dc8b0429f39643bd35892b15

Includes adjusted error message and unit tests.

Note: the error code for the original warning has changed from `Found` to `Deprecated`.
:point_right:  This needs a changelog entry.

Related to #809