### PR TITLE
PHP 8.0: NewClasses: handle 3 new classes

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -743,6 +743,10 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '7.4' => true,
         ),
 
+        'PhpToken' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
         'WeakMap' => array(
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -742,6 +742,11 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '7.3' => false,
             '7.4' => true,
         ),
+
+        'WeakMap' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
     );
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -957,6 +957,11 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '7.4'       => true,
             'extension' => 'ffi',
         ),
+
+        'ValueError' => array(
+            '7.4' => false,
+            '8.0' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -407,3 +407,7 @@ if (is_a($var, mysqli_warning::class)) {}
 $conn = new sqlite3();
 Class mySqlite3Stmt extends Sqlite3Stmt {}
 function MySqlite3ResultTypeHint(SQLite3Result $result) {]
+
+class FooBar {
+    public function foo(): WeakMap {};
+}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -411,3 +411,5 @@ function MySqlite3ResultTypeHint(SQLite3Result $result) {]
 class FooBar {
     public function foo(): WeakMap {};
 }
+
+function processToken(PhpToken $stackPtr) {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -413,3 +413,8 @@ class FooBar {
 }
 
 function processToken(PhpToken $stackPtr) {}
+
+try {
+    throw new ValueError('Unknown type');
+} catch (\ValueError $e) {
+}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -209,6 +209,7 @@ class NewClassesUnitTest extends BaseSniffTest
             array('FFI\CType', '7.3', array(347), '7.4'),
             array('ReflectionReference', '7.3', array(344), '7.4'),
             array('WeakReference', '7.3', array(345), '7.4'),
+            array('WeakMap', '7.4', array(412), '8.0'),
 
             array('DATETIME', '5.1', array(146), '5.2'),
             array('datetime', '5.1', array(147, 320), '5.2'),

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -209,6 +209,7 @@ class NewClassesUnitTest extends BaseSniffTest
             array('FFI\CType', '7.3', array(347), '7.4'),
             array('ReflectionReference', '7.3', array(344), '7.4'),
             array('WeakReference', '7.3', array(345), '7.4'),
+            array('PhpToken', '7.4', array(415), '8.0'),
             array('WeakMap', '7.4', array(412), '8.0'),
 
             array('DATETIME', '5.1', array(146), '5.2'),

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -255,6 +255,7 @@ class NewClassesUnitTest extends BaseSniffTest
             array('JsonException', '7.2', array(250, 339), '7.3'),
             array('FFI\Exception', '7.3', array(349), '7.4'),
             array('FFI\ParserException', '7.3', array(349), '7.4'),
+            array('ValueError', '7.4', array(418, 419), '8.0'),
         );
     }
 


### PR DESCRIPTION
The commits in this PR line up with the commits in PHP Core to add the classes.

Related to #809

---

### PHP 8.0: NewClasses: account for new WeakMap class

> Added WeakMap.

Refs:
* https://wiki.php.net/rfc/weak_maps
* php/php-src#4882
* php/php-src@d8c9902

### PHP 8.0: NewClasses: account for new PhpToken class

> The new PhpToken class adds an object-based interface to the tokenizer.
>  It provides a more uniform and ergonomic representation, while being more
memory efficient and faster.

Refs:
* https://wiki.php.net/rfc/token_as_object
* https://github.com/php/php-src/blob/4522cbb789ea4d0b70b5a1bdf7f3c0f4648d8fb7/UPGRADING#L929-L933
* php/php-src#5176
* php/php-src@5a09b9f

### PHP 8.0: NewClasses: account for new ValueError exception class

> Added ValueError class.

Refs:
* https://github.com/php/php-src/blob/master/UPGRADING#L639
* php/php-src@bc61997

