### PR TITLE
NewMagicClassConstant: bug fix - work around a tokenizer issue

### DIFF
--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -46,7 +46,16 @@ class NewMagicClassConstantSniff extends Sniff
      */
     public function register()
     {
-        return array(\T_STRING);
+        /*
+         * In PHPCS < 3.4.1, the class keyword after a double colon + comment may be tokenized as
+         * `T_CLASS` instead of as `T_STRING`, so registering both.
+         *
+         * @link https://github.com/squizlabs/php_codesniffer/issues/2431
+         */
+        return array(
+            \T_STRING,
+            \T_CLASS,
+        );
     }
 
     /**

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.inc
@@ -9,7 +9,7 @@ namespace foo {
 namespace MyNameSpace {
     class xyz {}
 
-    remove_filter('theme_filter', [\MyNameSpace\xyz::class, 'methodName'], 30);
+    remove_filter('theme_filter', [\MyNameSpace\xyz:: /* comment */ class, 'methodName'], 30);
 }
 
 /*


### PR DESCRIPTION
As noted inline:
> In PHPCS < 3.4.1, the class keyword after a double colon + comment may be tokenized as
> `T_CLASS` instead of as `T_STRING`, so registering both.

Adjusted an existing unit test to safeguard this change.

Upstream issue about the tokenizer problem:
* https://github.com/squizlabs/php_codesniffer/issues/2431