### PR TITLE
PHP 8.0 | NewIniDirectives: allow for new com.dotnet_version directive

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -857,6 +857,10 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '7.4' => true,
         ],
 
+        'com.dotnet_version' => [
+            '7.4' => false,
+            '8.0' => true,
+        ],
         'pm.status_listen' => [
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -532,3 +532,6 @@ $test = ini_get('zend.exception_string_param_max_len');
 
 ini_set('pm.status_listen', '127.0.0.1:9001');
 $test = ini_get('pm.status_listen');
+
+ini_set('com.dotnet_version', 'v4.0.30319');
+$test = ini_get('com.dotnet_version');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -262,6 +262,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             ['opcache.preload_user', '7.4', [464, 465], '7.3'],
             ['zend.exception_ignore_args', '7.4', [338, 339], '7.3'],
 
+            ['com.dotnet_version', '8.0', [536, 537], '7.4'],
             ['pm.status_listen', '8.0', [533, 534], '7.4'],
             ['zend.exception_string_param_max_len', '8.0', [530, 531], '7.4'],
         ];


### PR DESCRIPTION
> - com.dotnet_version
>    New INI directive to choose the version of the .NET framework to use for dotnet objects.

Refs:
* https://github.com/php/php-src/blob/0a84fba0deb1c1b75770a436c4236dc56e6d0463/UPGRADING#L1099-L1101
* https://github.com/php/php-src/commit/e6044d4455d7fbaced7f3a6ac28172d963017e51

Related to #809