### PR TITLE
CI: fix coverage builds failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ jobs:
     - stage: coverage
       php: 7.4
       env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="^2.0" CUSTOM_INI=1
-    - php: 7.2
+    - php: 7.3
       env: PHPCS_VERSION="2.6.0" COVERALLS_VERSION="^2.0"
     # PHP 7.3+ is only fully supported icw PHPCS 2.9.2 and 3.3.1+.
     - php: 7.2
@@ -202,7 +202,10 @@ before_install:
     if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Sniff" ]]; then
       composer install --prefer-dist --no-suggest
     elif [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
-      # Ignore platform requirements to allow PHPUnit to install on PHP 8.
+      # Temporary fix - PHPUnit 9.3 is buggy when used for code coverage, so not allowed "normally".
+      # As PHP 8 doesn't run code coverage, we can safely install it there though.
+      composer require --no-update phpunit/phpunit:"^9.3"
+      # Not all PHPUnit dependencies have stable releases yet allowing for PHP 8.0.
       composer install --prefer-dist --no-suggest --ignore-platform-reqs
     else
       # Remove devtools as it would block install on old PHPCS versions (< 3.0).

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require-dev" : {
     "php-parallel-lint/php-parallel-lint": "^1.2.0",
     "php-parallel-lint/php-console-highlighter": "^0.5",
-    "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+    "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
     "phpcsstandards/phpcsdevtools": "^1.0"
   },
   "conflict": {


### PR DESCRIPTION
The code coverage builds on PHP 7.3/7.4 started to fail without clear reason recently.

It has now become clear that the underlying reason is that the [PHP Code Coverage](https://github.com/sebastianbergmann/php-code-coverage) package started to use PHP-Parser as of PHP Code Coverage version 9.0.

The first PHPUnit version which has a dependency on PHP Code Coverage 9.x is PHPUnit 9.3, so if we limit the PHPUnit 9.x range to `9.0 - 9.2`, the code coverage builds will be fine (for now).

We then have the situation that PHPUnit 9.3 is needed to run the tests on PHP 8.0. As we don't run code coverage on PHP 8.0, that is not a really issue though, so we just hard-require PHPUnit 9.3 for PHP `nightly` in the Travis script.

This now also allows to revert the work-around for the PHP 7.3 code coverage build failing as was put in place in 63abdd8cd037322fa58e908f64139e1db5c07659.

While this solution is not ideal, it at least will create a workable situation again until PHP 8.0 comes out. Hopefully a proper solution will be found and implemented before that time, so we can remove this work-around.

Once this PR has been merged, I will rebase the open PR to make it mergable.

See also: https://github.com/sebastianbergmann/php-code-coverage/issues/798