### PR TITLE
PHP 8.0: New `PHPCompatibility.Syntax.NewMagicConstantDereferencing` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Syntax;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Tokens\Collections;
+
+/**
+ * Detect dereferencing of magic constants as allowed per PHP 8.0.
+ *
+ * PHP version 8.0
+ *
+ * @link https://wiki.php.net/rfc/variable_syntax_tweaks#constants_and_magic_constants
+ *
+ * @since 10.0.0
+ */
+class NewMagicConstantDereferencingSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return Collections::$magicConstants;
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.4') === false) {
+            return;
+        }
+
+        $tokens       = $phpcsFile->getTokens();
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
+            return;
+        }
+
+        if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_SQUARE_BRACKET
+            // Work around bug #3013 in PHPCS 3.5.5 and lower.
+            && $tokens[$nextNonEmpty]['code'] !== \T_OPEN_SHORT_ARRAY
+        ) {
+            return;
+        }
+
+        if (isset($tokens[$nextNonEmpty]['bracket_closer']) === false) {
+            // Live coding or parse error.
+            return;
+        }
+
+        $hasContent = $phpcsFile->findNext(
+            Tokens::$emptyTokens,
+            ($nextNonEmpty + 1),
+            $tokens[$nextNonEmpty]['bracket_closer'],
+            true
+        );
+
+        if ($hasContent === false) {
+            /*
+             * Attempt to assign to the magic constant as if it were an array.
+             * Not allowed now, nor prior to PHP 8, so not our concern.
+             */
+            return;
+        }
+
+        // Make sure this isn't an array assignment. That would be illegal, i.e. a parse error.
+        $nextNext = $tokens[$nextNonEmpty]['bracket_closer'];
+        do {
+            $nextNext = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNext + 1), null, true);
+            if ($nextNext === false) {
+                break;
+            }
+
+            // If the next token is an assignment, that's all we need to know.
+            if (isset(BCTokens::assignmentTokens()[$tokens[$nextNext]['code']]) === true) {
+                return;
+            }
+
+            // Check if this is an multi-access array assignment, e.g., `__FILE__[1][2] = 'val';` .
+            if (($tokens[$nextNext]['code'] === \T_OPEN_SQUARE_BRACKET
+                // Work around for nested array access being incorrectly tokenized in PHPCS 2.8.x.
+                || $tokens[$nextNext]['code'] === \T_OPEN_SHORT_ARRAY)
+                && isset($tokens[$nextNext]['bracket_closer']) === true
+            ) {
+                $nextNext = $tokens[$nextNext]['bracket_closer'];
+                continue;
+            }
+
+            break;
+        } while (true);
+
+        $phpcsFile->addError(
+            'Dereferencing of magic constants is not present in PHP version 7.4 or earlier. Found dereferencing of: %s',
+            $nextNonEmpty,
+            'Found',
+            [$tokens[$stackPtr]['content']]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.inc
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * OK - normal use of magic constants.
+ */
+require __DIR__ . '/filename.php';
+expectsCallback([__CLASS__, 'method']);
+
+// Not a magic constant.
+echo __MAGIC__;
+
+/*
+ * PHP 8.0: Magic constant dereferencing.
+ */
+echo __FUNCTION__[0];
+$a = array(__trait__[$i]);
+$b = __NAMESPACE__[$x][$y];
+expectsCallback([__CLASS__[strlen(__CLASS__) - 1], 'method']);
+$var = functionCall(__METHOD__[++$i]);
+echo __LINE__[0][1];
+echo __file__[strlen(__FILE__) - 1];
+require __DIR__[0];
+
+/*
+ * Check against false positives.
+ */
+
+// Array assignments to magic constants is not possible.
+__NAMESPACE__[] = 'x';
+__Dir__[ /* comment */ ] += 'x';
+__line__[0] -= 'x';
+__METHOD__[0][1] .= 'x';
+__namespace__[0][1][2] *= 'x';
+
+// Dereferencing using curly braces is not supported.
+echo __LINE__{0};
+
+// Live coding.
+// Intentional parse error, this has to be the last test case in the file.
+echo __METHOD__[

--- a/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewMagicConstantDereferencing sniff.
+ *
+ * @group newMagicConstantDereferencing
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewMagicConstantDereferencingSniff
+ *
+ * @since 10.0.0
+ */
+class NewMagicConstantDereferencingUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test that an error is thrown for magic constant dereferencing prior to PHP 8.
+     *
+     * @dataProvider dataNewMagicConstantDereferencing
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewMagicConstantDereferencing($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, 'Dereferencing of magic constants is not present in PHP version 7.4 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewMagicConstantDereferencing()
+     *
+     * @return array
+     */
+    public function dataNewMagicConstantDereferencing()
+    {
+        return [
+            [15],
+            [16],
+            [17],
+            [18],
+            [19],
+            [20],
+            [21],
+            [22],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code, nor for code which is still invalid.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return [
+            [6],
+            [7],
+            [10],
+            [29],
+            [30],
+            [31],
+            [32],
+            [33],
+            [36],
+            [40],
+        ];
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Constants are currently array-dereferencable, that is `FOO[0]` is legal. However, magic constants are non-dereferencable.
>
> This RFC proposes to treat magic constants the same way as constants, that is, writing `__FUNCTION__[0]` etc becomes legal.

Ref:
* https://wiki.php.net/rfc/variable_syntax_tweaks#constants_and_magic_constants
* https://github.com/php/php-src/commit/357fbc99028e6a9934740161a0f23a66ddaee3b4

Includes unit tests.

Related to #809