### PR TITLE
New/RemovedPCREModifiers: decouple the sniffs, introduce `PCRERegexTrait` and implement PHPCSUtils

### DIFF
--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Helpers;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Utils\PassedParameters;
+use PHPCSUtils\Utils\TextStrings;
+
+/**
+ * Trait to help examine the regex parameters in function calls to PCRE functions.
+ *
+ * Used by the NewPCREModifiersSniff/RemovedPCREModifiersSniff sniffs.
+ *
+ * @since 10.0.0 Logic split off from the `RemovedPCREModifiersSniff` sniff to this trait.
+ */
+trait PCRERegexTrait
+{
+
+    /**
+     * Regex bracket delimiters.
+     *
+     * @since 7.0.5  This array was originally contained within the `process()` method.
+     * @since 10.0.0 Moved from the `RemovedPCREModifiersSniff` to this trait.
+     *
+     * @var array
+     */
+    private $doublesSeparators = [
+        '{' => '}',
+        '[' => ']',
+        '(' => ')',
+        '<' => '>',
+    ];
+
+    /**
+     * Retrieve the regex patterns from a PCRE regex parameter.
+     *
+     * A regex parameter can be either a pattern as a string or an array of pattern strings.
+     * In case it's an array, in most PCRE functions, the patterns will be in the array value,
+     * but for the `preg_replace_callback_array()` function, the pattern strings are in the keys.
+     *
+     * This method brings order in this chaos.
+     *
+     * @since 10.0.0 This logic was originally contained in the `RemovedPCREModifiersSniff`.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $paramInfo    A parameter info array for the regex parameter as
+     *                                                  retrieved via the methods in the `PassedParameters`
+     *                                                  class.
+     *
+     * @return array A multi-dimensional array of parameter info arrays for the actual patterns.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the $paramInfo passed is invalid.
+     */
+    public function getRegexPatternsFromParameter(File $phpcsFile, $functionName, array $paramInfo)
+    {
+        if (isset($paramInfo['start'], $paramInfo['end']) === false) {
+            throw new RuntimeException(
+                'The $paramInfo parameter must contain a parameter info array as retrieved from the PassedParameters class'
+            );
+        }
+
+        $tokens         = $phpcsFile->getTokens();
+        $patterns       = [];
+        $functionNameLc = \strtolower($functionName);
+
+        // Differentiate between an array of patterns passed and a single pattern.
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $paramInfo['start'], ($paramInfo['end'] + 1), true);
+        if ($nextNonEmpty !== false && ($tokens[$nextNonEmpty]['code'] === \T_ARRAY || $tokens[$nextNonEmpty]['code'] === \T_OPEN_SHORT_ARRAY)) {
+            $arrayItems = PassedParameters::getParameters($phpcsFile, $nextNonEmpty);
+            if ($functionNameLc === 'preg_replace_callback_array') {
+                // For preg_replace_callback_array(), the patterns will be in the array keys.
+                foreach ($arrayItems as $itemInfo) {
+                    $hasKey = $phpcsFile->findNext(\T_DOUBLE_ARROW, $itemInfo['start'], ($itemInfo['end'] + 1));
+                    if ($hasKey === false) {
+                        continue;
+                    }
+
+                    $itemInfo['end'] = ($hasKey - 1);
+                    $itemInfo['raw'] = \trim($phpcsFile->getTokensAsString($itemInfo['start'], ($hasKey - $itemInfo['start'])));
+                    $patterns[]      = $itemInfo;
+                }
+            } else {
+                // Otherwise, the patterns will be in the array values.
+                foreach ($arrayItems as $itemInfo) {
+                    $hasKey = $phpcsFile->findNext(\T_DOUBLE_ARROW, $itemInfo['start'], ($itemInfo['end'] + 1));
+                    if ($hasKey !== false) {
+                        // Param info array only needs adjusting if this was a keyed array item.
+                        $itemInfo['start'] = ($hasKey + 1);
+                        $itemInfo['raw']   = \trim($phpcsFile->getTokensAsString($itemInfo['start'], (($itemInfo['end'] + 1) - $itemInfo['start'])));
+                    }
+
+                    $patterns[] = $itemInfo;
+                }
+            }
+        } else {
+            $patterns[] = $paramInfo;
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * Retrieve the regex modifiers from a regex pattern parameter.
+     *
+     * @since 7.1.2
+     * @since 10.0.0 Moved from the `RemovedPCREModifiersSniff` to this trait.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param array                       $patternInfo Array containing the start and end token
+     *                                                 pointer of the potential regex pattern
+     *                                                 and the clean string value of the pattern.
+     *
+     * @return string A text string containing the modifiers found or an empty string for no modifiers.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the $patternInfo passed is invalid.
+     */
+    protected function getRegexModifiers(File $phpcsFile, array $patternInfo)
+    {
+        if (isset($patternInfo['start'], $patternInfo['end']) === false) {
+            throw new RuntimeException(
+                'The $patternInfo parameter must contain a parameter info array as retrieved from the PassedParameters class'
+            );
+        }
+
+        $regex  = '';
+        $tokens = $phpcsFile->getTokens();
+
+        /*
+         * The pattern might be build up of a combination of strings, variables
+         * and function calls. We are only concerned with the strings.
+         */
+        for ($i = $patternInfo['start']; $i <= $patternInfo['end']; $i++) {
+            if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === true) {
+                $content = TextStrings::stripQuotes($tokens[$i]['content']);
+                if ($tokens[$i]['code'] === \T_DOUBLE_QUOTED_STRING) {
+                    $content = Sniff::stripVariables($content);
+                }
+
+                $regex .= \trim($content);
+            }
+        }
+
+        // Deal with multi-line regexes which were broken up in several string tokens.
+        if ($tokens[$patternInfo['start']]['line'] !== $tokens[$patternInfo['end']]['line']) {
+            $regex = TextStrings::stripQuotes($regex);
+        }
+
+        if ($regex === '') {
+            // No string tokens found in the parameter (e.g. if a variable was passed in).
+            return '';
+        }
+
+        $regexFirstChar = \substr($regex, 0, 1);
+
+        // Make sure that the character identified as the delimiter is valid.
+        // Otherwise, it is a false positive caused by string concatenation.
+        if (\preg_match('`[a-z0-9\\\\ ]`i', $regexFirstChar) === 1) {
+            return '';
+        }
+
+        if (isset($this->doublesSeparators[$regexFirstChar])) {
+            $regexEndPos = \strrpos($regex, $this->doublesSeparators[$regexFirstChar]);
+        } else {
+            $regexEndPos = \strrpos($regex, $regexFirstChar);
+        }
+
+        if ($regexEndPos === false) {
+            // Couldn't match the regex delimiters.
+            return '';
+        }
+
+        return \substr($regex, $regexEndPos + 1);
+    }
+}

--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\Arrays;
+use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -103,9 +104,10 @@ trait PCRERegexTrait
                     continue;
                 }
 
-                $itemInfo['end'] = ($hasKey - 1);
-                $itemInfo['raw'] = \trim($phpcsFile->getTokensAsString($itemInfo['start'], ($hasKey - $itemInfo['start'])));
-                $patterns[]      = $itemInfo;
+                $itemInfo['end']   = ($hasKey - 1);
+                $itemInfo['raw']   = \trim(GetTokensAsString::normal($phpcsFile, $itemInfo['start'], $itemInfo['end']));
+                $itemInfo['clean'] = \trim(GetTokensAsString::compact($phpcsFile, $itemInfo['start'], $itemInfo['end'], true));
+                $patterns[]        = $itemInfo;
             }
 
             return $patterns;
@@ -117,7 +119,8 @@ trait PCRERegexTrait
             if ($hasKey !== false) {
                 // Param info array only needs adjusting if this was a keyed array item.
                 $itemInfo['start'] = ($hasKey + 1);
-                $itemInfo['raw']   = \trim($phpcsFile->getTokensAsString($itemInfo['start'], (($itemInfo['end'] + 1) - $itemInfo['start'])));
+                $itemInfo['raw']   = \trim(GetTokensAsString::normal($phpcsFile, $itemInfo['start'], $itemInfo['end']));
+                $itemInfo['clean'] = \trim(GetTokensAsString::compact($phpcsFile, $itemInfo['start'], $itemInfo['end'], true));
             }
 
             $patterns[] = $itemInfo;

--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Sniff;
+use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -97,7 +98,7 @@ trait PCRERegexTrait
         if ($functionNameLc === 'preg_replace_callback_array') {
             // For preg_replace_callback_array(), the patterns will be in the array keys.
             foreach ($arrayItems as $itemInfo) {
-                $hasKey = $phpcsFile->findNext(\T_DOUBLE_ARROW, $itemInfo['start'], ($itemInfo['end'] + 1));
+                $hasKey = Arrays::getDoubleArrowPtr($phpcsFile, $itemInfo['start'], $itemInfo['end']);
                 if ($hasKey === false) {
                     continue;
                 }
@@ -112,7 +113,7 @@ trait PCRERegexTrait
 
         // Otherwise, the patterns will be in the array values.
         foreach ($arrayItems as $itemInfo) {
-            $hasKey = $phpcsFile->findNext(\T_DOUBLE_ARROW, $itemInfo['start'], ($itemInfo['end'] + 1));
+            $hasKey = Arrays::getDoubleArrowPtr($phpcsFile, $itemInfo['start'], $itemInfo['end']);
             if ($hasKey !== false) {
                 // Param info array only needs adjusting if this was a keyed array item.
                 $itemInfo['start'] = ($hasKey + 1);

--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -81,9 +81,7 @@ trait PCRERegexTrait
         }
 
         $tokens = $phpcsFile->getTokens();
-        if ($tokens[$nextNonEmpty]['code'] !== \T_ARRAY
-            && $tokens[$nextNonEmpty]['code'] !== \T_OPEN_SHORT_ARRAY
-        ) {
+        if (isset(Collections::$arrayTokensBC[$tokens[$nextNonEmpty]['code']]) === false) {
             // Parameter not passed as an array, treat it as a string pattern.
             return [$paramInfo];
         }

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -120,7 +120,7 @@ abstract class Sniff implements PHPCS_Sniff
      *
      * @return string String without variables in it.
      */
-    public function stripVariables($string)
+    public static function stripVariables($string)
     {
         if (\strpos($string, '$') === false) {
             return $string;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -21,7 +21,8 @@ use PHP_CodeSniffer\Files\File;
  * and removed as of PHP 7.0.
  *
  * {@internal If and when this sniff would need to start checking for other modifiers, a minor
- * refactor will be needed as all references to the `e` modifier are currently hard-coded.}
+ * refactor will be needed as all references to the `e` modifier are currently hard-coded
+ * and the target functions are limited to the ones which supported the `e` modifier.}
  *
  * PHP version 5.5
  * PHP version 7.0

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -54,6 +54,17 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
         'preg_filter'  => true,
     ];
 
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 8.2.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('5.5') === false);
+    }
 
     /**
      * Process the parameters of a matched function.
@@ -91,19 +102,6 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 
             $this->examineModifiers($phpcsFile, $pattern['end'], $functionName, $modifiers);
         }
-    }
-
-
-    /**
-     * Do a version check to determine if this sniff needs to run at all.
-     *
-     * @since 8.2.0
-     *
-     * @return bool
-     */
-    protected function bowOutEarly()
-    {
-        return ($this->supportsAbove('5.5') === false);
     }
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
@@ -31,3 +31,16 @@ preg_replace_callback_array(
     ],
     $subject
 );
+
+// Verify support for heredocs and nowdocs.
+$text = preg_match_all(
+    <<<'EOD'
+/(?<!\\\\)     # not preceded by a backslash
+  <            # an open bracket
+  >            # close bracket
+/iJx
+EOD
+    ,
+    '[$1]',
+    $text
+  );

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -65,7 +65,7 @@ class NewPCREModifiersUnitTest extends BaseSniffTest
     public function dataPCRENewModifier()
     {
         return [
-            ['J', '7.1', [3, 4, 10, 17, 19, 25], '7.2'],
+            ['J', '7.1', [3, 4, 10, 17, 19, 25, 43], '7.2'],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -20,6 +20,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group regexModifiers
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\NewPCREModifiersSniff
+ * @covers \PHPCompatibility\Helpers\PCRERegexTrait
  *
  * @since 8.2.0
  */
@@ -64,7 +65,7 @@ class NewPCREModifiersUnitTest extends BaseSniffTest
     public function dataPCRENewModifier()
     {
         return [
-            ['J', '7.1', [3, 4, 6, 17, 19, 25], '7.2'],
+            ['J', '7.1', [3, 4, 10, 17, 19, 25], '7.2'],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.inc
@@ -209,3 +209,20 @@ preg_replace("/double-quoted/$e", $Replace, $Source); // Ok.
 // https://wordpress.org/support/topic/false-positive-preg_replace-e-modifier/
 $code = preg_replace("'(?<![\$.a-zA-Z0-9_])while\('", '3#(', $code); // Ok.
 $code = preg_replace("'(?<![\$.a-zA-Z0-9_])while\('e", '3#(', $code); // Bad.
+
+// Verify support for heredocs and nowdocs.
+preg_filter(<<<EOD
+`
+  multi
+  line[r]
+`x{$mod['e']}
+EOD
+    , $replace, $source); // OK.
+
+preg_filter(<<<EOD
+`
+  multi$text
+  line[r]
+`xe
+EOD
+    , $replace, $source); // Bad.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -20,6 +20,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group regexModifiers
  *
  * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedPCREModifiersSniff
+ * @covers \PHPCompatibility\Helpers\PCRERegexTrait
  *
  * @since 5.6
  */
@@ -63,8 +64,8 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTest
             [58],
             [59],
             [60],
-            [63],
-            [78],
+            [72],
+            [80],
             [84],
 
             // Bracket delimiters.
@@ -82,8 +83,8 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTest
             [122, 'preg_filter'],
             [123, 'preg_filter'],
             [124, 'preg_filter'],
-            [127, 'preg_filter'],
-            [142, 'preg_filter'],
+            [136, 'preg_filter'],
+            [144, 'preg_filter'],
             [148, 'preg_filter'],
 
             // Regex build up of multiple tokens.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -86,6 +86,10 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTest
             [142, 'preg_filter'],
             [148, 'preg_filter'],
 
+            // Regex build up of multiple tokens.
+            [153],
+            [154],
+
             // Array of patterns.
             [162],
             [163],

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -112,6 +112,9 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTest
 
             // Quote as a delimiter.
             [211],
+
+            // Heredoc/Nowdoc.
+            [228, 'preg_filter'],
         ];
     }
 
@@ -180,6 +183,9 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTest
 
             // Quote as a delimiter.
             [210],
+
+            // Heredoc/Nowdoc.
+            [220],
         ];
     }
 


### PR DESCRIPTION
### RemovedPCREModifiers: enable some tests

Looks like some of the test cases were not actually being tested.

These cases were originally added in 6c75f62 and luckily still pass, even though they weren't being tested between then and now.

### New/RemovedPCREModifiers: decouple the sniffs, introduce `PCRERegexTrait`

This moves the logic which is needed by both the `NewPCREModifiers` as well as the `RemovedPCREModifiers` to a dedicated trait.

This allows us to decouple the `NewPCREModifiers` sniff from the `RemovedPCREModifiersSniff` and let it extend the `AbstractFunctionCallParameterSniff` class instead.

Sniffs which extend other sniffs can run into problems with the autoloading used in PHPCS as per the reports in issue #638 and #793.
This is part of an effort to fix those problems.

Having this trait in place will also make it easier to potentially, eventually address issue #965.

This commit does not change the actual functionality of the sniffs.
It only moves the relevant code to the trait and makes the trait methods stand-alone methods which return a value instead of passing off directly to the next function.

As part of making the code stand-alone, the `Sniff::stripVariables()` method has been made static.

The only difference in functionality is that now the last token in the regex pattern will be used to report the error on in all cases.
Previously, this was only the case for array parameters, not for string parameters.

Includes adjusted line numbers in the test files for this.

### RemovedPCREModifiers: move a method up

... for consistency with the parent class and the sister-class.

### RemovedPCREModifiers: minor (internal) documentation improvement

### PCRERegexTrait: lower nesting level of getRegexPatternsFromParameter()

The original code copied over from the `RemovedPCREModifiers` was nested quite deeply.

This changes that code to use an "early return" pattern, lowering the nesting levels and improving code readability.

There are no functional changes in this commit.

### PCRERegexTrait: use PHPCSUtils `getDoubleArrowPtr()` method

This will be more reliable than just searching for a double arrow as, while unlikely in this particular case, just searching for a double arrow could incorrectly identify an arrow of a nested array, the arrow in a `yield` or for an arrow function as the array double arrow.

The `Arrays::getDoubleArrowPtr()` method contains protection against all these type of issues.

### PCRERegexTrait: use PHPCSUtils `GetTokensAsString`

* Switch out the call to the PHPCS native `getTokensAsString()` method for calls to the methods in the PHPCSUtils `GetTokensAsString` class for improved results.
* Also, the return value of the PHPCSUtils `PassedParameters::getParameters()` et al methods also have a `clean` key, so for feature completeness, the content of that key should also be adjusted to be in line with the actual regex.

### PCRERegexTrait: use PHPCSUtils `TextStrings::getCompleteTextString()`

As part of the `getRegexModifiers()` method, we're walking the tokens within the regex parameter to retrieve all the text string parts of the parameter.

The code already took multi-line text strings into account, but didn't handle heredoc or nowdoc constructs being used to declare the regex yet. While this may be rare, it is allowed and the `TextStrings::getCompleteTextString()` method handles both multi-line text strings as well as supporting all types of text string tokens.

Includes making sure that interpolated variables are also being stripped from heredoc texts.

Includes removing handling of quotes for multi-line text string. The `TextStrings::getCompleteTextString()` method already handles this correctly.

Includes unit tests via the sniff integration tests.

### PCRERegexTrait: use PHPCSUtils `Collections::$arrayTokensBC`

To check whether the parameter is an array, we can use the `Collections::$arrayTokensBC` array, which also includes the `T_OPEN_SQUARE_BRACKET` which in some cases is in actual fact a short array when not correctly tokenized.

No need to follow this by a call to `Arrays::isShortArray()` as the regex parameter can't really be a short list as that doesn't make any sense at all.

