### PR TITLE
PHP 8.1 compatibility: fix deprecation notice

### DIFF
--- a/PHPCompatibility/Helpers/TestVersionTrait.php
+++ b/PHPCompatibility/Helpers/TestVersionTrait.php
@@ -58,12 +58,14 @@ trait TestVersionTrait
         static $arrTestVersions = [];
 
         $default     = [null, null];
-        $testVersion = \trim(Helper::getConfigData('testVersion'));
+        $testVersion = Helper::getConfigData('testVersion');
 
         // Case-sensitivity tolerance.
         if (empty($testVersion) === true) {
-            $testVersion = \trim(Helper::getConfigData('testversion'));
+            $testVersion = Helper::getConfigData('testversion');
         }
+
+        $testVersion = \trim((string) $testVersion);
 
         if (empty($testVersion) === false && isset($arrTestVersions[$testVersion]) === false) {
 

--- a/PHPCompatibility/Util/Tests/Helpers/TestVersionTraitUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/TestVersionTraitUnitTest.php
@@ -289,7 +289,6 @@ class TestVersionTraitUnitTest extends TestCase
         }
 
         $this->assertSame($expected, $this->supportsBelow($phpVersion));
-//        $this->assertSame($expected, $this->helperClass->supportsBelow($phpVersion));
     }
 
     /**


### PR DESCRIPTION
PHP 8.1 deprecates passing `null` to PHP native functions where the parameter(s) is not explicitly nullable.

While in PHP 8.1 this is only a deprecation, it should, of course, still be fixed.

This commit contains a fix for the one issue in PHPCompatibility found related to this so far (based on the unit tests).

Passing `null` to `trim()` is now deprecated, so more defensive coding or explicit type casting is needed.
This comes into play for the `TestVersionTrait::getTestVersion()` method.

Includes removing a stray line of commented out (test) code.