### PR TITLE
RemovedNonCryptoHash: improve comment tolerance

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -96,14 +96,14 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
 
         $targetParam = $parameters[1];
 
-        if (isset($this->disabledCryptos[TextStrings::stripQuotes($targetParam['raw'])]) === false) {
+        if (isset($this->disabledCryptos[TextStrings::stripQuotes($targetParam['clean'])]) === false) {
             return;
         }
 
         if (\strtolower($functionName) === 'hash_init'
             && (isset($parameters[2]) === false
-            || ($parameters[2]['raw'] !== 'HASH_HMAC'
-                && $parameters[2]['raw'] !== (string) \HASH_HMAC))
+            || ($parameters[2]['clean'] !== 'HASH_HMAC'
+                && $parameters[2]['clean'] !== (string) \HASH_HMAC))
         ) {
             // For hash_init(), these hashes are only disabled with HASH_HMAC set.
             return;
@@ -115,7 +115,7 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
             $this->stringToErrorCode($functionName),
             [
                 $functionName,
-                $targetParam['raw'],
+                $targetParam['clean'],
             ]
         );
     }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
@@ -17,3 +17,7 @@ hash_hmac('fnv1a32');
 hash_hmac_file("fnv164");
 hash_pbkdf2('fnv1a64');
 hash_init( 'joaat', 1);
+hash_pbkdf2(
+    'adler32' // Comment.
+);
+hash_init( 'crc32b', HASH_HMAC /*comment*/);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
@@ -60,6 +60,8 @@ class RemovedNonCryptoHashUnitTest extends BaseSniffTest
             [17, 'hash_hmac_file'],
             [18, 'hash_pbkdf2'],
             [19, 'hash_init'],
+            [20, 'hash_pbkdf2'],
+            [23, 'hash_init'],
         ];
     }
 


### PR DESCRIPTION
The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

This allows for more reliable results for the sniff.

Includes unit test.