### PR TITLE
PHP 8.0 | New `NewAttributes` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Attributes;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\GetTokensAsString;
+
+/**
+ * Attributes as a form of structured, syntactic metadata to declarations of classes, properties,
+ * functions, methods, parameters and constants is supported as of PHP 8.0.
+ *
+ * {@internal This sniff does not check whether attributes are used correctly and in
+ * combination with syntaxes for which attributes are valid.
+ * If that's not the case, PHP 8.0 would throw a parse error anyway.}
+ *
+ * PHP version 8.0
+ *
+ * @link https://wiki.php.net/rfc/attributes_v2
+ * @link https://wiki.php.net/rfc/attribute_amendments
+ * @link https://wiki.php.net/rfc/shorter_attribute_syntax
+ * @link https://wiki.php.net/rfc/shorter_attribute_syntax_change
+ * @link https://www.php.net/manual/en/language.attributes.php
+ *
+ * @since 10.0.0
+ */
+class NewAttributesSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $targets = [\T_COMMENT];
+
+        if (\defined('T_ATTRIBUTE') === true) {
+            // PHP 8.0 or PHPCS >= 3.6.0.
+            $targets[] = \T_ATTRIBUTE;
+
+        }
+
+        return $targets;
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['type'] === 'T_ATTRIBUTE') {
+            /*
+             * Either PHP 8.0 or PHPCS 3.6.0+.
+             * PHP 8.0 tokenizes the start marker of the attribute as `T_ATTRIBUTE` and the
+             * end marker as `T_CLOSE_SQUARE_BRACKET.
+             * In PHPCS 3.6.0+ the end marker will be tokenized as `T_ATTRIBUTE_END` and
+             * the start marker will have an 'attribute_closer' token array index.
+             */
+            if (isset($tokens[$stackPtr]['attribute_closer']) === true) {
+                // This is PHPCS >= 3.6.0.
+                $this->throwError(
+                    $phpcsFile,
+                    $stackPtr,
+                    GetTokensAsString::compact($phpcsFile, $stackPtr, $tokens[$stackPtr]['attribute_closer'], true)
+                );
+                return;
+            }
+
+            // This must be PHP 8.0 in combination with PHPCS < 3.6.0.
+            $nestedBrackets = 1;
+            for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
+                if ($tokens[$i]['code'] === \T_OPEN_SQUARE_BRACKET) {
+                    ++$nestedBrackets;
+                    continue;
+                }
+
+                if ($tokens[$i]['code'] === \T_CLOSE_SQUARE_BRACKET) {
+                    --$nestedBrackets;
+
+                    if ($nestedBrackets === 0) {
+                        // Found the end of the attribute.
+                        break;
+                    }
+                }
+
+                if ($tokens[$i]['code'] === \T_CLOSE_TAG) {
+                    /*
+                     * Prevent looping to the end of the file for a particular edge case which
+                     * breaks the tokenizer 8.0.
+                     */
+                    break;
+                }
+            }
+
+            $this->throwError($phpcsFile, $stackPtr, GetTokensAsString::compact($phpcsFile, $stackPtr, $i, true));
+            return;
+        }
+
+        /*
+         * PHP < 8.0 in combination with PHPCS < 3.6.0 will tokenize attributes as comments.
+         * This comment can contain multiple attributes on the same line or can be followed
+         * by actual code.
+         * The attribute closer can also be on a later line.
+         */
+        $contents = $tokens[$stackPtr]['content'];
+
+        if (\substr($contents, 0, 2) !== '#[') {
+            // Bow out early if we already know this is not an attribute.
+            return;
+        }
+
+        $expectedErrors = \substr_count($contents, '#[');
+        $actualErrors   = 0;
+
+        while (empty($contents) === false && \substr($contents, 0, 2) === '#[') {
+            $length         = \strlen($contents);
+            $nestedBrackets = 1;
+
+            for ($i = 2; $i < $length; $i++) {
+                if ($contents[$i] === '[') {
+                    ++$nestedBrackets;
+                    continue;
+                }
+
+                if ($contents[$i] === ']') {
+                    --$nestedBrackets;
+
+                    if ($nestedBrackets === 0) {
+                        // Found the end of the attribute.
+                        $this->throwError($phpcsFile, $stackPtr, \substr($contents, 0, ($i + 1)));
+                        ++$actualErrors;
+
+                        if (($i + 1) === $length) {
+                            $contents = '';
+                        } else {
+                            $contents = \trim(\substr($contents, ($i + 1)));
+                        }
+                        break;
+                    }
+                }
+            }
+
+            if ($i === $length) {
+                // Reached the end of the content without finding a closing bracket.
+                break;
+            }
+        }
+
+        if ($expectedErrors === $actualErrors) {
+            // This was a single-line attribute, closer found.
+            return;
+        }
+
+        // This must be a multi-line attribute.
+        $nestedBrackets = 1;
+        for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
+            if ($tokens[$i]['code'] === \T_OPEN_SQUARE_BRACKET) {
+                ++$nestedBrackets;
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_CLOSE_SQUARE_BRACKET) {
+                --$nestedBrackets;
+
+                if ($nestedBrackets === 0) {
+                    // Found the end of the attribute.
+                    break;
+                }
+            }
+
+            if ($tokens[$i]['code'] === \T_CLOSE_TAG) {
+                /*
+                 * Prevent looping to the end of the file for a particular edge case which
+                 * breaks the tokenizer on PHP < 8.0.
+                 */
+                break;
+            }
+        }
+
+        $this->throwError(
+            $phpcsFile,
+            $stackPtr,
+            \rtrim($contents, "\r\n") . GetTokensAsString::compact($phpcsFile, $stackPtr, $i, true)
+        );
+    }
+
+    /**
+     * Throw an error when an attribute is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     * @param string                      $content   Attribute content for use in the error message.
+     *
+     * @return void
+     */
+    protected function throwError($phpcsFile, $stackPtr, $content)
+    {
+        $phpcsFile->addError(
+            'Attributes are not supported in PHP 7.4 or earlier. Found: %s',
+            $stackPtr,
+            'Found',
+            [$content]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.inc
+++ b/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.inc
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Not attributes.
+ */
+
+/*[StarComment*/
+//[SlashComment]
+# [HashComment]
+
+$var = 10; # Hash comment
+
+/*
+ * PHP 8.0: Attributes.
+ */
+
+#[Attribute]
+class MyAttribute {}
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_FUNCTION)]
+class MyOtherAttribute {}
+
+#[MyAttribute]
+#[\MyExample\MyAttribute]
+#[MyAttribute(1234)]
+#[MyAttribute(value: 1234)]
+/**
+ * docblock
+ */
+#[MyAttribute(MyAttribute::VALUE)]
+#[MyAttribute(array("key" => "value"))]
+#[MyAttribute(100 + 200)]
+class Thing {}
+
+#[MyAttribute(1234), MyAttribute(5678)]
+class MultipleAttributesGrouped {}
+
+$object = new #[ExampleAttribute] class () { };
+
+#[WithoutArgument]
+#[Another\SingleArgument(0)]
+#[FewArguments('Hello', 'World')]
+#[\My\Attributes\FewArguments("foo", "bar")]
+function multipleAttributesMultipleLines() {}
+
+$f2 = #[ExampleAttribute] function () { };
+
+$f3 = #[ExampleAttribute] fn () => 1;
+
+#[WithoutArgument]#[SingleArgument(0)]#[FewArguments('Hello', 'World')]
+function multipleAttributesSingleLines() {}
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]#[ORM\Column("integer")]   #[ORM\GeneratedValue]
+    private $id;
+
+    #[Assert\Range(["min" => 120, "max" => 180, "minMessage" => "You must be at least {{ limit }}cm tall to enter"])]
+    #[ORM\Column(ORM\Column::T_INTEGER)]
+    protected $height;
+}
+
+#[Attr1, Attr2]
+class MultilineAttributeExamples
+{
+    #[Attr2("foo"),
+      Attr2("bar")]
+    public function testMultiLine()
+    {
+    }
+
+    #[
+      Attr1("foo"),
+      Attr2("bar"),
+    ]
+    public function testMultiLineDifferentFormatAndTrailingComma()
+    {
+    }
+}
+
+function attributeUsedForTypedParameter(
+    #[MyAttr([1, 2])] Type $myParam,
+) {}
+
+#[
+  ORM\Entity,
+  ORM\Table("user")
+]
+class AnotherMultilineAttributeTest
+{
+    #[ORM\Id, ORM\Column("integer"), ORM\GeneratedValue]
+    private $id;
+
+    #[ORM\Column("string", ORM\Column::UNIQUE)]
+    #[Assert\Email(["message" => "text"])] #[Assert\Text(["message" => "text"]),
+        Assert\Domain(["message" => "text"]),
+        Assert\Id(Assert\Id::REGEX[10]),
+    ]
+    private $email;
+}
+
+// This code will cause a tokenizer error in PHP < 8.0. This must be the last test in the file!
+#[DeprecationReason('reason: <https://some-website/reason?>')]
+function main() {}
+const APP_SECRET = 'app-secret';
+echo "Test\n";

--- a/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.inc
+++ b/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.inc
@@ -102,6 +102,11 @@ class AnotherMultilineAttributeTest
 
 // This code will cause a tokenizer error in PHP < 8.0. This must be the last test in the file!
 #[DeprecationReason('reason: <https://some-website/reason?>')]
-function main() {}
+function attribute_containing_text_looking_like_close_tag() {}
 const APP_SECRET = 'app-secret';
 echo "Test\n";
+
+#[DeprecationReason(
+    'reason: <https://some-website/reason?>'
+)]
+function attribute_containing_mulitline_text_looking_like_close_tag() {}

--- a/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
+++ b/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Attributes;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewAttributes sniff.
+ *
+ * @group newAttributes
+ * @group attributes
+ *
+ * @covers \PHPCompatibility\Sniffs\Attributes\NewAttributesSniff
+ *
+ * @since 10.0.0
+ */
+class NewAttributesUnitTest extends BaseSniffTest
+{
+
+    /**
+     * testNewAttributes
+     *
+     * @dataProvider dataNewAttributes
+     *
+     * @param int    $line  The line number.
+     * @param string $found Optional. Found attribute contents.
+     *
+     * @return void
+     */
+    public function testNewAttributes($line, $found = '')
+    {
+        $file  = $this->sniffFile(__FILE__, '7.4');
+        $error = 'Attributes are not supported in PHP 7.4 or earlier.';
+        if ($found !== '') {
+            $error .= ' Found: ' . $found;
+        }
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewAttributes()
+     *
+     * @return array
+     */
+    public function dataNewAttributes()
+    {
+        return [
+            [17],
+            [20],
+            [23],
+            [24],
+            [25],
+            [26],
+            [30],
+            [31],
+            [32],
+            [35],
+            [38],
+            [40],
+            [41],
+            [42],
+            [43],
+            [46],
+            [48],
+            [50, '#[WithoutArgument]'],
+            [50, '#[SingleArgument(0)]'],
+            [50, "#[FewArguments('Hello', 'World')]"],
+            [53],
+            [56, '#[ORM\Id]'],
+            [56, '#[ORM\Column("integer")]'],
+            [56, '#[ORM\GeneratedValue]'],
+            [59],
+            [60],
+            [64],
+            [67, '#[Attr2("foo"), Attr2("bar")]'],
+            [73, '#[ Attr1("foo"), Attr2("bar"), ]'],
+            [83, '#[MyAttr([1, 2])]'],
+            [86, '#[ ORM\Entity, ORM\Table("user") ]'],
+            [92],
+            [95],
+            [96, '#[Assert\Email(["message" => "text"])]'],
+            [96, '#[Assert\Text(["message" => "text"]), Assert\Domain(["message" => "text"]), Assert\Id(Assert\Id::REGEX[10]), ]'],
+            [104],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 12 lines.
+        for ($line = 1; $line <= 12; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
+++ b/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Tests\Attributes;
 
 use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Test the NewAttributes sniff.
@@ -55,7 +56,7 @@ class NewAttributesUnitTest extends BaseSniffTest
      */
     public function dataNewAttributes()
     {
-        return [
+        $data = [
             [17],
             [20],
             [23],
@@ -93,6 +94,18 @@ class NewAttributesUnitTest extends BaseSniffTest
             [96, '#[Assert\Text(["message" => "text"]), Assert\Domain(["message" => "text"]), Assert\Id(Assert\Id::REGEX[10]), ]'],
             [104],
         ];
+
+        /*
+         * In PHP < 8.0 in combination with PHPCS < 3.6.1, anything after the test case on
+         * line 104 will be tokenized as `T_INLINE_HTML` and undetectable.
+         */
+        if (version_compare(Helper::getVersion(), '3.6.1', '>=') === true
+            || version_compare(PHP_VERSION_ID, '80000', '>=') === true
+        ) {
+            $data[] = [109];
+        }
+
+        return $data;
     }
 
 


### PR DESCRIPTION
PHP 8.0 introduces Attributes as a form of structured, syntactic metadata to declarations of classes, properties, functions, methods, parameters and constants. Attributes allow to define configuration directives directly embedded with the declaration of that code.

The syntax for attributes in PHP has changed a number of times via various RFC amendments.
As a result of that, it took a little while as well before the final tokenization of attributes in PHPCS was known, but upstream PR squizlabs/PHP_CodeSniffer#3203 has now (finally) been merged and released as part of PHPCS 3.6.0.

This PR introduces a new sniff to detect the use of attributes.

This new sniff _only_ focusses on detecting the _syntax_ for attributes being used - `#[...]`.
It does not verify whether the _contents_ within the attribute is valid, nor whether the attribute is used in a _supported location_.
Invalid attributes like that would be a parse error in PHP 8.0+.

It can be argued that single-line attributes should not throw an error, but a warning, as those will not necessarily cause problems when used in code which also needs to run on PHP 7, as they will just be ignored and treated as a comment.
This is however not the case for multi-line or in-line attributes, which would cause parse error in PHP < 8.0, so for consistency, I've chosen to let the sniff always throw an error.

In rare cases, specifically for the code sample in the last test case, the PHPCS tokenizer cannot prevent the rest of the file becoming mangled on PHP < 8.0.
This is similar to the tokenizer problems caused by indented heredocs/nowdocs as introduced in PHP 7.3, where the rest of the file after the new syntax will be tokenized incorrectly.
In that case, the sniff will still (correctly) throw an error for the attribute, however detection of (other) issues in the rest of the file will be broken.
Also see: squizlabs/PHP_CodeSniffer#3294

As the attributes feature is likely to be expanded in the future, the sniff has been placed in a new dedicated category which will allow for additional attribute related sniffs to be added at a later point in time.

If and when new attribute related features are added to PHP, validation of whether an attribute is valid in PHP 8.0 may need to be added to this sniff, but this is a moot point until that time.

Includes unit tests.

Refs:
 * https://wiki.php.net/rfc/attributes_v2
 * https://wiki.php.net/rfc/attribute_amendments
 * https://wiki.php.net/rfc/shorter_attribute_syntax
 * https://wiki.php.net/rfc/shorter_attribute_syntax_change
 * https://www.php.net/manual/en/language.attributes.php

Related to #809