### PR TITLE
NewReturnTypeDeclarations: bug fix & consistency fix

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -153,7 +153,6 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
         $returnType      = ltrim($properties['return_type'], '?'); // Trim off potential nullability.
         $returnType      = strtolower($returnType);
         $returnTypeToken = $properties['return_type_token'];
-        $returnTypeEnd   = $properties['return_type_end_token'];
 
         if (isset($this->newTypes[$returnType]) === true) {
             $itemInfo = array(
@@ -168,7 +167,7 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
         $itemInfo = array(
             'name'   => 'Class name',
         );
-        $this->handleFeature($phpcsFile, $returnTypeEnd, $itemInfo);
+        $this->handleFeature($phpcsFile, $returnTypeToken, $itemInfo);
     }
 
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -151,6 +151,7 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
         }
 
         $returnType      = ltrim($properties['return_type'], '?'); // Trim off potential nullability.
+        $returnType      = strtolower($returnType);
         $returnTypeToken = $properties['return_type_token'];
         $returnTypeEnd   = $properties['return_type_end_token'];
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -2,7 +2,7 @@
 
 // PHP 7.0+
 function fooBool($a): bool {}
-function fooInt($a): int {}
+function fooInt($a): INT {}
 function fooFloat($a): float {}
 function fooString($a): ?string {}
 function fooArray($a): array {}
@@ -19,14 +19,14 @@ function fooIterable($a): iterable {}
 function fooVoid($a): void {}
 
 // Anonymous function.
-function($a): callable {}
+function($a): Callable {}
 
 // OK: no return type hint.
 function fooNone($a) {}
 function ($a) {}
 
 // PHP 7.2+
-function fooObject($a): object {}
+function fooObject($a): ObJect {}
 
 function fooInterspersedWithComments($a) :
 	// Comment.

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -69,7 +69,7 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             array('Class name', '5.6', 13, '7.0'),
             array('Class name', '5.6', 14, '7.0'),
             array('Class name', '5.6', 15, '7.0'),
-            array('Class name', '5.6', 37, '7.0'),
+            array('Class name', '5.6', 35, '7.0'),
             array('int', '5.6', 43, '7.0'),
 
             array('iterable', '7.0', 18, '7.1'),


### PR DESCRIPTION
### NewReturnTypeDeclarations: bug fix - build-in type declarations are case-insensitive

Up to now, the sniff would check for the type declaration as found. However, the build-in types are treated in PHP internally in a case-insensitive manner, so should be recognized by the sniff as such.

Tested by adjusting some existing unit tests.

### NewReturnTypeDeclarations: change the error position for class name based types

In contrast to the other errors, class names can have multiple tokens and the error for a class name based return type would be thrown on the _last_ (class name) token of the type declaration, not the first (and only) as was done for the other types.

This minor change, syncs the error position for all return type errors to the _start_ of the return type.

