### PR TITLE
PHP 8.0: NewNestedStaticAccess: add support for class constant dereferencing

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
@@ -134,7 +134,7 @@ class NewNestedStaticAccessSniff extends Sniff
             && $this->supportsBelow('7.4') === true
         ) {
             $phpcsFile->addError(
-                'Class constants cannot be dereferenced in PHP 7.4 or earlier.',
+                'Dereferencing class constants was not supported in PHP 7.4 or earlier.',
                 $stackPtr,
                 'ClassConstantDereferenced'
             );

--- a/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
@@ -18,9 +18,13 @@ use PHP_CodeSniffer\Util\Tokens;
  * (Nested) Static property and constant fetches as well as method calls can be applied to
  * any dereferencable expression since PHP 7.0.
  *
+ * Class constants can be dereferenced since PHP 8.0.
+ *
  * PHP version 7.0
+ * PHP version 8.0
  *
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
+ * @link https://wiki.php.net/rfc/variable_syntax_tweaks#class_constant_dereferencability
  *
  * @since 10.0.0
  */
@@ -64,7 +68,8 @@ class NewNestedStaticAccessSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.6') === false) {
+        // PHP 8.0 supports both nested static access and class constant dereferencing
+        if ($this->supportsBelow('7.4') === false) {
             return;
         }
 
@@ -122,19 +127,27 @@ class NewNestedStaticAccessSniff extends Sniff
             return;
         }
 
-        // Ignore the one form of nested static access which is still not supported: ?::CONST::?.
+        // Class constants cannot be dereferenced before PHP 8.0.
         if ($seenBrackets === false
             && $tokens[$prev]['code'] === \T_STRING
             && $tokens[$prevOperator]['code'] === \T_DOUBLE_COLON
+            && $this->supportsBelow('7.4') === true
         ) {
+            $phpcsFile->addError(
+                'Class constants cannot be dereferenced in PHP 7.4 or earlier.',
+                $stackPtr,
+                'Found'
+            );
             return;
         }
 
         // This is nested static access.
-        $phpcsFile->addError(
-            'Nested access to static properties, constants and methods was not supported in PHP 5.6 or earlier.',
-            $stackPtr,
-            'Found'
-        );
+        if ($this->supportsBelow('5.6') === true) {
+            $phpcsFile->addError(
+                'Nested access to static properties, constants and methods was not supported in PHP 5.6 or earlier.',
+                $stackPtr,
+                'Found'
+            );
+        }
     }
 }

--- a/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
@@ -136,7 +136,7 @@ class NewNestedStaticAccessSniff extends Sniff
             $phpcsFile->addError(
                 'Class constants cannot be dereferenced in PHP 7.4 or earlier.',
                 $stackPtr,
-                'Found'
+                'ClassConstantDereferenced'
             );
             return;
         }
@@ -146,7 +146,7 @@ class NewNestedStaticAccessSniff extends Sniff
             $phpcsFile->addError(
                 'Nested access to static properties, constants and methods was not supported in PHP 5.6 or earlier.',
                 $stackPtr,
-                'Found'
+                'NestedStaticAccess'
             );
         }
     }

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.inc
@@ -30,7 +30,7 @@ echo ($foo->bar())::baz();
 // Parse error in any PHP version. Outside the scope of this sniff.
 echo $bar::($foo['bar'])::$baz;
 
-// PHP 8.0: class constant dereferencing
+// PHP 8.0: class constant dereferencing.
 self::MY_CONSTANT::$baz;
 Foo::MY_CONSTANT::$baz;
 

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.inc
@@ -30,7 +30,7 @@ echo ($foo->bar())::baz();
 // Parse error in any PHP version. Outside the scope of this sniff.
 echo $bar::($foo['bar'])::$baz;
 
-// Still not supported.
+// PHP 8.0: class constant dereferencing
 self::MY_CONSTANT::$baz;
 Foo::MY_CONSTANT::$baz;
 

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
@@ -26,7 +26,7 @@ class NewNestedStaticAccessUnitTest extends BaseSniffTest
 {
 
     /**
-     * testNestedStaticAccess
+     * Verify that nested static access emits an error in PHP 5.6, but not in PHP 7.0.
      *
      * @dataProvider dataNestedStaticAccess
      *
@@ -73,7 +73,7 @@ class NewNestedStaticAccessUnitTest extends BaseSniffTest
 
 
     /**
-     * testClassConstantDereferencing
+     * Verify that class constant dereferencing emits an error in PHP 7.4.
      *
      * @dataProvider dataClassConstantDereferencing
      *

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
@@ -38,6 +38,9 @@ class NewNestedStaticAccessUnitTest extends BaseSniffTest
     {
         $file = $this->sniffFile(__FILE__, '5.6');
         $this->assertError($file, $line, 'Nested access to static properties, constants and methods was not supported in PHP 5.6 or earlier.');
+
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file, $line);
     }
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
@@ -84,7 +84,7 @@ class NewNestedStaticAccessUnitTest extends BaseSniffTest
     public function testClassConstantDereferencing($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
-        $this->assertError($file, $line, 'Class constants cannot be dereferenced in PHP 7.4 or earlier.');
+        $this->assertError($file, $line, 'Dereferencing class constants was not supported in PHP 7.4 or earlier.');
     }
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
@@ -70,6 +70,37 @@ class NewNestedStaticAccessUnitTest extends BaseSniffTest
 
 
     /**
+     * testClassConstantDereferencing
+     *
+     * @dataProvider dataClassConstantDereferencing
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testClassConstantDereferencing($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, 'Class constants cannot be dereferenced in PHP 7.4 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testClassConstantDereferencing()
+     *
+     * @return array
+     */
+    public function dataClassConstantDereferencing()
+    {
+        return [
+            [34],
+            [35],
+        ];
+    }
+
+
+    /**
      * Verify the sniff doesn't throw false positives.
      *
      * @dataProvider dataNoFalsePositives
@@ -98,8 +129,6 @@ class NewNestedStaticAccessUnitTest extends BaseSniffTest
             [27],
             [28],
             [31],
-            [34],
-            [35],
         ];
     }
 
@@ -111,7 +140,7 @@ class NewNestedStaticAccessUnitTest extends BaseSniffTest
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '7.0');
+        $file = $this->sniffFile(__FILE__, '8.0');
         $this->assertNoViolation($file);
     }
 }


### PR DESCRIPTION
> ... class constant accesses are only array and object dereferencable. This
> means that while `Foo::$bar::$baz` is legal, `Foo::BAR::$baz` is not.
>
> This RFC proposes to make class constant accesses static derefencable as
> well, so that `Foo::BAR::$baz` and `Foo::BAR::BAZ` become legal.

Ref:
* https://wiki.php.net/rfc/variable_syntax_tweaks#class_constant_dereferencability
* https://github.com/php/php-src/pull/5061
* https://github.com/php/php-src/commit/ab154b7a64f5fe7ac103ed85b498fcb14109725e

Includes unit tests.

Relates to #809.