### PR TITLE
PHP 8.0: RequiredToOptionalFunctionParameters - account for more changes

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -44,6 +44,83 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
      * @var array
      */
     protected $functionParameters = [
+        'array_diff_assoc' => [
+            1 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_diff_key' => [
+            1 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_diff_uassoc' => [
+            /*
+             * $array2 is actually at position 1, but has another required parameter after it,
+             * so we need to detect on the last parameter.
+             */
+            2 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_diff_ukey' => [
+            // Note from array_diff_uassoc applies here too.
+            2 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_diff' => [
+            1 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_intersect_assoc' => [
+            1 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_intersect_key' => [
+            1 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_intersect_uassoc' => [
+            // Note from array_diff_uassoc applies here too.
+            2 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_intersect_ukey' => [
+            // Note from array_diff_uassoc applies here too.
+            2 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_intersect' => [
+            1 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
         'array_merge' => [
             0 => [
                 'name' => 'array(s) to merge',
@@ -63,6 +140,54 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
                 'name' => 'element to push',
                 '7.2'  => true,
                 '7.3'  => false,
+            ],
+        ],
+        'array_udiff_assoc' => [
+            // Note from array_diff_uassoc applies here too.
+            2 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_udiff_uassoc' => [
+            // Note from array_diff_uassoc applies here too.
+            3 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_udiff' => [
+            // Note from array_diff_uassoc applies here too.
+            2 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_uintersect_assoc' => [
+            // Note from array_diff_uassoc applies here too.
+            2 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_uintersect_uassoc' => [
+            // Note from array_diff_uassoc applies here too.
+            3 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'array_uintersect' => [
+            // Note from array_diff_uassoc applies here too.
+            2 => [
+                'name' => 'array2',
+                '7.4'  => true,
+                '8.0'  => false,
             ],
         ],
         'array_unshift' => [

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -149,6 +149,33 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractComplexVersionSn
                 '7.1'  => false,
             ],
         ],
+        'imagepolygon' => [
+            /*
+             * $num_points is actually at position 2, but has another required parameter after it,
+             * so we need to detect on the last parameter.
+             */
+            3 => [
+                'name' => 'num_points',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'imageopenpolygon' => [
+            // Note from imagepolygon applies here too.
+            3 => [
+                'name' => 'num_points',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
+        'imagefilledpolygon' => [
+            // Note from imagepolygon applies here too.
+            3 => [
+                'name' => 'num_points',
+                '7.4'  => true,
+                '8.0'  => false,
+            ],
+        ],
         'preg_match_all' => [
             2 => [
                 'name' => 'matches',

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
@@ -45,3 +45,31 @@ imagepolygon($image, $points, $num_points, $color); // OK.
 imagepolygon($image, $points, $color); // PHP 8.0+.
 imageopenpolygon($image, $points, $color); // PHP 8.0+.
 imagefilledpolygon($image, $points, $color); // PHP 8.0+.
+
+array_diff_uassoc($array, $array2, $array3, $array4, $key_compare_func); // OK.
+array_diff_ukey($array, $array2, $key_compare_func); // OK.
+array_intersect_uassoc($array, $array2, $key_compare_func); // OK.
+array_intersect_ukey($array, $array2, $key_compare_func); // OK.
+array_udiff_assoc( $array1, $array2, $array3, $value_compare_func ); // OK.
+array_udiff_uassoc($array1, $array2, $value_compare_func, $key_compare_func); // OK.
+array_udiff($array1, $array2, $value_compare_func ); // OK.
+array_uintersect_assoc( $array1, $array2, $value_compare_func ); // OK.
+array_uintersect_uassoc($array1, $array2, $array3, $value_compare_func, $key_compare_func); // OK.
+array_uintersect($array1, $array2, $value_compare_func ); // OK.
+
+array_diff_assoc($array); // PHP 8.0+.
+array_diff_key($array); // PHP 8.0+.
+array_diff_uassoc($array, $key_compare_func); // PHP 8.0+.
+array_diff_ukey(...$array, $key_compare_func); // PHP 8.0+.
+array_diff($array); // PHP 8.0+.
+array_intersect_assoc($array); // PHP 8.0+.
+array_intersect_key($array); // PHP 8.0+.
+array_intersect_uassoc($array, $key_compare_func); // PHP 8.0+.
+array_intersect_ukey(...$array, $key_compare_func); // PHP 8.0+.
+array_intersect($array); // PHP 8.0+.
+array_udiff_assoc ( $array, $value_compare_func ); // PHP 8.0+.
+array_udiff_uassoc($array, $value_compare_func, $key_compare_func); // PHP 8.0+.
+array_udiff($array, $value_compare_func ); // PHP 8.0+.
+array_uintersect_assoc( $array, $value_compare_func ); // PHP 8.0+.
+array_uintersect_uassoc($array, $value_compare_func, $key_compare_func); // PHP 8.0+.
+array_uintersect($array, $value_compare_func ); // PHP 8.0+.

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
@@ -40,3 +40,8 @@ fgetcsv($handle); // PHP 5.1+.
 
 xmlwriter_write_element($xmlwriter, $name); // PHP 5.2.3+.
 xmlwriter_write_element_ns($xmlwriter, $prefix, $name, $uri); // PHP 5.2.3+.
+
+imagepolygon($image, $points, $num_points, $color); // OK.
+imagepolygon($image, $points, $color); // PHP 8.0+.
+imageopenpolygon($image, $points, $color); // PHP 8.0+.
+imagefilledpolygon($image, $points, $color); // PHP 8.0+.

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -83,6 +83,9 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
             ['fgetcsv', 'length', '5.0', [39], '5.1'],
             ['xmlwriter_write_element', 'content', '5.2.2', [41], '5.3', '5.2'],
             ['xmlwriter_write_element_ns', 'content', '5.2.2', [42], '5.3', '5.2'],
+            ['imagepolygon', 'num_points', '7.4', [45], '8.0'],
+            ['imageopenpolygon', 'num_points', '7.4', [46], '8.0'],
+            ['imagefilledpolygon', 'num_points', '7.4', [47], '8.0'],
         ];
     }
 
@@ -122,6 +125,7 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
             [32],
             [34],
             [38],
+            [44],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -86,6 +86,22 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
             ['imagepolygon', 'num_points', '7.4', [45], '8.0'],
             ['imageopenpolygon', 'num_points', '7.4', [46], '8.0'],
             ['imagefilledpolygon', 'num_points', '7.4', [47], '8.0'],
+            ['array_diff_assoc', 'array2', '7.4', [60], '8.0'],
+            ['array_diff_key', 'array2', '7.4', [61], '8.0'],
+            ['array_diff_uassoc', 'array2', '7.4', [62], '8.0'],
+            ['array_diff_ukey', 'array2', '7.4', [63], '8.0'],
+            ['array_diff', 'array2', '7.4', [64], '8.0'],
+            ['array_intersect_assoc', 'array2', '7.4', [65], '8.0'],
+            ['array_intersect_key', 'array2', '7.4', [66], '8.0'],
+            ['array_intersect_uassoc', 'array2', '7.4', [67], '8.0'],
+            ['array_intersect_ukey', 'array2', '7.4', [68], '8.0'],
+            ['array_intersect', 'array2', '7.4', [69], '8.0'],
+            ['array_udiff_assoc', 'array2', '7.4', [70], '8.0'],
+            ['array_udiff_uassoc', 'array2', '7.4', [71], '8.0'],
+            ['array_udiff', 'array2', '7.4', [72], '8.0'],
+            ['array_uintersect_assoc', 'array2', '7.4', [73], '8.0'],
+            ['array_uintersect_uassoc', 'array2', '7.4', [74], '8.0'],
+            ['array_uintersect', 'array2', '7.4', [75], '8.0'],
         ];
     }
 
@@ -126,6 +142,16 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
             [34],
             [38],
             [44],
+            [49],
+            [50],
+            [51],
+            [52],
+            [53],
+            [54],
+            [55],
+            [56],
+            [57],
+            [58],
         ];
     }
 


### PR DESCRIPTION
Related to #809 

### PHP 8.0: RequiredToOptionalFunctionParameters - handle optional param for three GD functions

> The $num_points parameter of imagepolygon(), imageopenpolygon() and
>  imagefilledpolygon() is now optional, i.e. these functions may be called
>  with either 3 or 4 arguments. If the arguments is omitted, it is calculated
>  as count($points)/2.

**Implementation note:**
The `$num_points` parameter is the 3rd parameter and has become optional, but the `$color` parameter which is the 4th parameter, is still expected to be passed, so detection needs to take place on the minimum number of arguments having changed, not on the actual position of the argument now optional.

Refs:
* https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L611-L614
* php/php-src@2de79f0

Includes adjusted unit tests.

### PHP 8.0 | RequiredToOptionalFunctionParameters: allow for single arg array_diff/intersect calls

> array_diff(), array_intersect() and their variations can now be used with
> a single array as argument. This means that usages like the following are
> now possible:
>
> ```php
>     // OK even if $excludes is empty.
>     array_diff($array, ...$excludes);
>      // OK even if $arrays only contains a single array.
>     array_intersect(...$arrays);
> ```

**Note:**
A number of these functions have a **required** _callback_ parameter _after_ the parameter which has now become optional, so detection needs to take place on the minimum number of arguments having changed, not on the actual position of the removed argument.

Includes tests safeguarding this.

Refs:
* https://github.com/php/php-src/blob/0a84fba0deb1c1b75770a436c4236dc56e6d0463/UPGRADING#L805-L812
* php/php-src@73ab7b3

