### PR TITLE
PHP 8.0 | New `PHPCompatibility.ParameterValues.ChangedIntToBoolParamType` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCSUtils\BackCompat\BCTokens;
+
+/**
+ * Detect calls to functions where the expected type of a parameter has been changed from integer to boolean.
+ *
+ * Throws an error when a hard-coded numeric value is passed.
+ *
+ * PHP version 8.0+
+ *
+ * @since 10.0.0
+ */
+class ChangedIntToBoolParamTypeSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = [
+        'ob_implicit_flush' => [
+            1 => [
+                'name'  => 'flag',
+                'since' => '8.0',
+            ],
+        ],
+        'sem_get' => [
+            4 => [
+                'name'  => 'auto_release',
+                'since' => '8.0',
+            ],
+        ],
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * Checks against the first PHP version listed in the above array.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('8.0') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        static $search;
+
+        if (isset($search) === false) {
+            $search  = [
+                \T_LNUMBER => \T_LNUMBER,
+                \T_DNUMBER => \T_DNUMBER,
+            ];
+            $search += BCTokens::arithmeticTokens();
+            $search += Tokens::$emptyTokens;
+        }
+
+        $functionLC   = \strtolower($functionName);
+        $functionInfo = $this->targetFunctions[$functionLC];
+        foreach ($functionInfo as $offset => $paramInfo) {
+            if (isset($parameters[$offset]) === false) {
+                continue;
+            }
+
+            if ($this->supportsAbove($paramInfo['since']) === false) {
+                continue;
+            }
+
+            $target = $parameters[$offset];
+
+            $hasNonNumeric = $phpcsFile->findNext($search, $target['start'], ($target['end'] + 1), true);
+            if ($hasNonNumeric !== false) {
+                // Not a purely numerical value. Ignore.
+                continue;
+            }
+
+            $error = 'The $%s parameter of %s() expects a boolean value instead of an integer since PHP %s. Found: %s';
+            $code  = $this->stringToErrorCode($functionName . '_' . $paramInfo['name']) . 'NumericFound';
+            $data  = [
+                $paramInfo['name'],
+                $functionLC,
+                $paramInfo['since'],
+                $target['clean'],
+            ];
+
+            $phpcsFile->addError($error, $target['start'], $code, $data);
+        }
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.inc
@@ -1,0 +1,27 @@
+<?php
+
+// OK.
+sem_get( $key, $max_acquire, $perm, );
+sem_get($SHM_KEY, 1024, 0644 | IPC_CREAT);
+sem_get( $SEMKey, 2, 0666, true);
+sem_get( $SEMKey, 2, 0666, false);
+ob_implicit_flush();
+ob_implicit_flush(true);
+
+// Ignore as undetermined.
+sem_get( $key, $max_acquire, $perm, $auto_release );
+sem_get( $key, $max_acquire, $perm, SEMVER_RELEASE );
+sem_get( $key, $max_acquire, $perm, self::RELEASE_TOGGLE );
+ob_implicit_flush($flag);
+
+// Ignore for complexity + could be valid cross-version toggle.
+sem_get( $key, $max_acquire, $perm, $test ? 1 : true );
+
+// Error.
+sem_get( $key, $max_acquire, $perm, 0 );
+sem_get( $key, $max_acquire, $perm, 1 );
+sem_get( $key, $max_acquire, $perm, -1 );
+Sem_Get( $key, $max_acquire, $perm, 0 );
+sem_get( $key, $max_acquire, $perm, 1.0 );
+sem_get( $key, $max_acquire, $perm, 1 * 1);
+ob_implicit_flush(0);

--- a/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the ChangedIntToBoolParamType sniff.
+ *
+ * @group changedIntToBoolParamType
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\ChangedIntToBoolParamTypeSniff
+ *
+ * @since 10.0.0
+ */
+class ChangedIntToBoolParamTypeUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test that numeric values being passed as $auto_release to sem_get() throw an error.
+     *
+     * @dataProvider dataChangedIntToBoolParamType
+     *
+     * @param int    $line         Line number where the error should occur.
+     * @param string $since        The PHP version in which the change was made.
+     * @param string $paramName    The name of the parameter the error relates to.
+     * @param string $functionName The name of the function the error relates to.
+     *
+     * @return void
+     */
+    public function testChangedIntToBoolParamType($line, $since, $paramName, $functionName)
+    {
+        $file  = $this->sniffFile(__FILE__, $since);
+        $error = "The {$paramName} parameter of {$functionName}() expects a boolean value instead of an integer since PHP {$since}";
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testChangedIntToBoolParamType)
+     *
+     * @return array
+     */
+    public function dataChangedIntToBoolParamType()
+    {
+        return [
+            [21, '8.0', '$auto_release', 'sem_get'],
+            [22, '8.0', '$auto_release', 'sem_get'],
+            [23, '8.0', '$auto_release', 'sem_get'],
+            [24, '8.0', '$auto_release', 'sem_get'],
+            [25, '8.0', '$auto_release', 'sem_get'],
+            [26, '8.0', '$auto_release', 'sem_get'],
+            [27, '8.0', '$flag', 'ob_implicit_flush'],
+        ];
+    }
+
+
+    /**
+     * Verify no false positives are thrown for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '99.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 19 lines.
+        for ($line = 1; $line <= 19; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4'); // Version before first change.
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
>  The `$auto_release` parameter of `sem_get()` was changed to accept bool values
>  rather than int.

> The `$flag` parameter of `ob_implicit_flush()` was changed to accept bool
> values rather than int.

This new sniff will detect hard-coded integer/float values being passed as the affected parameter in the above mentioned functions.

The sniff has been set up to allow for more functions / function parameters to be added in the future.

Includes unit tests.

Refs:
* https://github.com/php/php-src/blob/0a84fba0deb1c1b75770a436c4236dc56e6d0463/UPGRADING#L621-L622
* https://github.com/php/php-src/blob/0a84fba0deb1c1b75770a436c4236dc56e6d0463/UPGRADING#L813-L814
* https://github.com/php/php-src/pull/6148
* https://github.com/php/php-src/commit/46d22e435f43529aa55b54460dd265c4bd22409f

Related to #809