### PR TITLE
RemovedImplodeFlexibleParamOrder: use `BCTokens::textStringTokens()`

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
 
 /**
  * Passing the `$glue` and `$pieces` parameters to `implode()` in reverse order has
@@ -277,11 +278,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
                 return;
             }
 
-            if ($tokenCode === \T_CONSTANT_ENCAPSED_STRING
-                || $tokenCode === \T_DOUBLE_QUOTED_STRING
-                || $tokenCode === \T_HEREDOC
-                || $tokenCode === \T_NOWDOC
-            ) {
+            if (isset(BCTokens::textStringTokens()[$tokenCode]) === true) {
                 $this->throwNotice($phpcsFile, $stackPtr, $functionName);
                 return;
             }


### PR DESCRIPTION
This is a property which was introduced in PHPCS 2.9.0, so is not available to us natively, but PHPCSUtils backfills it.