### PR TITLE
NewStripTagsAllowableTagsArray: use PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer_Tokens as Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -37,21 +38,6 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
      */
     protected $targetFunctions = array(
         'strip_tags' => true,
-    );
-
-    /**
-     * Text string tokens to examine.
-     *
-     * @since 9.3.0
-     *
-     * @var array
-     */
-    private $textStringTokens = array(
-        \T_CONSTANT_ENCAPSED_STRING => true,
-        \T_DOUBLE_QUOTED_STRING     => true,
-        \T_INLINE_HTML              => true,
-        \T_HEREDOC                  => true,
-        \T_NOWDOC                   => true,
     );
 
 
@@ -112,7 +98,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
         }
 
         if ($this->supportsAbove('7.4') === true) {
-            if (strpos($targetParam['raw'], '>') === false) {
+            if (strpos($targetParam['clean'], '>') === false) {
                 // Efficiency: prevent needlessly walking the array.
                 return;
             }
@@ -132,7 +118,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
                         break;
                     }
 
-                    if (isset($this->textStringTokens[$tokens[$i]['code']]) === true
+                    if (isset(BCTokens::textStringTokens()[$tokens[$i]['code']]) === true
                         && strpos($tokens[$i]['content'], '>') !== false
                     ) {
 
@@ -140,7 +126,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
                             'When passing strip_tags() the $allowable_tags parameter as an array, the tags should not be enclosed in <> brackets. Found: %s',
                             $i,
                             'Invalid',
-                            array($item['raw'])
+                            array($item['clean'])
                         );
 
                         // Only throw one error per array item.

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.inc
@@ -32,3 +32,11 @@ $str = strip_tags(
 // Prevent false positive.
 $str = strip_tags($input, ['br', ...function_call('<a>,<p>')]); // PHP 7.4 syntax: unpacking within an array.
 $str = strip_tags($input, []);
+
+$str = strip_tags(
+    $input,
+    array(
+        'a', // <a href=...>
+        'p', // <p> 
+    ),
+);

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
@@ -124,6 +124,12 @@ class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTest
         return array(
             array(33),
             array(34),
+            array(36),
+            array(37),
+            array(38),
+            array(39),
+            array(40),
+            array(41),
         );
     }
 


### PR DESCRIPTION
1. Use `BCTokens::textStringTokens()`

This is a property which was introduced in PHPCS 2.9.0, so is not available to us natively, but PHPCSUtils backfills it.

2. Improve comment tolerance

The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

This allows for more reliable and faster results for the sniff.

Includes unit test.