### PR TITLE
RemovedIconvEncoding: cleaner error output

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -80,7 +80,7 @@ class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
             'All previously accepted values for the $type parameter of iconv_set_encoding() have been deprecated since PHP 5.6. Found %s',
             $parameters[1]['start'],
             'DeprecatedValueFound',
-            [$parameters[1]['raw']]
+            [$parameters[1]['clean']]
         );
     }
 }


### PR DESCRIPTION
The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

Using the `clean` index will allow for "cleaner" code snippets in the error messages.