### PR TITLE
Performance: use FQN for all global functions

### DIFF
--- a/PHPCompatibility/AbstractComplexVersionSniff.php
+++ b/PHPCompatibility/AbstractComplexVersionSniff.php
@@ -81,7 +81,7 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
      */
     protected function getVersionArray(array $itemArray)
     {
-        return array_diff_key($itemArray, array_flip($this->getNonVersionArrayKeys()));
+        return \array_diff_key($itemArray, \array_flip($this->getNonVersionArrayKeys()));
     }
 
 

--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -100,7 +100,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
 
         $tokens     = $phpcsFile->getTokens();
         $function   = $tokens[$stackPtr]['content'];
-        $functionLc = strtolower($function);
+        $functionLc = \strtolower($function);
 
         if (isset($this->targetFunctions[$functionLc]) === false) {
             return;

--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -142,7 +142,7 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
         }
 
         // Remove the last 'and' from the message.
-        $error = substr($error, 0, (\strlen($error) - 5));
+        $error = \substr($error, 0, (\strlen($error) - 5));
 
         if ($errorInfo['alternative'] !== '') {
             $error .= $this->getAlternativeOptionTemplate();

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -112,23 +112,23 @@ abstract class Sniff implements PHPCS_Sniff
         static $arrTestVersions = [];
 
         $default     = [null, null];
-        $testVersion = trim(Helper::getConfigData('testVersion'));
+        $testVersion = \trim(Helper::getConfigData('testVersion'));
 
         // Case-sensitivity tolerance.
         if (empty($testVersion) === true) {
-            $testVersion = trim(Helper::getConfigData('testversion'));
+            $testVersion = \trim(Helper::getConfigData('testversion'));
         }
 
         if (empty($testVersion) === false && isset($arrTestVersions[$testVersion]) === false) {
 
             $arrTestVersions[$testVersion] = $default;
 
-            if (preg_match('`^\d+\.\d+$`', $testVersion)) {
+            if (\preg_match('`^\d+\.\d+$`', $testVersion)) {
                 $arrTestVersions[$testVersion] = [$testVersion, $testVersion];
                 return $arrTestVersions[$testVersion];
             }
 
-            if (preg_match('`^(\d+\.\d+)?\s*-\s*(\d+\.\d+)?$`', $testVersion, $matches)) {
+            if (\preg_match('`^(\d+\.\d+)?\s*-\s*(\d+\.\d+)?$`', $testVersion, $matches)) {
                 if (empty($matches[1]) === false || empty($matches[2]) === false) {
                     // If no lower-limit is set, we set the min version to 4.0.
                     // Whilst development focuses on PHP 5 and above, we also accept
@@ -140,8 +140,8 @@ abstract class Sniff implements PHPCS_Sniff
                     // If no upper-limit is set, we set the max version to 99.9.
                     $max = empty($matches[2]) ? '99.9' : $matches[2];
 
-                    if (version_compare($min, $max, '>')) {
-                        trigger_error(
+                    if (\version_compare($min, $max, '>')) {
+                        \trigger_error(
                             "Invalid range in testVersion setting: '" . $testVersion . "'",
                             \E_USER_WARNING
                         );
@@ -153,7 +153,7 @@ abstract class Sniff implements PHPCS_Sniff
                 }
             }
 
-            trigger_error(
+            \trigger_error(
                 "Invalid testVersion setting: '" . $testVersion . "'",
                 \E_USER_WARNING
             );
@@ -188,7 +188,7 @@ abstract class Sniff implements PHPCS_Sniff
         $testVersion = $testVersion[1];
 
         if (\is_null($testVersion)
-            || version_compare($testVersion, $phpVersion) >= 0
+            || \version_compare($testVersion, $phpVersion) >= 0
         ) {
             return true;
         } else {
@@ -217,7 +217,7 @@ abstract class Sniff implements PHPCS_Sniff
         $testVersion = $testVersion[0];
 
         if (\is_null($testVersion) === false
-            && version_compare($testVersion, $phpVersion) <= 0
+            && \version_compare($testVersion, $phpVersion) <= 0
         ) {
             return true;
         } else {
@@ -267,7 +267,7 @@ abstract class Sniff implements PHPCS_Sniff
      */
     public function stringToErrorCode($baseString)
     {
-        return preg_replace('`[^a-z0-9_]`i', '_', strtolower($baseString));
+        return \preg_replace('`[^a-z0-9_]`i', '_', \strtolower($baseString));
     }
 
 
@@ -284,11 +284,11 @@ abstract class Sniff implements PHPCS_Sniff
      */
     public function stripVariables($string)
     {
-        if (strpos($string, '$') === false) {
+        if (\strpos($string, '$') === false) {
             return $string;
         }
 
-        return preg_replace(self::REGEX_COMPLEX_VARS, '', $string);
+        return \preg_replace(self::REGEX_COMPLEX_VARS, '', $string);
     }
 
 
@@ -367,7 +367,7 @@ abstract class Sniff implements PHPCS_Sniff
 
         $end       = $phpcsFile->findNext($find, ($start + 1), null, true, null, true);
         $className = $phpcsFile->getTokensAsString($start, ($end - $start));
-        $className = trim($className);
+        $className = \trim($className);
 
         return $this->getFQName($phpcsFile, $stackPtr, $className);
     }
@@ -471,7 +471,7 @@ abstract class Sniff implements PHPCS_Sniff
 
         $start     = ($start + 1);
         $className = $phpcsFile->getTokensAsString($start, ($stackPtr - $start));
-        $className = trim($className);
+        $className = \trim($className);
 
         return $this->getFQName($phpcsFile, $stackPtr, $className);
     }
@@ -493,14 +493,14 @@ abstract class Sniff implements PHPCS_Sniff
      */
     public function getFQName(File $phpcsFile, $stackPtr, $name)
     {
-        if (strpos($name, '\\') === 0) {
+        if (\strpos($name, '\\') === 0) {
             // Already fully qualified.
             return $name;
         }
 
         // Remove the namespace keyword if used.
-        if (strpos($name, 'namespace\\') === 0) {
-            $name = substr($name, 10);
+        if (\strpos($name, 'namespace\\') === 0) {
+            $name = \substr($name, 10);
         }
 
         $namespace = Namespaces::determineNamespace($phpcsFile, $stackPtr);
@@ -528,11 +528,11 @@ abstract class Sniff implements PHPCS_Sniff
      */
     public function isNamespaced($FQName)
     {
-        if (strpos($FQName, '\\') !== 0) {
+        if (\strpos($FQName, '\\') !== 0) {
             throw new RuntimeException('$FQName must be a fully qualified name');
         }
 
-        return (strpos(substr($FQName, 1), '\\') !== false);
+        return (\strpos(\substr($FQName, 1), '\\') !== false);
     }
 
 
@@ -708,10 +708,10 @@ abstract class Sniff implements PHPCS_Sniff
             }
 
             // Strip off potential nullable indication.
-            $typeHint = ltrim($param['type_hint'], '?');
+            $typeHint = \ltrim($param['type_hint'], '?');
 
             // Strip off potential (global) namespace indication.
-            $typeHint = ltrim($typeHint, '\\');
+            $typeHint = \ltrim($typeHint, '\\');
 
             if ($typeHint !== '') {
                 $typeHints[] = $typeHint;
@@ -747,7 +747,7 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         $functionName   = $tokens[$stackPtr]['content'];
-        $functionNameLc = strtolower($functionName);
+        $functionNameLc = \strtolower($functionName);
 
         // Bow out if not one of the functions we're targetting.
         if (isset($this->hashAlgoFunctions[$functionNameLc]) === false) {
@@ -761,7 +761,7 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         // Algorithm is a text string, so we need to remove the quotes.
-        $algo = strtolower(trim($algoParam['raw']));
+        $algo = \strtolower(\trim($algoParam['raw']));
         $algo = TextStrings::stripQuotes($algo);
 
         return $algo;
@@ -1071,8 +1071,8 @@ abstract class Sniff implements PHPCS_Sniff
             $regexInt   = '`^\s*[0-9]+`';
             $regexFloat = '`^\s*(?:[+-]?(?:(?:(?P<LNUM>[0-9]+)|(?P<DNUM>([0-9]*\.(?P>LNUM)|(?P>LNUM)\.[0-9]*)))[eE][+-]?(?P>LNUM))|(?P>DNUM))`';
 
-            $intString   = preg_match($regexInt, $content, $intMatch);
-            $floatString = preg_match($regexFloat, $content, $floatMatch);
+            $intString   = \preg_match($regexInt, $content, $intMatch);
+            $floatString = \preg_match($regexFloat, $content, $floatMatch);
 
             // Does the text string start with a number ? If so, PHP would juggle it and use it as a number.
             if ($allowFloats === false) {
@@ -1084,26 +1084,26 @@ abstract class Sniff implements PHPCS_Sniff
 
                     $content = 0.0;
                 } else {
-                    $content = (float) trim($intMatch[0]);
+                    $content = (float) \trim($intMatch[0]);
                 }
             } else {
                 if ($intString !== 1 && $floatString !== 1) {
                     $content = 0.0;
                 } else {
-                    $content = ($floatString === 1) ? (float) trim($floatMatch[0]) : (float) trim($intMatch[0]);
+                    $content = ($floatString === 1) ? (float) \trim($floatMatch[0]) : (float) \trim($intMatch[0]);
                 }
             }
 
             // Allow for different behaviour for hex numeric strings between PHP 5 vs PHP 7.
-            if ($intString === 1 && trim($intMatch[0]) === '0'
-                && preg_match('`^\s*(0x[A-Fa-f0-9]+)`', $stringContent, $hexNumberString) === 1
+            if ($intString === 1 && \trim($intMatch[0]) === '0'
+                && \preg_match('`^\s*(0x[A-Fa-f0-9]+)`', $stringContent, $hexNumberString) === 1
                 && $this->supportsBelow('5.6') === true
             ) {
                 // The filter extension still allows for hex numeric strings in PHP 7, so
                 // use that to get the numeric value if possible.
                 // If the filter extension is not available, the value will be zero, but so be it.
-                if (function_exists('filter_var')) {
-                    $filtered = filter_var($hexNumberString[1], \FILTER_VALIDATE_INT, \FILTER_FLAG_ALLOW_HEX);
+                if (\function_exists('filter_var')) {
+                    $filtered = \filter_var($hexNumberString[1], \FILTER_VALIDATE_INT, \FILTER_FLAG_ALLOW_HEX);
                     if ($filtered !== false) {
                         $content = $filtered;
                     }

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -988,7 +988,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         $this->newExceptions = \array_change_key_case($this->newExceptions, \CASE_LOWER);
 
         // Add the Exception classes to the Classes list.
-        $this->newClasses = array_merge($this->newClasses, $this->newExceptions);
+        $this->newClasses = \array_merge($this->newClasses, $this->newExceptions);
 
         return [
             \T_NEW,
@@ -1076,8 +1076,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             return;
         }
 
-        $className   = substr($FQClassName, 1); // Remove global namespace indicator.
-        $classNameLc = strtolower($className);
+        $className   = \substr($FQClassName, 1); // Remove global namespace indicator.
+        $classNameLc = \strtolower($className);
 
         if (isset($this->newClasses[$classNameLc]) === false) {
             return;
@@ -1114,7 +1114,7 @@ class NewClassesSniff extends AbstractNewFeatureSniff
 
         foreach ($typeHints as $hint) {
 
-            $typeHintLc = strtolower($hint);
+            $typeHintLc = \strtolower($hint);
 
             if (isset($this->newClasses[$typeHintLc]) === true) {
                 $itemInfo = [
@@ -1177,8 +1177,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
                     continue;
                 }
 
-                $name   = ltrim($name, '\\');
-                $nameLC = strtolower($name);
+                $name   = \ltrim($name, '\\');
+                $nameLC = \strtolower($name);
 
                 if (isset($this->newExceptions[$nameLC]) === true) {
                     $itemInfo = [
@@ -1215,8 +1215,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             return;
         }
 
-        $returnTypeHint   = ltrim($returnTypeHint, '\\');
-        $returnTypeHintLc = strtolower($returnTypeHint);
+        $returnTypeHint   = \ltrim($returnTypeHint, '\\');
+        $returnTypeHintLc = \strtolower($returnTypeHint);
 
         if (isset($this->newClasses[$returnTypeHintLc]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -117,8 +117,8 @@ class NewTypedPropertiesSniff extends AbstractNewFeatureSniff
         }
 
         // Still here ? In that case, this will be a typed property.
-        $type      = ltrim($properties['type'], '?'); // Trim off potential nullability.
-        $type      = strtolower($type);
+        $type      = \ltrim($properties['type'], '?'); // Trim off potential nullability.
+        $type      = \strtolower($type);
         $typeToken = $properties['type_token'];
 
         if ($this->supportsBelow('7.3') === true) {

--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -203,7 +203,7 @@ class RemovedClassesSniff extends AbstractRemovedFeatureSniff
         $this->removedExceptions = \array_change_key_case($this->removedExceptions, \CASE_LOWER);
 
         // Add the Exception classes to the Classes list.
-        $this->removedClasses = array_merge($this->removedClasses, $this->removedExceptions);
+        $this->removedClasses = \array_merge($this->removedClasses, $this->removedExceptions);
 
         return [
             \T_NEW,
@@ -291,8 +291,8 @@ class RemovedClassesSniff extends AbstractRemovedFeatureSniff
             return;
         }
 
-        $className   = substr($FQClassName, 1); // Remove global namespace indicator.
-        $classNameLc = strtolower($className);
+        $className   = \substr($FQClassName, 1); // Remove global namespace indicator.
+        $classNameLc = \strtolower($className);
 
         if (isset($this->removedClasses[$classNameLc]) === false) {
             return;
@@ -329,7 +329,7 @@ class RemovedClassesSniff extends AbstractRemovedFeatureSniff
 
         foreach ($typeHints as $hint) {
 
-            $typeHintLc = strtolower($hint);
+            $typeHintLc = \strtolower($hint);
 
             if (isset($this->removedClasses[$typeHintLc]) === true) {
                 $itemInfo = [
@@ -392,8 +392,8 @@ class RemovedClassesSniff extends AbstractRemovedFeatureSniff
                     continue;
                 }
 
-                $name   = ltrim($name, '\\');
-                $nameLC = strtolower($name);
+                $name   = \ltrim($name, '\\');
+                $nameLC = \strtolower($name);
 
                 if (isset($this->removedExceptions[$nameLC]) === true) {
                     $itemInfo = [
@@ -430,8 +430,8 @@ class RemovedClassesSniff extends AbstractRemovedFeatureSniff
             return;
         }
 
-        $returnTypeHint   = ltrim($returnTypeHint, '\\');
-        $returnTypeHintLc = strtolower($returnTypeHint);
+        $returnTypeHint   = \ltrim($returnTypeHint, '\\');
+        $returnTypeHintLc = \strtolower($returnTypeHint);
 
         if (isset($this->removedClasses[$returnTypeHintLc]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -77,7 +77,7 @@ class NewMagicClassConstantSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if (strtolower($tokens[$stackPtr]['content']) !== 'class') {
+        if (\strtolower($tokens[$stackPtr]['content']) !== 'class') {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -199,7 +199,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
 
                 $level = null;
                 if ($codeString !== '') {
-                    if (is_numeric($codeString)) {
+                    if (\is_numeric($codeString)) {
                         $level = (int) $codeString;
                     } else {
                         // With the above logic, the string can only contain digits and operators, eval!
@@ -216,7 +216,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
                     continue;
                 }
 
-                $conditions = array_reverse($tokens[$continue]['conditions'], true);
+                $conditions = \array_reverse($tokens[$continue]['conditions'], true);
                 // PHPCS adds more structures to the conditions array than we want to take into
                 // consideration, so clean up the array.
                 foreach ($conditions as $tokenPtr => $tokenCode) {
@@ -230,7 +230,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
                     continue;
                 }
 
-                $conditionToken = key($targetCondition);
+                $conditionToken = \key($targetCondition);
                 if ($conditionToken === $stackPtr) {
                     $phpcsFile->addWarning(
                         "Targeting a 'switch' control structure with a 'continue' statement is strongly discouraged and will throw a warning as of PHP 7.3.",

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -126,7 +126,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
         if (isset($this->newDirectives[$directiveContent]) === false) {
             $error = 'Declare can only be used with the directives %s. Found: %s';
             $data  = [
-                implode(', ', array_keys($this->newDirectives)),
+                \implode(', ', \array_keys($this->newDirectives)),
                 $directiveContent,
             ];
 
@@ -335,7 +335,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      */
     protected function isNumeric($value)
     {
-        return is_numeric($value);
+        return \is_numeric($value);
     }
 
 
@@ -353,8 +353,8 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
     protected function validEncoding($value)
     {
         static $encodings;
-        if (isset($encodings) === false && function_exists('mb_list_encodings')) {
-            $encodings = mb_list_encodings();
+        if (isset($encodings) === false && \function_exists('mb_list_encodings')) {
+            $encodings = \mb_list_encodings();
         }
 
         if (empty($encodings) || \is_array($encodings) === false) {

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -265,7 +265,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
         }
 
         $function   = $tokens[$stackPtr]['content'];
-        $functionLc = strtolower($function);
+        $functionLc = \strtolower($function);
 
         if ($this->isWhiteListed($functionLc) === true) {
             // Function is whitelisted.
@@ -273,7 +273,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
         }
 
         foreach ($this->removedExtensions as $extension => $versionList) {
-            if (strpos($functionLc, $extension) === 0) {
+            if (\strpos($functionLc, $extension) === 0) {
                 $itemInfo = [
                     'name'   => $extension,
                 ];
@@ -302,15 +302,15 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
         }
 
         if (\is_string($this->functionWhitelist) === true) {
-            if (strpos($this->functionWhitelist, ',') !== false) {
-                $this->functionWhitelist = explode(',', $this->functionWhitelist);
+            if (\strpos($this->functionWhitelist, ',') !== false) {
+                $this->functionWhitelist = \explode(',', $this->functionWhitelist);
             } else {
                 $this->functionWhitelist = (array) $this->functionWhitelist;
             }
         }
 
         if (\is_array($this->functionWhitelist) === true) {
-            $this->functionWhitelist = array_map('strtolower', $this->functionWhitelist);
+            $this->functionWhitelist = \array_map('strtolower', $this->functionWhitelist);
             return \in_array($content, $this->functionWhitelist, true);
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
@@ -76,7 +76,7 @@ class ForbiddenFinalPrivateMethodsSniff extends Sniff
             return;
         }
 
-        if (strtolower($name) === '__construct') {
+        if (\strtolower($name) === '__construct') {
             // The rule does not apply to constructors. Bow out.
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -73,7 +73,7 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
         foreach ($parameters as $param) {
             if (Variables::isSuperglobalName($param['name']) === true) {
                 $error     = 'Parameter shadowing super global (%s) causes a fatal error since PHP 5.4';
-                $errorCode = $this->stringToErrorCode(substr($param['name'], 1)) . 'Found';
+                $errorCode = $this->stringToErrorCode(\substr($param['name'], 1)) . 'Found';
                 $data      = [$param['name']];
 
                 $phpcsFile->addError($error, $param['token'], $errorCode, $data);

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -60,7 +60,7 @@ class ForbiddenToStringParametersSniff extends Sniff
         }
 
         $functionName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
-        if (strtolower($functionName) !== '__tostring') {
+        if (\strtolower($functionName) !== '__tostring') {
             // Not the right function.
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -134,7 +134,7 @@ class NewClosureSniff extends Sniff
                         'Closures / anonymous functions could not use "%s::" in PHP 5.3 or earlier',
                         $usesClassRef,
                         'ClassRefFound',
-                        [strtolower($tokens[$usesClassRef]['content'])]
+                        [\strtolower($tokens[$usesClassRef]['content'])]
                     );
 
                     $usesClassRef = $this->findClassRefUsageInClosure($phpcsFile, ($usesClassRef + 1), $scopeEnd);

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -84,7 +84,7 @@ class NewExceptionsFromToStringSniff extends Sniff
         }
 
         $functionName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
-        if (strtolower($functionName) !== '__tostring') {
+        if (\strtolower($functionName) !== '__tostring') {
             // Not the right function.
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -182,8 +182,8 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
             }
 
             // Strip off potential nullable indication.
-            $typeHint = ltrim($param['type_hint'], '?');
-            $typeHint = strtolower($typeHint);
+            $typeHint = \ltrim($param['type_hint'], '?');
+            $typeHint = \strtolower($typeHint);
 
             if ($supportsPHP4 === true) {
                 $phpcsFile->addError(
@@ -209,7 +209,7 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
                     $phpcsFile->addError(
                         "'%s' type cannot be used outside of class scope",
                         $param['token'],
-                        ucfirst($typeHint) . 'OutsideClassScopeFound',
+                        \ucfirst($typeHint) . 'OutsideClassScopeFound',
                         [$typeHint]
                     );
                 }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -156,8 +156,8 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
             return;
         }
 
-        $returnType      = ltrim($properties['return_type'], '?'); // Trim off potential nullability.
-        $returnType      = strtolower($returnType);
+        $returnType      = \ltrim($properties['return_type'], '?'); // Trim off potential nullability.
+        $returnType      = \strtolower($returnType);
         $returnTypeToken = $properties['return_type_token'];
 
         if (isset($this->newTypes[$returnType]) === true) {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -152,7 +152,7 @@ class NonStaticMagicMethodsSniff extends Sniff
         }
 
         $methodName   = FunctionDeclarations::getName($phpcsFile, $stackPtr);
-        $methodNameLc = strtolower($methodName);
+        $methodNameLc = \strtolower($methodName);
 
         if (isset($this->magicMethods[$methodNameLc]) === false) {
             // Not one of the magic methods we're looking for.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -69,7 +69,7 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
             return;
         }
 
-        if (strtolower($name) !== '__construct') {
+        if (\strtolower($name) !== '__construct') {
             // The rule only applies to constructors. Bow out.
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -128,7 +128,7 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $functionName   = FunctionDeclarations::getName($phpcsFile, $stackPtr);
-        $functionNameLc = strtolower($functionName);
+        $functionNameLc = \strtolower($functionName);
 
         if (isset($this->newMagicMethods[$functionNameLc]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -81,7 +81,7 @@ class RemovedMagicAutoloadSniff extends Sniff
 
         $funcName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
 
-        if (strtolower($funcName) !== '__autoload') {
+        if (\strtolower($funcName) !== '__autoload') {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -68,7 +68,7 @@ class RemovedNamespacedAssertSniff extends Sniff
 
         $funcName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
 
-        if (strtolower($funcName) !== 'assert') {
+        if (\strtolower($funcName) !== 'assert') {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -125,7 +125,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
                 continue;
             }
 
-            if (strtolower($funcName) === '__construct') {
+            if (\strtolower($funcName) === '__construct') {
                 $newConstructorFound = true;
             }
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -65,7 +65,7 @@ class ReservedFunctionNamesSniff implements Sniff
             return;
         }
 
-        if (preg_match('|^__[^_]|', $functionName) !== 1) {
+        if (\preg_match('|^__[^_]|', $functionName) !== 1) {
             // Name doesn't start with double underscore.
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -190,7 +190,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 continue;
             }
 
-            $foundFunctionName = strtolower($tokens[$i]['content']);
+            $foundFunctionName = \strtolower($tokens[$i]['content']);
 
             if (isset($this->changedFunctions[$foundFunctionName]) === false) {
                 // Not one of the target functions.

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -75,7 +75,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens     = $phpcsFile->getTokens();
-        $functionLc = strtolower($tokens[$stackPtr]['content']);
+        $functionLc = \strtolower($tokens[$stackPtr]['content']);
         if (isset($this->targetFunctions[$functionLc]) === false) {
             return;
         }
@@ -135,13 +135,13 @@ class ArgumentFunctionsUsageSniff extends Sniff
 
         $throwError = false;
 
-        $closer = end($tokens[$stackPtr]['nested_parenthesis']);
+        $closer = \end($tokens[$stackPtr]['nested_parenthesis']);
         if (isset($tokens[$closer]['parenthesis_owner'])
             && $tokens[$tokens[$closer]['parenthesis_owner']]['type'] === 'T_CLOSURE'
         ) {
             $throwError = true;
         } else {
-            $opener       = key($tokens[$stackPtr]['nested_parenthesis']);
+            $opener       = \key($tokens[$stackPtr]['nested_parenthesis']);
             $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
             if ($tokens[$prevNonEmpty]['code'] !== \T_STRING) {
                 return;

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -1031,7 +1031,7 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $function   = $tokens[$stackPtr]['content'];
-        $functionLc = strtolower($function);
+        $functionLc = \strtolower($function);
 
         if (isset($this->newFunctionParameters[$functionLc]) === false) {
             return;
@@ -1177,8 +1177,8 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
      */
     protected function filterErrorData(array $data, array $itemInfo, array $errorInfo)
     {
-        array_shift($data);
-        array_unshift($data, $itemInfo['name'], $errorInfo['paramName']);
+        \array_shift($data);
+        \array_unshift($data, $itemInfo['name'], $errorInfo['paramName']);
         return $data;
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4555,7 +4555,7 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $function   = $tokens[$stackPtr]['content'];
-        $functionLc = strtolower($function);
+        $functionLc = \strtolower($function);
 
         if (isset($this->newFunctions[$functionLc]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -126,7 +126,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $function   = $tokens[$stackPtr]['content'];
-        $functionLc = strtolower($function);
+        $functionLc = \strtolower($function);
 
         if (isset($this->removedFunctionParameters[$functionLc]) === false) {
             return;
@@ -173,7 +173,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
 
         foreach ($this->removedFunctionParameters[$functionLc] as $offset => $parameterDetails) {
             if ($offset <= $parameterOffsetFound) {
-                if (isset($parameterDetails['callback']) && method_exists($this, $parameterDetails['callback'])) {
+                if (isset($parameterDetails['callback']) && \method_exists($this, $parameterDetails['callback'])) {
                     if ($this->{$parameterDetails['callback']}($phpcsFile, $parameters[($offset + 1)]) === false) {
                         continue;
                     }
@@ -279,8 +279,8 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
      */
     protected function filterErrorData(array $data, array $itemInfo, array $errorInfo)
     {
-        array_shift($data);
-        array_unshift($data, $errorInfo['paramName'], $itemInfo['name']);
+        \array_shift($data);
+        \array_unshift($data, $errorInfo['paramName'], $itemInfo['name']);
         return $data;
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4816,7 +4816,7 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         $tokens = $phpcsFile->getTokens();
 
         $function   = $tokens[$stackPtr]['content'];
-        $functionLc = strtolower($function);
+        $functionLc = \strtolower($function);
 
         if (isset($this->removedFunctions[$functionLc]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -225,7 +225,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
         }
 
         $function   = $tokens[$stackPtr]['content'];
-        $functionLc = strtolower($function);
+        $functionLc = \strtolower($function);
 
         if (isset($this->functionParameters[$functionLc]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -69,8 +69,8 @@ class NewGeneratorReturnSniff extends Sniff
          * For PHP 5.5+ we need to look for T_YIELD.
          * For PHPCS 3.1.0+, we also need to look for T_YIELD_FROM.
          */
-        if (version_compare(\PHP_VERSION_ID, '50500', '<') === true
-            && version_compare(Helper::getVersion(), '3.1.0', '<') === true
+        if (\version_compare(\PHP_VERSION_ID, '50500', '<') === true
+            && \version_compare(Helper::getVersion(), '3.1.0', '<') === true
         ) {
             $targets[] = \T_STRING;
         }

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -907,7 +907,7 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             return;
         }
 
-        $functionLc = strtolower($tokens[$stackPtr]['content']);
+        $functionLc = \strtolower($tokens[$stackPtr]['content']);
         if (isset($this->iniFunctions[$functionLc]) === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -623,7 +623,7 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             return;
         }
 
-        $functionLc = strtolower($tokens[$stackPtr]['content']);
+        $functionLc = \strtolower($tokens[$stackPtr]['content']);
         if (isset($this->iniFunctions[$functionLc]) === false) {
             return;
         }
@@ -706,6 +706,6 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
      */
     protected function getAlternativeOptionTemplate()
     {
-        return str_replace('%s', "'%s'", parent::getAlternativeOptionTemplate());
+        return \str_replace('%s', "'%s'", parent::getAlternativeOptionTemplate());
     }
 }

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -73,7 +73,7 @@ class NewConstantArraysUsingDefineSniff extends Sniff
             return;
         }
 
-        $functionLc = strtolower($tokens[$stackPtr]['content']);
+        $functionLc = \strtolower($tokens[$stackPtr]['content']);
         if ($functionLc !== 'define') {
             return;
         }

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -83,8 +83,8 @@ class InternalInterfacesSniff extends Sniff
         }
 
         foreach ($interfaces as $interface) {
-            $interface   = ltrim($interface, '\\');
-            $interfaceLc = strtolower($interface);
+            $interface   = \ltrim($interface, '\\');
+            $interfaceLc = \strtolower($interface);
             if (isset($this->internalInterfaces[$interfaceLc]) === true) {
                 $error     = 'The interface %s %s';
                 $errorCode = $this->stringToErrorCode($interfaceLc) . 'Found';

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -235,8 +235,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
         }
 
         foreach ($interfaces as $interface) {
-            $interface   = ltrim($interface, '\\');
-            $interfaceLc = strtolower($interface);
+            $interface   = \ltrim($interface, '\\');
+            $interfaceLc = \strtolower($interface);
 
             if (isset($this->newInterfaces[$interfaceLc]) === true) {
                 $itemInfo = [
@@ -250,7 +250,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
                 $nextFunc = $stackPtr;
                 while (($nextFunc = $phpcsFile->findNext(\T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
                     $funcName   = $phpcsFile->getDeclarationName($nextFunc);
-                    $funcNameLc = strtolower($funcName);
+                    $funcNameLc = \strtolower($funcName);
                     if ($funcNameLc === '') {
                         continue;
                     }
@@ -294,7 +294,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
 
         foreach ($typeHints as $hint) {
 
-            $typeHintLc = strtolower($hint);
+            $typeHintLc = \strtolower($hint);
 
             if (isset($this->newInterfaces[$typeHintLc]) === true) {
                 $itemInfo = [
@@ -327,8 +327,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
             return;
         }
 
-        $returnTypeHint   = ltrim($returnTypeHint, '\\');
-        $returnTypeHintLc = strtolower($returnTypeHint);
+        $returnTypeHint   = \ltrim($returnTypeHint, '\\');
+        $returnTypeHintLc = \strtolower($returnTypeHint);
 
         if (isset($this->newInterfaces[$returnTypeHintLc]) === false) {
             return;
@@ -393,8 +393,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
                     continue;
                 }
 
-                $name   = ltrim($name, '\\');
-                $nameLC = strtolower($name);
+                $name   = \ltrim($name, '\\');
+                $nameLC = \strtolower($name);
 
                 if (isset($this->newInterfaces[$nameLC]) === true) {
                     $itemInfo = [

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -59,7 +59,7 @@ class CaseSensitiveKeywordsSniff extends Sniff
         }
 
         $tokens         = $phpcsFile->getTokens();
-        $tokenContentLC = strtolower($tokens[$stackPtr]['content']);
+        $tokenContentLC = \strtolower($tokens[$stackPtr]['content']);
 
         if ($tokenContentLC !== $tokens[$stackPtr]['content']) {
             $phpcsFile->addError(

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -107,7 +107,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
     public function register()
     {
         // Do the list merge only once.
-        $this->allForbiddenNames = array_merge($this->forbiddenNames, $this->softReservedNames);
+        $this->allForbiddenNames = \array_merge($this->forbiddenNames, $this->softReservedNames);
 
         $targets = [
             \T_CLASS,
@@ -147,7 +147,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
                 return;
             }
 
-            $nameLc = strtolower($name);
+            $nameLc = \strtolower($name);
             if (isset($this->allForbiddenNames[$nameLc]) === false) {
                 return;
             }
@@ -160,9 +160,9 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
                 return;
             }
 
-            $namespaceParts = explode('\\', $namespaceName);
+            $namespaceParts = \explode('\\', $namespaceName);
             foreach ($namespaceParts as $namespacePart) {
-                $partLc = strtolower($namespacePart);
+                $partLc = \strtolower($namespacePart);
                 if (isset($this->allForbiddenNames[$partLc]) === true) {
                     $name   = $namespacePart;
                     $nameLc = $partLc;

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -92,7 +92,7 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
      */
     public function register()
     {
-        $tokens   = array_keys($this->targetedTokens);
+        $tokens   = \array_keys($this->targetedTokens);
         $tokens[] = \T_STRING;
 
         return $tokens;
@@ -113,7 +113,7 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
     {
         $tokens         = $phpcsFile->getTokens();
         $tokenCode      = $tokens[$stackPtr]['code'];
-        $tokenContentLc = strtolower($tokens[$stackPtr]['content']);
+        $tokenContentLc = \strtolower($tokens[$stackPtr]['content']);
         $isString       = false;
 
         /*

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -231,7 +231,7 @@ class ForbiddenNamesSniff extends Sniff
          * - `use const HelloWorld` => move to the next token (HelloWorld) to verify.
          */
         elseif ($tokens[$stackPtr]['type'] === 'T_USE'
-            && isset($this->validUseNames[strtolower($tokens[$nextNonEmpty]['content'])]) === true
+            && isset($this->validUseNames[\strtolower($tokens[$nextNonEmpty]['content'])]) === true
         ) {
             $maybeUseNext = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext !== false && $this->isEndOfUseStatement($tokens[$maybeUseNext]) === false) {
@@ -263,7 +263,7 @@ class ForbiddenNamesSniff extends Sniff
             && isset($tokens[$stackPtr]['nested_parenthesis']) === true
             && $tokens[$nextNonEmpty]['code'] === \T_LIST
         ) {
-            $parentheses = array_reverse($tokens[$stackPtr]['nested_parenthesis'], true);
+            $parentheses = \array_reverse($tokens[$stackPtr]['nested_parenthesis'], true);
             foreach ($parentheses as $open => $close) {
                 if (isset($tokens[$open]['parenthesis_owner'])
                     && $tokens[$tokens[$open]['parenthesis_owner']]['code'] === \T_FOREACH
@@ -298,14 +298,14 @@ class ForbiddenNamesSniff extends Sniff
             }
 
             $endToken      = $phpcsFile->findNext([\T_SEMICOLON, \T_OPEN_CURLY_BRACKET], ($stackPtr + 1), null, false, null, true);
-            $namespaceName = trim($phpcsFile->getTokensAsString(($stackPtr + 1), ($endToken - $stackPtr - 1)));
+            $namespaceName = \trim($phpcsFile->getTokensAsString(($stackPtr + 1), ($endToken - $stackPtr - 1)));
             if (empty($namespaceName) === true) {
                 return;
             }
 
-            $namespaceParts = explode('\\', $namespaceName);
+            $namespaceParts = \explode('\\', $namespaceName);
             foreach ($namespaceParts as $namespacePart) {
-                $partLc = strtolower($namespacePart);
+                $partLc = \strtolower($namespacePart);
                 if (isset($this->invalidNames[$partLc]) === false) {
                     continue;
                 }
@@ -321,7 +321,7 @@ class ForbiddenNamesSniff extends Sniff
             unset($i, $namespacePart, $partLc);
         }
 
-        $nextContentLc = strtolower($tokens[$nextNonEmpty]['content']);
+        $nextContentLc = \strtolower($tokens[$nextNonEmpty]['content']);
         if (isset($this->invalidNames[$nextContentLc]) === false) {
             return;
         }
@@ -365,7 +365,7 @@ class ForbiddenNamesSniff extends Sniff
      */
     public function processString(File $phpcsFile, $stackPtr, $tokens)
     {
-        $tokenContentLc = strtolower($tokens[$stackPtr]['content']);
+        $tokenContentLc = \strtolower($tokens[$stackPtr]['content']);
 
         // Look for any define/defined tokens (both T_STRING ones, blame Tokenizer).
         if ($tokenContentLc !== 'define' && $tokenContentLc !== 'defined') {
@@ -379,7 +379,7 @@ class ForbiddenNamesSniff extends Sniff
         }
 
         $defineName   = TextStrings::stripQuotes($firstParam['raw']);
-        $defineNameLc = strtolower($defineName);
+        $defineNameLc = \strtolower($defineName);
 
         if (isset($this->invalidNames[$defineNameLc]) && $this->supportsAbove($this->invalidNames[$defineNameLc])) {
             $data = [

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -185,10 +185,10 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
         $translate = [];
         foreach ($this->newKeywords as $token => $versions) {
             if (\defined($token)) {
-                $tokens[] = constant($token);
+                $tokens[] = \constant($token);
             }
             if (isset($versions['content'])) {
-                $translate[strtolower($versions['content'])] = $token;
+                $translate[\strtolower($versions['content'])] = $token;
             }
         }
 
@@ -226,7 +226,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
 
         // Translate T_STRING token if necessary.
         if ($tokens[$stackPtr]['type'] === 'T_STRING') {
-            $content = strtolower($tokens[$stackPtr]['content']);
+            $content = \strtolower($tokens[$stackPtr]['content']);
 
             if (isset($this->translateContentToToken[$content]) === false) {
                 // Not one of the tokens we're looking for.

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -64,7 +64,7 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
     {
         $tokens = [];
         foreach ($this->newConstructs as $token => $versions) {
-            $tokens[] = constant($token);
+            $tokens[] = \constant($token);
         }
         return $tokens;
     }

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -83,7 +83,7 @@ class AssignmentOrderSniff extends Sniff
         }
 
         // Verify that all variables used in the list() construct are unique.
-        if (\count($listVars) !== \count(array_unique($listVars))) {
+        if (\count($listVars) !== \count(\array_unique($listVars))) {
             $phpcsFile->addError(
                 'list() will assign variable from left-to-right since PHP 7.0. Ensure all variables in list() are unique to prevent unexpected results.',
                 $stackPtr,

--- a/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
@@ -77,7 +77,7 @@ class ForbiddenToStringParametersSniff extends Sniff
             return;
         }
 
-        if (strtolower($tokens[$nextNonEmpty]['content']) !== '__tostring') {
+        if (\strtolower($tokens[$nextNonEmpty]['content']) !== '__tostring') {
             // Not a call to the __toString() method.
             return;
         }

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -79,7 +79,7 @@ class NewDirectCallsToCloneSniff extends Sniff
             return;
         }
 
-        if (strtolower($tokens[$nextNonEmpty]['content']) !== '__clone') {
+        if (\strtolower($tokens[$nextNonEmpty]['content']) !== '__clone') {
             // Not a call to the __clone() method.
             return;
         }

--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -54,14 +54,14 @@ class NewPHPOpenTagEOFSniff extends Sniff
             \T_OPEN_TAG_WITH_ECHO,
         ];
 
-        $this->shortOpenTags = (bool) ini_get('short_open_tag');
+        $this->shortOpenTags = (bool) \ini_get('short_open_tag');
         if ($this->shortOpenTags === false) {
             $targets[] = \T_INLINE_HTML;
         } else {
             $targets[] = \T_STRING;
         }
 
-        if (version_compare(\PHP_VERSION_ID, '70399', '>')) {
+        if (\version_compare(\PHP_VERSION_ID, '70399', '>')) {
             $targets[] = \T_OPEN_TAG;
         }
 
@@ -115,7 +115,7 @@ class NewPHPOpenTagEOFSniff extends Sniff
 
             case \T_OPEN_TAG_WITH_ECHO:
                 // PHP 5.4+.
-                if (rtrim($contents) === '<?=') {
+                if (\rtrim($contents) === '<?=') {
                     $error = true;
                 }
                 break;

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -47,9 +47,9 @@ class RemovedAlternativePHPTagsSniff extends Sniff
      */
     public function register()
     {
-        if (version_compare(\PHP_VERSION_ID, '70000', '<') === true) {
+        if (\version_compare(\PHP_VERSION_ID, '70000', '<') === true) {
             // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.asp_tagsRemoved
-            $this->aspTags = (bool) ini_get('asp_tags');
+            $this->aspTags = (bool) \ini_get('asp_tags');
         }
 
         return [
@@ -79,7 +79,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
 
         $tokens  = $phpcsFile->getTokens();
         $openTag = $tokens[$stackPtr];
-        $content = trim($openTag['content']);
+        $content = \trim($openTag['content']);
 
         if ($content === '' || $content === '<?php') {
             return;
@@ -94,7 +94,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
                 ];
                 $errorCode = 'ASPOpenTagFound';
 
-            } elseif (strpos($content, '<script ') !== false) {
+            } elseif (\strpos($content, '<script ') !== false) {
                 $data      = [
                     'Script',
                     $content,
@@ -106,7 +106,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
         }
         // Account for incorrect script open tags.
         elseif ($openTag['code'] === \T_INLINE_HTML
-            && preg_match('`(<script (?:[^>]+)?language=[\'"]?php[\'"]?(?:[^>]+)?>)`i', $content, $match) === 1
+            && \preg_match('`(<script (?:[^>]+)?language=[\'"]?php[\'"]?(?:[^>]+)?>)`i', $content, $match) === 1
         ) {
             $found     = $match[1];
             $data      = [
@@ -128,7 +128,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
 
         // If we're still here, we can't be sure if what we found was really intended as ASP open tags.
         if ($openTag['code'] === \T_INLINE_HTML && $this->aspTags === false) {
-            if (strpos($content, '<%') !== false) {
+            if (\strpos($content, '<%') !== false) {
                 $error   = 'Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: %s';
                 $snippet = $this->getSnippet($content, '<%');
                 $data    = ['<%' . $snippet];
@@ -155,13 +155,13 @@ class RemovedAlternativePHPTagsSniff extends Sniff
         $startPos = 0;
 
         if ($startAt !== '') {
-            $startPos = strpos($content, $startAt);
+            $startPos = \strpos($content, $startAt);
             if ($startPos !== false) {
                 $startPos += \strlen($startAt);
             }
         }
 
-        $snippet = substr($content, $startPos, $length);
+        $snippet = \substr($content, $startPos, $length);
         if ((\strlen($content) - $startPos) > $length) {
             $snippet .= '...';
         }

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -67,8 +67,8 @@ class ReservedNamesSniff extends Sniff
             return;
         }
 
-        $nameParts = explode('\\', $name);
-        $firstPart = strtolower($nameParts[0]);
+        $nameParts = \explode('\\', $name);
+        $firstPart = \strtolower($nameParts[0]);
         if ($firstPart !== 'php') {
             return;
         }

--- a/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
@@ -163,6 +163,6 @@ class ValidIntegersSniff extends Sniff
      */
     private function isInvalidOctalInteger($tokenContent)
     {
-        return (preg_match('`^0[0-7]*[8-9]+[0-9]*$`D', $tokenContent) === 1);
+        return (\preg_match('`^0[0-7]*[8-9]+[0-9]*$`D', $tokenContent) === 1);
     }
 }

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -134,7 +134,7 @@ class NewOperatorsSniff extends AbstractNewFeatureSniff
         $tokens = [];
         foreach ($this->newOperators as $token => $versions) {
             if (\defined($token)) {
-                $tokens[] = constant($token);
+                $tokens[] = \constant($token);
             } elseif (isset($this->newOperatorsPHPCSCompat[$token])) {
                 $tokens[] = $this->newOperatorsPHPCSCompat[$token];
             }

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
@@ -87,7 +87,7 @@ class ChangedObStartEraseFlagsSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        if ((preg_match('`PHP_OUTPUT_HANDLER_(CLEANABLE|FLUSHABLE|REMOVABLE|STDFLAGS)`', $targetParam['clean']) === 1
+        if ((\preg_match('`PHP_OUTPUT_HANDLER_(CLEANABLE|FLUSHABLE|REMOVABLE|STDFLAGS)`', $targetParam['clean']) === 1
             || $this->isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], true) !== false)
             && $this->supportsBelow('5.3') === true
         ) {

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -81,7 +81,7 @@ class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCallParame
             }
 
             if (isset(BCTokens::textStringTokens()[$tokens[$i]['code']]) === true
-                && strpos($tokens[$i]['content'], '/>') !== false
+                && \strpos($tokens[$i]['content'], '/>') !== false
             ) {
                 $phpcsFile->addError(
                     'Self-closing XHTML tags are ignored. Only non-self-closing tags should be used in the strip_tags() $allowable_tags parameter since PHP 5.3.4. Found: %s',

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -87,13 +87,13 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
                 continue;
             }
 
-            if (strpos($tokens[$i]['content'], 'c+') !== false && $this->supportsBelow('5.2.5')) {
+            if (\strpos($tokens[$i]['content'], 'c+') !== false && $this->supportsBelow('5.2.5')) {
                 $errors['cplusFound'] = [
                     'c+',
                     '5.2.5',
                     $targetParam['clean'],
                 ];
-            } elseif (strpos($tokens[$i]['content'], 'c') !== false && $this->supportsBelow('5.2.5')) {
+            } elseif (\strpos($tokens[$i]['content'], 'c') !== false && $this->supportsBelow('5.2.5')) {
                 $errors['cFound'] = [
                     'c',
                     '5.2.5',
@@ -101,7 +101,7 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
                 ];
             }
 
-            if (strpos($tokens[$i]['content'], 'e') !== false && $this->supportsBelow('7.0.15')) {
+            if (\strpos($tokens[$i]['content'], 'e') !== false && $this->supportsBelow('7.0.15')) {
                 $errors['eFound'] = [
                     'e',
                     '7.0.15',

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
@@ -78,7 +78,7 @@ class NewHTMLEntitiesEncodingDefaultSniff extends AbstractFunctionCallParameterS
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $functionLC = strtolower($functionName);
+        $functionLC = \strtolower($functionName);
         if (isset($parameters[$this->targetFunctions[$functionLC]]) === true) {
             return;
         }

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
@@ -75,7 +75,7 @@ class NewIDNVariantDefaultSniff extends AbstractFunctionCallParameterSniff
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $functionLC = strtolower($functionName);
+        $functionLC = \strtolower($functionName);
         if (isset($parameters[$this->targetFunctions[$functionLC]]) === true) {
             return;
         }

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -114,7 +114,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $functionLC = strtolower($functionName);
+        $functionLC = \strtolower($functionName);
         if ($functionLC === 'iconv_mime_encode') {
             // Special case the iconv_mime_encode() function.
             return $this->processIconvMimeEncode($phpcsFile, $stackPtr, $functionName, $parameters);
@@ -125,7 +125,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
         }
 
         $paramName = '$encoding';
-        if (strpos($functionLC, 'iconv_') === 0) {
+        if (\strpos($functionLC, 'iconv_') === 0) {
             $paramName = '$charset';
         } elseif ($functionLC === 'mb_convert_encoding') {
             $paramName = '$from_encoding';
@@ -157,7 +157,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
     {
         $error = 'The default value of the %s parameter index for iconv_mime_encode() was changed from ISO-8859-1 to UTF-8 in PHP 5.6. For cross-version compatibility, the %s should be explicitly set.';
 
-        $functionLC = strtolower($functionName);
+        $functionLC = \strtolower($functionName);
         if (isset($parameters[$this->targetFunctions[$functionLC]]) === false) {
             $phpcsFile->addError(
                 $error,
@@ -184,8 +184,8 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
             || $tokens[$firstNonEmpty]['code'] === \T_OPEN_SHORT_ARRAY
         ) {
             // Note: the item names are treated case-sensitively in PHP, so match on exact case.
-            $hasInputCharset  = preg_match('`([\'"])input-charset\1\s*=>`', $targetParam['clean']);
-            $hasOutputCharset = preg_match('`([\'"])output-charset\1\s*=>`', $targetParam['clean']);
+            $hasInputCharset  = \preg_match('`([\'"])input-charset\1\s*=>`', $targetParam['clean']);
+            $hasOutputCharset = \preg_match('`([\'"])output-charset\1\s*=>`', $targetParam['clean']);
             if ($hasInputCharset === 1 && $hasOutputCharset === 1) {
                 // Both input as well as output charset are set.
                 return;

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -102,7 +102,7 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $functionLC = strtolower($functionName);
+        $functionLC = \strtolower($functionName);
         foreach ($this->targetFunctions[$functionLC] as $pos => $name) {
             if (isset($parameters[$pos]) === false) {
                 continue;

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -98,7 +98,7 @@ class NewPCREModifiersSniff extends RemovedPCREModifiersSniff
         $error = 'The PCRE regex modifier "%s" is not present in PHP version %s or earlier';
 
         foreach ($this->newModifiers as $modifier => $versionArray) {
-            if (strpos($modifiers, $modifier) === false) {
+            if (\strpos($modifiers, $modifier) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -113,7 +113,7 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
             }
 
             foreach ($this->newFormats as $pattern => $versionArray) {
-                if (preg_match($pattern, $content, $matches) !== 1) {
+                if (\preg_match($pattern, $content, $matches) !== 1) {
                     continue;
                 }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -94,7 +94,7 @@ class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParameterSn
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $functionLC = strtolower($functionName);
+        $functionLC = \strtolower($functionName);
         if (isset($parameters[$this->targetFunctions[$functionLC]]) === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -100,7 +100,7 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
         }
 
         if ($this->supportsAbove('7.4') === true) {
-            if (strpos($targetParam['clean'], 'escapeshellarg(') === false) {
+            if (\strpos($targetParam['clean'], 'escapeshellarg(') === false) {
                 // Efficiency: prevent needlessly walking the array.
                 return;
             }

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -98,7 +98,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
         }
 
         if ($this->supportsAbove('7.4') === true) {
-            if (strpos($targetParam['clean'], '>') === false) {
+            if (\strpos($targetParam['clean'], '>') === false) {
                 // Efficiency: prevent needlessly walking the array.
                 return;
             }
@@ -119,7 +119,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
                     }
 
                     if (isset(BCTokens::textStringTokens()[$tokens[$i]['code']]) === true
-                        && strpos($tokens[$i]['content'], '>') !== false
+                        && \strpos($tokens[$i]['content'], '>') !== false
                     ) {
                         $phpcsFile->addWarning(
                             'When passing strip_tags() the $allowable_tags parameter as an array, the tags should not be enclosed in <> brackets. Found: %s',

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -152,7 +152,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
         $hasTernary = $phpcsFile->findNext(\T_INLINE_THEN, $start, $end);
         if ($hasTernary !== false
             && isset($tokens[$start]['nested_parenthesis'], $tokens[$hasTernary]['nested_parenthesis'])
-            && count($tokens[$start]['nested_parenthesis']) === count($tokens[$hasTernary]['nested_parenthesis'])
+            && \count($tokens[$start]['nested_parenthesis']) === \count($tokens[$hasTernary]['nested_parenthesis'])
         ) {
             $start = ($hasTernary + 1);
         }
@@ -190,9 +190,9 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
                     continue;
                 }
 
-                $nameLc = strtolower($tokens[$i]['content']);
+                $nameLc = \strtolower($tokens[$i]['content']);
                 if (isset($this->arrayFunctions[$nameLc]) === false
-                    && (strpos($nameLc, 'array_') !== 0
+                    && (\strpos($nameLc, 'array_') !== 0
                     || isset($this->arrayFunctionExceptions[$nameLc]) === true)
                 ) {
                     continue;
@@ -248,7 +248,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
         $hasTernary = $phpcsFile->findNext(\T_INLINE_THEN, $start, $end);
         if ($hasTernary !== false
             && isset($tokens[$start]['nested_parenthesis'], $tokens[$hasTernary]['nested_parenthesis'])
-            && count($tokens[$start]['nested_parenthesis']) === count($tokens[$hasTernary]['nested_parenthesis'])
+            && \count($tokens[$start]['nested_parenthesis']) === \count($tokens[$hasTernary]['nested_parenthesis'])
         ) {
             $start = ($hasTernary + 1);
         }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -86,7 +86,7 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         $tokens         = $phpcsFile->getTokens();
-        $functionNameLc = strtolower($functionName);
+        $functionNameLc = \strtolower($functionName);
 
         // Check whether the options parameter in the function call is passed.
         if (isset($parameters[$this->targetFunctions[$functionNameLc]]) === false) {
@@ -115,14 +115,14 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
             if ($tokens[$i]['code'] === \T_DOUBLE_QUOTED_STRING) {
                 $content = $this->stripVariables($content);
             }
-            $content = trim($content);
+            $content = \trim($content);
 
             if (empty($content) === false) {
                 $options .= $content;
             }
         }
 
-        if (strpos($options, 'e') !== false) {
+        if (\strpos($options, 'e') !== false) {
             $error   = 'The Mbstring regex "e" modifier is deprecated since PHP 7.1';
             $code    = 'Deprecated';
             $isError = false;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -100,7 +100,7 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        if (strtolower($functionName) === 'hash_init'
+        if (\strtolower($functionName) === 'hash_init'
             && (isset($parameters[2]) === false
             || ($parameters[2]['raw'] !== 'HASH_HMAC'
                 && $parameters[2]['raw'] !== (string) \HASH_HMAC))

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -92,7 +92,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
         }
 
         $tokens         = $phpcsFile->getTokens();
-        $functionNameLc = strtolower($functionName);
+        $functionNameLc = \strtolower($functionName);
         $firstParam     = $parameters[1];
 
         // Differentiate between an array of patterns passed and a single pattern.
@@ -108,7 +108,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
                     }
 
                     $value['end'] = ($hasKey - 1);
-                    $value['raw'] = trim($phpcsFile->getTokensAsString($value['start'], ($hasKey - $value['start'])));
+                    $value['raw'] = \trim($phpcsFile->getTokensAsString($value['start'], ($hasKey - $value['start'])));
                     $this->processRegexPattern($value, $phpcsFile, $value['end'], $functionName);
                 }
             } else {
@@ -117,7 +117,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
                     $hasKey = $phpcsFile->findNext(\T_DOUBLE_ARROW, $value['start'], ($value['end'] + 1));
                     if ($hasKey !== false) {
                         $value['start'] = ($hasKey + 1);
-                        $value['raw']   = trim($phpcsFile->getTokensAsString($value['start'], (($value['end'] + 1) - $value['start'])));
+                        $value['raw']   = \trim($phpcsFile->getTokensAsString($value['start'], (($value['end'] + 1) - $value['start'])));
                     }
 
                     $this->processRegexPattern($value, $phpcsFile, $value['end'], $functionName);
@@ -173,7 +173,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
                     $content = $this->stripVariables($content);
                 }
 
-                $regex .= trim($content);
+                $regex .= \trim($content);
             }
         }
 
@@ -187,22 +187,22 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        $regexFirstChar = substr($regex, 0, 1);
+        $regexFirstChar = \substr($regex, 0, 1);
 
         // Make sure that the character identified as the delimiter is valid.
         // Otherwise, it is a false positive caused by the string concatenation.
-        if (preg_match('`[a-z0-9\\\\ ]`i', $regexFirstChar) === 1) {
+        if (\preg_match('`[a-z0-9\\\\ ]`i', $regexFirstChar) === 1) {
             return;
         }
 
         if (isset($this->doublesSeparators[$regexFirstChar])) {
-            $regexEndPos = strrpos($regex, $this->doublesSeparators[$regexFirstChar]);
+            $regexEndPos = \strrpos($regex, $this->doublesSeparators[$regexFirstChar]);
         } else {
-            $regexEndPos = strrpos($regex, $regexFirstChar);
+            $regexEndPos = \strrpos($regex, $regexFirstChar);
         }
 
         if ($regexEndPos !== false) {
-            $modifiers = substr($regex, $regexEndPos + 1);
+            $modifiers = \substr($regex, $regexEndPos + 1);
             $this->examineModifiers($phpcsFile, $stackPtr, $functionName, $modifiers);
         }
     }
@@ -223,7 +223,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
      */
     protected function examineModifiers(File $phpcsFile, $stackPtr, $functionName, $modifiers)
     {
-        if (strpos($modifiers, 'e') !== false) {
+        if (\strpos($modifiers, 'e') !== false) {
             $error     = '%s() - /e modifier is deprecated since PHP 5.5';
             $isError   = false;
             $errorCode = 'Deprecated';

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -86,7 +86,7 @@ class NewArrayUnpackingSniff extends Sniff
 
         $nestingLevel = 0;
         if (isset($tokens[($opener + 1)]['nested_parenthesis'])) {
-            $nestingLevel = count($tokens[($opener + 1)]['nested_parenthesis']);
+            $nestingLevel = \count($tokens[($opener + 1)]['nested_parenthesis']);
         }
 
         $find              = $this->arrayTokens;
@@ -119,7 +119,7 @@ class NewArrayUnpackingSniff extends Sniff
 
             // Ensure this is not function call variable unpacking.
             if (isset($tokens[$i]['nested_parenthesis'])
-                && count($tokens[$i]['nested_parenthesis']) > $nestingLevel
+                && \count($tokens[$i]['nested_parenthesis']) > $nestingLevel
             ) {
                 continue;
             }

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -138,8 +138,8 @@ class NewClassMemberAccessSniff extends Sniff
             return [];
         }
 
-        $parenthesisCloser = end($tokens[$stackPtr]['nested_parenthesis']);
-        $parenthesisOpener = key($tokens[$stackPtr]['nested_parenthesis']);
+        $parenthesisCloser = \end($tokens[$stackPtr]['nested_parenthesis']);
+        $parenthesisOpener = \key($tokens[$stackPtr]['nested_parenthesis']);
 
         if (isset($tokens[$parenthesisOpener]['parenthesis_owner']) === true) {
             // If there is an owner, these parentheses are for a different purpose.

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -46,7 +46,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
             \T_END_NOWDOC,
         ];
 
-        if (version_compare(\PHP_VERSION_ID, '70299', '>') === false) {
+        if (\version_compare(\PHP_VERSION_ID, '70299', '>') === false) {
             // Start identifier of a PHP 7.3 flexible heredoc/nowdoc.
             $targets[] = \T_STRING;
         }
@@ -98,11 +98,11 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
         $trailingError     = 'Having code - other than a semi-colon or new line - after the closing marker of a heredoc/nowdoc is not supported in PHP 7.2 or earlier.';
         $trailingErrorCode = 'ClosingMarkerNoNewLine';
 
-        if (version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
+        if (\version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
             /*
              * Check for indented closing marker.
              */
-            if (ltrim($tokens[$stackPtr]['content']) !== $tokens[$stackPtr]['content']) {
+            if (\ltrim($tokens[$stackPtr]['content']) !== $tokens[$stackPtr]['content']) {
                 $phpcsFile->addError($indentError, $stackPtr, $indentErrorCode);
             }
 
@@ -119,7 +119,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
                 return;
             }
 
-            if (preg_match('`^<<<([\'"]?)([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)\1[\r\n]+`', $tokens[$stackPtr]['content'], $matches) !== 1) {
+            if (\preg_match('`^<<<([\'"]?)([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)\1[\r\n]+`', $tokens[$stackPtr]['content'], $matches) !== 1) {
                 // Not the start of a PHP 7.3 flexible heredoc/nowdoc.
                 return;
             }
@@ -131,9 +131,9 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
                     continue;
                 }
 
-                $trimmed = ltrim($tokens[$i]['content']);
+                $trimmed = \ltrim($tokens[$i]['content']);
 
-                if (strpos($trimmed, $identifier) !== 0) {
+                if (\strpos($trimmed, $identifier) !== 0) {
                     continue;
                 }
 
@@ -151,11 +151,11 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
                  * Check for tokens after the closing marker.
                  */
                 // Remove the identifier.
-                $afterMarker = substr($trimmed, \strlen($identifier));
+                $afterMarker = \substr($trimmed, \strlen($identifier));
                 // Remove a potential semi-colon at the beginning of what's left of the string.
-                $afterMarker = ltrim($afterMarker, ';');
+                $afterMarker = \ltrim($afterMarker, ';');
                 // Remove new line characters at the end of the string.
-                $afterMarker = rtrim($afterMarker, "\r\n");
+                $afterMarker = \rtrim($afterMarker, "\r\n");
 
                 if ($afterMarker !== '') {
                     $phpcsFile->addError($trailingError, $i, $trailingErrorCode);
@@ -184,7 +184,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
         $error     = 'The body of a heredoc/nowdoc can not contain the heredoc/nowdoc closing marker as text at the start of a line since PHP 7.3.';
         $errorCode = 'ClosingMarkerNoNewLine';
 
-        if (version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
+        if (\version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
             $nextNonWhitespace = $phpcsFile->findNext(\T_WHITESPACE, ($stackPtr + 1), null, true, null, true);
             if ($nextNonWhitespace === false
                 || $tokens[$nextNonWhitespace]['code'] === \T_SEMICOLON
@@ -202,7 +202,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
                 $nextHereNowDoc = null;
             }
 
-            $identifier        = trim($tokens[$stackPtr]['content']);
+            $identifier        = \trim($tokens[$stackPtr]['content']);
             $realClosingMarker = $stackPtr;
 
             while (($realClosingMarker = $phpcsFile->findNext(\T_STRING, ($realClosingMarker + 1), $nextHereNowDoc, false, $identifier)) !== false) {
@@ -234,11 +234,11 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
                 }
             }
 
-            $quotedIdentifier = preg_quote($tokens[$stackPtr]['content'], '`');
+            $quotedIdentifier = \preg_quote($tokens[$stackPtr]['content'], '`');
 
             // Throw an error for each line in the body which starts with the identifier.
             for ($i = ($opener + 1); $i < $stackPtr; $i++) {
-                if (preg_match('`^[ \t]*' . $quotedIdentifier . '\b`', $tokens[$i]['content']) === 1) {
+                if (\preg_match('`^[ \t]*' . $quotedIdentifier . '\b`', $tokens[$i]['content']) === 1) {
                     $phpcsFile->addError($error, $i, $errorCode);
                 }
             }

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -118,20 +118,20 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
 
         // Registers T_ARRAY, T_OPEN_SHORT_ARRAY and T_CONSTANT_ENCAPSED_STRING.
         $additionalTargets                        = $this->newArrayStringDereferencing->register();
-        $this->newArrayStringDereferencingTargets = array_flip($additionalTargets);
+        $this->newArrayStringDereferencingTargets = \array_flip($additionalTargets);
         $targets[] = $additionalTargets;
 
         // Registers T_NEW and T_CLONE.
         $additionalTargets                 = $this->newClassMemberAccess->register();
-        $this->newClassMemberAccessTargets = array_flip($additionalTargets);
+        $this->newClassMemberAccessTargets = \array_flip($additionalTargets);
         $targets[]                         = $additionalTargets;
 
         // Registers T_STRING.
         $additionalTargets = $this->newFunctionArrayDereferencing->register();
-        $this->newFunctionArrayDereferencingTargets = array_flip($additionalTargets);
+        $this->newFunctionArrayDereferencingTargets = \array_flip($additionalTargets);
         $targets[] = $additionalTargets;
 
-        return call_user_func_array('array_merge', $targets);
+        return \call_user_func_array('array_merge', $targets);
     }
 
 

--- a/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
@@ -91,7 +91,7 @@ class NewUnicodeEscapeSequenceSniff extends Sniff
             }
 
             $startQuote = $textString[0];
-            $endQuote   = substr($textString, -1);
+            $endQuote   = \substr($textString, -1);
             if (($startQuote === "'" && $endQuote === "'")
                 || $startQuote !== $endQuote
             ) {
@@ -101,7 +101,7 @@ class NewUnicodeEscapeSequenceSniff extends Sniff
         }
 
         $content = TextStrings::stripQuotes($tokens[$stackPtr]['content']);
-        $count   = preg_match_all('`(?<!\\\\)\\\\u\{([^}\n\r]*)(\})?`', $content, $matches, \PREG_SET_ORDER);
+        $count   = \preg_match_all('`(?<!\\\\)\\\\u\{([^}\n\r]*)(\})?`', $content, $matches, \PREG_SET_ORDER);
         if ($count === false || $count === 0) {
             return;
         }
@@ -144,16 +144,16 @@ class NewUnicodeEscapeSequenceSniff extends Sniff
      */
     protected function isValidUnicodeEscapeSequence($codepoint)
     {
-        if (trim($codepoint) === '') {
+        if (\trim($codepoint) === '') {
             return false;
         }
 
         // Check if it's a valid hex codepoint.
-        if (preg_match('`^[0-9A-F]+$`iD', $codepoint, $match) !== 1) {
+        if (\preg_match('`^[0-9A-F]+$`iD', $codepoint, $match) !== 1) {
             return false;
         }
 
-        if (hexdec($codepoint) > 1114111) {
+        if (\hexdec($codepoint) > 1114111) {
             // Outside of the maximum permissable range.
             return false;
         }

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -62,7 +62,7 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
         $tokens = [];
         foreach ($this->newTypeCasts as $token => $versions) {
             if (\defined($token)) {
-                $tokens[] = constant($token);
+                $tokens[] = \constant($token);
             }
         }
 
@@ -75,7 +75,7 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
          *
          * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/1574
          */
-        if (version_compare(Helper::getVersion(), '3.4.0', '<') === true) {
+        if (\version_compare(Helper::getVersion(), '3.4.0', '<') === true) {
             $tokens[] = \T_STRING_CAST;
             $tokens[] = \T_CONSTANT_ENCAPSED_STRING;
         }
@@ -105,7 +105,7 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
             $tokenContent = $tokens[$stackPtr]['content'];
             switch ($tokenType) {
                 case 'T_STRING_CAST':
-                    if (preg_match('`^\(\s*binary\s*\)$`i', $tokenContent) !== 1) {
+                    if (\preg_match('`^\(\s*binary\s*\)$`i', $tokenContent) !== 1) {
                         return;
                     }
 
@@ -113,8 +113,8 @@ class NewTypeCastsSniff extends AbstractNewFeatureSniff
                     break;
 
                 case 'T_CONSTANT_ENCAPSED_STRING':
-                    if ((strpos($tokenContent, 'b"') === 0 && substr($tokenContent, -1) === '"')
-                        || (strpos($tokenContent, "b'") === 0 && substr($tokenContent, -1) === "'")
+                    if ((\strpos($tokenContent, 'b"') === 0 && \substr($tokenContent, -1) === '"')
+                        || (\strpos($tokenContent, "b'") === 0 && \substr($tokenContent, -1) === "'")
                     ) {
                         $tokenType = 'T_BINARY_CAST';
                     } else {

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -64,7 +64,7 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
     {
         $tokens = [];
         foreach ($this->deprecatedTypeCasts as $token => $versions) {
-            $tokens[] = constant($token);
+            $tokens[] = \constant($token);
         }
 
         return $tokens;
@@ -88,7 +88,7 @@ class RemovedTypeCastsSniff extends AbstractRemovedFeatureSniff
         $tokenType = $tokens[$stackPtr]['type'];
 
         // Special case `T_DOUBLE_CAST` as the same token is used for (float) and (double) casts.
-        if ($tokenType === 'T_DOUBLE_CAST' && strpos($tokens[$stackPtr]['content'], 'real') === false) {
+        if ($tokenType === 'T_DOUBLE_CAST' && \strpos($tokens[$stackPtr]['content'], 'real') === false) {
             // Float/double casts, not (real) cast.
             return;
         }

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -109,12 +109,12 @@ class LowPHPCSSniff extends Sniff
         $phpcsVersion = Helper::getVersion();
 
         // Don't do anything if the PHPCS version used is above the minimum recommended version.
-        if (version_compare($phpcsVersion, self::MIN_RECOMMENDED_VERSION, '>=')) {
+        if (\version_compare($phpcsVersion, self::MIN_RECOMMENDED_VERSION, '>=')) {
             $this->examine = false;
             return ($phpcsFile->numTokens + 1);
         }
 
-        if (version_compare($phpcsVersion, self::MIN_SUPPORTED_VERSION, '<')) {
+        if (\version_compare($phpcsVersion, self::MIN_SUPPORTED_VERSION, '<')) {
             $isError      = true;
             $message      = 'IMPORTANT: Please be advised that the minimum PHP_CodeSniffer version the PHPCompatibility standard supports is %s. You are currently using PHP_CodeSniffer %s. Please upgrade your PHP_CodeSniffer installation. The recommended version of PHP_CodeSniffer for PHPCompatibility is %s or higher.';
             $errorCode    = 'Unsupported_' . $this->stringToErrorCode(self::MIN_SUPPORTED_VERSION);
@@ -172,7 +172,7 @@ class LowPHPCSSniff extends Sniff
         }
 
         $messageWidth  = ($reportWidth - 15); // 15 is length of " # | WARNING | ".
-        $delimiterLine = str_repeat('-', ($messageWidth));
+        $delimiterLine = \str_repeat('-', ($messageWidth));
         $disableNotice = 'To disable this notice, add --exclude=PHPCompatibility.Upgrade.LowPHPCS to your command or add <exclude name="PHPCompatibility.Upgrade.LowPHPCS.%s"/> to your custom ruleset. ';
         $thankYou      = 'Thank you for using PHPCompatibility!';
 

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -99,15 +99,15 @@ class LowPHPSniff extends Sniff
             return ($phpcsFile->numTokens + 1);
         }
 
-        $phpVersion = phpversion();
+        $phpVersion = \phpversion();
 
         // Don't do anything if the PHPCS version used is above the minimum recommended version.
-        if (version_compare($phpVersion, self::MIN_RECOMMENDED_VERSION, '>=')) {
+        if (\version_compare($phpVersion, self::MIN_RECOMMENDED_VERSION, '>=')) {
             $this->examine = false;
             return ($phpcsFile->numTokens + 1);
         }
 
-        if (version_compare($phpVersion, self::MIN_SUPPORTED_VERSION, '<')) {
+        if (\version_compare($phpVersion, self::MIN_SUPPORTED_VERSION, '<')) {
             $isError      = true;
             $message      = 'IMPORTANT: Please be advised that the minimum PHP version the PHPCompatibility standard supports is %s. You are currently using PHP %s. Please upgrade your PHP installation. The recommended version of PHP for PHPCompatibility is %s or higher.';
             $errorCode    = 'Unsupported_' . $this->stringToErrorCode(self::MIN_SUPPORTED_VERSION);
@@ -165,7 +165,7 @@ class LowPHPSniff extends Sniff
         }
 
         $messageWidth  = ($reportWidth - 15); // 15 is length of " # | WARNING | ".
-        $delimiterLine = str_repeat('-', ($messageWidth));
+        $delimiterLine = \str_repeat('-', ($messageWidth));
         $disableNotice = 'To disable this notice, add --exclude=PHPCompatibility.Upgrade.LowPHP to your command or add <exclude name="PHPCompatibility.Upgrade.LowPHP.%s"/> to your custom ruleset. ';
         $thankYou      = 'Thank you for using PHPCompatibility!';
 

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -87,7 +87,7 @@ class NewUseConstFunctionSniff extends Sniff
             return;
         }
 
-        if (isset($this->validUseNames[strtolower($tokens[$nextNonEmpty]['content'])]) === false) {
+        if (isset($this->validUseNames[\strtolower($tokens[$nextNonEmpty]['content'])]) === false) {
             // Not a `use const` or `use function` statement.
             return;
         }

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -381,8 +381,8 @@ class ForbiddenThisUseContextsSniff extends Sniff
 
             if (isset($tokens[$i]['nested_parenthesis']) === true) {
                 $nestedParenthesis     = $tokens[$i]['nested_parenthesis'];
-                $nestedOpenParenthesis = array_keys($nestedParenthesis);
-                $lastOpenParenthesis   = array_pop($nestedOpenParenthesis);
+                $nestedOpenParenthesis = \array_keys($nestedParenthesis);
+                $lastOpenParenthesis   = \array_pop($nestedOpenParenthesis);
 
                 $previousNonEmpty = $phpcsFile->findPrevious(
                     Tokens::$emptyTokens,

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -132,7 +132,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
         }
 
         $tokens  = $phpcsFile->getTokens();
-        $varName = substr($tokens[$stackPtr]['content'], 1);
+        $varName = \substr($tokens[$stackPtr]['content'], 1);
 
         if (isset($this->removedGlobalVariables[$varName]) === false) {
             return;
@@ -206,7 +206,7 @@ class RemovedPredefinedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
     protected function filterErrorMsg($error, array $itemInfo, array $errorInfo)
     {
         if ($itemInfo['name'] === 'php_errormsg') {
-            $error = str_replace('Global', 'The', $error);
+            $error = \str_replace('Global', 'The', $error);
         }
         return $error;
     }

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -101,7 +101,7 @@ class BaseSniffTest extends TestCase
      */
     protected function setUpPHPCS()
     {
-        if (class_exists('\PHP_CodeSniffer') === true) {
+        if (\class_exists('\PHP_CodeSniffer') === true) {
             /*
              * PHPCS 2.x.
              */
@@ -145,10 +145,10 @@ class BaseSniffTest extends TestCase
     protected function getSniffCode()
     {
         $class    = \get_class($this);
-        $parts    = explode('\\', $class);
-        $sniff    = array_pop($parts);
-        $sniff    = str_replace('UnitTest', '', $sniff);
-        $category = array_pop($parts);
+        $parts    = \explode('\\', $class);
+        $sniff    = \array_pop($parts);
+        $sniff    = \str_replace('UnitTest', '', $sniff);
+        $category = \array_pop($parts);
         return self::STANDARD_NAME . '.' . $category . '.' . $sniff;
     }
 
@@ -170,18 +170,18 @@ class BaseSniffTest extends TestCase
      */
     public function sniffFile($pathToFile, $targetPhpVersion = 'none')
     {
-        if (strpos($pathToFile, 'UnitTest.php') !== false) {
+        if (\strpos($pathToFile, 'UnitTest.php') !== false) {
             // Ok, so __FILE__ was passed, change the file extension.
-            $pathToFile = str_replace('UnitTest.php', 'UnitTest.inc', $pathToFile);
+            $pathToFile = \str_replace('UnitTest.php', 'UnitTest.inc', $pathToFile);
         }
-        $pathToFile = realpath($pathToFile);
+        $pathToFile = \realpath($pathToFile);
 
         if (isset(self::$sniffFiles[$pathToFile][$targetPhpVersion])) {
             return self::$sniffFiles[$pathToFile][$targetPhpVersion];
         }
 
         try {
-            if (class_exists('\PHP_CodeSniffer\Files\LocalFile')) {
+            if (\class_exists('\PHP_CodeSniffer\Files\LocalFile')) {
                 // PHPCS 3.x, 4.x.
                 $config            = new \PHP_CodeSniffer\Config();
                 $config->cache     = false;
@@ -281,11 +281,11 @@ class BaseSniffTest extends TestCase
             $insteadFoundMessages[] = $issue['message'];
         }
 
-        $insteadMessagesString = implode(', ', $insteadFoundMessages);
+        $insteadMessagesString = \implode(', ', $insteadFoundMessages);
 
         $msg = "Expected $type message '$expectedMessage' on line $lineNumber not found. Instead found: $insteadMessagesString.";
 
-        if (method_exists($this, 'assertStringContainsString') === false) {
+        if (\method_exists($this, 'assertStringContainsString') === false) {
             // PHPUnit < 7.
             return $this->assertContains($expectedMessage, $insteadMessagesString, $msg);
         }
@@ -334,7 +334,7 @@ class BaseSniffTest extends TestCase
         }
 
         $failMessage = "Failed asserting no standards violation on line $lineNumber. Found: \n"
-            . implode("\n", $encounteredMessages);
+            . \implode("\n", $encounteredMessages);
         $this->assertCount(0, $encounteredMessages, $failMessage);
     }
 

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
@@ -78,7 +78,7 @@ class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
             */
         ];
 
-        if (version_compare(Helper::getVersion(), '3.5.3', '!=')) {
+        if (\version_compare(Helper::getVersion(), '3.5.3', '!=')) {
             $data[] = [212];
             $data[] = [218];
         }

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -87,7 +87,7 @@ class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
             [149, self::ERROR_TYPE_ZERO],
         ];
 
-        if (version_compare(Helper::getVersion(), '3.5.3', '!=')) {
+        if (\version_compare(Helper::getVersion(), '3.5.3', '!=')) {
             $data[] = [160, self::ERROR_TYPE_ZERO];
         }
 

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsInvokedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesAsInvokedFunctionsUnitTest.php
@@ -42,7 +42,7 @@ class ForbiddenNamesAsInvokedFunctionsUnitTest extends BaseSniffTest
     {
         $file  = $this->sniffFile(__FILE__, $introducedIn);
         $error = "'{$keyword}' is a reserved keyword introduced in PHP version {$introducedIn} and cannot be invoked as a function";
-        $lines = array_merge($linesFunction, $linesMethod);
+        $lines = \array_merge($linesFunction, $linesMethod);
         foreach ($lines as $line) {
             $this->assertError($file, $line, $error);
         }

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -48,7 +48,7 @@ class ForbiddenNamesUnitTest extends BaseSniffTest
 
         $this->assertNoViolation($file, 2);
 
-        $lineCount = \count(file($filename));
+        $lineCount = \count(\file($filename));
         // Each line of the use case files (starting at line 3) exhibits an
         // error.
         for ($i = 3; $i < $lineCount; $i++) {

--- a/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
@@ -45,7 +45,7 @@ class NewPHPOpenTagEOFUnitTest extends BaseSniffTest
      */
     public function testNewPHPOpenTagEOF($fileNumber, $line)
     {
-        $fileName = __DIR__ . '/' . sprintf(self::TEST_FILE, $fileNumber);
+        $fileName = __DIR__ . '/' . \sprintf(self::TEST_FILE, $fileNumber);
 
         $file = $this->sniffFile($fileName, '7.3');
         $this->assertError($file, $line, 'A PHP open tag at the end of a file, without trailing newline, was not supported in PHP 7.3 or earlier and would result in a syntax error or be interpreted as a literal string');
@@ -82,7 +82,7 @@ class NewPHPOpenTagEOFUnitTest extends BaseSniffTest
      */
     public function testNoFalsePositivesOnLine($fileNumber, $line)
     {
-        $fileName = __DIR__ . '/' . sprintf(self::TEST_FILE, $fileNumber);
+        $fileName = __DIR__ . '/' . \sprintf(self::TEST_FILE, $fileNumber);
 
         $file = $this->sniffFile($fileName, '7.3');
         $this->assertNoViolation($file, $line);
@@ -117,7 +117,7 @@ class NewPHPOpenTagEOFUnitTest extends BaseSniffTest
      */
     public function testNoFalsePositivesOnFile($fileNumber)
     {
-        $fileName = __DIR__ . '/' . sprintf(self::TEST_FILE, $fileNumber);
+        $fileName = __DIR__ . '/' . \sprintf(self::TEST_FILE, $fileNumber);
 
         $file = $this->sniffFile($fileName, '7.3');
         $this->assertNoViolation($file);
@@ -151,7 +151,7 @@ class NewPHPOpenTagEOFUnitTest extends BaseSniffTest
      */
     public function testNoViolationsInFileOnValidVersion($fileNumber)
     {
-        $fileName = __DIR__ . '/' . sprintf(self::TEST_FILE, $fileNumber);
+        $fileName = __DIR__ . '/' . \sprintf(self::TEST_FILE, $fileNumber);
 
         $file = $this->sniffFile($fileName, '7.4');
         $this->assertNoViolation($file);
@@ -176,7 +176,7 @@ class NewPHPOpenTagEOFUnitTest extends BaseSniffTest
         ];
 
         // In PHPCS 2.x, the `Internal.NoCodeFound` error will come through, even when unit testing.
-        if (version_compare(Helper::getVersion(), '3.0.0', '>')) {
+        if (\version_compare(Helper::getVersion(), '3.0.0', '>')) {
             $data[] = [4];
         }
 

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -50,9 +50,9 @@ class RemovedAlternativePHPTagsUnitTest extends BaseSniffTest
         // Run the parent `@beforeClass` method.
         parent::resetSniffFiles();
 
-        if (version_compare(\PHP_VERSION_ID, '70000', '<')) {
+        if (\version_compare(\PHP_VERSION_ID, '70000', '<')) {
             // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.asp_tagsRemoved
-            self::$aspTags = (bool) ini_get('asp_tags');
+            self::$aspTags = (bool) \ini_get('asp_tags');
         }
     }
 

--- a/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
@@ -37,7 +37,7 @@ class NewNumericLiteralSeparatorUnitTest extends BaseSniffTest
      */
     public function testNewNumericLiteralSeparator($line)
     {
-        if (version_compare(Helper::getVersion(), '3.5.3', '==')) {
+        if (\version_compare(Helper::getVersion(), '3.5.3', '==')) {
             $this->markTestSkipped('PHPCS 3.5.3 is not supported for this sniff');
         }
 
@@ -69,7 +69,7 @@ class NewNumericLiteralSeparatorUnitTest extends BaseSniffTest
 
         // The test case on line 39 is half a valid numeric literal with underscore, half parse error.
         // The sniff will behave differently on PHP 7.4 vs PHP < 7.4.
-        if (version_compare(\PHP_VERSION_ID, '70399', '>') || version_compare(Helper::getVersion(), '3.5.3', '<')) {
+        if (\version_compare(\PHP_VERSION_ID, '70399', '>') || \version_compare(Helper::getVersion(), '3.5.3', '<')) {
             $data[] = [41];
         }
 
@@ -120,7 +120,7 @@ class NewNumericLiteralSeparatorUnitTest extends BaseSniffTest
 
         // The test case on line 39 is half a valid numeric literal with underscore, half parse error.
         // The sniff will behave differently on PHP 7.4 vs PHP < 7.4.
-        if (version_compare(\PHP_VERSION_ID, '70399', '<=') && version_compare(Helper::getVersion(), '3.5.3', '>')) {
+        if (\version_compare(\PHP_VERSION_ID, '70399', '<=') && \version_compare(Helper::getVersion(), '3.5.3', '>')) {
             $data[] = [41];
         }
 

--- a/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
@@ -109,7 +109,7 @@ class RemovedTernaryAssociativityUnitTest extends BaseSniffTest
     public function testNoFalsePositives()
     {
         $file    = $this->sniffFile(__FILE__, '7.4');
-        $exclude = array_flip($this->problemLines);
+        $exclude = \array_flip($this->problemLines);
 
         for ($line = 1; $line <= $this->totalLines; $line++) {
             if (isset($exclude[$line])) {

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
@@ -42,7 +42,7 @@ class NewFopenModesUnitTest extends BaseSniffTest
     public function testFopenMode($line, $mode, $errorVersion, $okVersion, $displayVersion = null)
     {
         $file  = $this->sniffFile(__FILE__, $errorVersion);
-        $error = sprintf(
+        $error = \sprintf(
             'Passing "%s" as the $mode to fopen() is not supported in PHP %s or lower.',
             $mode,
             isset($displayVersion) ? $displayVersion : $errorVersion

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -121,7 +121,7 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
     {
         $file  = $this->sniffFile(__FILE__, '5.4-7.0');
         $error = 'The default value of the %s parameter index for iconv_mime_encode() was changed from ISO-8859-1 to UTF-8 in PHP 5.6';
-        $error = sprintf($error, $missing);
+        $error = \sprintf($error, $missing);
 
         if ($type === 'error') {
             $this->assertError($file, $line, $error);

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
@@ -39,7 +39,7 @@ class NewNegativeStringOffsetUnitTest extends BaseSniffTest
     public function testNegativeStringOffset($line, $paramName, $functionName)
     {
         $file  = $this->sniffFile(__FILE__, '7.0');
-        $error = sprintf(
+        $error = \sprintf(
             'Negative string offsets were not supported for the $%1$s parameter in %2$s() in PHP 7.0 or lower.',
             $paramName,
             $functionName

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -42,7 +42,7 @@ class NewPackFormatUnitTest extends BaseSniffTest
     public function testNewPackFormat($line, $code, $errorVersion, $okVersion, $displayVersion = null)
     {
         $file  = $this->sniffFile(__FILE__, $errorVersion);
-        $error = sprintf(
+        $error = \sprintf(
             'Passing the $format(s) "%s" to pack() is not supported in PHP %s or lower.',
             $code,
             isset($displayVersion) ? $displayVersion : $errorVersion

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -54,7 +54,7 @@ class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
             self::$php73plus = false;
             // When using PHP 7.3+, the closing marker will be misidentified if the
             // body contains the heredoc/nowdoc identifier.
-            if (version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
+            if (\version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
                 self::$php73plus = true;
             }
         }
@@ -76,7 +76,7 @@ class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
      */
     public function testIndentedHeredocNowdoc($fileNumber, $line, $skipNoViolation = false)
     {
-        $fileName = __DIR__ . '/' . sprintf(self::TEST_FILE, $fileNumber);
+        $fileName = __DIR__ . '/' . \sprintf(self::TEST_FILE, $fileNumber);
 
         $file = $this->sniffFile($fileName, '7.2');
         $this->assertError($file, $line, 'Heredoc/nowdoc with an indented closing marker is not supported in PHP 7.2 or earlier.');
@@ -127,7 +127,7 @@ class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
      */
     public function testCodeAfterHeredocNowdoc($fileNumber, $line, $skipNoViolation = false)
     {
-        $fileName = __DIR__ . '/' . sprintf(self::TEST_FILE, $fileNumber);
+        $fileName = __DIR__ . '/' . \sprintf(self::TEST_FILE, $fileNumber);
 
         $file = $this->sniffFile($fileName, '7.2');
         $this->assertError($file, $line, 'Having code - other than a semi-colon or new line - after the closing marker of a heredoc/nowdoc is not supported in PHP 7.2 or earlier.');
@@ -174,7 +174,7 @@ class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
      */
     public function testForbiddenClosingMarkerInBody($line)
     {
-        $fileName = __DIR__ . '/' . sprintf(self::TEST_FILE, 2);
+        $fileName = __DIR__ . '/' . \sprintf(self::TEST_FILE, 2);
 
         $file = $this->sniffFile($fileName, '7.3');
         $this->assertError($file, $line, 'The body of a heredoc/nowdoc can not contain the heredoc/nowdoc closing marker as text at the start of a line since PHP 7.3.');
@@ -219,7 +219,7 @@ class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
      */
     public function testNoFalsePositives()
     {
-        $fileName = __DIR__ . '/' . sprintf(self::TEST_FILE, 1);
+        $fileName = __DIR__ . '/' . \sprintf(self::TEST_FILE, 1);
 
         $file = $this->sniffFile($fileName, '7.2');
         $this->assertNoViolation($file);

--- a/PHPCompatibility/Tests/Upgrade/LowPHPCSUnitTest.php
+++ b/PHPCompatibility/Tests/Upgrade/LowPHPCSUnitTest.php
@@ -66,13 +66,13 @@ class LowPHPCSUnitTest extends BaseSniffTest
      */
     public function testUpgradeNotice()
     {
-        if (version_compare($this->phpcsVersion, LowPHPCSSniff::MIN_SUPPORTED_VERSION, '<')) {
+        if (\version_compare($this->phpcsVersion, LowPHPCSSniff::MIN_SUPPORTED_VERSION, '<')) {
             $this->assertError(
                 $this->sniffResult,
                 1,
                 'Please be advised that the minimum PHP_CodeSniffer version the PHPCompatibility standard supports is ' . LowPHPCSSniff::MIN_SUPPORTED_VERSION
             );
-        } elseif (version_compare($this->phpcsVersion, LowPHPCSSniff::MIN_RECOMMENDED_VERSION, '<')) {
+        } elseif (\version_compare($this->phpcsVersion, LowPHPCSSniff::MIN_RECOMMENDED_VERSION, '<')) {
             $this->assertWarning(
                 $this->sniffResult,
                 1,

--- a/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
+++ b/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
@@ -54,7 +54,7 @@ class LowPHPUnitTest extends BaseSniffTest
 
         // Sniff file without testVersion as all checks run independently of testVersion being set.
         $this->sniffResult = $this->sniffFile(__FILE__);
-        $this->phpVersion  = phpversion();
+        $this->phpVersion  = \phpversion();
     }
 
 
@@ -65,13 +65,13 @@ class LowPHPUnitTest extends BaseSniffTest
      */
     public function testUpgradeNotice()
     {
-        if (version_compare($this->phpVersion, LowPHPSniff::MIN_SUPPORTED_VERSION, '<')) {
+        if (\version_compare($this->phpVersion, LowPHPSniff::MIN_SUPPORTED_VERSION, '<')) {
             $this->assertError(
                 $this->sniffResult,
                 1,
                 'Please be advised that the minimum PHP version the PHPCompatibility standard supports is ' . LowPHPSniff::MIN_SUPPORTED_VERSION
             );
-        } elseif (version_compare($this->phpVersion, LowPHPSniff::MIN_RECOMMENDED_VERSION, '<')) {
+        } elseif (\version_compare($this->phpVersion, LowPHPSniff::MIN_RECOMMENDED_VERSION, '<')) {
             $this->assertWarning(
                 $this->sniffResult,
                 1,

--- a/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
@@ -174,7 +174,7 @@ class FunctionsUnitTest extends TestCase
      */
     public function testGetTestVersionInvalidRange($testVersion)
     {
-        $message = sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion);
+        $message = \sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion);
         $this->phpWarningTestHelper($message);
 
         $this->testGetTestVersion($testVersion, [null, null]);
@@ -210,7 +210,7 @@ class FunctionsUnitTest extends TestCase
      */
     public function testGetTestVersionInvalidVersion($testVersion)
     {
-        $message = sprintf('Invalid testVersion setting: \'%s\'', trim($testVersion));
+        $message = \sprintf('Invalid testVersion setting: \'%s\'', \trim($testVersion));
         $this->phpWarningTestHelper($message);
 
         $this->testGetTestVersion($testVersion, [null, null]);
@@ -447,7 +447,7 @@ class FunctionsUnitTest extends TestCase
      */
     public function phpWarningTestHelper($message)
     {
-        if (method_exists($this, 'expectWarning')) {
+        if (\method_exists($this, 'expectWarning')) {
             // PHPUnit 9.0+.
             $this->expectWarning();
             $this->expectWarningMessage($message);
@@ -455,7 +455,7 @@ class FunctionsUnitTest extends TestCase
             return;
         }
 
-        if (\method_exists($this, 'expectException') && class_exists('PHPUnit\Framework\Error\Warning')) {
+        if (\method_exists($this, 'expectException') && \class_exists('PHPUnit\Framework\Error\Warning')) {
             // PHPUnit 5.7/6/7/8.
             $this->expectException('PHPUnit\Framework\Error\Warning');
             $this->expectExceptionMessage($message);


### PR DESCRIPTION
Functions in PHP are namespaced as well, however, when PHP cannot find the function in the namespace, it will fall through to the global namespace.

The step to first check within the namespace can be skipped by either using `use function ...` (PHP 5.6+) or by prefixing the function name with a `\`.

As PHPCompatibility uses global functions throughout, a little performance gain can be archived by using the FQN for functions.

This PR implements this throughout the codebase.

This was previously already done for constants (#783) and for the functions which benefit from PHP 8 opcodes (#784).