### PR TITLE
PHP 8.0: account for new mixed param/return/property type

### DIFF
--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -65,3 +65,11 @@ class InvalidExample {
     public boolean $booleanType;
     protected integer $integerType = 123;
 }
+
+// Mixed type declaration - PHP 8.0+.
+class PHP8Mixed {
+    public static mixed $mixed;
+
+    // Invalid: Nullable mixed type declaration.
+    private ?miXed $nullableMixed;
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -80,3 +80,9 @@ $arrow = fn(\FQN\ClassName $b) => $b::method();
 $arrow = fn(callable $a) => $a();
 $arrow = fn(integer $a) => $a . 'test';
 $arrow = fn($a) => $a * 10; // OK.
+
+// Mixed type declaration - PHP 8.0+.
+$closure = function (mixed $a) {};
+
+// Invalid: Nullable mixed type declaration.
+function NullableMixed(?mixed $a) {};

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -36,7 +36,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
      * @param array  $line              The line number where the error is expected.
      * @param string $okVersion         A PHP version in which the type hint was ok to be used.
      * @param bool   $testNoViolation   Whether or not to test noViolation.
-     *                                  Defaults to true. Only set to false for self/parent outside class scope.
+     *                                  Defaults to true.
      *
      * @return void
      */
@@ -86,6 +86,8 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             ['parent', '5.1', 73, '5.2', false],
             ['int', '5.6', 78, '7.0'],
             ['callable', '5.3', 80, '5.4'],
+            ['mixed', '7.4', 85, '8.0'],
+            ['mixed', '7.4', 88, '8.0', false],
         ];
     }
 
@@ -192,6 +194,30 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
 
 
     /**
+     * Verify an error is thrown for nullable mixed types.
+     *
+     * @return void
+     */
+    public function testInvalidNullableMixed()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, 88, 'Mixed types cannot be nullable, null is already part of the mixed type');
+    }
+
+
+    /**
+     * Test no false positives for non-nullable "mixed" type.
+     *
+     * @return void
+     */
+    public function testInvalidNullableMixedNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, 85);
+    }
+
+
+    /**
      * testTypeDeclaration
      *
      * @dataProvider dataTypeDeclaration
@@ -256,6 +282,8 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             [79],
             [80],
             [81],
+            [85],
+            [88],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -48,3 +48,9 @@ class Foo {
         $closure = function ($a): ?static {};
     }
 }
+
+// Mixed type declaration - PHP 8.0+.
+function fooMixed($a): mixed {}
+
+// Invalid: Nullable mixed type declaration.
+$arrow = fn($a) : ?mixed => $a * 10;


### PR DESCRIPTION
As of PHP 8.0, `mixed` can be used as a parameter type for function declarations, a return type for function declarations and as a property type.

The RFC explicitly does not allow for the `mixed` type to be combined with the nullability indicator.
While in itself, that is not a cross-version compatibility issue, I have made a very conscious choice to add a check for this anyway as - while discouraged with `mixed` being a soft reserved keyword -, prior to PHP 8, a class _could_ be named `mixed`, so a `?Mixed` type hint referring to such a class could exist in code and _would_ be a cross-version compatibility issue as since PHP 8 that will throw a "Fatal error: Mixed types cannot be nullable".

Refs:
* https://wiki.php.net/rfc/mixed_type_v2
* php/php-src#5313
* php/php-src@aec4c0f

Includes unit tests.

Related to #809

--- 

### PHP 8.0: NewParamTypeDeclarations: allow for `mixed` type declarations

### PHP 8.0: NewReturnTypeDeclarations: allow for "mixed" return type

Includes removing the `testNoViolationsInFileOnValidVersion()` test as the sniff will now throw errors either way.

### PHP 8.0: NewTypedProperties: allow for "mixed" type

