### PR TITLE
PHP 8.0: NewFunctions: handle 11 new functions

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4476,6 +4476,14 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.4' => false,
             '8.0' => true,
         ),
+        'str_ends_with' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
+        'str_starts_with' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'openssl_cms_encrypt' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4460,6 +4460,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.4' => false,
             '8.0' => true,
         ),
+        'get_debug_type' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'openssl_cms_encrypt' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4464,6 +4464,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.4' => false,
             '8.0' => true,
         ),
+        'get_resource_id' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'openssl_cms_encrypt' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4456,6 +4456,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.4' => true,
         ),
 
+        'fdiv' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'openssl_cms_encrypt' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4488,6 +4488,14 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.4' => false,
             '8.0' => true,
         ),
+        'enchant_dict_add' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
+        'enchant_dict_is_added' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'openssl_cms_encrypt' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4468,6 +4468,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.4' => false,
             '8.0' => true,
         ),
+        'preg_last_error_msg' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'openssl_cms_encrypt' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4484,6 +4484,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.4' => false,
             '8.0' => true,
         ),
+        'imagegetinterpolation' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'openssl_cms_encrypt' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4496,6 +4496,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.4' => false,
             '8.0' => true,
         ),
+        'ldap_count_references' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'openssl_cms_encrypt' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4472,6 +4472,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.4' => false,
             '8.0' => true,
         ),
+        'str_contains' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'openssl_cms_encrypt' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -994,3 +994,5 @@ str_contains();
 str_ends_with();
 str_starts_with();
 imagegetinterpolation();
+enchant_dict_add();
+enchant_dict_is_added();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -987,3 +987,4 @@ openssl_cms_read();
 openssl_cms_sign();
 openssl_cms_verify();
 fdiv();
+get_debug_type();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -990,3 +990,4 @@ fdiv();
 get_debug_type();
 get_resource_id();
 preg_last_error_msg();
+str_contains();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -986,3 +986,4 @@ openssl_cms_decrypt();
 openssl_cms_read();
 openssl_cms_sign();
 openssl_cms_verify();
+fdiv();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -991,3 +991,5 @@ get_debug_type();
 get_resource_id();
 preg_last_error_msg();
 str_contains();
+str_ends_with();
+str_starts_with();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -989,3 +989,4 @@ openssl_cms_verify();
 fdiv();
 get_debug_type();
 get_resource_id();
+preg_last_error_msg();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -996,3 +996,4 @@ str_starts_with();
 imagegetinterpolation();
 enchant_dict_add();
 enchant_dict_is_added();
+ldap_count_references();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -993,3 +993,4 @@ preg_last_error_msg();
 str_contains();
 str_ends_with();
 str_starts_with();
+imagegetinterpolation();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -988,3 +988,4 @@ openssl_cms_sign();
 openssl_cms_verify();
 fdiv();
 get_debug_type();
+get_resource_id();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1047,6 +1047,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('imagecreatefromtga', '7.3', array(487), '7.4'),
 
             array('fdiv', '7.4', array(989), '8.0'),
+            array('get_debug_type', '7.4', array(990), '8.0'),
             array('openssl_cms_encrypt', '7.4', array(984), '8.0'),
             array('openssl_cms_decrypt', '7.4', array(985), '8.0'),
             array('openssl_cms_read', '7.4', array(986), '8.0'),

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1048,6 +1048,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
 
             array('fdiv', '7.4', array(989), '8.0'),
             array('get_debug_type', '7.4', array(990), '8.0'),
+            array('get_resource_id', '7.4', array(991), '8.0'),
             array('openssl_cms_encrypt', '7.4', array(984), '8.0'),
             array('openssl_cms_decrypt', '7.4', array(985), '8.0'),
             array('openssl_cms_read', '7.4', array(986), '8.0'),

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1049,6 +1049,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('fdiv', '7.4', array(989), '8.0'),
             array('get_debug_type', '7.4', array(990), '8.0'),
             array('get_resource_id', '7.4', array(991), '8.0'),
+            array('preg_last_error_msg', '7.4', array(992), '8.0'),
             array('openssl_cms_encrypt', '7.4', array(984), '8.0'),
             array('openssl_cms_decrypt', '7.4', array(985), '8.0'),
             array('openssl_cms_read', '7.4', array(986), '8.0'),

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1054,6 +1054,8 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('str_ends_with', '7.4', array(994), '8.0'),
             array('str_starts_with', '7.4', array(995), '8.0'),
             array('imagegetinterpolation', '7.4', array(996), '8.0'),
+            array('enchant_dict_add', '7.4', array(997), '8.0'),
+            array('enchant_dict_is_added', '7.4', array(998), '8.0'),
             array('openssl_cms_encrypt', '7.4', array(984), '8.0'),
             array('openssl_cms_decrypt', '7.4', array(985), '8.0'),
             array('openssl_cms_read', '7.4', array(986), '8.0'),

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1050,6 +1050,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('get_debug_type', '7.4', array(990), '8.0'),
             array('get_resource_id', '7.4', array(991), '8.0'),
             array('preg_last_error_msg', '7.4', array(992), '8.0'),
+            array('str_contains', '7.4', array(993), '8.0'),
             array('openssl_cms_encrypt', '7.4', array(984), '8.0'),
             array('openssl_cms_decrypt', '7.4', array(985), '8.0'),
             array('openssl_cms_read', '7.4', array(986), '8.0'),

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1051,6 +1051,8 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('get_resource_id', '7.4', array(991), '8.0'),
             array('preg_last_error_msg', '7.4', array(992), '8.0'),
             array('str_contains', '7.4', array(993), '8.0'),
+            array('str_ends_with', '7.4', array(994), '8.0'),
+            array('str_starts_with', '7.4', array(995), '8.0'),
             array('openssl_cms_encrypt', '7.4', array(984), '8.0'),
             array('openssl_cms_decrypt', '7.4', array(985), '8.0'),
             array('openssl_cms_read', '7.4', array(986), '8.0'),

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1046,6 +1046,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('password_algos', '7.3', array(486), '7.4'),
             array('imagecreatefromtga', '7.3', array(487), '7.4'),
 
+            array('fdiv', '7.4', array(989), '8.0'),
             array('openssl_cms_encrypt', '7.4', array(984), '8.0'),
             array('openssl_cms_decrypt', '7.4', array(985), '8.0'),
             array('openssl_cms_read', '7.4', array(986), '8.0'),

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1056,6 +1056,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('imagegetinterpolation', '7.4', array(996), '8.0'),
             array('enchant_dict_add', '7.4', array(997), '8.0'),
             array('enchant_dict_is_added', '7.4', array(998), '8.0'),
+            array('ldap_count_references', '7.4', array(999), '8.0'),
             array('openssl_cms_encrypt', '7.4', array(984), '8.0'),
             array('openssl_cms_decrypt', '7.4', array(985), '8.0'),
             array('openssl_cms_read', '7.4', array(986), '8.0'),

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1053,6 +1053,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
             array('str_contains', '7.4', array(993), '8.0'),
             array('str_ends_with', '7.4', array(994), '8.0'),
             array('str_starts_with', '7.4', array(995), '8.0'),
+            array('imagegetinterpolation', '7.4', array(996), '8.0'),
             array('openssl_cms_encrypt', '7.4', array(984), '8.0'),
             array('openssl_cms_decrypt', '7.4', array(985), '8.0'),
             array('openssl_cms_read', '7.4', array(986), '8.0'),


### PR DESCRIPTION
The commits in this PR line up with the commits in PHP Core to add the functions.

Related to #809

---

### PHP 8.0: NewFunctions: account for new fdiv() function

> Added fdiv() function, which performs a floating-point division under
> IEEE 754 semantics. Division by zero is considered well-defined and
> will return one of Inf, -Inf or NaN.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L570-L572
* php/php-src@e35bdb4

### PHP 8.0: NewFunctions: account for new get_debug_type() function

> Added get_debug_type() function, which returns a type useful for error
> messages. Unlike gettype(), it uses canonical type names, returns class
> names for objects, and indicates the resource type for resources.
> RFC: https://wiki.php.net/rfc/get_debug_type

Refs:
* https://wiki.php.net/rfc/get_debug_type
* php/php-src@ef0e447

### PHP 8.0: NewFunctions: account for new get_resource_id() function

> Added get_resource_id($resource) function, which returns the same value as
(int) $resource. It provides the same functionality under a clearer API.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L719-L720
* php/php-src#5427
* php/php-src@a0abc26

### PHP 8.0: NewFunctions: account for new preg_last_error_msg() function

> Added preg_last_error_msg(), which returns a human-readable message for
> the last PCRE error. It complements preg_last_error(), which returns an
> integer enum instead.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L556-L558
* php/php-src@aa79a22
* php/php-src@03bd433

### PHP 8.0: NewFunctions: account for new str_contains() function

> Added str_contains($haystack, $needle) function, which checks whether
> $haystack contains $needle as a sub-string. It is equivalent to writing
> strpos($haystack, $needle) !== false.

Refs:
* https://wiki.php.net/rfc/str_contains
* php/php-src@1668ad7

### PHP 8.0: NewFunctions: account for str_starts_with() and str_ends_with() functions

> `str_starts_with()` checks if a string begins with another string and returns a boolean value (true/false) whether it does.
> `str_ends_with()` checks if a string ends with another string and returns a boolean value (true/false) whether it does.

Refs:
* https://wiki.php.net/rfc/add_str_starts_with_and_ends_with_functions
* php/php-src#5300
* php/php-src@31fb6a0

### PHP 8.0: NewFunctions: account for imagegetinterpolation() function

> The function imagegetinterpolation() to get the current interpolation method
> has been added.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L615-L616
* php/php-src@03bd433

### PHP 8.0: NewFunctions: account for new Enchant functions

> Add enchant_dict_add and enchant_dict_is_added functions

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/NEWS#L73
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L591-L592

Includes unit test.

### PHP 8.0: NewFunctions: account for new LDAP function

> Added ldap_count_references(), which returns the number of reference
> messages in a search result.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L723-L724
* php/php-src@915abeb

Includes unit test.

