### PR TITLE
PHP 5.6 / 8.0: NewConstantDereferencing: add support for constant array / object dereferencing

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Syntax;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Detect constant dereferencing.
+ *
+ * As of PHP 5.6, constants can now be dereferenced to access individual elements and characters.
+ *
+ * As of PHP 8.0, constants can also be dereferenced to invoke method calls, though this support only applies to syntax and must be used in conjunction with the scalar objects extension to work at runtime.
+ *
+ * PHP version 5.6
+ * PHP version 8.0
+ *
+ * @link https://wiki.php.net/rfc/const_scalar_exprs
+ * @link https://github.com/php/php-src/commit/d5ddd2dbb263cd626a5e0f203c00d6f39168507b
+ * @link https://wiki.php.net/rfc/variable_syntax_tweaks#constant_dereferencability
+ *
+ * @since 10.0.0
+ */
+class NewConstantDereferencingSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_OPEN_SQUARE_BRACKET,
+            \T_OPEN_CURLY_BRACKET,
+            \T_OBJECT_OPERATOR,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Not a reference, out of scope
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($tokens[$prevNonEmpty]['type'] !== 'T_STRING') {
+            return;
+        }
+
+        // Reference to non-constant, out of scope
+        $prevNonEmpty     = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+        $outOfScopeTokens = [
+            'T_CLASS',
+            'T_DOUBLE_COLON',
+            'T_EXTENDS',
+            'T_IMPLEMENTS',
+            'T_INTERFACE',
+            'T_NAMESPACE',
+            'T_OBJECT_OPERATOR',
+            'T_TRAIT',
+        ];
+        if (in_array($tokens[$prevNonEmpty]['type'], $outOfScopeTokens)) {
+            return;
+        }
+
+        // PHP 5.5 and below do not support array dereferencing of constants
+        if ($this->supportsBelow('5.5') === true
+            && in_array($tokens[$stackPtr]['type'], ['T_OPEN_SQUARE_BRACKET', 'T_OPEN_CURLY_BRACKET'])
+        ) {
+            $phpcsFile->addError(
+                'Array dereferencing of constants is not present in PHP version 5.5 or earlier',
+                $stackPtr,
+                'ArrayConstantDereferenced'
+            );
+            return;
+        }
+
+        // PHP 7.4 and below do not support object dereferencing of constants
+        if ($this->supportsBelow('7.4') === true
+            && $tokens[$stackPtr]['type'] === 'T_OBJECT_OPERATOR'
+        ) {
+            $phpcsFile->addError(
+                'Object dereferencing of constants is not present in PHP version 7.4 or earlier',
+                $stackPtr,
+                'ObjectConstantDereferenced'
+            );
+        }
+    }
+}

--- a/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
@@ -75,33 +75,15 @@ class NewConstantDereferencingSniff extends Sniff
         ];
         $nextNonEmpty     = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         $nextNonEmptyCode = $tokens[$nextNonEmpty]['code'];
-        if (!isset($referenceTokens[$nextNonEmptyCode])) {
+        if (!isset($referenceTokens[$nextNonEmptyCode])
+            || ($nextNonEmptyCode === T_OPEN_CURLY_BRACKET
+            && isset($tokens[$nextNonEmpty]['scope_opener']) === true)) {
             return;
         }
 
         // Reference to non-constant, out of scope
-        $prevNonEmpty     = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        $outOfScopeTokens = [
-            \T_NAMESPACE       => true,
-            \T_USE             => true,
-            \T_CLASS           => true,
-            \T_TRAIT           => true,
-            \T_INTERFACE       => true,
-            \T_EXTENDS         => true,
-            \T_IMPLEMENTS      => true,
-            \T_NEW             => true,
-            \T_FUNCTION        => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_INSTANCEOF      => true,
-            \T_INSTEADOF       => true,
-            \T_GOTO            => true,
-            \T_AS              => true,
-            \T_PUBLIC          => true,
-            \T_PROTECTED       => true,
-            \T_PRIVATE         => true,
-            'PHPCS_T_COMMA'   => true,
-        ];
-        if (isset($outOfScopeTokens[$tokens[$prevNonEmpty]['code']])) {
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($tokens[$prevNonEmpty]['code'] === \T_OBJECT_OPERATOR) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
@@ -43,9 +43,7 @@ class NewConstantDereferencingSniff extends Sniff
     public function register()
     {
         return [
-            \T_OPEN_SQUARE_BRACKET,
-            \T_OPEN_CURLY_BRACKET,
-            \T_OBJECT_OPERATOR,
+            T_STRING,
         ];
     }
 
@@ -62,33 +60,58 @@ class NewConstantDereferencingSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
+        // Impacted features are supported in PHP 8, bail early
+        if ($this->supportsBelow('7.4') === false) {
+            return;
+        }
+
         $tokens = $phpcsFile->getTokens();
 
         // Not a reference, out of scope
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($tokens[$prevNonEmpty]['type'] !== 'T_STRING') {
+        $referenceTokens  = [
+            T_OPEN_SQUARE_BRACKET => true,
+            T_OPEN_CURLY_BRACKET  => true,
+            T_OBJECT_OPERATOR     => true,
+        ];
+        $nextNonEmpty     = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmptyCode = $tokens[$nextNonEmpty]['code'];
+        if (!isset($referenceTokens[$nextNonEmptyCode])) {
             return;
         }
 
         // Reference to non-constant, out of scope
-        $prevNonEmpty     = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+        $prevNonEmpty     = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         $outOfScopeTokens = [
-            'T_CLASS',
-            'T_DOUBLE_COLON',
-            'T_EXTENDS',
-            'T_IMPLEMENTS',
-            'T_INTERFACE',
-            'T_NAMESPACE',
-            'T_OBJECT_OPERATOR',
-            'T_TRAIT',
+            T_NAMESPACE       => true,
+            T_USE             => true,
+            T_CLASS           => true,
+            T_TRAIT           => true,
+            T_INTERFACE       => true,
+            T_EXTENDS         => true,
+            T_IMPLEMENTS      => true,
+            T_NEW             => true,
+            T_FUNCTION        => true,
+            T_OBJECT_OPERATOR => true,
+            T_INSTANCEOF      => true,
+            T_INSTEADOF       => true,
+            T_GOTO            => true,
+            T_AS              => true,
+            T_PUBLIC          => true,
+            T_PROTECTED       => true,
+            T_PRIVATE         => true,
+            'PHPCS_T_COMMA'   => true,
         ];
-        if (in_array($tokens[$prevNonEmpty]['type'], $outOfScopeTokens)) {
+        if (isset($outOfScopeTokens[$tokens[$prevNonEmpty]['code']])) {
             return;
         }
 
         // PHP 5.5 and below do not support array dereferencing of constants
+        $openBracketTokens = [
+            T_OPEN_SQUARE_BRACKET => true,
+            T_OPEN_CURLY_BRACKET  => true,
+        ];
         if ($this->supportsBelow('5.5') === true
-            && in_array($tokens[$stackPtr]['type'], ['T_OPEN_SQUARE_BRACKET', 'T_OPEN_CURLY_BRACKET'])
+            && isset($openBracketTokens[$nextNonEmptyCode])
         ) {
             $phpcsFile->addError(
                 'Array dereferencing of constants is not present in PHP version 5.5 or earlier',
@@ -100,7 +123,7 @@ class NewConstantDereferencingSniff extends Sniff
 
         // PHP 7.4 and below do not support object dereferencing of constants
         if ($this->supportsBelow('7.4') === true
-            && $tokens[$stackPtr]['type'] === 'T_OBJECT_OPERATOR'
+            && $nextNonEmptyCode === T_OBJECT_OPERATOR
         ) {
             $phpcsFile->addError(
                 'Object dereferencing of constants is not present in PHP version 7.4 or earlier',

--- a/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
@@ -80,7 +80,8 @@ class NewConstantDereferencingSniff extends Sniff
         $nextNonEmptyCode = $tokens[$nextNonEmpty]['code'];
         if (!isset($referenceTokens[$nextNonEmptyCode])
             || ($nextNonEmptyCode === T_OPEN_CURLY_BRACKET
-            && isset($tokens[$nextNonEmpty]['scope_opener']) === true)) {
+            && isset($tokens[$nextNonEmpty]['scope_opener']) === true)
+        ) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
@@ -43,7 +43,7 @@ class NewConstantDereferencingSniff extends Sniff
     public function register()
     {
         return [
-            T_STRING,
+            \T_STRING,
         ];
     }
 
@@ -69,9 +69,9 @@ class NewConstantDereferencingSniff extends Sniff
 
         // Not a reference, out of scope
         $referenceTokens  = [
-            T_OPEN_SQUARE_BRACKET => true,
-            T_OPEN_CURLY_BRACKET  => true,
-            T_OBJECT_OPERATOR     => true,
+            \T_OPEN_SQUARE_BRACKET => true,
+            \T_OPEN_CURLY_BRACKET  => true,
+            \T_OBJECT_OPERATOR     => true,
         ];
         $nextNonEmpty     = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         $nextNonEmptyCode = $tokens[$nextNonEmpty]['code'];
@@ -82,23 +82,23 @@ class NewConstantDereferencingSniff extends Sniff
         // Reference to non-constant, out of scope
         $prevNonEmpty     = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         $outOfScopeTokens = [
-            T_NAMESPACE       => true,
-            T_USE             => true,
-            T_CLASS           => true,
-            T_TRAIT           => true,
-            T_INTERFACE       => true,
-            T_EXTENDS         => true,
-            T_IMPLEMENTS      => true,
-            T_NEW             => true,
-            T_FUNCTION        => true,
-            T_OBJECT_OPERATOR => true,
-            T_INSTANCEOF      => true,
-            T_INSTEADOF       => true,
-            T_GOTO            => true,
-            T_AS              => true,
-            T_PUBLIC          => true,
-            T_PROTECTED       => true,
-            T_PRIVATE         => true,
+            \T_NAMESPACE       => true,
+            \T_USE             => true,
+            \T_CLASS           => true,
+            \T_TRAIT           => true,
+            \T_INTERFACE       => true,
+            \T_EXTENDS         => true,
+            \T_IMPLEMENTS      => true,
+            \T_NEW             => true,
+            \T_FUNCTION        => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_INSTANCEOF      => true,
+            \T_INSTEADOF       => true,
+            \T_GOTO            => true,
+            \T_AS              => true,
+            \T_PUBLIC          => true,
+            \T_PROTECTED       => true,
+            \T_PRIVATE         => true,
             'PHPCS_T_COMMA'   => true,
         ];
         if (isset($outOfScopeTokens[$tokens[$prevNonEmpty]['code']])) {
@@ -107,8 +107,8 @@ class NewConstantDereferencingSniff extends Sniff
 
         // PHP 5.5 and below do not support array dereferencing of constants
         $openBracketTokens = [
-            T_OPEN_SQUARE_BRACKET => true,
-            T_OPEN_CURLY_BRACKET  => true,
+            \T_OPEN_SQUARE_BRACKET => true,
+            \T_OPEN_CURLY_BRACKET  => true,
         ];
         if ($this->supportsBelow('5.5') === true
             && isset($openBracketTokens[$nextNonEmptyCode])
@@ -123,7 +123,7 @@ class NewConstantDereferencingSniff extends Sniff
 
         // PHP 7.4 and below do not support object dereferencing of constants
         if ($this->supportsBelow('7.4') === true
-            && $nextNonEmptyCode === T_OBJECT_OPERATOR
+            && $nextNonEmptyCode === \T_OBJECT_OPERATOR
         ) {
             $phpcsFile->addError(
                 'Object dereferencing of constants is not present in PHP version 7.4 or earlier',

--- a/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
@@ -17,9 +17,12 @@ use PHP_CodeSniffer\Util\Tokens;
 /**
  * Detect constant dereferencing.
  *
- * As of PHP 5.6, constants can now be dereferenced to access individual elements and characters.
+ * As of PHP 5.6, constants can now be dereferenced to access individual
+ * elements and characters.
  *
- * As of PHP 8.0, constants can also be dereferenced to invoke method calls, though this support only applies to syntax and must be used in conjunction with the scalar objects extension to work at runtime.
+ * As of PHP 8.0, constants can also be dereferenced to invoke method calls,
+ * though this support only applies to syntax and must be used in conjunction
+ * with the scalar objects extension to work at runtime.
  *
  * PHP version 5.6
  * PHP version 8.0
@@ -60,14 +63,14 @@ class NewConstantDereferencingSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        // Impacted features are supported in PHP 8, bail early
+        // Impacted features are fully supported in PHP 8.0 and above, bail early.
         if ($this->supportsBelow('7.4') === false) {
             return;
         }
 
         $tokens = $phpcsFile->getTokens();
 
-        // Not a reference, out of scope
+        // Check if this is a reference.
         $referenceTokens  = [
             \T_OPEN_SQUARE_BRACKET => true,
             \T_OPEN_CURLY_BRACKET  => true,
@@ -81,13 +84,13 @@ class NewConstantDereferencingSniff extends Sniff
             return;
         }
 
-        // Reference to non-constant, out of scope
+        // Check if this T_STRING is a constant.
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($tokens[$prevNonEmpty]['code'] === \T_OBJECT_OPERATOR) {
             return;
         }
 
-        // PHP 5.5 and below do not support array dereferencing of constants
+        // PHP 5.5 and below does not support array dereferencing of constants.
         $openBracketTokens = [
             \T_OPEN_SQUARE_BRACKET => true,
             \T_OPEN_CURLY_BRACKET  => true,
@@ -103,7 +106,7 @@ class NewConstantDereferencingSniff extends Sniff
             return;
         }
 
-        // PHP 7.4 and below do not support object dereferencing of constants
+        // PHP 7.4 and below does not support object dereferencing of constants.
         if ($this->supportsBelow('7.4') === true
             && $nextNonEmptyCode === \T_OBJECT_OPERATOR
         ) {

--- a/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewConstantDereferencingSniff.php
@@ -101,7 +101,7 @@ class NewConstantDereferencingSniff extends Sniff
             $phpcsFile->addError(
                 'Array dereferencing of constants is not present in PHP version 5.5 or earlier',
                 $stackPtr,
-                'ArrayConstantDereferenced'
+                'ArrayDereferencing'
             );
             return;
         }
@@ -113,7 +113,7 @@ class NewConstantDereferencingSniff extends Sniff
             $phpcsFile->addError(
                 'Object dereferencing of constants is not present in PHP version 7.4 or earlier',
                 $stackPtr,
-                'ObjectConstantDereferenced'
+                'ObjectDereferencing'
             );
         }
     }

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.inc
@@ -1,0 +1,23 @@
+<?php
+
+// OK: non-constants using array or object dereferencing
+echo $a[0];
+echo $a{0};
+echo $a->length();
+
+// OK: references to non-constants
+class Foo { }
+echo $foo::$bar[0];
+class Bar extends Foo { }
+class Bar implements Foo { }
+interface Foo { }
+namespace Foo { }
+echo $foo->bar[0];
+trait Foo { }
+
+// PHP 5.5: constant array dereferencing
+echo FOO[0];
+echo FOO{0};
+
+// PHP 7.4: constant object dereferencing
+echo FOO->length();

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.inc
@@ -26,7 +26,7 @@ public Foo $foo;
 public function addMatcher(MatcherInvocation $matcher): void {}
 class ORM implements \ArrayAccess {}
 
-// PHP 5.5: constant array dereferencing
+// PHP 5.5: constant array dereferencing.
 echo FOO[0];
 echo FOO{0};
 echo \Foo\BAR[0];
@@ -35,7 +35,7 @@ echo FOO[0]['foo'];
 echo \Foo\BAR['foo'][1];
 echo \Foo::BAR[20]['bar'];
 
-// PHP 7.4: constant object dereferencing
+// PHP 7.4: constant object dereferencing.
 echo FOO->length();
 echo \Foo\BAR->length();
 echo \Foo::BAR->length();

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.inc
@@ -14,10 +14,23 @@ interface Foo { }
 namespace Foo { }
 echo $foo->bar[0];
 trait Foo { }
+use Foo as Bar;
+$foo = new Foo;
+function foo() { }
+if ($foo instanceof Foo) { }
+use A, B { B::foo insteadof A };
+goto foo;
+private Foo $foo;
+protected Foo $foo;
+public Foo $foo;
 
 // PHP 5.5: constant array dereferencing
 echo FOO[0];
 echo FOO{0};
+echo \Foo\BAR[0];
+echo \Foo::BAR[0];
 
 // PHP 7.4: constant object dereferencing
 echo FOO->length();
+echo \Foo\BAR->length();
+echo \Foo::BAR->length();

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.inc
@@ -23,12 +23,17 @@ goto foo;
 private Foo $foo;
 protected Foo $foo;
 public Foo $foo;
+public function addMatcher(MatcherInvocation $matcher): void {}
+class ORM implements \ArrayAccess {}
 
 // PHP 5.5: constant array dereferencing
 echo FOO[0];
 echo FOO{0};
 echo \Foo\BAR[0];
 echo \Foo::BAR[0];
+echo FOO[0]['foo'];
+echo \Foo\BAR['foo'][1];
+echo \Foo::BAR[20]['bar'];
 
 // PHP 7.4: constant object dereferencing
 echo FOO->length();

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.inc
@@ -6,25 +6,16 @@ echo $a{0};
 echo $a->length();
 
 // OK: references to non-constants
-class Foo { }
-echo $foo::$bar[0];
-class Bar extends Foo { }
-class Bar implements Foo { }
-interface Foo { }
-namespace Foo { }
-echo $foo->bar[0];
-trait Foo { }
-use Foo as Bar;
+class Bar extends Foo implements Baz, \ArrayAccess {}
+interface Foo {}
+namespace Foo {}
+trait Foo {}
 $foo = new Foo;
-function foo() { }
-if ($foo instanceof Foo) { }
-use A, B { B::foo insteadof A };
+if ($foo instanceof Foo) {}
+use A as C, B { B::foo insteadof A };
 goto foo;
 private Foo $foo;
-protected Foo $foo;
-public Foo $foo;
 public function addMatcher(MatcherInvocation $matcher): void {}
-class ORM implements \ArrayAccess {}
 
 // PHP 5.5: constant array dereferencing.
 echo FOO[0];

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
@@ -39,6 +39,9 @@ class NewConstantDereferencingUnitTest extends BaseSniffTest
     {
         $file = $this->sniffFile(__FILE__, '5.5');
         $this->assertError($file, $line, 'Array dereferencing of constants is not present in PHP version 5.5 or earlier');
+
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file, $line);
     }
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewArrayStringDereferencing sniff.
+ *
+ * @group newArrayStringDereferencing
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewArrayStringDereferencingSniff
+ *
+ * @since 10.0.0
+ */
+class NewConstantDereferencingUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test for errors related to array dereferencing of constants in
+     * PHP 5.5 and below.
+     *
+     * @dataProvider dataArrayDereferencing
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testArrayDereferencing($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.5');
+        $this->assertError($file, $line, 'Array dereferencing of constants is not present in PHP version 5.5 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testArrayDereferencing()
+     *
+     * @return array
+     */
+    public function dataArrayDereferencing()
+    {
+        return [
+            [19],
+            [20],
+        ];
+    }
+
+    /**
+     * Test for errors related to object dereferencing of constants in
+     * PHP 7.4 and below.
+     *
+     * @dataProvider dataObjectDereferencing
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testObjectDereferencing($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, 'Object dereferencing of constants is not present in PHP version 7.4 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testObjectDereferencing()
+     *
+     * @return array
+     */
+    public function dataObjectDereferencing()
+    {
+        return [
+            [23],
+        ];
+    }
+
+    /**
+     * Test against false positives for dereferencing non-constants.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.5');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return [
+            // Non-constants using array or object dereferencing
+            [4],
+            [5],
+            [6],
+
+            // References to non-constants
+            [9],
+            [10],
+            [11],
+            [12],
+            [13],
+            [14],
+            [15],
+            [16],
+        ];
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
@@ -51,8 +51,10 @@ class NewConstantDereferencingUnitTest extends BaseSniffTest
     public function dataArrayDereferencing()
     {
         return [
-            [19],
-            [20],
+            [28],
+            [29],
+            [30],
+            [31],
         ];
     }
 
@@ -82,7 +84,9 @@ class NewConstantDereferencingUnitTest extends BaseSniffTest
     public function dataObjectDereferencing()
     {
         return [
-            [23],
+            [34],
+            [35],
+            [36],
         ];
     }
 
@@ -125,6 +129,15 @@ class NewConstantDereferencingUnitTest extends BaseSniffTest
             [14],
             [15],
             [16],
+            [17],
+            [18],
+            [19],
+            [20],
+            [21],
+            [22],
+            [23],
+            [24],
+            [25],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
@@ -54,13 +54,13 @@ class NewConstantDereferencingUnitTest extends BaseSniffTest
     public function dataArrayDereferencing()
     {
         return [
-            [30],
-            [31],
-            [32],
-            [33],
-            [34],
-            [35],
-            [36],
+            [21],
+            [22],
+            [23],
+            [24],
+            [25],
+            [26],
+            [27],
         ];
     }
 
@@ -90,9 +90,9 @@ class NewConstantDereferencingUnitTest extends BaseSniffTest
     public function dataObjectDereferencing()
     {
         return [
-            [39],
-            [40],
-            [41],
+            [30],
+            [31],
+            [32],
         ];
     }
 
@@ -137,15 +137,6 @@ class NewConstantDereferencingUnitTest extends BaseSniffTest
             [16],
             [17],
             [18],
-            [19],
-            [20],
-            [21],
-            [22],
-            [23],
-            [24],
-            [25],
-            [26],
-            [27],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
@@ -51,10 +51,13 @@ class NewConstantDereferencingUnitTest extends BaseSniffTest
     public function dataArrayDereferencing()
     {
         return [
-            [28],
-            [29],
             [30],
             [31],
+            [32],
+            [33],
+            [34],
+            [35],
+            [36],
         ];
     }
 
@@ -84,9 +87,9 @@ class NewConstantDereferencingUnitTest extends BaseSniffTest
     public function dataObjectDereferencing()
     {
         return [
-            [34],
-            [35],
-            [36],
+            [39],
+            [40],
+            [41],
         ];
     }
 
@@ -138,6 +141,8 @@ class NewConstantDereferencingUnitTest extends BaseSniffTest
             [23],
             [24],
             [25],
+            [26],
+            [27],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewConstantDereferencingUnitTest.php
@@ -13,12 +13,12 @@ namespace PHPCompatibility\Tests\Syntax;
 use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
- * Test the NewArrayStringDereferencing sniff.
+ * Test the NewConstantDereferencing sniff.
  *
- * @group newArrayStringDereferencing
+ * @group newConstantDereferencing
  * @group syntax
  *
- * @covers \PHPCompatibility\Sniffs\Syntax\NewArrayStringDereferencingSniff
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewConstantDereferencingSniff
  *
  * @since 10.0.0
  */


### PR DESCRIPTION
> This RFC brings static scalar expressions to the parser. This allows places that only take static values (const declarations, ... etc) to also be able to take static expressions.

> Constants... are currently special cased and only dereferencable under the `[]` operator (and do not even support the nominally equivalent `{}` operator).
>
> This RFC proposes to make constants (and class constants) fully array and object dereferencable, i.e. to allow both `FOO{0}` and `FOO->length()` (the latter only being relevant in conjunction with scalar objects).

Ref:
* https://wiki.php.net/rfc/const_scalar_exprs
* https://github.com/php/php-src/commit/d5ddd2dbb263cd626a5e0f203c00d6f39168507b
* https://wiki.php.net/rfc/variable_syntax_tweaks#constant_dereferencability

Includes unit tests.

Relates to #809.