### PR TITLE
CS: fix short array in test generation script

### DIFF
--- a/bin/generate-forbidden-names-test-files
+++ b/bin/generate-forbidden-names-test-files
@@ -14,7 +14,7 @@
  */
 
 // This array is pulled from PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
-$invalidNames = array(
+$invalidNames = [
     'abstract' => '5.0',
     'and' => 'all',
     'array' => 'all',
@@ -87,11 +87,11 @@ $invalidNames = array(
     '__FUNCTION__' => 'all',
     '__METHOD__' => 'all',
     '__NAMESPACE__' => '5.3',
-);
+];
 
 echo "Generating files containing invalid PHP code that is attempting to use reserved keywords in various capacities.\n\n";
 
-$tests = array(
+$tests = [
     'namespace'                              => function ($name) {
         return "namespace $name;\n";
     },
@@ -120,7 +120,7 @@ $tests = array(
         return "class Foobar { use function $name }\n";
     },
     'class-use-trait-alias-method'           => function ($name) {
-        if (in_array($name, array('public', 'protected', 'private', 'final'), true) === true) {
+        if (in_array($name, ['public', 'protected', 'private', 'final'], true) === true) {
             return '';
         } else {
             return "class Foobar { use BazTrait { oldfunction as $name } }\n";
@@ -172,7 +172,7 @@ $tests = array(
     'interface-extends'                      => function ($name) {
         return "interface Foobar extends $name {}\n";
     },
-);
+];
 
 $path = realpath(dirname(__DIR__))
     . DIRECTORY_SEPARATOR . 'PHPCompatibility'


### PR DESCRIPTION
Follow up on #1215.

I always seem to forget this file as it doesn't get picked up by PHPCS natively.