### PR TITLE
GH Actions: fix builds failing

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -7,8 +7,6 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   checkcs:

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -46,20 +46,21 @@ jobs:
 
       # On stable PHPCS versions, allow for PHP deprecation notices.
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-      - name: Setup ini config
-        id: set_ini
-        run: |
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
-          else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL'
-          fi
+# Temporarily commented out while waiting for a fix for https://github.com/shivammathur/setup-php/issues/405
+#      - name: Setup ini config
+#        id: set_ini
+#        run: |
+#          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+#            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+#          else
+#            echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+#          fi
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+#          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
       - name: 'Composer: set PHPCS version for tests'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,25 +151,26 @@ jobs:
           # On stable PHPCS versions, allow for PHP deprecation notices.
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
-          if [ ${{ matrix.custom_ini }} == "true" ]; then
-            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, short_open_tag=On'
-            else
-              echo '::set-output name=PHP_INI::short_open_tag=On'
-            fi
-          else
-            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
-            else
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL'
-            fi
-          fi
+# Temporarily commented out while waiting for a fix for https://github.com/shivammathur/setup-php/issues/405
+#          if [ ${{ matrix.custom_ini }} == "true" ]; then
+#            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+#              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, short_open_tag=On'
+#            else
+#              echo '::set-output name=PHP_INI::error_reporting=E_ALL, short_open_tag=On'
+#            fi
+#          else
+#            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+#              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+#            else
+#              echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+#            fi
+#          fi
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+#          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
       - name: 'Composer: adjust dependencies'
@@ -243,25 +244,26 @@ jobs:
           # On stable PHPCS versions, allow for PHP deprecation notices.
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
-          if [ ${{ matrix.custom_ini }} == "true" ]; then
-            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, short_open_tag=On'
-            else
-              echo '::set-output name=PHP_INI::short_open_tag=On'
-            fi
-          else
-            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
-            else
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL'
-            fi
-          fi
+# Temporarily commented out while waiting for a fix for https://github.com/shivammathur/setup-php/issues/405
+#          if [ ${{ matrix.custom_ini }} == "true" ]; then
+#            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+#              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, short_open_tag=On'
+#            else
+#              echo '::set-output name=PHP_INI::short_open_tag=On'
+#            fi
+#          else
+#            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+#              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+#            else
+#              echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+#            fi
+#          fi
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+#          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
 
       - name: 'Composer: adjust dependencies'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   #### PHP LINT STAGE ####


### PR DESCRIPTION
A recent change in the `shivammathur/setup-php@v2` has broken the handling of ini values passed via step output parameters.

I have [reported this bug upstream](https://github.com/shivammathur/setup-php/issues/405).

For now, I'm fixing the build failures by commenting out the custom ini value setting.

Once the upstream bug has been fixed, this commit should be reverted.