### PR TITLE
PHP 8.0 | OptionalToRequiredFunctionParameters: handle crypt $salt becoming required

### DIFF
--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -70,6 +70,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
     {
         return [
             ['mktime', 'hour', '5.1', '8.0', [19], '5.0'],
+            ['crypt', 'salt', '5.6', '8.0', [8], '5.5'],
             ['parse_str', 'result', '7.2', '8.0', [7], '7.1'],
         ];
     }
@@ -121,49 +122,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
 
 
     /**
-     * testOptionalRecommendedParameter
-     *
-     * @dataProvider dataOptionalRecommendedParameter
-     *
-     * @param string $functionName        Function name.
-     * @param string $parameterName       Parameter name.
-     * @param string $softRecommendedFrom The PHP version in which the parameter became recommended.
-     * @param array  $lines               The line numbers in the test file which apply to this class.
-     * @param string $okVersion           A PHP version in which to test for no violation.
-     *
-     * @return void
-     */
-    public function testOptionalRecommendedParameter($functionName, $parameterName, $softRecommendedFrom, $lines, $okVersion)
-    {
-        $file  = $this->sniffFile(__FILE__, $softRecommendedFrom);
-        $error = "The \"{$parameterName}\" parameter for function {$functionName}() is missing. Passing this parameter is strongly recommended since PHP {$softRecommendedFrom}";
-        foreach ($lines as $line) {
-            $this->assertWarning($file, $line, $error);
-        }
-
-        $file = $this->sniffFile(__FILE__, $okVersion);
-        foreach ($lines as $line) {
-            $this->assertNoViolation($file, $line);
-        }
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testOptionalRecommendedParameter()
-     *
-     * @return array
-     */
-    public function dataOptionalRecommendedParameter()
-    {
-        return [
-            ['crypt', 'salt', '5.6', [8], '5.5'],
-        ];
-    }
-
-
-    /**
-     * testNoFalsePositives
+     * Verify no false positives are thrown for valid code.
      *
      * @dataProvider dataNoFalsePositives
      *


### PR DESCRIPTION
> Calling crypt() without an explicit salt is no longer supported. If you
>  would like to produce a strong hash with an auto-generated salt, use
>  password_hash() instead.

The `$salt` parameter for `crypt()` was previously _strongly recommended_ to be passed, but not passing it was not formally deprecated.

With this in mind, the sniff special-cased this check.

With the parameter now being required, building the error message in combination with the special casing of "recommended" instead of "deprecated" would become exponentially more complicated.

With this in mind, I've removed the special-casing and, while not _technically_ correct, with a `testVersion` including PHP 5.6, the optional nature of the parameter will be reported as _deprecated_ instead of _recommended_.

:point_right: This includes a change in the errorcodes being used by the sniff, which should be annotated in the changelog.

Refs:
* https://github.com/php/php-src/blob/0a84fba0deb1c1b75770a436c4236dc56e6d0463/UPGRADING#L608-L610
* https://github.com/php/php-src/commit/032f862133dbd2acc04cb75004428d6209f6046b

Related to #809