### PR TITLE
GH Actions: show CS and linting results inline in the PR

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
+          tools: cs2pr
 
       - name: 'Composer: adjust dependencies'
         run: |
@@ -61,7 +62,11 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        run: vendor/bin/phpcs --no-cache
+        continue-on-error: true
+        run: vendor/bin/phpcs --no-cache --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml
 
       # Check that the sniffs available are feature complete.
       # For now, just check that all sniffs have unit tests.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
+          tools: cs2pr
 
       - name: 'Composer: adjust dependencies'
         # Remove PHPUnit requirement to save some bandwidth.
@@ -48,7 +49,12 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Lint against parse errors
+        if: ${{ matrix.php != '5.4' && startsWith( matrix.php, '8' ) == false }}
         run: composer lint
+
+      - name: Lint against parse errors
+        if: ${{ matrix.php == '5.4' || startsWith( matrix.php, '8' ) }}
+        run: composer lint -- --checkstyle | cs2pr
 
   #### TEST STAGE ####
   test:


### PR DESCRIPTION
### GH Actions: report CS violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

### GH Actions: report linting violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

As it is not really necessary to display the same linting error ten times, I've added conditions to only pass the linting results on to the PR for low/high PHP.

Ref: https://github.com/staabm/annotate-pull-request-from-checkstyle

