### PR TITLE
PHP 8.0 | OptionalToRequiredFunctionParameters: handle required $method / OpenSSL

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -68,6 +68,18 @@ class OptionalToRequiredFunctionParametersSniff extends RequiredToOptionalFuncti
                 '8.0'  => true,
             ],
         ],
+        'openssl_seal' => [
+            4 => [
+                'name' => 'method',
+                '8.0'  => true,
+            ],
+        ],
+        'openssl_open' => [
+            4 => [
+                'name' => 'method',
+                '8.0'  => true,
+            ],
+        ],
         'parse_str' => [
             1 => [
                 'name' => 'result',

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
@@ -20,3 +20,9 @@ mktime();
 
 mb_parse_str($encoded_string, $result); // Ok.
 mb_parse_str($encoded_string); // Not ok.
+
+openssl_seal ( $data, $sealed_data, $env_keys, $pub_key_ids, $method, $iv ); // Ok.
+openssl_seal ( $data, $sealed_data, $env_keys, $pub_key_ids ); // Not ok.
+
+openssl_open ( $sealed_data, $open_data, $env_key, $priv_key_id, $method, $iv ); // Ok.
+openssl_open ( $sealed_data, $open_data, $env_key, $priv_key_id ); // Not ok.

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -114,6 +114,8 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
         return [
             ['gmmktime', 'hour', '8.0', [18], '7.4'],
             ['mb_parse_str', 'result', '8.0', [22], '7.4'],
+            ['openssl_seal', 'method', '8.0', [25], '7.4'],
+            ['openssl_open', 'method', '8.0', [28], '7.4'],
         ];
     }
 


### PR DESCRIPTION
> `openssl_seal()` and `openssl_open()` now require $method to be passed, as the
> previous default of "RC4" is considered insecure.

Refs:
* https://github.com/php/php-src/blob/0a84fba0deb1c1b75770a436c4236dc56e6d0463/UPGRADING#L418-L419
* https://github.com/php/php-src/commit/3e149427561dc04650aacfa61f9eb431da397997

Related to #809