### PR TITLE
PHP 8.0: NewInterfaces: add new Stringable interface to the sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -111,6 +111,11 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
             '5.6' => false,
             '7.0' => true,
         ),
+
+        'Stringable' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
     );
 
     /**

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -107,3 +107,6 @@ try {
 try {
 } catch (\My\Except\Throwable $e) {
 }
+
+// PHP 8.0 new interfaces.
+function StringableTypeHint( Stringable $a ) {}

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -82,6 +82,7 @@ class NewInterfacesUnitTest extends BaseSniffTest
             array('SessionIdInterface', '5.5.0', array(89), '5.6', '5.5'),
             array('Throwable', '5.6', array(37, 52, 62, 93, 98, 103), '7.0'),
             array('SessionUpdateTimestampHandlerInterface', '5.6', array(90), '7.0'),
+            array('Stringable', '7.4', array(112), '8.0'),
         );
     }
 


### PR DESCRIPTION
> Added Stringable interface, which is automatically implemented if a class defines a __toString() method.

Refs:
* https://wiki.php.net/rfc/stringable
* https://github.com/php/php-src/pull/5083
* https://github.com/php/php-src/commit/336eb48c36f3c1c115349307c18e6cf16ab003df

Related to #809