### PR TITLE
Ini sniffs: move `$iniFunctions` property to sniffs

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -63,21 +63,6 @@ abstract class Sniff implements PHPCS_Sniff
         'hash'           => 1,
     ];
 
-    /**
-     * List of functions which take an ini directive as parameter (always the first parameter).
-     *
-     * Used by the new/removed ini directives sniffs.
-     * Key is the function name, value is the 1-based parameter position in the function call.
-     *
-     * @since 7.1.0
-     *
-     * @var array
-     */
-    protected $iniFunctions = [
-        'ini_get' => 1,
-        'ini_set' => 1,
-    ];
-
 
     /**
      * Add a PHPCS message to the output stack as either a warning or an error.

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -32,6 +32,21 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
 {
 
     /**
+     * List of functions which take an ini directive as parameter (always the first parameter).
+     *
+     * Key is the function name, value is the 1-based parameter position in the function call.
+     *
+     * @since 7.1.0
+     * @since 10.0.0 Moved from the base `Sniff` class to this sniff.
+     *
+     * @var array
+     */
+    protected $iniFunctions = [
+        'ini_get' => 1,
+        'ini_set' => 1,
+    ];
+
+    /**
      * A list of new INI directives
      *
      * The array lists : version number with false (not present) or true (present).

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -34,6 +34,21 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
 {
 
     /**
+     * List of functions which take an ini directive as parameter (always the first parameter).
+     *
+     * Key is the function name, value is the 1-based parameter position in the function call.
+     *
+     * @since 7.1.0
+     * @since 10.0.0 Moved from the base `Sniff` class to this sniff.
+     *
+     * @var array
+     */
+    protected $iniFunctions = [
+        'ini_get' => 1,
+        'ini_set' => 1,
+    ];
+
+    /**
      * A list of deprecated/removed INI directives.
      *
      * The array lists : version number with false (deprecated) and true (removed).


### PR DESCRIPTION
As this property is only used by two sniffs, having it declared in the individual sniffs instead of in the base `Sniff` class will simplify things when the sniffs will change to a different parent sniff (once the new parent becomes available in PHPCSUtils).

Doing this now, prevents us having to deprecate the property later in a minor and removing it in the next major.