### PR TITLE
PHP 8.0: New `PHPCompatibility.FunctionDeclarations.RemovedCallingDestructAfterConstructorExit` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * As of PHP 8.0, when an object constructor exit()s, the destructor will no longer be called.
+ *
+ * Note: shutdown functions registered with `register_shutdown_function()` will still be called.
+ *
+ * PHP version 8.0
+ *
+ * @link https://github.com/php/php-src/blob/71bfa5344ab207072f4cd25745d7023096338385/UPGRADING#L200-L201
+ *
+ * @since 10.0.0
+ */
+class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(\T_FUNCTION);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('8.0') === false) {
+            return;
+        }
+
+        if (Scopes::isOOMethod($phpcsFile, $stackPtr) === false) {
+            // Function, not method.
+            return;
+        }
+
+        $name = FunctionDeclarations::getName($phpcsFile, $stackPtr);
+        if (empty($name) === true) {
+            // Parse error or live coding.
+            return;
+        }
+
+        if (strtolower($name) !== '__construct') {
+            // The rule only applies to constructors. Bow out.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
+            // Parse error or live coding.
+            return;
+        }
+
+        $current = $tokens[$stackPtr]['scope_opener'];
+        $end     = $tokens[$stackPtr]['scope_closer'];
+        do {
+            $current = $phpcsFile->findNext(\T_EXIT, ($current + 1), $end);
+            if ($current === false) {
+                // No exit found.
+                return;
+            }
+
+            $phpcsFile->addError(
+                'When %s() is called within an object constructor, the object destructor will no longer be called since PHP 8.0',
+                $current,
+                'Found',
+                [$tokens[$current]['content']]
+            );
+
+        } while (true);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * OK no change in behaviour cross-version.
+ */
+class CrossVersionValid
+{
+    function __construct() {
+        throw new Exception();
+    }
+
+    function __destruct() {
+        // Destructor will not be called on thrown exception in constructor.
+    }
+}
+
+$anon = new class() {
+    function __Construct() {
+        throw new Exception();
+    }
+
+    function __Destruct() {
+        // Destructor will not be called on thrown exception in constructor.
+    }
+};
+
+/*
+ * PHP 8.0: If an object constructor exit()s, the object destructor will no longer be called.
+ */
+class CrossVersionInValid
+{
+    function __construct() {
+        exit(1);
+    }
+
+    function __destruct() {
+        // Destructor will not be called on exit() in constructor.
+    }
+}
+
+$anon = new class() {
+    function __CONSTRUCT() {
+        if ($something) {
+            die();
+        } else {
+            exit(2);
+        }
+    }
+};

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedCallingDestructAfterConstructorExit sniff.
+ *
+ * @group removedCallingDestructAfterConstructorExit
+ * @group functiondeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\RemovedCallingDestructAfterConstructorExitSniff
+ *
+ * @since 10.0.0
+ */
+class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify that the sniff throws an error when an exit/die is encountered in a class constructor for PHP 8.0+.
+     *
+     * @dataProvider dataRemovedCallingDestructAfterConstructorExit
+     *
+     * @param int    $line The line number where an error is expected.
+     * @param string $name The name of the exit type used.
+     *
+     * @return void
+     */
+    public function testRemovedCallingDestructAfterConstructorExit($line, $name)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, "When $name() is called within an object constructor, the object destructor will no longer be called since PHP 8.0");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedCallingDestructAfterConstructorExit()
+     *
+     * @return array
+     */
+    public function dataRemovedCallingDestructAfterConstructorExit()
+    {
+        return array(
+            array(33, 'exit'),
+            array(44, 'die'),
+            array(46, 'exit'),
+        );
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = array();
+        // No errors expected on the first 26 lines.
+        for ($line = 1; $line <= 26; $line++) {
+            $cases[] = array($line);
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> If an object constructor exit()s, the object destructor will no longer be
> called. This matches the behavior when the constructor throws.

Notes:
* This sniff will throw an error, even when there is no destructor as a destructor may be declared in a parent class.
    :point_right: **_We could reduce the potential noise from this sniff a little further by only throwing the error when the class either contains a `__destruct()` method or extends a parent class. Should we ?_**
* The name for the sniff feels a bit long. Suggestions for a better/shorter name welcome.

Opinions ?

Refs:
* https://github.com/php/php-src/blob/71bfa5344ab207072f4cd25745d7023096338385/UPGRADING#L200-L201
* https://github.com/php/php-src/pull/5768 (I suspect, but not 100% sure)
* https://github.com/php/php-src/commit/75a04eac978333467ccd98225d7ef21942ce9e91

Related to #809