### PR TITLE
PHP 8.0: RemovedFunctionParameters: handle removed parameter x 3

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -55,7 +55,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         'define' => array(
             2 => array(
                 'name' => 'case_insensitive',
-                '7.3'  => false, // Slated for removal in PHP 8.0.0.
+                '7.3'  => false,
+                '8.0'  => true,
             ),
         ),
         'gmmktime' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -78,6 +78,12 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
                 '5.2.4' => true,
             ),
         ),
+        'mb_decode_numericentity' => array(
+            3 => array(
+                'name' => 'is_hex',
+                '8.0'  => true,
+            ),
+        ),
         'mktime' => array(
             6 => array(
                 'name' => 'is_dst',

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -47,9 +47,9 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
     protected $removedFunctionParameters = array(
         'curl_version' => array(
             0 => array(
-                'name'     => 'age',
-                '7.4'      => false,
-                'callback' => 'curlVersionInvalidValue',
+                'name' => 'age',
+                '7.4'  => false,
+                '8.0'  => true,
             ),
         ),
         'define' => array(
@@ -281,36 +281,5 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         array_shift($data);
         array_unshift($data, $errorInfo['paramName'], $itemInfo['name']);
         return $data;
-    }
-
-    /**
-     * Check whether curl_version() was passed the default CURLVERSION_NOW.
-     *
-     * @since 9.3.0
-     *
-     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param array                 $parameter Parameter info array.
-     *
-     * @return bool True if the value was not CURLVERSION_NOW, false otherwise.
-     */
-    protected function curlVersionInvalidValue(File $phpcsFile, array $parameter)
-    {
-        $tokens = $phpcsFile->getTokens();
-        $raw    = '';
-        for ($i = $parameter['start']; $i <= $parameter['end']; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
-                continue;
-            }
-
-            $raw .= $tokens[$i]['content'];
-        }
-
-        if ($raw !== 'CURLVERSION_NOW'
-            && $raw !== (string) \CURLVERSION_NOW
-        ) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -19,3 +19,6 @@ curl_version( CURLVERSION_NOW ); // OK.
 curl_version( 4 ); // OK when on Curl version 4.
 curl_version( 10505678 );
 curl_version( $age );
+
+mb_decode_numericentity($str, $convmap); // OK.
+mb_decode_numericentity($str, $convmap, $encoding, $is_hex); // Error.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -118,6 +118,11 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             array('mktime', 'is_dst', '5.1', '7.0', array(8), '5.0'),
             array('gmmktime', 'is_dst', '5.1', '7.0', array(9), '5.0'),
             array('define', 'case_insensitive', '7.3', '8.0', array(15), '7.2'),
+
+            array('curl_version', 'age', '7.4', '8.0', array(18), '7.3'),
+            array('curl_version', 'age', '7.4', '8.0', array(19), '7.3'),
+            array('curl_version', 'age', '7.4', '8.0', array(20), '7.3'),
+            array('curl_version', 'age', '7.4', '8.0', array(21), '7.3'),
         );
     }
 
@@ -160,16 +165,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
      */
     public function dataDeprecatedParameter()
     {
-        $data = array(
-            array('curl_version', 'age', '7.4', array(20), '7.3'),
-            array('curl_version', 'age', '7.4', array(21), '7.3'),
-        );
-
-        if (\CURLVERSION_NOW !== 4) {
-            $data[] = array('curl_version', 'age', '7.4', array(19), '7.3');
-        }
-
-        return $data;
+        return array();
     }
 
 
@@ -197,20 +193,13 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
      */
     public function dataNoFalsePositives()
     {
-        $data = array(
+        return array(
             array(4),
             array(5),
             array(14),
             array(17),
-            array(18),
             array(23),
         );
-
-        if (\CURLVERSION_NOW === 4) {
-            $data[] = array(19);
-        }
-
-        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -116,6 +116,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
         return array(
             array('mktime', 'is_dst', '5.1', '7.0', array(8), '5.0'),
             array('gmmktime', 'is_dst', '5.1', '7.0', array(9), '5.0'),
+            array('define', 'case_insensitive', '7.3', '8.0', array(15), '7.2'),
         );
     }
 
@@ -159,7 +160,6 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
     public function dataDeprecatedParameter()
     {
         $data = array(
-            array('define', 'case_insensitive', '7.3', array(15), '7.2'),
             array('curl_version', 'age', '7.4', array(20), '7.3'),
             array('curl_version', 'age', '7.4', array(21), '7.3'),
         );

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -128,48 +128,6 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
 
 
     /**
-     * testDeprecatedParameter
-     *
-     * @dataProvider dataDeprecatedParameter
-     *
-     * @param string $functionName  Function name.
-     * @param string $parameterName Parameter name.
-     * @param string $deprecatedIn  The PHP version in which the parameter was deprecated.
-     * @param array  $lines         The line numbers in the test file which apply to this class.
-     * @param string $okVersion     A PHP version in which the parameter was ok to be used.
-     * @param string $testVersion   Optional. A PHP version in which to test for the deprecation message.
-     *
-     * @return void
-     */
-    public function testDeprecatedParameter($functionName, $parameterName, $deprecatedIn, $lines, $okVersion, $testVersion = null)
-    {
-        $file = $this->sniffFile(__FILE__, $okVersion);
-        foreach ($lines as $line) {
-            $this->assertNoViolation($file, $line);
-        }
-
-        $errorVersion = (isset($testVersion)) ? $testVersion : $deprecatedIn;
-        $file         = $this->sniffFile(__FILE__, $errorVersion);
-        $error        = "The \"{$parameterName}\" parameter for function {$functionName}() is deprecated since PHP {$deprecatedIn}";
-        foreach ($lines as $line) {
-            $this->assertWarning($file, $line, $error);
-        }
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testDeprecatedParameter()
-     *
-     * @return array
-     */
-    public function dataDeprecatedParameter()
-    {
-        return array();
-    }
-
-
-    /**
      * testNoFalsePositives
      *
      * @dataProvider dataNoFalsePositives

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -66,6 +66,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
         return array(
             array('ldap_first_attribute', 'ber_identifier', '5.2.4', array(11), '5.2', '5.3'),
             array('ldap_next_attribute', 'ber_identifier', '5.2.4', array(12), '5.2', '5.3'),
+            array('mb_decode_numericentity', 'is_hex', '8.0', array(24), '7.4'),
         );
     }
 
@@ -202,6 +203,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             array(14),
             array(17),
             array(18),
+            array(23),
         );
 
         if (\CURLVERSION_NOW === 4) {


### PR DESCRIPTION
### PHP 8.0: RemovedFunctionParameters - handle removed support for case-insensitive constants

> Removed the ability to define case-insensitive constants. The third
argument to define() may no longer be true.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L30-L31
* https://wiki.php.net/rfc/case_insensitive_constant_deprecation
* php/php-src@23a5be3

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctionParameters - removed support for mb_decode_numericentity() / $is_hex

> The `$is_hex parameter`, which was not used internally, has been removed from
`mb_decode_numericentity()`.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L283-L284
* https://bugs.php.net/bug.php?id=78579
* php/php-src@48892e6

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctionParameters - removed support for curl_version() / $age

> The deprecated parameter `$version` of curl_version() has been removed.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L818
* php/php-src@a43fd3b

Now the parameter has been removed, I'm removing the value check which was previously being done in PHPCompatibility.

Also note that while the changelog talks about the `$version` parameter, the parameter is actually called `$age` in the manual.

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctionParameters - remove set of test functions

As the `testDeprecatedParameter()` method is now unused, I'm removing the unit test and its data provider as select PHPUnit versions do not handle tests with empty data providers correctly.

This test can be brought back back when needed in the future by reverting this commit.

Related to #809