### PR TITLE
BaseSniffTest: fail test on missing message, don't error

### DIFF
--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -272,7 +272,7 @@ class BaseSniffTest extends TestCase
     private function assertForType($issues, $type, $lineNumber, $expectedMessage)
     {
         if (isset($issues[$lineNumber]) === false) {
-            throw new \Exception("Expected $type '$expectedMessage' on line number $lineNumber, but none found.");
+            $this->fail("Expected $type '$expectedMessage' on line number $lineNumber, but none found.");
         }
 
         $insteadFoundMessages = array();


### PR DESCRIPTION
When an (unexpected) exception is thrown by a test, the test will be marked as "Errored", not as "Failed".

With that in mind, when an error/warning is expected on a certain line and it isn't found, the test should fail, not error.

Fixed now.

Note: this will make it easier to see which tests are _failing_ on PHP  due to tokenizer changes and which tests are erroring due to the code not being defensive enough. (all those new `TypeError`/`ValueError` exceptions being thrown in PHP 8)