### PR TITLE
Refactor OptionalToRequiredFunctionParameterSniff and RequiredToOptionalFunctionParametersSniff

### DIFF
--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
@@ -26,3 +26,7 @@ openssl_seal ( $data, $sealed_data, $env_keys, $pub_key_ids ); // Not ok.
 
 openssl_open ( $sealed_data, $open_data, $env_key, $priv_key_id, $method, $iv ); // Ok.
 openssl_open ( $sealed_data, $open_data, $env_key, $priv_key_id ); // Not ok.
+
+// Prevent false positives on namespaced functions.
+\gmmktime(); // Not OK, global function.
+MyNameSpace\mktime(); // OK.

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -113,7 +113,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
     public function dataOptionalRequiredParameterRemoved()
     {
         return [
-            ['gmmktime', 'hour', '8.0', [18], '7.4'],
+            ['gmmktime', 'hour', '8.0', [18, 31], '7.4'],
             ['mb_parse_str', 'result', '8.0', [22], '7.4'],
             ['openssl_seal', 'method', '8.0', [25], '7.4'],
             ['openssl_open', 'method', '8.0', [28], '7.4'],
@@ -150,6 +150,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
             [14],
             [15],
             [21],
+            [32],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
@@ -73,3 +73,7 @@ array_udiff($array, $value_compare_func ); // PHP 8.0+.
 array_uintersect_assoc( $array, $value_compare_func ); // PHP 8.0+.
 array_uintersect_uassoc($array, $value_compare_func, $key_compare_func); // PHP 8.0+.
 array_uintersect($array, $value_compare_func ); // PHP 8.0+.
+
+// Prevent false positives on namespaced functions.
+\getenv(); // Not OK, global function.
+MyNameSpace\ftp_put( $ftp_stream, $remote_file, $local_file); // OK.

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -67,7 +67,7 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
             ['preg_match_all', 'matches', '5.3', [8], '5.4'],
             ['stream_socket_enable_crypto', 'crypto_type', '5.5', [9], '5.6'],
             ['bcscale', 'scale', '7.2', [12], '7.3'],
-            ['getenv', 'varname', '7.0', [15], '7.1'],
+            ['getenv', 'varname', '7.0', [15, 78], '7.1'],
             ['array_push', 'element to push', '7.2', [18], '7.3'],
             ['array_unshift', 'element to prepend', '7.2', [21], '7.3'],
             ['ftp_fget', 'mode', '7.2', [24], '7.3'],
@@ -152,6 +152,7 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
             [56],
             [57],
             [58],
+            [79],
         ];
     }
 


### PR DESCRIPTION
### OptionalToRequiredFunctionParameter: decouple from RequiredToOptionalFunctionParametersSniff

This is a technical refactor and contains no significant functional changes.

The `OptionalToRequiredFunctionParameterSniff` class previously extended the `RequiredToOptionalFunctionParametersSniff` class, which in turn extended the `AbstractComplexVersionSniff`.

The sniff has now been refactored to directly extend the `AbstractFunctionCallParameterSniff` class instead.

The purpose of this refactor is three-fold:
1. Multiple people have reported issues with fatal "class already declared" errors for this sniff extending another sniff.
    While this is primarily an issue with the autoloader in PHPCS, the issue can be avoided by not allowing one sniff to directly extend another.
    Note: the same problem does not exist when extending an _abstract_ sniff, so this solution will be fine.
2. The (global) function call determination in the `AbstractFunctionCallParameterSniff` sniff is better than the one which was previously contained in the `RequiredToOptionalFunctionParametersSniff`, preventing some potential false positives as demonstrated by the additional unit tests.
3. In the (near) future, PHPCSUtils is expected to contain a version of the `AbstractFunctionCallParameterSniff` which is better still.
    By decoupling this sniff from the `RequiredToOptionalFunctionParametersSniff` and by extension from the `AbstractComplexVersionSniff` sniff, we pave the way for the breaking change of removing the `AbstractComplexVersionSniff` class.
    The switch over to the PHPCSUtils version of the `AbstractFunctionCallParameterSniff` in itself is not a breaking change and can therefore safely be done in a future minor release.

Note: Aside from the tests still passing, I have also verified that the sniff error codes are not affected by this change, so from a "custom ruleset"/"ignore annotations" point of view this refactor does not contain any breaking changes.

Fixes #608
Fixes #638
Fixes #793
Fixes #1042

### RequiredToOptionalFunctionParameters: decouple from AbstractComplexVersionSniff

This is a technical refactor and contains no significant functional changes.

The `RequiredToOptionalFunctionParametersSniff` class previously extended the `AbstractComplexVersionSniff`.

The sniff has now been refactored to extend the `AbstractFunctionCallParameterSniff` class instead.

The purpose of this refactor is two-fold:
1. The (global) function call determination in the `AbstractFunctionCallParameterSniff` sniff is better than the one which was previously contained in the `RequiredToOptionalFunctionParametersSniff`, preventing some potential false positives as demonstrated by the additional unit tests.
2. In the (near) future, PHPCSUtils is expected to contain a version of the `AbstractFunctionCallParameterSniff` which is better still.
    By decoupling this sniff from the `RequiredToOptionalFunctionParametersSniff` and by extension from the `AbstractComplexVersionSniff` sniff, we pave the way for the breaking change of removing the `AbstractComplexVersionSniff` class.
    The switch over to the PHPCSUtils version of the `AbstractFunctionCallParameterSniff` in itself is not a breaking change and can therefore safely be done in a future minor release.

Note: Aside from the tests still passing, I have also verified that the sniff error codes are not affected by this change, so from a "custom ruleset"/"ignore annotations" point of view this refactor does not contain any breaking changes.

