### PR TITLE
ArgumentFunctionsUsage: bug fix / compatibility with PHP 8

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -102,7 +102,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
             return;
         }
 
-        $data = $tokens[$stackPtr]['content'];
+        $data = array($tokens[$stackPtr]['content']);
 
         /*
          * Check for use of the functions in the global scope.


### PR DESCRIPTION
The `$data` parameter of the PHPCS `addError()`/`addWarning()` methods should always be passed as an array.

On PHP < 8, if it wasn't PHP was tolerant and accepted it anyway (cast to an array). On PHP 8.0, this is no longer the case and not passing `$data` as an array will result in a fatal `TypeError`.