### PR TITLE
RemovedSetlocaleString: tweaks using PHPCSUtils

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -93,7 +93,7 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
             $message   = 'Passing the $category as a string to setlocale() has been deprecated since PHP 4.2';
             $isError   = false;
             $errorCode = 'Deprecated';
-            $data      = [$targetParam['raw']];
+            $data      = [$targetParam['clean']];
 
             if ($this->supportsAbove('7.0') === true) {
                 $message  .= ' and is removed since PHP 7.0';

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Detect passing a string literal as `$category` to `setlocale()`.
@@ -85,9 +86,7 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
                 return;
             }
 
-            if ($tokens[$i]['code'] !== \T_CONSTANT_ENCAPSED_STRING
-                && $tokens[$i]['code'] !== \T_DOUBLE_QUOTED_STRING
-            ) {
+            if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === false) {
                 continue;
             }
 


### PR DESCRIPTION
### RemovedSetlocaleString: use the PHPCS native `Tokens::$stringTokens`

### RemovedSetlocaleString: cleaner error output

The PHPCSUtils `PassedParameters::getParameters()` method provides both a `raw`, as well as a `clean` index, where `clean` contains the token content stripped of comments.

Using the `clean` index will allow for "cleaner" code snippets in the error messages.

