### PR TITLE
GH Actions: tweak coverage run

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches-ignore:
       - master
+      - develop
     paths-ignore:
       - '**.md'
   # Allow manually triggering the workflow.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - develop
   pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:
@@ -14,6 +15,7 @@ jobs:
   # Linting against high/low of each PHP major should catch everything.
   # If needs be, we can always add interim versions back at a later point in time.
   lint:
+    if: ${{ github.ref != 'refs/heads/develop' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -58,6 +60,7 @@ jobs:
 
   #### TEST STAGE ####
   test:
+    if: ${{ github.ref != 'refs/heads/develop' }}
     # No use running the tests if there is a linting error somewhere as they would fail anyway.
     needs: lint
 
@@ -212,6 +215,8 @@ jobs:
   coverage:
     # No use running the coverage builds if there are failing test builds.
     needs: test
+    # The default condition is success(), but this is false when one of the previous jobs is skipped
+    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
 
     runs-on: ubuntu-latest
 
@@ -313,6 +318,8 @@ jobs:
 
   coveralls-finish:
     needs: coverage
+    if: always() && needs.coverage.result == 'success'
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
As things were, coverage would only be run on pull requests and on `master`.
Generally speaking, this is sufficient, but it does mean that the coverage over time is no longer properly tracked, which is a shame.

The tweaks I'm making now should:
* Still run the normal `test` and `coverage` jobs on pull requests and merges to `master`.
* For merges to `develop`, skip the `test` job, but do run the `coverage`, so it will be tracked again.
* Skip the `quicktest` on `develop` as those are the same builds as for `coverage`, so no need to run those twice.
* Also make sure that the coveralls-finish will actually run. Should after a build running just coverage already, but didn't.