### PR TITLE
RemovedOptionalBeforeRequiredParam: bug fix - false positive on variadic params

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -96,6 +96,14 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
         $firstOptional = null;
 
         foreach ($parameters as $key => $param) {
+            /*
+             * Ignore variadic parameters, which are optional by nature.
+             * These always have to be declared last and this has been this way since their introduction.
+             */
+            if ($param['variable_length'] === true) {
+                continue;
+            }
+
             // Handle optional parameters.
             if (isset($param['default']) === true) {
                 if ($key === $lastKey) {

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -19,5 +19,11 @@ $arrow = fn(?bool $a = true, ?bool $b): string => $a ? (string) $b : '';
 // Parse error, nothing in default, not our concern. Throw error anyway.
 $closure = function ($a = /*comment*/, $b) {};
 
+// Prevent false positives on variadic parameters.
+function variadicIsOptionalByNature($a, int ...$b) {}
+function variadicIsOptionalByNatureWithExtraOptional($a, $b = null, ...$c) {}
+// Intentional parse error. This has always been an error though, so ignore for this sniff.
+function variadicBeforeRequiredWasAlwaysAnError(...$a, $b) {}
+
 // Intentional parse error. This has to be the last test in the file.
 $closure = function( $a = [], $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -89,8 +89,13 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTest
             $cases[] = array($line);
         }
 
-        // Add parse error test case.
+        // Don't error on variadic parameters.
         $cases[] = array(23);
+        $cases[] = array(24);
+        $cases[] = array(26);
+
+        // Add parse error test case.
+        $cases[] = array(29);
 
         return $cases;
     }


### PR DESCRIPTION

_PR #1165 introduced a new PHP 8.0 related sniff. This sniff has not been in a released version of PHPCompatibility yet._

Variadic parameters are optional by nature. They also MUST be declared last in the parameter list and this requirement has been in place since their introduction.

In other words: variadic parameters should be ignored completely for the purposes of this sniff.

Includes unit tests.