### PR TITLE
PHP 8.0: RemovedFunctions: account for two more deprecated functions

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4691,6 +4691,9 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         'openssl_pkey_free' => [
             '8.0' => false,
         ],
+        'openssl_free_key' => [
+            '8.0' => false,
+        ],
         'pg_clientencoding' => [
             '8.0'         => false,
             'alternative' => 'pg_client_encoding()',
@@ -4786,6 +4789,9 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
         'pg_setclientencoding' => [
             '8.0'         => false,
             'alternative' => 'pg_set_client_encoding()',
+        ],
+        'shmop_close' => [
+            '8.0' => false,
         ],
         'xmlrpc_decode_request' => [
             '8.0'       => true,

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1214,3 +1214,6 @@ pg_numrows();
 pg_result();
 pg_setclientencoding();
 imap_header();
+shmop_close();
+openssl_free_key();
+

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -71,6 +71,8 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             ['libxml_disable_entity_loader', '8.0', [1191], '7.4'],
             ['openssl_x509_free', '8.0', [1189], '7.4'],
             ['openssl_pkey_free', '8.0', [1190], '7.4'],
+            ['shmop_close', '8.0', [1217], '7.4'],
+            ['openssl_free_key', '8.0', [1218], '7.4'],
         ];
     }
 


### PR DESCRIPTION
Both related to extensions changing the return type from resources to object, making these functions redundant.

>   . shmop_open() will now return a Shmop object rather than a resource. Return
>     value checks using is_resource() should be replaced with checks for `false`.
>     The shmop_close() function no longer has an effect, and is deprecated;
>     instead the Shmop instance is automatically destroyed if it is no longer
>     referenced.

>   . The openssl_pkey_free() function is deprecated and no longer has an effect,
>     instead the OpenSSLAsymmetricKey instance is automatically destroyed if it is no
>     longer referenced.

Refs:
* https://github.com/php/php-src/blob/5aaffc8095eeb69407855b33d1939dd5ebd619ca/UPGRADING#L1101-L1105
* https://github.com/php/php-src/blob/5aaffc8095eeb69407855b33d1939dd5ebd619ca/UPGRADING#L424-426
* https://github.com/php/php-src/commit/18f58080dcb07295c09ae2f757691c96a5a312de
* https://github.com/php/php-src/commit/9f44eca6b60f8073dc9e2aa31154f9d70b42938d