### PR TITLE
PHP 8.0: OptionalToRequiredFunctionParameters: add support for 3 changed functions

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -72,6 +72,7 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
             1 => array(
                 'name' => 'result',
                 '7.2'  => false,
+                '8.0'  => true,
             ),
         ),
     );

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -55,6 +55,12 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
                 '8.0'  => true,
             ),
         ),
+        'mb_parse_str' => array(
+            1 => array(
+                'name' => 'result',
+                '8.0'  => true,
+            ),
+        ),
         'mktime' => array(
             0 => array(
                 'name' => 'hour',

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -49,6 +49,19 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
                 '5.6'  => 'recommended',
             ),
         ),
+        'gmmktime' => array(
+            1 => array(
+                'name' => 'hour',
+                '8.0'  => true,
+            ),
+        ),
+        'mktime' => array(
+            0 => array(
+                'name' => 'hour',
+                '5.1'  => false,
+                '8.0'  => true,
+            ),
+        ),
         'parse_str' => array(
             1 => array(
                 'name' => 'result',
@@ -165,7 +178,7 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
             }
 
             // Remove the last 'and' from the message.
-            $error = substr($error, 0, (\strlen($error) - 5));
+            $error = \substr($error, 0, (\strlen($error) - 5));
         }
 
         $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
@@ -9,3 +9,11 @@ crypt( $str ); // Recommended.
 
 // Prevent false positive on new. Issue #913.
 $crypt = new Crypt('password');
+
+// OK.
+gmmktime($hour, $minute, $second);
+mktime($hour);
+
+// Not OK.
+gmmktime();
+mktime();

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
@@ -17,3 +17,6 @@ mktime($hour);
 // Not OK.
 gmmktime();
 mktime();
+
+mb_parse_str($encoded_string, $result); // Ok.
+mb_parse_str($encoded_string); // Not ok.

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -154,6 +154,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
     {
         return array(
             array('gmmktime', 'hour', '8.0', array(18), '7.4'),
+            array('mb_parse_str', 'result', '8.0', array(22), '7.4'),
         );
     }
 
@@ -228,6 +229,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
             array(4),
             array(14),
             array(15),
+            array(21),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -26,46 +26,6 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
 {
 
     /**
-     * testOptionalRequiredParameterDeprecated
-     *
-     * @dataProvider dataOptionalRequiredParameterDeprecated
-     *
-     * @param string $functionName     Function name.
-     * @param string $parameterName    Parameter name.
-     * @param string $softRequiredFrom The last PHP version in which the parameter was still optional.
-     * @param array  $lines            The line numbers in the test file which apply to this class.
-     * @param string $okVersion        A PHP version in which to test for no violation.
-     *
-     * @return void
-     */
-    public function testOptionalRequiredParameterDeprecated($functionName, $parameterName, $softRequiredFrom, $lines, $okVersion)
-    {
-        $file  = $this->sniffFile(__FILE__, $softRequiredFrom);
-        $error = "The \"{$parameterName}\" parameter for function {$functionName}() is missing. Passing this parameter is no longer optional. The optional nature of the parameter is deprecated since PHP {$softRequiredFrom}";
-        foreach ($lines as $line) {
-            $this->assertWarning($file, $line, $error);
-        }
-
-        $file = $this->sniffFile(__FILE__, $okVersion);
-        foreach ($lines as $line) {
-            $this->assertNoViolation($file, $line);
-        }
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testOptionalRequiredParameterDeprecated()
-     *
-     * @return array
-     */
-    public function dataOptionalRequiredParameterDeprecated()
-    {
-        return array();
-    }
-
-
-    /**
      * testOptionalRequiredParameterDeprecatedRemoved
      *
      * @dataProvider dataOptionalRequiredParameterDeprecatedRemoved

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -61,9 +61,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
      */
     public function dataOptionalRequiredParameterDeprecated()
     {
-        return array(
-            array('parse_str', 'result', '7.2', array(7), '7.1'),
-        );
+        return array();
     }
 
 
@@ -112,6 +110,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
     {
         return array(
             array('mktime', 'hour', '5.1', '8.0', array(19), '5.0'),
+            array('parse_str', 'result', '7.2', '8.0', array(7), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -68,6 +68,97 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
 
 
     /**
+     * testOptionalRequiredParameterDeprecatedRemoved
+     *
+     * @dataProvider dataOptionalRequiredParameterDeprecatedRemoved
+     *
+     * @param string $functionName     Function name.
+     * @param string $parameterName    Parameter name.
+     * @param string $softRequiredFrom The last PHP version in which the parameter was still optional (deprecated).
+     * @param string $hardRequiredFrom The last PHP version in which the parameter was still optional (removed).
+     * @param array  $lines            The line numbers in the test file which apply to this class.
+     * @param string $okVersion        A PHP version in which to test for no violation.
+     *
+     * @return void
+     */
+    public function testOptionalRequiredParameterDeprecatedRemoved($functionName, $parameterName, $softRequiredFrom, $hardRequiredFrom, $lines, $okVersion)
+    {
+        $file  = $this->sniffFile(__FILE__, $softRequiredFrom);
+        $error = "The \"{$parameterName}\" parameter for function {$functionName}() is missing. Passing this parameter is no longer optional. The optional nature of the parameter is deprecated since PHP {$softRequiredFrom}";
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, $error);
+        }
+
+        $file  = $this->sniffFile(__FILE__, $hardRequiredFrom);
+        $error = "The \"{$parameterName}\" parameter for function {$functionName}() is missing. Passing this parameter is no longer optional. The optional nature of the parameter is deprecated since PHP {$softRequiredFrom} and removed since PHP {$hardRequiredFrom}";
+        foreach ($lines as $line) {
+            $this->assertError($file, $line, $error);
+        }
+
+        $file = $this->sniffFile(__FILE__, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testOptionalRequiredParameterDeprecatedRemoved()
+     *
+     * @return array
+     */
+    public function dataOptionalRequiredParameterDeprecatedRemoved()
+    {
+        return array(
+            array('mktime', 'hour', '5.1', '8.0', array(19), '5.0'),
+        );
+    }
+
+
+    /**
+     * testOptionalRequiredParameterRemoved
+     *
+     * @dataProvider dataOptionalRequiredParameterRemoved
+     *
+     * @param string $functionName     Function name.
+     * @param string $parameterName    Parameter name.
+     * @param string $hardRequiredFrom The last PHP version in which the parameter was still optional.
+     * @param array  $lines            The line numbers in the test file which apply to this class.
+     * @param string $okVersion        A PHP version in which to test for no violation.
+     *
+     * @return void
+     */
+    public function testOptionalRequiredParameterRemoved($functionName, $parameterName, $hardRequiredFrom, $lines, $okVersion)
+    {
+        $file  = $this->sniffFile(__FILE__, $hardRequiredFrom);
+        $error = "The \"{$parameterName}\" parameter for function {$functionName}() is missing. Passing this parameter is no longer optional. The optional nature of the parameter is removed since PHP {$hardRequiredFrom}";
+        foreach ($lines as $line) {
+            $this->assertError($file, $line, $error);
+        }
+
+        $file = $this->sniffFile(__FILE__, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testOptionalRequiredParameterRemoved()
+     *
+     * @return array
+     */
+    public function dataOptionalRequiredParameterRemoved()
+    {
+        return array(
+            array('gmmktime', 'hour', '8.0', array(18), '7.4'),
+        );
+    }
+
+
+    /**
      * testOptionalRecommendedParameter
      *
      * @dataProvider dataOptionalRecommendedParameter
@@ -135,6 +226,8 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
     {
         return array(
             array(4),
+            array(14),
+            array(15),
         );
     }
 
@@ -146,7 +239,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '5.5'); // Version before earliest required/optional change.
+        $file = $this->sniffFile(__FILE__, '5.0'); // Version before earliest required/optional change.
         $this->assertNoViolation($file);
     }
 }


### PR DESCRIPTION
### PHP 8.0: OptionalToRequiredFunctionParameters - handle required params for (gm)mktime()

> mktime() and gmmktime() now require at least one argument. `time()` can be
> used to get the current timestamp.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L192-L194
* php/php-src@5a2787a

Includes adjusted unit tests.

### PHP 8.0: OptionalToRequiredFunctionParameters - handle required param for mb_parse_str()

> mb_parse_str() can no longer be used without specifying a result array.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L257
* php/php-src@ff780fe

Includes adjusted unit tests.

### PHP 8.0: OptionalToRequiredFunctionParameters - handle required param for parse_str()

> parse_str() can no longer be used without specifying a result array.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L355
* php/php-src@ff780fe

Includes adjusted unit tests.

### PHP 8.0: OptionalToRequiredFunctionParameters - remove set of test functions

As the `testOptionalRequiredParameterDeprecated()` method is now unused, I'm removing the unit test and its data provider as select PHPUnit versions do not handle tests with empty data providers correctly.

This test can be brought back when needed in the future by reverting this commit.

Related to #809