### PR TITLE
ArgumentFunctionsReportCurrentValue: various improvements/ ignore isset/empty / error on unset

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -381,6 +381,19 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     continue;
                 }
 
+                // Ignore use of any of the passed parameters in isset() or empty().
+                if ($tokens[$j]['code'] === \T_ISSET
+                    || $tokens[$j]['code'] === \T_EMPTY
+                ) {
+                    $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($j + 1), null, true);
+                    if ($nextNonEmpty !== false
+                        && isset($tokens[$nextNonEmpty]['parenthesis_closer'])
+                    ) {
+                        $j = $tokens[$nextNonEmpty]['parenthesis_closer'];
+                        continue;
+                    }
+                }
+
                 if ($tokens[$j]['code'] !== \T_VARIABLE) {
                     continue;
                 }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -417,8 +417,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
 
                 /*
                  * Ok, so we've found a variable which was passed as one of the parameters.
-                 * Now, is this variable being changed, i.e. incremented, decremented or
-                 * assigned something ?
+                 * Now, is this variable being changed, i.e. incremented, decremented, unset
+                 * or assigned something ?
                  */
                 $scanResult = 'warning';
                 if (isset($variableToken) === false) {
@@ -444,6 +444,21 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     $scanResult    = 'error';
                     $variableToken = $j;
                     break;
+                }
+
+                if (empty($tokens[$j]['nested_parenthesis']) === false) {
+                    $parentheses = $tokens[$j]['nested_parenthesis'];
+                    end($parentheses);
+                    $openParens   = key($parentheses);
+                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($openParens - 1), null, true);
+                    if ($prevNonEmpty !== false
+                        && $tokens[$prevNonEmpty]['code'] === \T_UNSET
+                    ) {
+                        // Variable is being unset.
+                        $scanResult    = 'error';
+                        $variableToken = $j;
+                        break;
+                    }
                 }
 
                 if ($tokens[$afterVar]['code'] === \T_OPEN_SQUARE_BRACKET

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -372,6 +372,15 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     continue;
                 }
 
+                // Ignore return, exit and throw statements completely.
+                if ($tokens[$j]['code'] === \T_RETURN
+                    || $tokens[$j]['code'] === \T_EXIT
+                    || $tokens[$j]['code'] === \T_THROW
+                ) {
+                    $j = BCFile::findEndOfStatement($phpcsFile, $j);
+                    continue;
+                }
+
                 if ($tokens[$j]['code'] !== \T_VARIABLE) {
                     continue;
                 }
@@ -390,21 +399,6 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     }
                 } elseif (\in_array($tokens[$j]['content'], $paramNames, true) === false) {
                     // Variable is not one of the function parameters.
-                    continue;
-                }
-
-                /*
-                 * Check if the variable is used within a return or exit/die statement.
-                 * In that case, we can safely ignore it.
-                 */
-                $startOfVariableStatement = BCFile::findStartOfStatement(
-                    $phpcsFile,
-                    $j,
-                    $this->ignoreForStartOfStatementVarUse
-                );
-                if ($tokens[$startOfVariableStatement]['code'] === \T_RETURN
-                    || $tokens[$startOfVariableStatement]['code'] === \T_EXIT
-                ) {
                     continue;
                 }
 

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -215,6 +215,16 @@ function ignoreParamInExitUnscopedCondition ( $stuff ) {
     $args = func_get_args(); // OK.
 }
 
+function ignore_isset($x) {
+    if (isset($x[0])) {}
+    func_get_args(); // OK.
+}
+
+function ignore_empty($x) {
+    if (empty($x)) {}
+    func_get_args ( ); // OK.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function foo($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -173,7 +173,7 @@ function ignoreParamInReturn ( $stuff ) {
         return [$somethingElse['key'], 'b' => $stuff];
     }
 
-    $args = func_get_args();
+    $args = func_get_args(); // OK.
 }
 
 function ignoreParamInExit ( $stuff ) {
@@ -181,7 +181,7 @@ function ignoreParamInExit ( $stuff ) {
         exit ( 'Did ' . functionCall() . $stuff );
     }
 
-    $args = func_get_args();
+    $args = func_get_args(); // OK.
 }
 
 function ignoreParamInDie ( $stuff ) {
@@ -189,7 +189,30 @@ function ignoreParamInDie ( $stuff ) {
         die ( 'Did ' . $stuff );
     }
 
-    $args = func_get_args();
+    $args = func_get_args(); // OK.
+}
+
+function ignoreParamInThrow ( $stuff, $msg ) {
+    if ( true === SOME_CONSTANT ) {
+        throw new Exception($msg);
+    }
+
+    $args = func_get_args(); // OK.
+}
+
+// Issue #1240 - return/exit with unscoped conditions.
+function ignoreParamInReturnUnscopedCondition ( $stuff ) {
+    if ( true === SOME_CONSTANT )
+        return $stuff;
+
+    $args = func_get_args(); // OK.
+}
+
+function ignoreParamInExitUnscopedCondition ( $stuff ) {
+    if ( true === SOME_CONSTANT )
+        do_something OR die( 'Did ' . functionCall( $stuff ) );
+
+    $args = func_get_args(); // OK.
 }
 
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -225,6 +225,11 @@ function ignore_empty($x) {
     func_get_args ( ); // OK.
 }
 
+function do_NOT_ignore_unset($x) {
+    unset($x[0]);
+    \func_get_args(); // Error.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function foo($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -230,6 +230,31 @@ function do_NOT_ignore_unset($x) {
     \func_get_args(); // Error.
 }
 
+// Issue #1240, part 2 - plain assignments.
+function ignorePlainAssignments($stuff) {
+    $other = $stuff;
+    $other = $stuff + 10;
+    $other = 10 + $stuff;
+    $args = func_get_args(); // OK.
+}
+
+function dontIgnoreDoubleAssignment($stuff) {
+    $other = $stuff = $other;
+    $args = func_get_args(); // Error.
+}
+
+function dontIgnoreReferenceAssignments($stuff) {
+    $other = &$stuff;
+    // Do some more.
+    $args = func_get_args(); // Warning, reference assignment.
+}
+
+function dontIgnoreNonPlainAssignments($matches) {
+    $other = preg_match('/regex/', $subject, $matches);
+    // Do some more.
+    $args = func_get_args(); // Warning, non-plain assignment.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function foo($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -69,6 +69,7 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTest
             [122, 'func_get_arg', '$a'],
             [161, 'func_get_args', '$string'],
             [230, 'func_get_args', '$x'],
+            [243, 'func_get_args', '$stuff'],
         ];
     }
 
@@ -103,6 +104,8 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTest
             [101, 'func_get_arg', '$c'],
             [129, 'func_get_args', '$x'],
             [134, 'debug_backtrace', '$x'],
+            [249, 'func_get_args', '$stuff'],
+            [255, 'func_get_args', '$matches'],
         ];
     }
 
@@ -158,8 +161,9 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTest
         $cases[] = [215];
         $cases[] = [220];
         $cases[] = [225];
+        $cases[] = [238];
 
-        $cases[] = [236]; // Parse error.
+        $cases[] = [261]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -30,8 +30,8 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTest
      *
      * @dataProvider dataValueChanged
      *
-     * @param array  $line         The line number where a warning is expected.
-     * @param string $functionName The name of the function to which the warning applies.
+     * @param array  $line         The line number where an error is expected.
+     * @param string $functionName The name of the function to which the error applies.
      * @param string $variableName The variable which was detected as having been changed.
      *
      * @return void

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -68,6 +68,7 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTest
             [120, 'func_get_arg', '$a'],
             [122, 'func_get_arg', '$a'],
             [161, 'func_get_args', '$string'],
+            [230, 'func_get_args', '$x'],
         ];
     }
 
@@ -158,7 +159,7 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTest
         $cases[] = [220];
         $cases[] = [225];
 
-        $cases[] = [231]; // Parse error.
+        $cases[] = [236]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -152,6 +152,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTest
         $cases[] = [176];
         $cases[] = [184];
         $cases[] = [192];
+        $cases[] = [200];
+        $cases[] = [208];
+        $cases[] = [215];
+
+        $cases[] = [221]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -155,8 +155,10 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTest
         $cases[] = [200];
         $cases[] = [208];
         $cases[] = [215];
+        $cases[] = [220];
+        $cases[] = [225];
 
-        $cases[] = [221]; // Parse error.
+        $cases[] = [231]; // Parse error.
 
         return $cases;
     }


### PR DESCRIPTION
👉 This PR will be easiest to review by looking at the individual commits.

---

### ArgumentFunctionsReportCurrentValue: don't report when parameter is only used in return/exit [2]

Follow up on #1208.

Improve the previously applied fix to bow out from reporting "use" of a passed parameter before a call to `func_get_args()` when the parameter is used in a `return` or `exit` statement.

The previous fix would break when the `return`/`exit` statement was within an unscoped condition.

Unscoped conditions (no curly braces) are a bane to the existence of sniff writers anywhere and can't be fully accounted for.
Even so, there are some common situations in which the previous fix can be improved to reduce false positives.

This current fix will skip over `return`/`exit` statements completely, instead of walking back from a matched variable to check if something is within a `return`/`exit` statement.
This also makes the sniff more efficient.

Secondly, the sniff will now also ignore parameter use in `throw` statements.

Includes additional unit tests.

Fixes #1240

### ArgumentFunctionsReportCurrentValue: minor fix to the unit test documentation

### ArgumentFunctionsReportCurrentValue: ignore variable use in isset() or empty()

Those uses are innocent, will not change the value of the passed parameter and can be safely ignored.

Includes unit tests.

### ArgumentFunctionsReportCurrentValue: throw an error for unset()

When one of the passed parameters is used in a call to `unset()`, we know for sure it has been changed, so the sniff should throw an error, not a warning.

Includes unit test.

### ArgumentFunctionsReportCurrentValue: don't report when parameter is only used in simple assignment

Prevent a false positive (warning) when a parameter is only _assigned_ to another variable and this is a "simple assignment".

For the purposes of this check, a "simple assignment" is defined as:
- The variable is not nested in parenthesis, i.e. not used in a potential function call which may adjust the variable by reference.
- Not preceded by a reference operator (reference assignment).
- Has an assignment operator before it and none after.

Any more complex statements where a passed parameter is being assigned to another with a call to one of the argument functions after it, will still be reported as "needs inspection".

Includes additional unit tests.

Fixes #1240

Related to #796
