### PR TITLE
Composer: only allow tagged releases of PHPCSUtils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -195,7 +195,11 @@ before_install:
     if [[ "$CUSTOM_INI" == 1 ]]; then
       echo 'short_open_tag = On' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     fi
-  - php -r "echo ini_get('short_open_tag');"
+  # Turn on Xdebug code coverage mode in case Xdebug 3 is being used.
+  - |
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" ]]; then
+      echo 'xdebug.mode = coverage' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    fi
 
   # Set up test environment using Composer.
   - travis_retry composer require --no-update squizlabs/php_codesniffer:${PHPCS_VERSION}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require" : {
     "php" : ">=5.4",
     "squizlabs/php_codesniffer" : "^2.6 || ^3.1.0",
-    "phpcsstandards/phpcsutils" : "^1.0 || dev-develop"
+    "phpcsstandards/phpcsutils" : "^1.0"
   },
   "require-dev" : {
     "php-parallel-lint/php-parallel-lint": "^1.2.0",
@@ -43,6 +43,8 @@
   "suggest" : {
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
+  "minimum-stability": "alpha",
+  "prefer-stable": true,
   "extra": {
     "branch-alias": {
       "dev-master": "9.x-dev",

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -25,6 +25,22 @@ if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
     define('PHP_CODESNIFFER_VERBOSITY', 0);
 }
 
+/*
+ * PHPUnit 9.3 is the first version which supports Xdebug 3, but we're using PHPUnit 9.2
+ * for code coverage due to PHP_Parser interfering with our tests.
+ *
+ * For now, until a fix is pulled to allow us to use PHPUnit 9.3, this will allow
+ * PHPUnit 9.2 to run with Xdebug 3 for code coverage.
+ */
+if (\extension_loaded('xdebug') && \version_compare(\phpversion('xdebug'), '3', '>=')) {
+    if (defined('XDEBUG_CC_UNUSED') === false) {
+        define('XDEBUG_CC_UNUSED', null);
+    }
+    if (defined('XDEBUG_CC_DEAD_CODE') === false) {
+        define('XDEBUG_CC_DEAD_CODE', null);
+    }
+}
+
 $ds = DIRECTORY_SEPARATOR;
 
 // Get the PHPCS dir from an environment variable.


### PR DESCRIPTION
A recent change to PHPCSUtils to support named parameters in PHP 8.0 is causing some tests to fail.

I'm working on preparing the fix(es) needed for this to be pulled once PHPCSUtils 1.0-alpha4 is tagged, but for now, let's prevent the builds from failing.

### Tests: Xdebug 3 compatibility fix

We are currently limiting the PHPUnit version being used to max PHPUnit 9.2.x due to an issue with the code coverage package having switched over to `PHP_Parser` which defines token constants for constants which the sniffs rely on not to exist unless a PHP_CodeSniffer version is used in which they are backfilled.

However, Xdebug `3.0` was released last week and the Travis images for high PHP versions have been updated to include Xdebug `3.0`, but now it turns out that PHPUnit 9.2.x is not compatible with Xdebug 3....

Declaring the "missing" constants which no longer exist in Xdebug 3, but which PHPUnit 9.2 is relying on to exist, will fix this, combined with enabling the Xdebug code coverage mode from within the Travis config.