### PR TITLE
PHP 8.0: New `PHPCompatibility.FunctionDeclarations.ForbiddenFinalPrivateMethods` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_File as File;
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Applying the final modifier on a private method will produce a warning since PHP 8.0
+ * unless that method is the constructor.
+ *
+ * Previously final private methods were allowed and overriding the method in a child class
+ * would result in a fatal "Cannot override final method". This was inappropriate as
+ * private methods are not inherited.
+ *
+ * > Due to how common the usage of `final private function __construct` is and given that
+ * > the same results cannot be achieved with a protected visibility, an exception to this rule
+ * > is made for constructors.
+ *
+ * PHP version 8.0
+ *
+ * @link https://wiki.php.net/rfc/inheritance_private_methods
+ *
+ * @since 10.0.0
+ */
+class ForbiddenFinalPrivateMethodsSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(\T_FUNCTION);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('8.0') === false) {
+            return;
+        }
+
+        if (Scopes::isOOMethod($phpcsFile, $stackPtr) === false) {
+            // Function, not method.
+            return;
+        }
+
+        $name = FunctionDeclarations::getName($phpcsFile, $stackPtr);
+        if (empty($name) === true) {
+            // Parse error or live coding.
+            return;
+        }
+
+        if (strtolower($name) === '__construct') {
+            // The rule does not apply to constructors. Bow out.
+            return;
+        }
+
+        $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
+        if ($properties['scope'] !== 'private' || $properties['is_final'] === false) {
+            // Not an private final method.
+            return;
+        }
+
+        $phpcsFile->addWarning(
+            'Private methods should not be declared as final since PHP 8.0',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.inc
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * OK cross version.
+ */
+class CrossVersionValid
+{
+    private final function __construct() {}
+    final public function publicFinal() {}
+    final protected static function protectedFinal() {}
+    private function privateNonOverloadable() {}
+}
+
+trait CrossVersionValidTrait
+{
+    final private function __CONSTRUCT() {}
+    final public static function publicFinal() {}
+    final protected function protectedFinal() {}
+    private function privateStillOverloadable() {} // Open question in RFC PR https://github.com/php/php-src/pull/5401
+}
+
+$anon = new class() {
+    final private function __Construct() {}
+    final public static function publicFinal();
+    final protected function protectedFinal();
+    private function privateNonOverloadable() {}
+};
+
+/*
+ * PHP 8.0: private methods cannot be final as they are never overridden by other classes.
+ */
+class CrossVersionInValid
+{
+    final private function privateFinal();
+    static private final function privateStaticFinal();
+}
+
+$anon = new class() {
+    final private function privateFinal();
+    static final private function privateStaticFinal();
+};
+
+trait CrossVersionInValidTrait
+{
+    final private function privateFinal();
+    static private final function privateStaticFinal();
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the ForbiddenFinalPrivateMethods sniff.
+ *
+ * @group forbiddenFinalPrivateMethods
+ * @group functiondeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenFinalPrivateMethodsSniff
+ *
+ * @since 10.0.0
+ */
+class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify that the sniff throws a warning for non-construct final private methods for PHP 8.0+.
+     *
+     * @dataProvider dataForbiddenFinalPrivateMethods
+     *
+     * @param int $line The line number where a warning is expected.
+     *
+     * @return void
+     */
+    public function testForbiddenFinalPrivateMethods($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertWarning($file, $line, 'Private methods should not be declared as final since PHP 8.0');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenFinalPrivateMethods()
+     *
+     * @return array
+     */
+    public function dataForbiddenFinalPrivateMethods()
+    {
+        return array(
+            array(34),
+            array(35),
+            array(39),
+            array(40),
+            array(45),
+            array(46),
+        );
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = array();
+        // No errors expected on the first 28 lines.
+        for ($line = 1; $line <= 28; $line++) {
+            $cases[] = array($line);
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION

> Applying the final modifier on a private method will now produce a warning
> unless that method is the constructor.

Refs:
* https://wiki.php.net/rfc/inheritance_private_methods
* https://github.com/php/php-src/blob/71bfa5344ab207072f4cd25745d7023096338385/UPGRADING#L197-L199
* https://github.com/php/php-src/pull/5401
* https://github.com/php/php-src/commit/272b887b7b8d48bc1615938dde825fe4b3af0eb5

Related to #809