### PR TITLE
 PHP 8.0: RemovedFunctions: handle removal of 23 previously deprecated functions

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4177,10 +4177,12 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'get_magic_quotes_gpc' => array(
             '7.4' => false,
+            '8.0' => true,
             'alternative' => null,
         ),
         'get_magic_quotes_runtime' => array(
             '7.4' => false,
+            '8.0' => true,
             'alternative' => null,
         ),
         'hebrevc' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4172,6 +4172,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'ezmlm_hash' => array(
             '7.4' => false,
+            '8.0' => true,
             'alternative' => null,
         ),
         'get_magic_quotes_gpc' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4071,6 +4071,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'read_exif_data' => array(
             '7.2' => false,
+            '8.0' => true,
             'alternative' => 'exif_read_data()',
         ),
 

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4156,10 +4156,12 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'fgetss' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => null,
         ),
         'gzgetss' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => null,
         ),
 

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4196,6 +4196,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'money_format' => array(
             '7.4' => false,
+            '8.0' => true,
             'alternative' => 'NumberFormatter::formatCurrency()',
         ),
         'restore_include_path' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4045,10 +4045,12 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'jpeg2wbmp' => array(
             '7.2' => false,
+            '8.0' => true,
             'alternative' => 'imagecreatefromjpeg() and imagewbmp()',
         ),
         'png2wbmp' => array(
             '7.2' => false,
+            '8.0' => true,
             'alternative' => 'imagecreatefrompng() or imagewbmp()',
         ),
         '__autoload' => array(
@@ -4077,6 +4079,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
 
         'image2wbmp' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'imagewbmp()',
         ),
         'mbregex_encoding' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4069,6 +4069,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'gmp_random' => array(
             '7.2' => false,
+            '8.0' => true,
             'alternative' => 'gmp_random_bits() or gmp_random_range()',
         ),
         'read_exif_data' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4057,6 +4057,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'create_function' => array(
             '7.2' => false,
+            '8.0' => true,
             'alternative' => 'an anonymous function',
         ),
         'each' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4187,6 +4187,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'hebrevc' => array(
             '7.4' => false,
+            '8.0' => true,
             'alternative' => null,
         ),
         'is_real' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4201,6 +4201,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'restore_include_path' => array(
             '7.4' => false,
+            '8.0' => true,
             'alternative' => "ini_restore('include_path')",
         ),
         'ibase_add_user' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4167,6 +4167,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
 
         'convert_cyr_string' => array(
             '7.4' => false,
+            '8.0' => true,
             'alternative' => 'mb_convert_encoding(), iconv() or UConverter',
         ),
         'ezmlm_hash' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4086,58 +4086,72 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'mbregex_encoding' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_regex_encoding()',
         ),
         'mbereg' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_ereg()',
         ),
         'mberegi' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_eregi()',
         ),
         'mbereg_replace' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_ereg_replace()',
         ),
         'mberegi_replace' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_eregi_replace()',
         ),
         'mbsplit' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_split()',
         ),
         'mbereg_match' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_ereg_match()',
         ),
         'mbereg_search' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_ereg_search()',
         ),
         'mbereg_search_pos' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_ereg_search_pos()',
         ),
         'mbereg_search_regs' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_ereg_search_regs()',
         ),
         'mbereg_search_init' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_ereg_search_init()',
         ),
         'mbereg_search_getregs' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_ereg_search_getregs()',
         ),
         'mbereg_search_getpos' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_ereg_search_getpos()',
         ),
         'mbereg_search_setpos' => array(
             '7.3' => false,
+            '8.0' => true,
             'alternative' => 'mb_ereg_search_setpos()',
         ),
         'fgetss' => array(

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4062,7 +4062,8 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'each' => array(
             '7.2' => false,
-            'alternative' => 'a foreach loop',
+            '8.0' => true,
+            'alternative' => 'a foreach loop or ArrayIterator',
         ),
         'gmp_random' => array(
             '7.2' => false,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -2820,6 +2820,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         ),
         'ldap_sort' => array(
             '7.0' => false,
+            '8.0' => true,
             'alternative' => null,
         ),
         'mcrypt_generic_end' => array(

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -164,7 +164,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('ociwritetemporarylob', '5.4', 'OCI-Lob::writeTemporary()', array(89), '5.3'),
 
             array('__autoload', '7.2', 'SPL autoload', array(589), '7.1'),
-            array('convert_cyr_string', '7.4', 'mb_convert_encoding(), iconv() or UConverter', array(243), '7.3'),
             array('is_real', '7.4', 'is_float()', array(239), '7.3'),
             array('money_format', '7.4', 'NumberFormatter::formatCurrency()', array(244), '7.3'),
             array('restore_include_path', '7.4', "ini_restore('include_path')", array(246), '7.3'),
@@ -1432,6 +1431,8 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('mbereg_search_getregs', '7.3', '8.0', 'mb_ereg_search_getregs()', array(164), '7.2'),
             array('mbereg_search_getpos', '7.3', '8.0', 'mb_ereg_search_getpos()', array(165), '7.2'),
             array('mbereg_search_setpos', '7.3', '8.0', 'mb_ereg_search_setpos()', array(166), '7.2'),
+
+            array('convert_cyr_string', '7.4', '8.0', 'mb_convert_encoding(), iconv() or UConverter', array(243), '7.3'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -66,8 +66,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
         return array(
             array('dl', '5.3', array(6), '5.2'),
             array('ocifetchinto', '5.4', array(63), '5.3'),
-            array('fgetss', '7.3', array(167), '7.2'),
-            array('gzgetss', '7.3', array(168), '7.2'),
             array('ezmlm_hash', '7.4', array(245), '7.3'),
             array('get_magic_quotes_gpc', '7.4', array(240), '7.3'),
             array('get_magic_quotes_runtime', '7.4', array(241), '7.3'),
@@ -1295,6 +1293,8 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('mysql_table_name', '5.5', '7.0', array(984), '5.4'),
 
             array('ldap_sort', '7.0', '8.0', array(97), '5.6'),
+            array('fgetss', '7.3', '8.0', array(167), '7.2'),
+            array('gzgetss', '7.3', '8.0', array(168), '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -66,8 +66,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
         return array(
             array('dl', '5.3', array(6), '5.2'),
             array('ocifetchinto', '5.4', array(63), '5.3'),
-            array('get_magic_quotes_gpc', '7.4', array(240), '7.3'),
-            array('get_magic_quotes_runtime', '7.4', array(241), '7.3'),
             array('hebrevc', '7.4', array(242), '7.3'),
         );
     }
@@ -1294,6 +1292,8 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('fgetss', '7.3', '8.0', array(167), '7.2'),
             array('gzgetss', '7.3', '8.0', array(168), '7.2'),
             array('ezmlm_hash', '7.4', '8.0', array(245), '7.3'),
+            array('get_magic_quotes_gpc', '7.4', '8.0', array(240), '7.3'),
+            array('get_magic_quotes_runtime', '7.4', '8.0', array(241), '7.3'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -168,7 +168,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
 
             array('jpeg2wbmp', '7.2', 'imagecreatefromjpeg() and imagewbmp()', array(144), '7.1'),
             array('png2wbmp', '7.2', 'imagecreatefrompng() or imagewbmp()', array(145), '7.1'),
-            array('create_function', '7.2', 'an anonymous function', array(146), '7.1'),
             array('__autoload', '7.2', 'SPL autoload', array(589), '7.1'),
             array('each', '7.2', 'a foreach loop', array(147), '7.1'),
             array('gmp_random', '7.2', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
@@ -1433,6 +1432,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('mcrypt_module_self_test', '7.1', '7.2', 'OpenSSL', array(130), '7.0'),
             array('mdecrypt_generic', '7.1', '7.2', 'OpenSSL', array(131), '7.0'),
 
+            array('create_function', '7.2', '8.0', 'an anonymous function', array(146), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -166,21 +166,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('ociwritetemporarylob', '5.4', 'OCI-Lob::writeTemporary()', array(89), '5.3'),
 
             array('__autoload', '7.2', 'SPL autoload', array(589), '7.1'),
-            array('mbregex_encoding', '7.3', 'mb_regex_encoding()', array(153), '7.2'),
-            array('mbereg', '7.3', 'mb_ereg()', array(154), '7.2'),
-            array('mberegi', '7.3', 'mb_eregi()', array(155), '7.2'),
-            array('mbereg_replace', '7.3', 'mb_ereg_replace()', array(156), '7.2'),
-            array('mberegi_replace', '7.3', 'mb_eregi_replace()', array(157), '7.2'),
-            array('mbsplit', '7.3', 'mb_split()', array(158), '7.2'),
-            array('mbereg_match', '7.3', 'mb_ereg_match()', array(159), '7.2'),
-            array('mbereg_search', '7.3', 'mb_ereg_search()', array(160), '7.2'),
-            array('mbereg_search_pos', '7.3', 'mb_ereg_search_pos()', array(161), '7.2'),
-            array('mbereg_search_regs', '7.3', 'mb_ereg_search_regs()', array(162), '7.2'),
-            array('mbereg_search_init', '7.3', 'mb_ereg_search_init()', array(163), '7.2'),
-            array('mbereg_search_getregs', '7.3', 'mb_ereg_search_getregs()', array(164), '7.2'),
-            array('mbereg_search_getpos', '7.3', 'mb_ereg_search_getpos()', array(165), '7.2'),
-            array('mbereg_search_setpos', '7.3', 'mb_ereg_search_setpos()', array(166), '7.2'),
-
             array('convert_cyr_string', '7.4', 'mb_convert_encoding(), iconv() or UConverter', array(243), '7.3'),
             array('is_real', '7.4', 'is_float()', array(239), '7.3'),
             array('money_format', '7.4', 'NumberFormatter::formatCurrency()', array(244), '7.3'),
@@ -1433,6 +1418,20 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('gmp_random', '7.2', '8.0', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
 
             array('image2wbmp', '7.3', '8.0', 'imagewbmp()', array(152), '7.2'),
+            array('mbregex_encoding', '7.3', '8.0', 'mb_regex_encoding()', array(153), '7.2'),
+            array('mbereg', '7.3', '8.0', 'mb_ereg()', array(154), '7.2'),
+            array('mberegi', '7.3', '8.0', 'mb_eregi()', array(155), '7.2'),
+            array('mbereg_replace', '7.3', '8.0', 'mb_ereg_replace()', array(156), '7.2'),
+            array('mberegi_replace', '7.3', '8.0', 'mb_eregi_replace()', array(157), '7.2'),
+            array('mbsplit', '7.3', '8.0', 'mb_split()', array(158), '7.2'),
+            array('mbereg_match', '7.3', '8.0', 'mb_ereg_match()', array(159), '7.2'),
+            array('mbereg_search', '7.3', '8.0', 'mb_ereg_search()', array(160), '7.2'),
+            array('mbereg_search_pos', '7.3', '8.0', 'mb_ereg_search_pos()', array(161), '7.2'),
+            array('mbereg_search_regs', '7.3', '8.0', 'mb_ereg_search_regs()', array(162), '7.2'),
+            array('mbereg_search_init', '7.3', '8.0', 'mb_ereg_search_init()', array(163), '7.2'),
+            array('mbereg_search_getregs', '7.3', '8.0', 'mb_ereg_search_getregs()', array(164), '7.2'),
+            array('mbereg_search_getpos', '7.3', '8.0', 'mb_ereg_search_getpos()', array(165), '7.2'),
+            array('mbereg_search_setpos', '7.3', '8.0', 'mb_ereg_search_setpos()', array(166), '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -169,7 +169,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('jpeg2wbmp', '7.2', 'imagecreatefromjpeg() and imagewbmp()', array(144), '7.1'),
             array('png2wbmp', '7.2', 'imagecreatefrompng() or imagewbmp()', array(145), '7.1'),
             array('__autoload', '7.2', 'SPL autoload', array(589), '7.1'),
-            array('each', '7.2', 'a foreach loop', array(147), '7.1'),
             array('gmp_random', '7.2', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
             array('read_exif_data', '7.2', 'exif_read_data()', array(149), '7.1'),
 
@@ -1433,6 +1432,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('mdecrypt_generic', '7.1', '7.2', 'OpenSSL', array(131), '7.0'),
 
             array('create_function', '7.2', '8.0', 'an anonymous function', array(146), '7.1'),
+            array('each', '7.2', '8.0', 'a foreach loop or ArrayIterator', array(147), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -66,7 +66,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
         return array(
             array('dl', '5.3', array(6), '5.2'),
             array('ocifetchinto', '5.4', array(63), '5.3'),
-            array('hebrevc', '7.4', array(242), '7.3'),
         );
     }
 
@@ -1294,6 +1293,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('ezmlm_hash', '7.4', '8.0', array(245), '7.3'),
             array('get_magic_quotes_gpc', '7.4', '8.0', array(240), '7.3'),
             array('get_magic_quotes_runtime', '7.4', '8.0', array(241), '7.3'),
+            array('hebrevc', '7.4', '8.0', array(242), '7.3'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -161,7 +161,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
 
             array('__autoload', '7.2', 'SPL autoload', array(589), '7.1'),
             array('is_real', '7.4', 'is_float()', array(239), '7.3'),
-            array('money_format', '7.4', 'NumberFormatter::formatCurrency()', array(244), '7.3'),
             array('restore_include_path', '7.4', "ini_restore('include_path')", array(246), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
@@ -1433,6 +1432,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('mbereg_search_setpos', '7.3', '8.0', 'mb_ereg_search_setpos()', array(166), '7.2'),
 
             array('convert_cyr_string', '7.4', '8.0', 'mb_convert_encoding(), iconv() or UConverter', array(243), '7.3'),
+            array('money_format', '7.4', '8.0', 'NumberFormatter::formatCurrency()', array(244), '7.3'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -66,7 +66,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
         return array(
             array('dl', '5.3', array(6), '5.2'),
             array('ocifetchinto', '5.4', array(63), '5.3'),
-            array('ldap_sort', '7.0', array(97), '5.6'),
             array('fgetss', '7.3', array(167), '7.2'),
             array('gzgetss', '7.3', array(168), '7.2'),
             array('ezmlm_hash', '7.4', array(245), '7.3'),
@@ -1310,6 +1309,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('mysql_dbname', '5.5', '7.0', array(983), '5.4'),
             array('mysql_table_name', '5.5', '7.0', array(984), '5.4'),
 
+            array('ldap_sort', '7.0', '8.0', array(97), '5.6'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -66,7 +66,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
         return array(
             array('dl', '5.3', array(6), '5.2'),
             array('ocifetchinto', '5.4', array(63), '5.3'),
-            array('ezmlm_hash', '7.4', array(245), '7.3'),
             array('get_magic_quotes_gpc', '7.4', array(240), '7.3'),
             array('get_magic_quotes_runtime', '7.4', array(241), '7.3'),
             array('hebrevc', '7.4', array(242), '7.3'),
@@ -1294,6 +1293,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('ldap_sort', '7.0', '8.0', array(97), '5.6'),
             array('fgetss', '7.3', '8.0', array(167), '7.2'),
             array('gzgetss', '7.3', '8.0', array(168), '7.2'),
+            array('ezmlm_hash', '7.4', '8.0', array(245), '7.3'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -167,8 +167,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('ociwritetemporarylob', '5.4', 'OCI-Lob::writeTemporary()', array(89), '5.3'),
 
             array('__autoload', '7.2', 'SPL autoload', array(589), '7.1'),
-            array('gmp_random', '7.2', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
-
             array('mbregex_encoding', '7.3', 'mb_regex_encoding()', array(153), '7.2'),
             array('mbereg', '7.3', 'mb_ereg()', array(154), '7.2'),
             array('mberegi', '7.3', 'mb_eregi()', array(155), '7.2'),
@@ -1432,6 +1430,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('read_exif_data', '7.2', '8.0', 'exif_read_data()', array(149), '7.1'),
             array('jpeg2wbmp', '7.2', '8.0', 'imagecreatefromjpeg() and imagewbmp()', array(144), '7.1'),
             array('png2wbmp', '7.2', '8.0', 'imagecreatefrompng() or imagewbmp()', array(145), '7.1'),
+            array('gmp_random', '7.2', '8.0', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
 
             array('image2wbmp', '7.3', '8.0', 'imagewbmp()', array(152), '7.2'),
         );

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -166,12 +166,9 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('ociwritelobtofile', '5.4', 'OCI-Lob::export()', array(88), '5.3'),
             array('ociwritetemporarylob', '5.4', 'OCI-Lob::writeTemporary()', array(89), '5.3'),
 
-            array('jpeg2wbmp', '7.2', 'imagecreatefromjpeg() and imagewbmp()', array(144), '7.1'),
-            array('png2wbmp', '7.2', 'imagecreatefrompng() or imagewbmp()', array(145), '7.1'),
             array('__autoload', '7.2', 'SPL autoload', array(589), '7.1'),
             array('gmp_random', '7.2', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
 
-            array('image2wbmp', '7.3', 'imagewbmp()', array(152), '7.2'),
             array('mbregex_encoding', '7.3', 'mb_regex_encoding()', array(153), '7.2'),
             array('mbereg', '7.3', 'mb_ereg()', array(154), '7.2'),
             array('mberegi', '7.3', 'mb_eregi()', array(155), '7.2'),
@@ -1433,6 +1430,10 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('create_function', '7.2', '8.0', 'an anonymous function', array(146), '7.1'),
             array('each', '7.2', '8.0', 'a foreach loop or ArrayIterator', array(147), '7.1'),
             array('read_exif_data', '7.2', '8.0', 'exif_read_data()', array(149), '7.1'),
+            array('jpeg2wbmp', '7.2', '8.0', 'imagecreatefromjpeg() and imagewbmp()', array(144), '7.1'),
+            array('png2wbmp', '7.2', '8.0', 'imagecreatefrompng() or imagewbmp()', array(145), '7.1'),
+
+            array('image2wbmp', '7.3', '8.0', 'imagewbmp()', array(152), '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -170,7 +170,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             array('png2wbmp', '7.2', 'imagecreatefrompng() or imagewbmp()', array(145), '7.1'),
             array('__autoload', '7.2', 'SPL autoload', array(589), '7.1'),
             array('gmp_random', '7.2', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
-            array('read_exif_data', '7.2', 'exif_read_data()', array(149), '7.1'),
 
             array('image2wbmp', '7.3', 'imagewbmp()', array(152), '7.2'),
             array('mbregex_encoding', '7.3', 'mb_regex_encoding()', array(153), '7.2'),
@@ -1433,6 +1432,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
 
             array('create_function', '7.2', '8.0', 'an anonymous function', array(146), '7.1'),
             array('each', '7.2', '8.0', 'a foreach loop or ArrayIterator', array(147), '7.1'),
+            array('read_exif_data', '7.2', '8.0', 'exif_read_data()', array(149), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -161,7 +161,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
 
             array('__autoload', '7.2', 'SPL autoload', array(589), '7.1'),
             array('is_real', '7.4', 'is_float()', array(239), '7.3'),
-            array('restore_include_path', '7.4', "ini_restore('include_path')", array(246), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
             array('ldap_control_paged_result', '7.4', 'ldap_search()', array(235), '7.3'),
         );
@@ -1433,6 +1432,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
 
             array('convert_cyr_string', '7.4', '8.0', 'mb_convert_encoding(), iconv() or UConverter', array(243), '7.3'),
             array('money_format', '7.4', '8.0', 'NumberFormatter::formatCurrency()', array(244), '7.3'),
+            array('restore_include_path', '7.4', '8.0', "ini_restore('include_path')", array(246), '7.3'),
         );
     }
 


### PR DESCRIPTION
The commits in this PR line up with the commits in PHP Core to remove the functions.

Related to #809

## Commit Details

### PHP 8.0: RemovedFunctions - handle removed support for create_function()

> Removed create_function(). Anonymous functions may be used instead.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L38
* https://wiki.php.net/rfc/deprecations_php_7_2
* php/php-src@ee16d99

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctions - handle removed support for each()

> Removed each(). foreach or ArrayIterator should be used instead.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L39
* https://wiki.php.net/rfc/deprecations_php_7_2
* php/php-src@6db97f5

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctions - handle removed support for read_exif_data()

> Removed read_exif_data(). exif_read_data() should be used instead.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L211-L212
* php/php-src@c88e2cc

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctions - handle removed support for three GD functions

> - The deprecated function `image2wbmp()` has been removed.
>    RFC: https://wiki.php.net/rfc/image2wbmp
> - The deprecated functions `png2wbmp()` and `jpeg2wbmp()` have been removed.
>    RFC: https://wiki.php.net/rfc/deprecate-png-jpeg-2wbmp

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L226-L229
* imagewbmp: php/php-src@dfa6c20
* (png|jpeg)2wbmp: php/php-src@e973663
* https://wiki.php.net/rfc/deprecate-png-jpeg-2wbmp

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctions - handle removed support for gmp_random()

> gmp_random() has been removed. One of `gmp_random_range()` or `gmp_random_bits()` should be used instead.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L233-L235
* https://wiki.php.net/rfc/deprecations_php_7_2
* php/php-src@734c305

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctions - handle removed support for ldap_sort()

> The deprecated function ldap_sort has been removed.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L249-L250
* php/php-src@f0ddc93

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctions - handle removed support for MBstring regex function aliases

> A number of deprecated mbregex aliases have been removed. See the following
> list for which functions should be used instead:
>
>      * mbregex_encoding()      -> mb_regex_encoding()
>      * mbereg()                -> mb_ereg()
>      * mberegi()               -> mb_eregi()
>      * mbereg_replace()        -> mb_ereg_replace()
>      * mberegi_replace()       -> mb_eregi_replace()
>      * mbsplit()               -> mb_split()
>      * mbereg_match()          -> mb_ereg_match()
>      * mbereg_search()         -> mb_ereg_search()
>      * mbereg_search_pos()     -> mb_ereg_search_pos()
>      * mbereg_search_regs()    -> mb_ereg_search_regs()
>      * mbereg_search_init()    -> mb_ereg_search_init()
>      * mbereg_search_getregs() -> mb_ereg_search_getregs()
>      * mbereg_search_getpos()  -> mb_ereg_search_getpos()
>      * mbereg_search_setpos() -> mb_ereg_search_setpos()

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L258-L274
* https://wiki.php.net/rfc/deprecations_php_7_3
* php/php-src@83bc092

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctions - handle removed support for fgetss(), gzgetss()

> - fgetss() has been removed.
> - gzgetss() has been removed.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L404
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L512
* https://wiki.php.net/rfc/deprecations_php_7_3
* php/php-src@c7d7af8

Includes adjusted unit tests.

### PHP 8.0: RemovedFunctions - handle removed support for convert_cyr_string()

> convert_cyr_string() has been removed.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L428
* php/php-src@64468d1

Includes adjusted unit test.

### PHP 8.0: RemovedFunctions - handle removed support for ezmlm_hash()

> ezmlm_hash() has been removed.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L430
* php/php-src@6339260

Includes adjusted unit test.

### PHP 8.0: RemovedFunctions - handle removed support for get_magic_quotes_gpc[_runtime]()

> get_magic_quotes_gpc() and get_magic_quotes_gpc_runtime() has been removed.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L432
* php/php-src@29ef077

Includes adjusted unit test.

### PHP 8.0: RemovedFunctions - handle removed support for hebrevc()

> hebrevc() has been removed.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L427
* php/php-src@b63c625

Includes adjusted unit test.

### PHP 8.0: RemovedFunctions - handle removed support for money_format()

> money_format() has been removed.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L429
* php/php-src@144b41c

Includes adjusted unit test.

### PHP 8.0: RemovedFunctions - handle removed support for restore_include_path()

> restore_include_path() has been removed.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L431
* php/php-src@c231bbb

Includes adjusted unit test.
