### PR TITLE
NewParamTypeDeclarations: bug fix x 2

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -199,7 +199,7 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
                     && (Conditions::hasCondition($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) === false
                         || ($tokens[$stackPtr]['code'] === \T_FUNCTION
                         && Scopes::isOOMethod($phpcsFile, $stackPtr) === false))
-                    && $this->supportsAbove('5.2') !== false
+                    && $this->supportsBelow('5.1') === false
                 ) {
                     $phpcsFile->addError(
                         "'%s' type cannot be used outside of class scope",

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -177,6 +177,7 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
 
             // Strip off potential nullable indication.
             $typeHint = ltrim($param['type_hint'], '?');
+            $typeHint = strtolower($typeHint);
 
             if ($supportsPHP4 === true) {
                 $phpcsFile->addError(

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -2,13 +2,13 @@
 
 // Array type declaration - PHP 5.1+
 function foo(array $a) {}
-function foo( array   $a ) {} // Test extra spacing.
+function foo( Array   $a ) {} // Test extra spacing.
 
 // Callable type declaration - PHP 5.4+
 function foo(callable $a) {}
 
 // Scalar type declarations - PHP 7.0+
-function foo(bool $a) {}
+function foo(BOOL $a) {}
 function foo(int $a) {}
 function foo(float $a) {}
 function foo(string $a) {}
@@ -49,7 +49,7 @@ function foo() {}
 function foo( $a, $b ) {}
 
 // Type hints in closures.
-function (callable $a) {}
+function (CallAble $a) {}
 function(int $a) {}
 
 // Deal with nullable type hints.


### PR DESCRIPTION
### NewParamTypeDeclarations: bug fix - build-in type declarations are case-insensitive

Up to now, the sniff would check for the type declaration as found. However, the build-in types are treated in PHP internally in a case-insensitive manner, so should be recognized by the sniff as such.

Tested by adjusting some existing unit tests.

### NewParamTypeDeclarations: bug fix - don't throw double errors

As per the inline documentation:
> // As of PHP 7.0, using `self` or `parent` outside class scope throws a fatal error.
> // Only throw this error for PHP 5.2+ as before that the "type hint not supported" error
> // will be thrown.

... the `OutsideClassScopeFound` error should only be throw for PHP  5.2+ and not for PHP 5.0/5.1.

As it was, the condition was incorrect and the error was thrown in both cases.

Fixed now.

