### PR TITLE
PHP 8.0 | RemovedNamespacedAssert: adjust for removal in PHP 8.0

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -20,13 +20,14 @@ use PHPCSUtils\Utils\Scopes;
  * Detect declaration of a namespaced function called `assert()`.
  *
  * As of PHP 7.3, a compile-time deprecation warning will be thrown when a function
- * called `assert()` is declared. In PHP 8 this will become a compile-error.
+ * called `assert()` is declared. In PHP 8 this is a compile-error.
  *
  * Methods are unaffected.
  * Global, non-namespaced, `assert()` function declarations were always a fatal
  * "function already declared" error, so not the concern of this sniff.
  *
  * PHP version 7.3
+ * PHP version 8.0
  *
  * @link https://www.php.net/manual/en/migration73.deprecated.php#migration73.deprecated.core.assert
  * @link https://wiki.php.net/rfc/deprecations_php_7_3#defining_a_free-standing_assert_function
@@ -81,6 +82,15 @@ class RemovedNamespacedAssertSniff extends Sniff
             return;
         }
 
-        $phpcsFile->addWarning('Declaring a free-standing function called assert() is deprecated since PHP 7.3.', $stackPtr, 'Found');
+        $error   = 'Declaring a namespaced function called assert() is deprecated since PHP 7.3';
+        $code    = 'Deprecated';
+        $isError = false;
+        if ($this->supportsAbove('8.0') === true) {
+            $error  .= ' and will throw a fatal error since PHP 8.0';
+            $code    = 'Removed';
+            $isError = true;
+        }
+
+        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
     }
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -49,10 +49,15 @@ class RemovedNamespacedAssertUnitTest extends BaseSniffTest
      *
      * @return void
      */
-    public function testIsDeprecated($testFile, $line)
+    public function testRemovedNamespacedAssert($testFile, $line)
     {
-        $file = $this->sniffFile(__DIR__ . '/' . $testFile, '7.3');
-        $this->assertWarning($file, $line, 'Declaring a free-standing function called assert() is deprecated since PHP 7.3');
+        $error = 'Declaring a namespaced function called assert() is deprecated since PHP 7.3';
+        $file  = $this->sniffFile(__DIR__ . '/' . $testFile, '7.3');
+        $this->assertWarning($file, $line, $error);
+
+        $error .= ' and will throw a fatal error since PHP 8.0';
+        $file   = $this->sniffFile(__DIR__ . '/' . $testFile, '8.0');
+        $this->assertError($file, $line, $error);
     }
 
     /**


### PR DESCRIPTION
> Declaring a function called `assert()` inside a namespace is no longer allowed, and issues `E_COMPILE_ERROR`. The `assert()` function is subject to special handling by the engine, which may lead to inconsistent behavior when defining a namespaced function with the same name.

Ref: https://www.php.net/manual/en/migration80.incompatible.php

This adjusts the existing sniff to take the change to fatal error in PHP 8.0 into account.

Note: the error code of the sniff has been changed! This is a minor breaking change and should be annotated in the changelog.

Related to #809