### PR TITLE
PHP 8.0: NewTrailingComma: add check for trailing comma in closure use lists

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.inc
@@ -10,8 +10,8 @@ function Foo7(
     return $foo + $bar;
 }
 
-$closure = function ($foo, $bar) {
-    return $foo + $bar;
+$closure = function ($foo, $bar) use ($baz, $booboo) {
+    return ($foo + $bar) * $baz / $booboo;
 };
 
 $arrow = fn($foo, $bar) => $foo + $bar;
@@ -63,11 +63,32 @@ class LotsOfParams8 {
 }
 
 /*
+ * PHP 8.0 trailing comma's in closure use lists.
+ */
+$closure = function ($foo, $bar) use ($baz, $booboo,) {
+    return ($foo + $bar) * $baz / $booboo;
+};
+
+$longArgs_longVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument,
+) use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3,
+) {
+   // body
+};
+
+/*
  * Still not allowed.
  */
 
 // Free-standing comma.
 $c = function(,) {}; // Parse error, but throw an error anyway.
+
+$c = function($foo) use(,) {}; // Parse error, but throw an error anyway.
 
 // Multiple trailing comma's.
 $a = fn($foo, $bar,,) => $bar; // Parse error, but throw an error anyway.

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
@@ -54,8 +54,41 @@ class NewTrailingCommaUnitTest extends BaseSniffTest
             array(44),
             array(48),
             array(59),
-            array(70),
-            array(73),
+            array(75),
+            array(89),
+            array(94),
+        );
+    }
+
+
+    /**
+     * Test correctly identifying trailing comma's in closure use lists.
+     *
+     * @dataProvider dataTrailingCommaClosureUse
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testTrailingCommaClosureUse($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, "Trailing comma's are not allowed in closure use lists in PHP 7.4 or earlier");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testTrailingCommaClosureUse()
+     *
+     * @return array
+     */
+    public function dataTrailingCommaClosureUse()
+    {
+        return array(
+            array(68),
+            array(79),
+            array(91),
         );
     }
 
@@ -90,8 +123,8 @@ class NewTrailingCommaUnitTest extends BaseSniffTest
             $data[] = array($line);
         }
 
-        $data[] = array(76);
-        $data[] = array(80);
+        $data[] = array(97);
+        $data[] = array(101);
 
         return $data;
     }


### PR DESCRIPTION
PHP 8.0 introduced trailing comma's in function declaration parameter lists. A sniff to detect these was added via PR #1164.

Since then, a new RFC has been voted on & accepted, to also allow trailing comma's in closure use lists.

This adds an additional check to the `PHPCompatibility.FunctionDeclarations.NewTrailingComma` sniff to detect trailing comma's in closure `use` lists.

Note: the error code for the original error message has been changed from `Found` to `InParameterList`, but as this sniff was only introduced recently and has not been released yet, this is not an BC-break.

Refs:
* https://wiki.php.net/rfc/trailing_comma_in_closure_use_list
* https://github.com/php/php-src/pull/5793

Related to #809