### PR TITLE
GH Actions: turn display_errors on

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -53,9 +53,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
           fi
 
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: error_reporting=E_ALL, display_errors=On
           coverage: none
           tools: cs2pr
 
@@ -162,15 +163,15 @@ jobs:
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
           if [ ${{ matrix.custom_ini }} == "true" ]; then
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, short_open_tag=On'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, short_open_tag=On'
             else
-              echo '::set-output name=PHP_INI::short_open_tag=On'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On, short_open_tag=On'
             fi
           else
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
             else
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
             fi
           fi
 
@@ -256,15 +257,15 @@ jobs:
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
           if [ ${{ matrix.custom_ini }} == "true" ]; then
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, short_open_tag=On'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, short_open_tag=On'
             else
-              echo '::set-output name=PHP_INI::short_open_tag=On'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On, short_open_tag=On'
             fi
           else
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
             else
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
             fi
           fi
 


### PR DESCRIPTION
Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.

In our script, we already enabled error_reporting, but the error display was not yet fixed. Sorted now.