### PR TITLE
PHP 8.0 | New `PHPCompatibility.Syntax.InterpolatedStringDereferencing` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2009-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Syntax;
+
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Utils\TextStrings;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Detect dereferencing of interpolated strings.
+ *
+ * PHP version 8.0
+ *
+ * @link https://wiki.php.net/rfc/variable_syntax_tweaks#interpolated_and_non-interpolated_strings
+ * @link https://www.php.net/manual/en/language.types.string.php#language.types.string.parsing
+ *
+ * @since 10.0.0
+ */
+class NewInterpolatedStringDereferencingSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_DOUBLE_QUOTED_STRING,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // PHP 8.0 supports dereferencing interpolated strings
+        if ($this->supportsBelow('7.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Check whether the text string uses interpolation.
+        $string     = TextStrings::getCompleteTextString($phpcsFile, $stackPtr, true);
+        $endOfQuote = $phpcsFile->findNext([\T_DOUBLE_QUOTED_STRING], $stackPtr + 1, null, true);
+        if ($this->stripVariables($string) === $string) {
+            return $endOfQuote;
+        }
+
+        // Check whether the string is being dereferenced.
+        $nextNonEmpty     = $phpcsFile->findNext(Tokens::$emptyTokens, $endOfQuote, null, true);
+        $nextNonEmptyCode = $tokens[$nextNonEmpty]['code'];
+        if ($nextNonEmptyCode !== \T_OPEN_SQUARE_BRACKET
+            && $nextNonEmptyCode !== \T_OBJECT_OPERATOR
+            // Work-around for a bug in PHPCS < 3.6.0.
+            // @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3172
+            && $nextNonEmptyCode !== \T_OPEN_SHORT_ARRAY
+        ) {
+            return $endOfQuote;
+        }
+
+        $phpcsFile->addError(
+            'Dereferencing of interpolated strings is not supported in PHP 7.4 or earlier',
+            $stackPtr,
+            'Found'
+        );
+
+        return $endOfQuote;
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewInterpolatedStringDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewInterpolatedStringDereferencingUnitTest.inc
@@ -1,0 +1,30 @@
+<?php
+
+// OK: strings that don't use interpolation or dereferencing.
+$a = 'foo';
+$a = "foo";
+$a = "foo
+bar";
+
+// OK: strings that use interpolation, but not dereferencing.
+$a = "$bar";
+$a = "foo$bar";
+$a = "foo
+$bar";
+
+// OK: strings that use dereferencing, but not interpolation.
+$a = 'foo'[0];
+$a = "foo"[0];
+$a = 'foo'->baz();
+$a = "foo"->baz();
+$a = "foo
+bar"->baz();
+
+// PHP 8.0: strings that use interpolation and dereferencing.
+$a = "foo$bar"[0];
+$a = "foo$bar"->baz();
+$a = "foo
+$bar"->baz();
+$a = "foo $lines
+$bar
+more foo"[10];

--- a/PHPCompatibility/Tests/Syntax/NewInterpolatedStringDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewInterpolatedStringDereferencingUnitTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewInterpolatedStringDereferencing sniff.
+ *
+ * @group newInterpolatedStringDereferencing
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewInterpolatedStringDereferencingSniff
+ *
+ * @since 10.0.0
+ */
+class NewInterpolatedStringDereferencingUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test that an error is thrown for interpolated string dereferencing prior to PHP 8.0.
+     *
+     * @dataProvider dataInterpolatedStringDereferencing
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testInterpolatedStringDereferencing($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, 'Dereferencing of interpolated strings is not supported in PHP 7.4 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInterpolatedStringDereferencing
+     *
+     * @return array
+     */
+    public function dataInterpolatedStringDereferencing()
+    {
+        return [
+            [24],
+            [25],
+            [26],
+            [28],
+        ];
+    }
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return [
+            // No interpolation, no dereferencing.
+            [4],
+            [5],
+            [6],
+
+            // Interpolation, no dereferencing.
+            [10],
+            [11],
+            [12],
+
+            // Dereferencing, no interpolation.
+            [16],
+            [17],
+            [18],
+            [19],
+            [20],
+        ];
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Non-interpolated strings `"foo"` are currently considered fully dereferencable, i.e. constructions such as `"foo"[0]` or `"foo"->bar()` are considered legal (syntactically at least). However, interpolated strings `"foo$bar"` are non-dereferencable.
>
> This RFC proposed to treat both types of strings consistently, i.e. `"foo$bar"[0]`, `"foo$bar"->baz()` etc become legal.

Ref:
* https://wiki.php.net/rfc/variable_syntax_tweaks#interpolated_and_non-interpolated_strings
* php/php-src#5061
* php/php-src@24e365f

Includes unit tests.

Relates to #809