### PR TITLE
GH Actions: don't test against PHPCS 4.x (yet)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,9 +135,9 @@ jobs:
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-          - php: '7.4'
-            phpcs_version: '4.0.x-dev@dev'
-            experimental: true
+          #- php: '7.4'
+          #  phpcs_version: '4.0.x-dev@dev'
+          #  experimental: true
 
           - php: '8.1' # Nightly.
             phpcs_version: 'dev-master'


### PR DESCRIPTION
As it looks like PHPCS 4.x is still quite a while away (2022 at the earliest), let's stop testing against PHPCS 4.x for the time being.

This should allow build failure reporting to be more accurate, as currently every PR has a failure on PHPCS 4.x due to a bug in some of the new code in 4.x (fix for this was pulled six months ago and still not merged).

The build against PHPCS 4.x should be re-enabled closer to the PHPCS 4.x release.

Note: PHPCSUtils will continue to test against PHPCS 4.x and will update the provided utilities ahead of time, so with a bit of luck, by the time the build against PHPCS 4.x is re-enabled, the build should largely pass thanks to the compatibility layers in PHPCSUtils.