### PR TITLE
PHP 8.0: RemovedIniDirectives: handle three removed/deprecated ini directives

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -508,6 +508,7 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
 
         'mbstring.func_overload' => array(
             '7.2' => false,
+            '8.0' => true,
         ),
         'sql.safe_mode' => array(
             '7.2' => true,

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -530,6 +530,7 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         ),
         'pdo_odbc.db2_instance_name' => array(
             '7.3' => false, // Has been marked as deprecated in the manual from before this time. Now hard-deprecated.
+            '8.0' => true,
         ),
 
         'allow_url_include' => array(

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -576,6 +576,10 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             '7.4'       => true,
             'extension' => 'ibase',
         ),
+
+        'assert.quiet_eval' => array(
+            '8.0' => true,
+        ),
     );
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -423,3 +423,6 @@ $test = ini_get('sybase.min_message_severity');
 
 ini_set('sybase.compatability_mode', 0);
 $test = ini_get('sybase.compatability_mode');
+
+ini_set('assert.quiet_eval', 0);
+$test = ini_get('assert.quiet_eval');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -101,6 +101,7 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             array('opcache.inherited_hack', '5.3', '7.3', array(181, 182), '5.2'),
 
             array('track_errors', '7.2', '8.0', array(172, 173), '7.1'),
+            array('pdo_odbc.db2_instance_name', '7.3', '8.0', array(184, 185), '7.2'),
         );
     }
 
@@ -152,8 +153,6 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             array('mbstring.http_input', '5.6', array(71, 72), '5.5'),
             array('mbstring.http_output', '5.6', array(74, 75), '5.5'),
             array('mbstring.internal_encoding', '5.6', array(77, 78), '5.5'),
-
-            array('pdo_odbc.db2_instance_name', '7.3', array(184, 185), '7.2'),
 
             array('allow_url_include', '7.4', array(238, 239), '7.3'),
         );

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -96,6 +96,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             array('mcrypt.algorithms_dir', '7.1', '7.2', array(135, 136), '7.0'),
             array('mcrypt.modes_dir', '7.1', '7.2', array(138, 139), '7.0'),
 
+            array('mbstring.func_overload', '7.2', '8.0', array(166, 167), '7.1'),
+
             array('opcache.inherited_hack', '5.3', '7.3', array(181, 182), '5.2'),
 
             array('track_errors', '7.2', '8.0', array(172, 173), '7.1'),
@@ -150,8 +152,6 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             array('mbstring.http_input', '5.6', array(71, 72), '5.5'),
             array('mbstring.http_output', '5.6', array(74, 75), '5.5'),
             array('mbstring.internal_encoding', '5.6', array(77, 78), '5.5'),
-
-            array('mbstring.func_overload', '7.2', array(166, 167), '7.1'),
 
             array('pdo_odbc.db2_instance_name', '7.3', array(184, 185), '7.2'),
 

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -252,6 +252,13 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             array('ingres.default_user', '5.1', array(307, 308), '5.0'),
             array('ingres.max_links', '5.1', array(310, 311), '5.0'),
             array('ingres.max_persistent', '5.1', array(313, 314), '5.0'),
+            array('pfpro.defaulthost', '5.1', array(217, 218), '5.0'),
+            array('pfpro.defaultport', '5.1', array(220, 221), '5.0'),
+            array('pfpro.defaulttimeout', '5.1', array(223, 224), '5.0'),
+            array('pfpro.proxyaddress', '5.1', array(226, 227), '5.0'),
+            array('pfpro.proxyport', '5.1', array(229, 230), '5.0'),
+            array('pfpro.proxylogon', '5.1', array(232, 233), '5.0'),
+            array('pfpro.proxypassword', '5.1', array(235, 236), '5.0'),
 
             array('hwapi.allow_persistent', '5.2', array(253, 254), '5.1'),
 
@@ -348,13 +355,7 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             array('ibase.dateformat', '7.4', array(211, 212), '7.3'),
             array('ibase.timeformat', '7.4', array(214, 215), '7.3'),
 
-            array('pfpro.defaulthost', '5.1', array(217, 218), '5.0'),
-            array('pfpro.defaultport', '5.1', array(220, 221), '5.0'),
-            array('pfpro.defaulttimeout', '5.1', array(223, 224), '5.0'),
-            array('pfpro.proxyaddress', '5.1', array(226, 227), '5.0'),
-            array('pfpro.proxyport', '5.1', array(229, 230), '5.0'),
-            array('pfpro.proxylogon', '5.1', array(232, 233), '5.0'),
-            array('pfpro.proxypassword', '5.1', array(235, 236), '5.0'),
+            array('assert.quiet_eval', '8.0', array(427, 428), '7.4'),
         );
     }
 


### PR DESCRIPTION
The commits in this PR line up with the commits in PHP Core to remove the ini directives.

Related to #809

---

### PHP 8.0: RemovedIniDirectives - handle removed support for mbstring.func_overload

> The mbstring.func_overload directive has been removed. The related
>  MB_OVERLOAD_MAIL, MB_OVERLOAD_STRING, and MB_OVERLOAD_REGEX constants have
>  also been removed. Finally, the "func_overload" and "func_overload_list"
>  entries in mb_get_info() have been removed.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L282-L285
* php/php-src@331e56c

Includes unit tests.

### PHP 8.0: RemovedIniDirectives - handle removed support for pdo_odbc.db2_instance_name

> The php.ini directive pdo_odbc.db2_instance_name has been removed

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L342
* php/php-src@fddc751

Includes adjusted unit tests.

### PHP 8.0: RemovedIniDirectives - handle removed support for assert.quiet_eval

> assert() will no longer evaluate string arguments, instead they will be
> treated like any other argument. assert($a == $b) should be used instead of
> assert('$a == $b'). The assert.quiet_eval ini directive and
> ASSERT_QUIET_EVAL constants have also been removed, as they would no longer
> have any effect.

Refs:
* https://github.com/php/php-src/blob/c0172aa2bdb9ea223c8491bdb300995b93a857a0/UPGRADING#L398-L402
* php/php-src@9bc2cac

Includes unit test.

