### PR TITLE
QA: consistency of error types and codes

### DIFF
--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -144,15 +144,17 @@ class RemovedTernaryAssociativitySniff extends Sniff
 
         if ($ternaryCount > 1 && $ternaryCount === $elseCount && $ternaryCount > $shortTernaryCount) {
             $message = 'The left-associativity of the ternary operator has been deprecated in PHP 7.4';
+            $code    = 'Deprecated';
             $isError = false;
             if ($this->supportsAbove('8.0') === true) {
                 $message .= ' and removed in PHP 8.0';
+                $code     = 'Removed';
                 $isError  = true;
             }
 
             $message .= '. Multiple consecutive ternaries detected. Use parenthesis to clarify the order in which the operations should be executed';
 
-            $this->addMessage($phpcsFile, $message, $stackPtr, $isError);
+            $this->addMessage($phpcsFile, $message, $stackPtr, $isError, $code);
         }
     }
 }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
@@ -115,6 +115,7 @@ class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSni
         }
 
         $error   = 'Using a string as the assertion passed to assert() is deprecated since PHP 7.2%s. Found: %s';
+        $code    = 'Deprecated';
         $isError = false;
         $data    = [
             '',
@@ -124,8 +125,9 @@ class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSni
         if ($this->supportsAbove('8.0') === true) {
             $data[0] = ' and removed since PHP 8.0';
             $isError = true;
+            $code    = 'Removed';
         }
 
-        $this->addMessage($phpcsFile, $error, $targetParam['start'], $isError, 'Found', $data);
+        $this->addMessage($phpcsFile, $error, $targetParam['start'], $isError, $code, $data);
     }
 }


### PR DESCRIPTION
As per #1163:
* Deprecations should throw warnings.
* Removals should throw errors.
* Both should use a different error code.

Note: the `RemovedAssertStringAssertion` sniff is new to PHPCompatibility 10.0.0, so this error code change has no consequences.
The error code change for the `RemovedTernaryAssociativity` should be noted in the changelog though as the sniff was introduced in PHPCompatibility 9.2.0.

Fixes #1163