### PR TITLE
PHP 8.0: NewIniDirectives: account for new FPM ini

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -856,6 +856,10 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '7.4' => true,
         ),
 
+        'pm.status_listen' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'zend.exception_string_param_max_len' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -529,3 +529,6 @@ $test = ini_get('sqlite3.defensive');
 
 ini_set('zend.exception_string_param_max_len', 30);
 $test = ini_get('zend.exception_string_param_max_len');
+
+ini_set('pm.status_listen', '127.0.0.1:9001');
+$test = ini_get('pm.status_listen');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -262,6 +262,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             array('opcache.preload_user', '7.4', array(464, 465), '7.3'),
             array('zend.exception_ignore_args', '7.4', array(338, 339), '7.3'),
 
+            array('pm.status_listen', '8.0', array(533, 534), '7.4'),
             array('zend.exception_string_param_max_len', '8.0', array(530, 531), '7.4'),
         );
     }


### PR DESCRIPTION
> - FPM:
>    Added a new option pm.status_listen that allows getting status from
>    different endpoint (e.g. port or UDS file) which is useful for getting
>    status when all children are busy with serving long running requests.

Refs:
* https://github.com/php/php-src/blob/71bfa5344ab207072f4cd25745d7023096338385/UPGRADING#L714-L717
* https://github.com/php/php-src/commit/44c7128fb726696a7c23ff694d1077cf0cf435d4

Includes unit tests.

Related to #809