### PR TITLE
Contributing: add links to PHP 4 and PHP 5 documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,9 @@ Please make sure that your pull request contains unit tests covering what's bein
 * The [NEWS](https://github.com/php/php-src/blob/master/NEWS) document of each release
 * The [Migrating from PHP x.x.x to PHP x.x.x section](https://www.php.net/manual/en/appendices.php) in the manual for each release (once published)
 * The [Changelog](https://www.php.net/manual/en/doc.changelog.php) in the manual
-* The [PHP manual](https://www.php.net/manual/en/index.php) in general
+* The official [PHP manual](https://www.php.net/manual/en/index.php) in general
+* The legacy [PHP 5 manual](https://php-legacy-docs.zend.com/manual/php5/en/index)
+* The legacy [PHP 4 manual](https://php-legacy-docs.zend.com/manual/php4/en/index)
 * The [PHP source code](https://github.com/php/php-src) in general
 
 ### Framework/CMS specific rulesets


### PR DESCRIPTION
The official PHP manual is removing references to PHP 4 and PHP 5.

For the purposes of PHPCompatibility, it is important to still be able to have access to that documentation to find details of changes and old vs new behaviour.

This commit adds links to a mirror which will keep copies of the PHP 4 and PHP 5 documentation available for reference.

Note: links to the PHP manual used in the docblocks of sniff classes may no longer work now the PHP 4 and 5 documentation is being removed and some may need to be changed as well. A separate issue will be opened for that.