### PR TITLE
Composer: tweak the PHPUnit 4.x version used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require-dev" : {
     "php-parallel-lint/php-parallel-lint": "^1.2.0",
     "php-parallel-lint/php-console-highlighter": "^0.5",
-    "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
+    "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
     "phpcsstandards/phpcsdevtools": "^1.0"
   },
   "conflict": {


### PR DESCRIPTION
The PHPUnit 4.x version used was based on a PHPUnit bug previously encountered in #511.

It appears though that with changes which have been made to the test set up in the mean time, this bug no longer rears its ugly head, so we can now switch back to using the highest available PHPUnit 4.x version again.

Note: this will allow for potentially using the [PHPUnit Polyfills](https://github.com/Yoast/PHPUnit-Polyfills/) instead of working around PHPUnit cross-version incompatibilities ourselves.