### PR TITLE
CI: use Parallel-Lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ jobs:
     - stage: coverage
       php: 7.4
       env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="^2.0" CUSTOM_INI=1
-    - php: 7.3
+    - php: 7.2
       env: PHPCS_VERSION="2.6.0" COVERALLS_VERSION="^2.0"
     # PHP 7.3+ is only fully supported icw PHPCS 2.9.2 and 3.3.1+.
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -216,10 +216,7 @@ before_script:
 
 script:
   # Lint all PHP files against parse errors.
-  - |
-    if [[ "$LINT" == "1" ]]; then
-      if find -L . -path ./vendor -prune -o -path ./PHPCompatibility/Tests/Keywords/ForbiddenNames -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi
-    fi
+  - if [[ "$LINT" == "1" ]]; then composer lint; fi
 
   # Run the unit tests.
   - |

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,8 @@
     "phpcsstandards/phpcsutils" : "^1.0 || dev-develop"
   },
   "require-dev" : {
+    "php-parallel-lint/php-parallel-lint": "^1.2.0",
+    "php-parallel-lint/php-console-highlighter": "^0.5",
     "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
     "phpcsstandards/phpcsdevtools": "^1.0"
   },
@@ -50,6 +52,9 @@
     ],
     "coverage-local": [
       "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/logs"
+    ],
+    "lint": [
+      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --exclude PHPCompatibility/Tests/Keywords/ForbiddenNames"
     ],
     "check-complete": [
       "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./PHPCompatibility"


### PR DESCRIPTION
... for faster linting and more informative results.

This was previously pulled as PR #972 and closed as we weren't doing a full Composer install on each build, but as #1189 changed that, it now is viable.

Refs:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint
* https://github.com/php-parallel-lint/PHP-Console-Highlighter