### PR TITLE
New HashAlgorithmsTrait, including implementation

### DIFF
--- a/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
+++ b/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Helpers;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
+use PHPCSUtils\Utils\TextStrings;
+
+/**
+ * Helper function and property for sniffs examining the use of hash algorithms.
+ *
+ * Used by the new/removed hash algorithm sniffs.
+ *
+ * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
+ *
+ * @since 5.5
+ * @since 7.0.7  Logic moved from the `RemovedHashAlgorithms` sniff to the generic `Sniff` class.
+ * @since 10.0.0 Logic moved from the generic `Sniff` class to a dedicated trait.
+ */
+trait HashAlgorithmsTrait
+{
+
+    /**
+     * List of functions using hash algorithm as parameter (always the first parameter).
+     *
+     * Key is the function name, value is the 1-based parameter position in the function call.
+     *
+     * @since 5.5
+     * @since 7.0.7  Moved from the `RemovedHashAlgorithms` sniff to the base `Sniff` class.
+     * @since 10.0.0 Moved from the base `Sniff` class to the `HashAlgorithmsTrait`.
+     *
+     * @var array
+     */
+    protected $hashAlgoFunctions = [
+        'hash_file'      => 1,
+        'hash_hmac_file' => 1,
+        'hash_hmac'      => 1,
+        'hash_init'      => 1,
+        'hash_pbkdf2'    => 1,
+        'hash'           => 1,
+    ];
+
+    /**
+     * Get the hash algorithm name from the parameter in a hash function call.
+     *
+     * @since 7.0.7  Logic moved from the `RemovedHashAlgorithms` sniff to the generic `Sniff` class.
+     * @since 10.0.0 Moved from the base `Sniff` class to the `HashAlgorithmsTrait`.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of T_STRING function token.
+     *
+     * @return string|false The algorithm name without quotes if this was a relevant hash
+     *                      function call or false if it was not.
+     */
+    public function getHashAlgorithmParameter(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token and that it is the right token.
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_STRING) {
+            return false;
+        }
+
+        $functionName   = $tokens[$stackPtr]['content'];
+        $functionNameLc = \strtolower($functionName);
+
+        // Bow out if not one of the functions we're targetting.
+        if (isset($this->hashAlgoFunctions[$functionNameLc]) === false) {
+            return false;
+        }
+
+        // Get the parameter from the function call which should contain the algorithm name.
+        $algoParam = PassedParameters::getParameter($phpcsFile, $stackPtr, $this->hashAlgoFunctions[$functionNameLc]);
+        if ($algoParam === false) {
+            return false;
+        }
+
+        // Algorithm is a text string, so we need to remove the quotes.
+        return TextStrings::stripQuotes(\strtolower($algoParam['raw']));
+    }
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHPCompatibility\Helpers\HashAlgorithmsTrait;
 use PHP_CodeSniffer\Files\File;
 
 /**
@@ -21,10 +22,12 @@ use PHP_CodeSniffer\Files\File;
  * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
  *
  * @since 7.0.7
- * @since 7.1.0 Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
+ * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
+ * @since 10.0.0 Now uses the new `HashAlgorithmsTrait`.
  */
 class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
 {
+    use HashAlgorithmsTrait;
 
     /**
      * A list of new hash algorithms, not present in older versions.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractRemovedFeatureSniff;
+use PHPCompatibility\Helpers\HashAlgorithmsTrait;
 use PHP_CodeSniffer\Files\File;
 
 /**
@@ -21,10 +22,12 @@ use PHP_CodeSniffer\Files\File;
  * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
  *
  * @since 5.5
- * @since 7.1.0 Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
+ * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
+ * @since 10.0.0 Now uses the new `HashAlgorithmsTrait`.
  */
 class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
 {
+    use HashAlgorithmsTrait;
 
     /**
      * A list of removed hash algorithms, which were present in older versions.

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -20,7 +20,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group hashAlgorithms
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewHashAlgorithmsSniff
- * @covers \PHPCompatibility\Sniff::getHashAlgorithmParameter
+ * @covers \PHPCompatibility\Helpers\HashAlgorithmsTrait
  *
  * @since 7.0.7
  */

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
@@ -20,7 +20,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group hashAlgorithms
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedHashAlgorithmsSniff
- * @covers \PHPCompatibility\Sniff::getHashAlgorithmParameter
+ * @covers \PHPCompatibility\Helpers\HashAlgorithmsTrait
  *
  * @since 5.5
  */


### PR DESCRIPTION
Move functionality which is only needed by select sniffs out of the base `Sniff` class to traits.

This addresses the hash algorithm specific functionality and moves both the property as well as the `getHashAlgorithmParameter()` method to a new `HashAlgorithmsTrait`.

In a future iteration, these sniffs will be further refactored to use an abstract from PHPCSUtils. Moving this logic from a parent class to a trait allows for that.

The trait is tested via the integration tests for the individual sniffs.

This PR contains no functional changes in the moved code.