### PR TITLE
NewClasses: detect Attribute class

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -743,6 +743,10 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '7.4' => true,
         ],
 
+        'Attribute' => [
+            '7.4' => false,
+            '8.0' => true,
+        ],
         'PhpToken' => [
             '7.4' => false,
             '8.0' => true,

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -427,3 +427,5 @@ $closure = function(OCILob $lob) {};
 try {
 } catch (UnhandledMatchError $e) {
 }
+
+class MyAttribute extends \Attribute {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -214,6 +214,7 @@ class NewClassesUnitTest extends BaseSniffTest
             ['ReflectionUnionType', '7.4', [422], '8.0'],
             ['OCICollection', '7.4', [424], '8.0'],
             ['OCILob', '7.4', [425], '8.0'],
+            ['Attribute', '7.4', [431], '8.0'],
 
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],


### PR DESCRIPTION
As part of the Attributes feature and as per the Attribute amendments RFC, a new PHP native `Attribute` class has been introduced.

Ref: https://wiki.php.net/rfc/attribute_amendments