### PR TITLE
PHP 8.0: New `PHPCompatibility.ParameterValues.RemovedSplAutoloadRegisterThrowFalse` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * Detect: Passing `false` to `spl_autoload_register()` is deprecated as of PHP 8.0.
+ *
+ * > spl_autoload_register() will now always throw a TypeError on invalid
+ * > arguments, therefore the second argument $throw is ignored and a
+ * > notice will be emitted if it is set to false.
+ *
+ * PHP version 8.0
+ *
+ * @link https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L393-L395
+ *
+ * @since 10.0.0
+ */
+class RemovedSplAutoloadRegisterThrowFalseSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'spl_autoload_register' => true,
+    );
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('8.0') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the stack.
+     * @param string                $functionName The token content (function name) which was matched.
+     * @param array                 $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        if (isset($parameters[2]) === false) {
+            return;
+        }
+
+        if ($parameters[2]['clean'] !== 'false') {
+            return;
+        }
+
+        $phpcsFile->addWarning(
+            'Explicitly passing "false" as the value for $throw to spl_autoload_register() is deprecated since PHP 8.0.',
+            $parameters[2]['start'],
+            'Deprecated'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.inc
@@ -1,0 +1,13 @@
+<?php
+/*
+ * Test spl_autoload_register() PHP 8.0 change in accepted values.
+ */
+
+// OK.
+spl_autoload_register();
+spl_autoload_register($autoload_function);
+spl_autoload_register($autoload_function, true, false);
+spl_autoload_register($autoload_function, $throw, $prepend);
+
+// Not OK.
+spl_autoload_register($autoload_function, false);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedSplAutoloadRegisterThrowFalse sniff.
+ *
+ * @group removedSplAutoloadRegisterThrowFalse
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedSplAutoloadRegisterThrowFalseSniff
+ *
+ * @since 10.0.0
+ */
+class RemovedSplAutoloadRegisterThrowFalseUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify a warning is thrown when an explicit false is passed as the second parameter.
+     *
+     * @dataProvider dataRemovedSplAutoloadRegisterThrowFalse
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedSplAutoloadRegisterThrowFalse($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertWarning($file, $line, 'Explicitly passing "false" as the value for $throw to spl_autoload_register() is deprecated since PHP 8.0.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedSplAutoloadRegisterThrowFalse()
+     *
+     * @return array
+     */
+    public function dataRemovedSplAutoloadRegisterThrowFalse()
+    {
+        return array(
+            array(13),
+        );
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+
+        // No errors expected on the first 11 lines.
+        for ($line = 1; $line <= 11; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> spl_autoload_register() will now always throw a TypeError on invalid
> arguments, therefore the second argument $do_throw is ignored and a
> notice will be emitted if it is set to false.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L393-L395
* https://github.com/php/php-src/pull/5301
* https://github.com/php/php-src/commit/2302b14aab3bf01a9a87d2ee87951a13bc7752a0

This sniff addresses that change.

Includes unit tests.

Related to #809