### PR TITLE
PHP 8.0: Handle removed `track_errors` and `$php_errormsg`

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -514,6 +514,7 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         ),
         'track_errors' => array(
             '7.2' => false,
+            '8.0' => true,
         ),
         'opcache.fast_shutdown' => array(
             '7.2' => true,

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -93,6 +93,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
         'php_errormsg' => array(
             '7.2' => false,
+            '8.0' => true,
             'alternative' => 'error_get_last()',
         ),
     );

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -97,6 +97,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             array('mcrypt.modes_dir', '7.1', '7.2', array(138, 139), '7.0'),
 
             array('opcache.inherited_hack', '5.3', '7.3', array(181, 182), '5.2'),
+
+            array('track_errors', '7.2', '8.0', array(172, 173), '7.1'),
         );
     }
 
@@ -150,7 +152,6 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             array('mbstring.internal_encoding', '5.6', array(77, 78), '5.5'),
 
             array('mbstring.func_overload', '7.2', array(166, 167), '7.1'),
-            array('track_errors', '7.2', array(172, 173), '7.1'),
 
             array('pdo_odbc.db2_instance_name', '7.3', array(184, 185), '7.2'),
 

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -85,15 +85,15 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
 
 
     /**
-     * testDeprecatedPHPErrorMsg
+     * testDeprecatedRemovedPHPErrorMsg
      *
-     * @dataProvider dataDeprecatedPHPErrorMsg
+     * @dataProvider dataDeprecatedRemovedPHPErrorMsg
      *
      * @param array $line The line number in the test file where a warning is expected.
      *
      * @return void
      */
-    public function testDeprecatedPHPErrorMsg($line)
+    public function testDeprecatedRemovedPHPErrorMsg($line)
     {
         $file = $this->sniffFile(__FILE__, '7.1');
         $this->assertNoViolation($file, $line);
@@ -101,6 +101,10 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
         $file  = $this->sniffFile(__FILE__, '7.2');
         $error = 'The variable \'$php_errormsg\' is deprecated since PHP 7.2; Use error_get_last() instead';
         $this->assertWarning($file, $line, $error);
+
+        $file  = $this->sniffFile(__FILE__, '8.0');
+        $error = 'The variable \'$php_errormsg\' is deprecated since PHP 7.2 and removed since PHP 8.0; Use error_get_last() instead';
+        $this->assertError($file, $line, $error);
     }
 
     /**
@@ -110,7 +114,7 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
      *
      * @return array
      */
-    public function dataDeprecatedPHPErrorMsg()
+    public function dataDeprecatedRemovedPHPErrorMsg()
     {
         return array(
             array(101),


### PR DESCRIPTION
> Removed `track_errors` ini directive. This means that `$php_errormsg` is no
longer available. The `error_get_last()` function may be used instead.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L28-L29
* https://github.com/php/php-src/commit/920b4b249f71e6cbfd795f81c6a08126a33c659e

Includes adjusted unit tests.

Related to #809