### PR TITLE
NewConstantArraysUsingDefine: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -78,7 +78,7 @@ class NewConstantArraysUsingDefineSniff extends Sniff
             return;
         }
 
-        $secondParam = PassedParameters::getParameter($phpcsFile, $stackPtr, 2);
+        $secondParam = PassedParameters::getParameter($phpcsFile, $stackPtr, 2, 'value');
         if (isset($secondParam['start'], $secondParam['end']) === false) {
             return;
         }


### PR DESCRIPTION
PHPCSUtils `1.0.0-alpha4` will add support for named parameters.
Ref: https://github.com/PHPCSStandards/PHPCSUtils/pull/235

To allow for this, any calls to `PassedParameters::getParameter()` to retrieve a parameter in a function call need to pass the name of the target parameter.

Within PHPCompatibility, this is the only sniff for which the tests would fail at the moment when used with PHPCSUtils alpha-4, so pre-eminently fixing this ahead of the release of PHPCSUtils 1.0.0-alpha4.

Adding unit tests for this change would break on alpha3 though, so I'm leaving those for a future PR once alpha4 has been released.