### PR TITLE
PHP 8.0: NewIniDirectives: account for configurable string length in getTraceAsString()

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -855,6 +855,11 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '7.3' => false,
             '7.4' => true,
         ),
+
+        'zend.exception_string_param_max_len' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
     );
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -526,3 +526,6 @@ $test = ini_get('oci8.statement_cache_size');
 
 ini_set('sqlite3.defensive', 1);
 $test = ini_get('sqlite3.defensive');
+
+ini_set('zend.exception_string_param_max_len', 30);
+$test = ini_get('zend.exception_string_param_max_len');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -261,6 +261,8 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('opcache.preload', '7.4', array(455, 456), '7.3'),
             array('opcache.preload_user', '7.4', array(464, 465), '7.3'),
             array('zend.exception_ignore_args', '7.4', array(338, 339), '7.3'),
+
+            array('zend.exception_string_param_max_len', '8.0', array(530, 531), '7.4'),
         );
     }
 


### PR DESCRIPTION
> - zend.exception_string_param_max_len
>   . New INI directive to set the maximum string length in an argument of a
>   stringified stack strace.

Refs:
* https://wiki.php.net/rfc/throwable_string_param_max_len
* https://github.com/php/php-src/blob/47e4001976f3ff85a6d479df39dc82d4ceb18b19/UPGRADING#L957-L959
* https://github.com/php/php-src/pull/5769
* https://github.com/php/php-src/commit/07db64156e180c30daa5ab5d41ed72f9bba77e6d

Includes unit tests.

Related to #809