### PR TITLE
NewConstantArraysUsingDefine: further implementation of PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -12,6 +12,8 @@ namespace PHPCompatibility\Sniffs\InitialValue;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -88,8 +90,11 @@ class NewConstantArraysUsingDefineSniff extends Sniff
             $targetNestingLevel = \count($tokens[$secondParam['start']]['nested_parenthesis']);
         }
 
-        $array = $phpcsFile->findNext([\T_ARRAY, \T_OPEN_SHORT_ARRAY], $secondParam['start'], ($secondParam['end'] + 1));
-        if ($array !== false) {
+        $array = $phpcsFile->findNext(Collections::$arrayTokensBC, $secondParam['start'], ($secondParam['end'] + 1));
+        if ($array !== false
+            && ($tokens[$array]['code'] === \T_ARRAY
+                || Arrays::isShortArray($phpcsFile, $array) === true)
+        ) {
             if ((isset($tokens[$array]['nested_parenthesis']) === false && $targetNestingLevel === 0) || \count($tokens[$array]['nested_parenthesis']) === $targetNestingLevel) {
                 $phpcsFile->addError(
                     'Constant arrays using define are not allowed in PHP 5.6 or earlier',

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
@@ -30,3 +30,7 @@ define('ANIMALS');
 // Array within a function call.
 define('WPDIRAUTH_LDAP_RETURN_KEYS',serialize(array('sn', 'givenname', 'mail')));
 define('WPDIRAUTH_LDAP_RETURN_KEYS',serialize(['sn', 'givenname', 'mail']));
+
+// Array dereferencing.
+define('DEREF', OTHER['key']);
+define('DEREF', 'string'[2]);

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -90,6 +90,8 @@ class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
             [28],
             [31],
             [32],
+            [35],
+            [36],
         ];
     }
 


### PR DESCRIPTION
The second of the new unit tests would fail on older PHPCS versions without the "is short array" check due to upstream tokenizer issues.

The tests are just some examples of what this fixes, in reality the `isShortArray()` method call prevents quite a few false positives for various upstream tokenizer quirks in various PHPCS versions.