### PR TITLE
PHP 8.0 | RemovedFunctionParameters: account for more deprecated/removed function params

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -92,6 +92,21 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
                 '7.0'  => true,
             ],
         ],
+        'pg_connect' => [
+            // These were already deprecated before, but version in which deprecation took place is unclear.
+            2 => [
+                'name' => 'options',
+                '8.0'  => true,
+            ],
+            3 => [
+                'name' => 'tty',
+                '8.0'  => true,
+            ],
+            4 => [
+                'name' => 'dbname',
+                '8.0'  => true,
+            ],
+        ],
     ];
 
 

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -67,6 +67,12 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
                 '7.0'  => true,
             ],
         ],
+        'imap_headerinfo' => [
+            4 => [
+                'name' => 'defaulthost',
+                '8.0'  => true,
+            ],
+        ],
         'ldap_first_attribute' => [
             2 => [
                 'name'  => 'ber_identifier',

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -98,6 +98,18 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
                 '7.0'  => true,
             ],
         ],
+        'odbc_do' => [
+            2 => [
+                'name' => 'flags',
+                '8.0'  => true,
+            ],
+        ],
+        'odbc_exec' => [
+            2 => [
+                'name' => 'flags',
+                '8.0'  => true,
+            ],
+        ],
         'pg_connect' => [
             // These were already deprecated before, but version in which deprecation took place is unclear.
             2 => [

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -28,3 +28,7 @@ $conn = pg_connect ( $host, $port, $options, $tty, $dbname ); // Error x 3.
 
 imap_headerinfo($imap_stream, $msg_number); // OK.
 imap_headerinfo($imap_stream, $msg_number, $fromlength, $subjectlength, $defaulthost); // Error.
+
+odbc_exec($connection_id, $query_string); // OK.
+odbc_exec($connection_id, $query_string, $flags); // Error.
+odbc_do($connection_id, $query_string, $flags); // Error.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -25,3 +25,6 @@ mb_decode_numericentity($str, $convmap, $encoding, $is_hex); // Error.
 
 $conn = pg_connect ( $connection_string, $connect_type ); // OK.
 $conn = pg_connect ( $host, $port, $options, $tty, $dbname ); // Error x 3.
+
+imap_headerinfo($imap_stream, $msg_number); // OK.
+imap_headerinfo($imap_stream, $msg_number, $fromlength, $subjectlength, $defaulthost); // Error.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -22,3 +22,6 @@ curl_version( $age );
 
 mb_decode_numericentity($str, $convmap); // OK.
 mb_decode_numericentity($str, $convmap, $encoding, $is_hex); // Error.
+
+$conn = pg_connect ( $connection_string, $connect_type ); // OK.
+$conn = pg_connect ( $host, $port, $options, $tty, $dbname ); // Error x 3.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -70,6 +70,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             ['pg_connect', 'options', '8.0', [27], '7.4'],
             ['pg_connect', 'tty', '8.0', [27], '7.4'],
             ['pg_connect', 'dbname', '8.0', [27], '7.4'],
+            ['imap_headerinfo', 'defaulthost', '8.0', [30], '7.4'],
         ];
     }
 
@@ -161,6 +162,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             [17],
             [23],
             [26],
+            [29],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -67,6 +67,9 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             ['ldap_first_attribute', 'ber_identifier', '5.2.4', [11], '5.2', '5.3'],
             ['ldap_next_attribute', 'ber_identifier', '5.2.4', [12], '5.2', '5.3'],
             ['mb_decode_numericentity', 'is_hex', '8.0', [24], '7.4'],
+            ['pg_connect', 'options', '8.0', [27], '7.4'],
+            ['pg_connect', 'tty', '8.0', [27], '7.4'],
+            ['pg_connect', 'dbname', '8.0', [27], '7.4'],
         ];
     }
 
@@ -157,6 +160,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             [14],
             [17],
             [23],
+            [26],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -71,6 +71,8 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             ['pg_connect', 'tty', '8.0', [27], '7.4'],
             ['pg_connect', 'dbname', '8.0', [27], '7.4'],
             ['imap_headerinfo', 'defaulthost', '8.0', [30], '7.4'],
+            ['odbc_exec', 'flags', '8.0', [33], '7.4'],
+            ['odbc_do', 'flags', '8.0', [34], '7.4'],
         ];
     }
 
@@ -163,6 +165,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             [23],
             [26],
             [29],
+            [32],
         ];
     }
 


### PR DESCRIPTION
Related to #809

### PHP 8.0 | RemovedFunctionParameters: handle changed pg_connect() function signature

> The deprecated pg_connect() syntax using multiple parameters instead of a
> connection string is no longer supported.

Notes:
1. It is unclear in which PHP version the deprecation of the old function signature took place.
2. The second parameter in the old vs the new signature is different - required `$port` versus optional `$connect_type` -, but as the new function signature has been supported for a long time already, annotating this as a change for the parameter from required to optional, doesn't make sense. At least not for PHP 8.0.

Refs:
* https://github.com/php/php-src/blob/0a84fba0deb1c1b75770a436c4236dc56e6d0463/UPGRADING#L441-L442
* php/php-src@3ab8883

### PHP 8.0 | RemovedFunctionParameters: handle changed imap_headerinfo() function signature

> The unused default_host argument of imap_headerinfo() has been removed.

Refs:
* https://github.com/php/php-src/blob/0a84fba0deb1c1b75770a436c4236dc56e6d0463/UPGRADING#L332
* php/php-src#6179
* php/php-src@5d7d5e2

### PHP 8.0 | RemovedFunctionParameters: handle changed odbc_exec() function signature

> The unused flags parameter of `odbc_exec()` has been removed.

Note: per the commit, this also applies to the `odbc_do()` alias of `odbc_exec()`.

Refs:
* https://github.com/php/php-src/blob/0a84fba0deb1c1b75770a436c4236dc56e6d0463/UPGRADING#L400
* php/php-src#6154
* php/php-src@9b50fd2

