### PR TITLE
GH Actions tweaks

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -7,8 +7,6 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   checkcs:

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -7,6 +7,8 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   checkcs:

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -7,6 +7,8 @@ on:
       - master
     paths-ignore:
       - '**.md'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   #### QUICK TEST STAGE ####

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   #### PHP LINT STAGE ####

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   #### PHP LINT STAGE ####


### PR DESCRIPTION
Some minor tweaks to the GH Actions workflow. (first commit ported over from #1267)

### GHActions: don't ignore PRs with only doc changes

... as it the required statuses prevent those PRs from being merged without the required statuses reporting.

### GH Actions: allow for manually triggering a workflow

Apparently this is not a standard feature, but has to be explicitly enabled.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

