### PR TITLE
NewTypedProperties: change parent class and other changes

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
-use PHPCompatibility\Sniff;
+use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer_File as File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Utils\Variables;
@@ -24,9 +24,32 @@ use PHPCSUtils\Utils\Variables;
  * @link https://wiki.php.net/rfc/typed_properties_v2
  *
  * @since 9.2.0
+ * @since 10.0.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
  */
-class NewTypedPropertiesSniff extends Sniff
+class NewTypedPropertiesSniff extends AbstractNewFeatureSniff
 {
+
+    /**
+     * A list of new types.
+     *
+     * The array lists : version number with false (not present) or true (present).
+     * If's sufficient to list the first version where the keyword appears.
+     *
+     * Note: this list should **not** include the initially supported types as that
+     * is handled via the "Typed properties are not supported in PHP 7.3 or earlier"
+     * error message.
+     *
+     * The types which were supported at the introduction of typed properties in PHP 7.4 were:
+     * bool, int, float, string, array, object, iterable, self, parent,
+     * any class or interface name, as well as nullability for all these.
+     * {@link https://wiki.php.net/rfc/typed_properties_v2#supported_types}
+     *
+     * @since 10.0.0
+     *
+     * @var array(string => array(string => bool))
+     */
+    protected $newTypes = array();
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -44,6 +67,7 @@ class NewTypedPropertiesSniff extends Sniff
      * Processes this test, when one of its tokens is encountered.
      *
      * @since 9.2.0
+     * @since 10.0.0 Refactored to work with the AbstractNewFeature sniff.
      *
      * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                   $stackPtr  The position of the current token in the
@@ -67,29 +91,28 @@ class NewTypedPropertiesSniff extends Sniff
         }
 
         // Still here ? In that case, this will be a typed property.
+        $type      = ltrim($properties['type'], '?'); // Trim off potential nullability.
+        $typeToken = $properties['type_token'];
+
         if ($this->supportsBelow('7.3') === true) {
             $phpcsFile->addError(
                 'Typed properties are not supported in PHP 7.3 or earlier. Found: %s',
-                $properties['type_token'],
+                $typeToken,
                 'Found',
-                array($properties['type'])
+                array($type)
             );
-        }
-
-        if ($this->supportsAbove('7.4') === true) {
-            $type = $properties['type'];
-            if ($properties['nullable_type'] === true) {
-                $type = ltrim($type, '?');
-            }
-
-            if ($type === 'void' || $type === 'callable') {
-                $phpcsFile->addError(
-                    '%s is not supported as a type declaration for properties',
-                    $properties['type_token'],
-                    'InvalidType',
-                    array($type)
-                );
-            }
+        } elseif (isset($this->newTypes[$type])) {
+            $itemInfo = array(
+                'name' => $type,
+            );
+            $this->handleFeature($phpcsFile, $typeToken, $itemInfo);
+        } elseif ($type === 'void' || $type === 'callable') {
+            $phpcsFile->addError(
+                '%s is not supported as a type declaration for properties',
+                $typeToken,
+                'InvalidType',
+                array($type)
+            );
         }
 
         $endOfStatement = $phpcsFile->findNext(\T_SEMICOLON, ($stackPtr + 1));
@@ -97,5 +120,33 @@ class NewTypedPropertiesSniff extends Sniff
             // Don't throw the same error multiple times for multi-property declarations.
             return ($endOfStatement + 1);
         }
+    }
+
+
+    /**
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
+     *
+     * @since 10.0.0
+     *
+     * @param array $itemInfo Base information about the item.
+     *
+     * @return array Version and other information about the item.
+     */
+    public function getItemArray(array $itemInfo)
+    {
+        return $this->newTypes[$itemInfo['name']];
+    }
+
+
+    /**
+     * Get the error message template for this sniff.
+     *
+     * @since 10.0.0
+     *
+     * @return string
+     */
+    protected function getErrorMsgTemplate()
+    {
+        return "The '%s' property type is not present in PHP version %s or earlier";
     }
 }

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -109,6 +109,7 @@ class NewTypedPropertiesSniff extends AbstractNewFeatureSniff
 
         // Still here ? In that case, this will be a typed property.
         $type      = ltrim($properties['type'], '?'); // Trim off potential nullability.
+        $type      = strtolower($type);
         $typeToken = $properties['type_token'];
 
         if ($this->supportsBelow('7.3') === true) {

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -25,14 +25,14 @@ class PHP74Example {
     private ?ClassName $nullableClassType;
 
     // Types are also legal on static properties
-    public static iterable $staticProp;
+    public static Iterable $staticProp;
 
     // Types can also be used with the "var" notation
     var bool $flag;
 
     // Typed properties may have default values (more below)
     public string $str = "foo";
-    public ?string $nullableStr = null;
+    public ?STRING $nullableStr = null;
 
     // The type applies to all properties in one declaration
     public float $a, $b;
@@ -54,13 +54,13 @@ class PHP74Example {
     static bool $bool = true;
 
     // Test reversed keyword order.
-    static public int $int = 0;
+    static public inT $int = 0;
 }
 
 // Invalid property types.
 class InvalidExample {
     public void $invalidType;
-    protected callable $callable = 'strlen';
+    protected Callable $callable = 'strlen';
     private ?callable $nullableCallable = null;
     public boolean $booleanType;
     protected integer $integerType = 123;

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -62,4 +62,6 @@ class InvalidExample {
     public void $invalidType;
     protected callable $callable = 'strlen';
     private ?callable $nullableCallable = null;
+    public boolean $booleanType;
+    protected integer $integerType = 123;
 }

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -72,6 +72,8 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             array(62),
             array(63),
             array(64),
+            array(65),
+            array(66),
         );
     }
 
@@ -120,6 +122,8 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             array(62, 'void'),
             array(63, 'callable'),
             array(64, 'callable'),
+            array(65, 'boolean'),
+            array(66, 'integer'),
         );
     }
 

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -30,14 +30,20 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
      *
      * @dataProvider dataNewTypedProperties
      *
-     * @param array $line The line number on which the error should occur.
+     * @param array $line            The line number on which the error should occur.
+     * @param bool  $testNoViolation Whether or not to test noViolation for PHP 7.4.
      *
      * @return void
      */
-    public function testNewTypedProperties($line)
+    public function testNewTypedProperties($line, $testNoViolation = false)
     {
         $file = $this->sniffFile(__FILE__, '7.3');
         $this->assertError($file, $line, 'Typed properties are not supported in PHP 7.3 or earlier');
+
+        if ($testNoViolation === true) {
+            $file = $this->sniffFile(__FILE__, '7.4');
+            $this->assertNoViolation($file, $line);
+        }
     }
 
     /**
@@ -50,19 +56,19 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
     public function dataNewTypedProperties()
     {
         return array(
-            array(23),
-            array(24),
-            array(25),
-            array(28),
-            array(31),
-            array(34),
-            array(35),
-            array(38),
-            array(41),
-            array(49),
-            array(51),
-            array(54),
-            array(57),
+            array(23, true),
+            array(24, true),
+            array(25, true),
+            array(28, true),
+            array(31, true),
+            array(34, true),
+            array(35, true),
+            array(38, true),
+            array(41, true),
+            array(49, true),
+            array(51, true),
+            array(54, true),
+            array(57, true),
             array(62),
             array(63),
             array(64),
@@ -115,21 +121,6 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             array(63, 'callable'),
             array(64, 'callable'),
         );
-    }
-
-
-    /**
-     * Verify the sniff doesn't throw false positives.
-     *
-     * @return void
-     */
-    public function testNoFalsePositivesInvalidPropertyType()
-    {
-        $file = $this->sniffFile(__FILE__, '7.4');
-
-        for ($line = 1; $line < 57; $line++) {
-            $this->assertNoViolation($file, $line);
-        }
     }
 
 


### PR DESCRIPTION
### NewTypedProperties: saner unit test organization

The "no violation" test was currently organized as part of the "invalid property type" tests.

This is not strictly correct. It's just that the "no violation" test can not be executed for the "invalid property type" test cases.

What with more property types being added in PHP 8 as well as other features, this will become true of more test cases, not related to them being an "invalid property type".

So for sanity sake, I'm moving the "no violation" test to the "is this is typed property" test, with a toggle to turn that test off for test cases which would also throw errors in later PHP versions.

### NewTypedProperties: refactor to use the AbstractNewFeature sniff as a base

As PHP 8 introduces new "types", the `NewTypedProperties` sniff needs the ability to throw the generic "Typed properties are not supported" error, as well as the ability to throw specific "This type was not supported before PHP x" errors for newly introduced _types_.

Up to now, only the first type of error message was supported.

This commit refactors the sniff to extend the `AbstractNewFeature` sniff to allow that sniff to handle the complex version number array negotiations.

With this initial refactor, the new `$newTypes` property is still empty, but that will change in the near future when more PHP 8 features are pulled to the repo.

### NewTypedProperties: move invalid types to property

The sniff as is, contains a cursory check for invalid types.

This commit moves the list of invalid types into a property to allow for more easily extending the list.

It also adds `boolean` and `integer` to the list, just like in the `NewParamTypeDeclarations` sniff, and allows for an alternative to be suggested.

Note: `static` has not been added to the list of invalid types as it is a property keyword and it wouldn't be possible to distinguish whether it was used as a keyword or a type (which is also why it isn't supported in PHP8).

Includes unit tests for the newly added types.

### NewTypedProperties: bug fix - build-in type declarations are case-insensitive

Up to now, the sniff would check for the type declaration as found. However, the build-in types are treated in PHP internally in a case-insensitive manner, so should be recognized by the sniff as such.

Tested by adjusting some existing unit tests.

