### PR TITLE
RemovedIconvEncoding: bug fix / compatibility with PHP 8

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -80,7 +80,7 @@ class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
             'All previously accepted values for the $type parameter of iconv_set_encoding() have been deprecated since PHP 5.6. Found %s',
             $parameters[1]['start'],
             'DeprecatedValueFound',
-            $parameters[1]['raw']
+            array($parameters[1]['raw'])
         );
     }
 }


### PR DESCRIPTION
The `$data` parameter of the PHPCS `addError()`/`addWarning()` methods should always be passed as an array.

On PHP < 8, if it wasn't PHP was tolerant and accepted it anyway (cast to an array). On PHP 8.0, this is no longer the case and not passing `$data` as an array will result in a fatal `TypeError`.