### PR TITLE
CS: switch to the PHPCSDevCS standard

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Please make sure that your pull request contains unit tests covering what's bein
 * All code should be compatible with PHPCS >= 2.6.0 and PHPCS >= 3.1.0.
 * All code should be compatible with PHP 5.4 to PHP nightly.
 * All code should comply with the PHPCompatibility coding standards.
-    The [ruleset used by PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility/blob/master/phpcs.xml.dist) is largely based on PSR-2 with minor variations and some additional checks for documentation and such.
+    The [ruleset used by PHPCompatibility](https://github.com/PHPCSStandards/PHPCSDevCS) is largely based on PSR-12 with minor variations and some additional checks for array layout and documentation and such.
 
 ### Typical sources of information about changes in PHP
 * The [PHP RFC wiki](https://wiki.php.net/rfc)
@@ -135,3 +135,35 @@ To fix these errors, make sure you are running PHPCS 2.7.1 or higher and add the
 ```
 
 This will prevent PHPCS trying to include the PHPCompatibility unit tests when creating the test suite.
+
+
+Checking Code Style Locally
+-----------------------
+
+PHPCompatibility uses the [PHPCSDevCS](https://github.com/PHPCSStandards/PHPCSDevCS) standard for code style.
+As PHPCompatibility is one of the dependencies of PHPCSDevCS, we have a recursive dependency which makes it slightly less intuitive to work with.
+On top of that, PHPCSDevCS has a higher minimum PHPCS requirement than PHPCompatibility, so fun times getting this working ;-)
+
+If you have a local test environment setup which is based on git clones, clone the [PHPCSDevCS](https://github.com/PHPCSStandards/PHPCSDevCS) repo and register it with your PHPCS clone using the `--installed_paths` argument.
+You can then run `phpcs` from the command-line from the root directory of this repo to check the code style of your branch/patch.
+
+> :light_bulb: Pro-tips:
+> * Make sure your PHPCS clone is checked out at a recent PHPCS version (PHPCS 3.5.0 or higher) before running the CS check.
+> * Keep the PHPCSDevCS repo up to date.
+>     You may want to start _watching releases_ on GitHub for the repo to know when there are updates available.
+> * The PHPCSDevCS repo is expected to add more external standards in the (near) future.
+>     If you run into _"Unknown standard"_ errors, this might be the cause and you'll need to make sure those additional external standards are also available on your system and registered with your local PHPCS clone.
+
+If you have a Composer based local test environment setup, there are helper scripts available to check the code style.
+* `composer checkcs`
+* `composer fixcs`
+
+These helper scripts will temporarily install PHPCSDevCS, run the code style check and then remove PHPCSDevCS again.
+
+If the PHPCS run exits with errors, fix those and run either one of the scripts again to make sure the temporary dependency is removed before committing your changes or run `composer remove-devcs` to make sure the `composer.json` file is cleaned up.
+
+> :light_bulb: Pro-tips:
+> * If you run into time-outs when running the `checkcs` or `fixcs` scripts, you can run the underlying scripts directly to get round that:
+>     - `composer install-devcs`
+>     - `vendor/bin/phpcs` or `vendor/bin/phpcbf`
+>     - `composer remove-devcs`

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ phpcs.xml
 /build/
 phpunit.xml
 .phpunit.result.cache
+.phpcs.cache
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
         - travis_retry composer install-devcs
       script:
         # Check the code style of the code base.
-        - vendor/bin/phpcs
+        - vendor/bin/phpcs --no-cache
 
         # Validate the xml file.
         # @link http://xmlsoft.org/xmllint.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,19 @@ jobs:
     #### SNIFF STAGE ####
     - stage: sniff
       php: 7.4
-      env: PHPCS_VERSION="dev-master"
       addons:
         apt:
           packages:
             - libxml2-utils
+      before_install:
+        - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+        - export XMLLINT_INDENT="    "
+        # Set up CS check.
+        # - Using PHPCS `master` as an early detection system for bugs upstream.
+        # - COMPOSER_ROOT_VERSION is needed to get round the recursive dependency when using CI.
+        - export COMPOSER_ROOT_VERSION="10.99.99"
+        - travis_retry composer require --no-update squizlabs/php_codesniffer:"dev-master"
+        - travis_retry composer install-devcs
       script:
         # Check the code style of the code base.
         - vendor/bin/phpcs
@@ -178,7 +186,7 @@ before_install:
   # On stable PHPCS versions, allow for PHP deprecation notices.
   # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
   - |
-    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Sniff" && $PHPCS_VERSION != "dev-master" ]]; then
+    if [[ $PHPCS_VERSION != "dev-master" ]]; then
       echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     fi
 
@@ -189,8 +197,6 @@ before_install:
     fi
   - php -r "echo ini_get('short_open_tag');"
 
-  - export XMLLINT_INDENT="    "
-
   # Set up test environment using Composer.
   - travis_retry composer require --no-update squizlabs/php_codesniffer:${PHPCS_VERSION}
   - |
@@ -199,9 +205,7 @@ before_install:
     fi
   # --prefer-dist will allow for optimal use of the travis caching ability.
   - |
-    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Sniff" ]]; then
-      travis_retry composer install --prefer-dist --no-suggest
-    elif [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
       # Temporary fix - PHPUnit 9.3 is buggy when used for code coverage, so not allowed "normally".
       # As PHP 8 doesn't run code coverage, we can safely install it there though.
       travis_retry composer require --no-update phpunit/phpunit:"^9.3"

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,12 @@
   "suggest" : {
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "9.x-dev",
+      "dev-develop": "10.x-dev"
+    }
+  },
   "scripts" : {
     "test": [
       "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
@@ -61,6 +67,22 @@
     ],
     "check-complete-strict": [
       "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./PHPCompatibility"
+    ],
+    "install-devcs": [
+      "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1.1\" --no-suggest"
+    ],
+    "remove-devcs": [
+      "composer remove --dev phpcsstandards/phpcsdevcs"
+    ],
+    "checkcs": [
+      "@install-devcs",
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
+      "@remove-devcs"
+    ],
+    "fixcs": [
+      "@install-devcs",
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
+      "@remove-devcs"
     ]
   }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -29,6 +29,9 @@
     <!-- Check up to 8 files simultaneously. -->
     <arg name="parallel" value="8"/>
 
+    <!-- Enable caching to a fixed file. -->
+    <arg name="cache" value=".phpcs.cache"/>
+
 
     <!--
     #############################################################################

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,8 +2,12 @@
 <ruleset name="PHPCS Coding Standards for PHPCompatibility">
     <description>Check the code of the PHPCompatibility standard itself.</description>
 
-    <arg value="sp"/>
-    <arg name="extensions" value="php"/>
+    <!--
+    #############################################################################
+    COMMAND LINE ARGUMENTS
+    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+    #############################################################################
+    -->
 
     <file>.</file>
 
@@ -13,161 +17,70 @@
     <!-- Exclude Composer vendor directory. -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
 
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="ps"/>
+
     <!-- Strip the filepaths down to the relevant bit. -->
     <arg name="basepath" value="./"/>
 
-    <!-- Check up to 8 files simultanously. -->
+    <!-- Check up to 8 files simultaneously. -->
     <arg name="parallel" value="8"/>
 
 
     <!--
-        PHP cross version compatibility ;-).
+    #############################################################################
+    USE THE PHPCSDev RULESET
+    This ruleset checks code against PSR2, PHPCompatibility and various
+    other sniffs.
+    For more information, see: https://github.com/PHPCSStandards/PHPCSDevTools
+    #############################################################################
     -->
-    <config name="testVersion" value="5.4-"/>
-    <rule ref="PHPCompatibility">
-        <!-- Exclude PHP constants back-filled by PHPCS 2.6.0+. -->
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_finallyFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_yieldFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_ellipsisFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_powFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_pow_equalFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_coalesceFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_spaceshipFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_fnFound"/>
-        <exclude name="PHPCompatibility.Constants.NewConstants.t_nullsafe_object_operatorFound"/>
-    </rule>
 
-    <!--
-        Minimal code style check.
-    -->
-    <rule ref="PSR2">
+    <config name="testVersion" value="5.4-"/>
+
+    <rule ref="PHPCSDev">
+
         <!-- To address at a later point in time. -->
         <exclude name="Generic.Files.LineLength.TooLong"/>
 
         <!-- Ignoring a number of whitespace issues around blank lines. -->
+        <exclude name="Squiz.WhiteSpace.FunctionSpacing.After"/>
+        <exclude name="Squiz.WhiteSpace.FunctionSpacing.Before"/>
         <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
         <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
         <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
+
+        <!-- Allow for the file docblock on the line directly following the PHP open tag.
+             As the sniff in PHPCS does not use modular error codes (yet - see upstream PR #2729),
+             the complete error code needs to be disabled, not just the bit involving
+             the file docblocks.
+        -->
+        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
+
+        <!-- All nice and good, but too much of a fuss for the outer array of nested arrays. -->
+        <exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/>
     </rule>
+
+
+    <!--
+    #############################################################################
+    SELECTIVE EXCLUSIONS
+    Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+    #############################################################################
+    -->
 
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
         <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
         <exclude-pattern>*/PHPCSAliases\.php</exclude-pattern>
     </rule>
 
-    <!-- Check that variable names are in camelCaps. -->
-    <rule ref="Squiz.NamingConventions.ValidVariableName">
-        <exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
-    </rule>
-
-    <!-- Check that function and method names are in camelCaps. -->
-    <rule ref="Generic.NamingConventions.CamelCapsFunctionName">
-        <properties>
-            <!-- Allow for two adjacent capital letters for acronyms. -->
-            <property name="strict" value="false"/>
-        </properties>
-    </rule>
-
-    <!-- PSR2 appears to ignore blank lines for superfluous whitespace and in several other places. Let's fix that. -->
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
-        <properties>
-            <property name="ignoreBlankLines" value="false"/>
-        </properties>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
-        <severity>5</severity>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile">
-        <severity>5</severity>
-    </rule>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
-        <severity>5</severity>
-    </rule>
-
-    <rule ref="Generic.PHP.LowerCaseType"/>
-    <rule ref="Generic.WhiteSpace.ArbitraryParenthesesSpacing"/>
-    <rule ref="PSR12.Classes.ClassInstantiation"/>
-    <rule ref="PSR12.Keywords.ShortFormTypeKeywords"/>
-    <rule ref="PSR12.Operators.OperatorSpacing"/>
-
-    <!-- Use short array syntax. -->
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-
-    <!-- Use normalized array indentation. -->
-    <rule ref="Generic.Arrays.ArrayIndent"/>
-    <rule ref="Squiz.Arrays.ArrayDeclaration"/>
-
-    <!-- Ignoring the Squiz indentation rules as normalized arrays are preferred. -->
-    <rule ref="Squiz.Arrays.ArrayDeclaration.KeyNotAligned">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Arrays.ArrayDeclaration.ValueNotAligned">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned">
-        <severity>0</severity>
-    </rule>
-
-    <!-- Single and multi-line arrays are both allowed. -->
-    <rule ref="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed">
-        <severity>0</severity>
-    </rule>
-
-    <!-- All nice and good, but too much of a fuss for the outer array of nested arrays. -->
-    <rule ref="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned">
-        <severity>0</severity>
-    </rule>
-
-    <!-- Align the equal operator in assignment blocks. -->
-    <rule ref="Generic.Formatting.MultipleStatementAlignment">
-        <properties>
-            <property name="maxPadding" value="25"/>
-        </properties>
-    </rule>
-
-	<rule ref="PEAR.Files.IncludingFile">
-        <exclude-pattern>*/phpunit-bootstrap\.php</exclude-pattern>
-	</rule>
-
-
-    <!--
-        Inline Documentation check.
-    -->
-    <rule ref="Generic.Commenting.DocComment">
-        <!-- Having a @see or @internal tag before the @param tags is fine. -->
-        <exclude name="Generic.Commenting.DocComment.ParamNotFirst"/>
-    </rule>
-
     <!-- No need to be as strict about comment punctuation for the unit tests. -->
     <rule ref="Generic.Commenting.DocComment.ShortNotCapital">
         <exclude-pattern>*/PHPCompatibility/Tests/*\.php</exclude-pattern>
         <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
-    </rule>
-
-
-    <rule ref="PEAR.Commenting">
-        <!-- Exclude PEAR specific tag requirements. -->
-        <exclude name="PEAR.Commenting.FileComment.MissingVersion" />
-        <exclude name="PEAR.Commenting.FileComment.MissingAuthorTag" />
-        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag" />
-        <exclude name="PEAR.Commenting.FileComment.MissingLicenseTag" />
-        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag" />
-        <exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag" />
-        <exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag" />
-        <exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag" />
-        <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag" />
-        <exclude name="PEAR.Commenting.ClassComment.MissingPackageTag" />
-
-        <!-- Having a @see or @internal tag before the @category tag is fine. -->
-        <exclude name="PEAR.Commenting.ClassComment.CategoryTagOrder"/>
-
-        <!-- Using @since for class changelog demands multiple tags. -->
-        <exclude name="PEAR.Commenting.ClassComment.DuplicateSinceTag"/>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
### Travis/Composer: use PHPCSDevCS for the code-style check

PHPCSDevCS is an external standard for PHPCS which is largely based on the PHPCS project ruleset which was already in use by PHPCompatibility with a few extra tweaks, including switching from PSR2 to PSR12.

The `PHPCSDevCS` package has a minimum PHPCS requirement of PHPCS 3.5.0 to take advantage of the latest sniffs.

Now, there are a few challenges with using the package:
1. The above mentioned PHPCS 3.5.0 requirement which would make testing with lower PHPCS versions difficult if we'd `require-dev`-ed the package.
2. A circular dependency as PHPCompatibility is a dependency of `PHPCSDevCS` - and we want the PHPCompatibility version to be used to be the current branch.
3. The fact that we are currently working on a new major, which means that, while the latest stable release is `9.x`, we already want to be using `10.x`.

To get round that, a couple of things are needed:
1. `PHPCSDevCS` needs to allow both PHPCompatibility `9.x` as well as `10.x` to be installed.
    This was added in version `1.1.1` of `PHPCSDevCS`.
    - `9.x` for other packages, like PHPCSUtils, using the standard until we release `10.0.0`.
    - `10.x` for us.
2. Branch aliases for the `master` and `develop` branches in the `composer.json` file.
    With these in place, running `composer install` locally and then requiring `phpcsstandards/phpcsdevcs` will work fine.
3. Setting `COMPOSER_ROOT_VERSION` in the Travis CI script as Travis doesn't do a full clone of the repo, so would still not be able to determine the version to use for the active branch correctly.

Note:
* The `branch-alias` for `dev-master` will need to be updated before we release version `10.0.0`.
* The `branch-alias` for `dev-develop` and the version`set as `COMPOSER_ROOT_VERSION` will need to be updated when work would start on a new major version.

Last thing - as the PHPCS requirements for `PHPCSDevCS` and `PHPCompatibility` are different, we don't want the package to be in `require-dev` as it would make testing more difficult for people using a Composer based dev setup.

So, instead, I've added Composer scripts to add the standard only for CS runs and remove it afterwards.

Refs:
* https://github.com/PHPCSStandards/PHPCSDevCS

With graceful thanks to @ramsey, @Seldaek and @naderman for [helping me figure this all out](https://twitter.com/ramsey/status/1299455790823215105).
(and not just for this repo, similar PRs will be lined up for some other repos using the standard in the near future)

### CS/QA: switch over to using the `PHPCSDev` ruleset

The `PHPCSDev` ruleset is largely based on the custom `phpcs.xml.dist` ruleset which was already in use for the PHPCompatibility standard.

By having `PHPCSDev` available as a named ruleset, we can more easily enforce consistency in the codestyle used for the new repos within the PHPCompatibility organisation (as well as the ones in PHPCSStandards, like PHPCSUtils).

This switches out the custom ruleset in favour of `PHPCSDev` with only a few exceptions.

Ref: https://github.com/PHPCSStandards/PHPCSDevCS

### PHPCS: enable caching

PHPCS added a result caching feature in PHPCS 3.0 which can make the CS scans significantly faster, so let's enable it.

The first run with caching enabled will be slower. Subsequent runs however, will be significantly faster.

To temporarily turn caching off, use `--no-cache`.
To clear the cache, delete the local `.phpcs.cache` file from the project root.

As Travis won't carry through a saved cache file between different branches, however, I'm turning this feature off for Travis to prevent the build being slower than necessary due to the caching.

### CONTRIBUTING: add information about running the CS check locally 