### PR TITLE
ArgumentFunctionsReportCurrentValue: don't report when parameter is only used in return/exit

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -97,7 +97,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
     );
 
     /**
-     * Tokens to ignore when determining the start of a statement.
+     * Tokens to ignore when determining the start of a statement for call to one of the functions.
      *
      * @since 9.1.0
      *
@@ -108,6 +108,21 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
         \T_DOUBLE_ARROW,
         \T_OPEN_SQUARE_BRACKET,
         \T_OPEN_PARENTHESIS,
+    );
+
+    /**
+     * Tokens to ignore when determining the start of a statement for a used variable.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $ignoreForStartOfStatementVarUse = array(
+        \T_COMMA,
+        \T_DOUBLE_ARROW,
+        \T_OPEN_SQUARE_BRACKET,
+        \T_OPEN_PARENTHESIS,
+        \T_OPEN_SHORT_ARRAY,
     );
 
     /**
@@ -375,6 +390,21 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     }
                 } elseif (\in_array($tokens[$j]['content'], $paramNames, true) === false) {
                     // Variable is not one of the function parameters.
+                    continue;
+                }
+
+                /*
+                 * Check if the variable is used within a return or exit/die statement.
+                 * In that case, we can safely ignore it.
+                 */
+                $startOfVariableStatement = BCFile::findStartOfStatement(
+                    $phpcsFile,
+                    $j,
+                    $this->ignoreForStartOfStatementVarUse
+                );
+                if ($tokens[$startOfVariableStatement]['code'] === \T_RETURN
+                    || $tokens[$startOfVariableStatement]['code'] === \T_EXIT
+                ) {
                     continue;
                 }
 

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -167,6 +167,31 @@ function author_can( $post, $capability ) {
 		}
 	}
 
+// Issue #1207.
+function ignoreParamInReturn ( $stuff ) {
+    if ( true === SOME_CONSTANT ) {
+        return [$somethingElse['key'], 'b' => $stuff];
+    }
+
+    $args = func_get_args();
+}
+
+function ignoreParamInExit ( $stuff ) {
+    if ( true === SOME_CONSTANT ) {
+        exit ( 'Did ' . functionCall() . $stuff );
+    }
+
+    $args = func_get_args();
+}
+
+function ignoreParamInDie ( $stuff ) {
+    if ( true === SOME_CONSTANT ) {
+        die ( 'Did ' . $stuff );
+    }
+
+    $args = func_get_args();
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function foo($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -149,6 +149,9 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTest
         $cases[] = array(162);
         $cases[] = array(164);
         $cases[] = array(173);
+        $cases[] = array(176);
+        $cases[] = array(184);
+        $cases[] = array(192);
 
         return $cases;
     }


### PR DESCRIPTION
If one of the passed parameters is used within a `return` or `exit` statement, _before_ the call to `function_get_args()` et al, we can safely ignore it.

Fixes #1207