### PR TITLE
RemovedCallingDestructAfterConstructorExit: reduce false positives

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
@@ -29,21 +29,96 @@ $anon = new class() {
  */
 class CrossVersionInValid
 {
-    function __construct() {
-        exit(1);
+    public function __construct() {
+        exit(1); // Error.
     }
 
-    function __destruct() {
+    public function __destruct() {
         // Destructor will not be called on exit() in constructor.
     }
 }
 
-$anon = new class() {
+$anon = new class() extends ClassWhichMayOrMayNotContainADestructMethod {
     function __CONSTRUCT() {
         if ($something) {
-            die();
+            die(); // Warning.
         } else {
-            exit(2);
+            exit(2); // Warning.
         }
     }
 };
+
+abstract class HasDestructAndExtends extends ClassWhichMayOrMayNotContainADestructMethod
+{
+    public function __construct() {
+        // Test skipping over irrelevant code.
+        $array = [
+            'closure' => function() { exit; }, // Ignore, nested closed scope.
+        ];
+
+        $anon = new class {
+            function something() {
+                exit; // Ignore, nested closed scope.
+            }
+        };
+
+        $array = array(
+            'closure' => function() { exit; }, // Ignore, nested closed scope.
+        );
+
+        die; // Error.
+    }
+
+    /**
+     * This should be easily skipped over.
+     */
+    abstract function something();
+
+    public function __DeStruct() {
+        // Destructor will not be called on exit() in constructor.
+    }
+}
+
+trait CrossVersionInValid
+{
+    public function __construct() {
+        exit(1); // Error.
+    }
+
+    public function __destruct() {
+        // Destructor will not be called on exit() in constructor.
+    }
+}
+
+class DoesntExtendAndDoesntHaveDestructMethodButUsesTrait {
+    use TraitWhichMayOrMayNotContainADestructMethod;
+
+    public function __construct() {
+        die(1); // Warning.
+    }
+}
+
+/*
+ * Prevent false positives.
+ */
+class DoesntExtendAndDoesntHaveDestructMethod {
+    public function __construct() {
+        exit(1);
+    }
+}
+
+trait CantExtendAndDoesntHaveDestructMethod {
+    public function __construct() {
+        exit(1);
+    }
+}
+
+class ExitNotInFunctionScope {
+    public function __construct() {
+        $this->property = function($param) {
+            exit(1);
+        };
+    }
+
+    public function __destruct() {}
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
@@ -30,15 +30,22 @@ class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTest
      *
      * @dataProvider dataRemovedCallingDestructAfterConstructorExit
      *
-     * @param int    $line The line number where an error is expected.
-     * @param string $name The name of the exit type used.
+     * @param int    $line    The line number where an error is expected.
+     * @param string $name    The name of the exit type used.
+     * @param bool   $isError Whether to expect an error or a warning. Defaults to true (= error).
      *
      * @return void
      */
-    public function testRemovedCallingDestructAfterConstructorExit($line, $name)
+    public function testRemovedCallingDestructAfterConstructorExit($line, $name, $isError = true)
     {
-        $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertError($file, $line, "When $name() is called within an object constructor, the object destructor will no longer be called since PHP 8.0");
+        $file  = $this->sniffFile(__FILE__, '8.0');
+        $error = "When $name() is called within an object constructor, the object destructor will no longer be called since PHP 8.0";
+
+        if ($isError === true) {
+            $this->assertError($file, $line, $error);
+        } else {
+            $this->assertWarning($file, $line, $error);
+        }
     }
 
     /**
@@ -52,8 +59,11 @@ class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTest
     {
         return [
             [33, 'exit'],
-            [44, 'die'],
-            [46, 'exit'],
+            [44, 'die', false],
+            [46, 'exit', false],
+            [69, 'die'],
+            [85, 'exit'],
+            [97, 'die', false],
         ];
     }
 
@@ -87,6 +97,13 @@ class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTest
         for ($line = 1; $line <= 26; $line++) {
             $cases[] = [$line];
         }
+
+        $cases[] = [56];
+        $cases[] = [61];
+        $cases[] = [66];
+        $cases[] = [106];
+        $cases[] = [112];
+        $cases[] = [119];
 
         return $cases;
     }


### PR DESCRIPTION
Follow up on PR #1200 which introduced this sniff.

> This sniff will throw an error, even when there is no destructor as a destructor may be declared in a parent class.
> :point_right: We could reduce the potential noise from this sniff a little further by only throwing the error when the class either contains a __destruct() method or extends a parent class. Should we ?

This PR implements the above by:
* Checking for a `__destruct()` method. If one is found, an error will be thrown.
* If no `__destruct()` method was found, but the class either extends another class or `use`s a trait, it will throw a _warning_ instead as a `__destruct()` method may still be declared in the parent class or the trait.
* If no `__destruct()` method is found and the class does not extend another, nor use `trait`s, the sniff will stay silent.

Includes implementing protection against false positives for calls to `exit()` found in nested closed constructs within a `__construct()` method.
Includes efficiency tweaks too in case of large `__construct()` methods with high code complexity.

Related to #809