### PR TITLE
[xml doc] ArgumentFunctionsReportCurrentValue

### DIFF
--- a/PHPCompatibility/Docs/FunctionUse/ArgumentFunctionsReportCurrentValueStandard.xml
+++ b/PHPCompatibility/Docs/FunctionUse/ArgumentFunctionsReportCurrentValueStandard.xml
@@ -1,0 +1,25 @@
+<documentation title="Functions Inspecting Function Arguments Report Current Value">
+    <standard><![CDATA[
+Since PHP 7.0, functions inspecting arguments no longer report the original value as passed to a parameter, but will instead provide the current value.
+
+Review the code and fix if needed. Mark occurrence as ignored by adding an ignore comment.
+]]></standard>
+    <code_comparison>
+        <code title="Valid: will return the original value"><![CDATA[
+// phpcs:ignore PHPCompatibility.FunctionUse
+ .ArgumentFunctionsReportCurrentValue
+ .NeedsInspection
+function myFunction($email) {
+    $newEmail = 'New value';
+    return func_get_arg(0);
+}
+        ]]></code>
+        <code title="Invalid: will return the new value"><![CDATA[
+function myFunction($email) {
+    $email = 'New value';
+    return func_get_arg(0);
+}
+        ]]></code>
+    </code_comparison>
+    <link>https://www.zend.com/php-migration/function-use/inspecting-arguments</link>
+</documentation>

--- a/PHPCompatibility/Docs/FunctionUse/ArgumentFunctionsReportCurrentValueStandard.xml
+++ b/PHPCompatibility/Docs/FunctionUse/ArgumentFunctionsReportCurrentValueStandard.xml
@@ -11,12 +11,14 @@ Review the code and fix if needed. Mark occurrence as ignored by adding an ignor
  .NeedsInspection
 function myFunction($email) {
     $newEmail = 'New value';
+    saveEmail($newEmail);
     return func_get_arg(0);
 }
         ]]></code>
         <code title="Invalid: will return the new value"><![CDATA[
 function myFunction($email) {
     $email = 'New value';
+    saveEmail($email);
     return func_get_arg(0);
 }
         ]]></code>

--- a/PHPCompatibility/Docs/FunctionUse/ArgumentFunctionsReportCurrentValueStandard.xml
+++ b/PHPCompatibility/Docs/FunctionUse/ArgumentFunctionsReportCurrentValueStandard.xml
@@ -1,27 +1,142 @@
-<documentation title="Functions Inspecting Function Arguments Report Current Value">
-    <standard><![CDATA[
-Since PHP 7.0, functions inspecting arguments no longer report the original value as passed to a parameter, but will instead provide the current value.
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Functions Inspecting Arguments Report Current Value"
+    >
+    <standard link="https://www.zend.com/php-migration/function-use/inspecting-arguments">
+    <![CDATA[
+    Since PHP 7.0, functions inspecting arguments no longer report the original value as passed to a parameter, but will instead provide the current value of the arguments at the point in the code flow the inspection function is being called.
 
-Review the code and fix if needed. Mark occurrence as ignored by adding an ignore comment.
-]]></standard>
+    The functions affected are `func_get_arg()`, `func_get_args()`, `debug_backtrace()` and `debug_print_backtrace()` and the change only affects the use of these functions within functions with declared parameters.
+
+    Inconsistency in the values being returned by these function calls can be prevented by calling the function inspecting the function arguments prior to any modification of the received arguments and, of course, by not modifying the original values of the arguments.
+    ]]>
+    </standard>
     <code_comparison>
-        <code title="Valid: will return the original value"><![CDATA[
-// phpcs:ignore PHPCompatibility.FunctionUse
- .ArgumentFunctionsReportCurrentValue
- .NeedsInspection
-function myFunction($email) {
-    $newEmail = 'New value';
-    saveEmail($newEmail);
-    return func_get_arg(0);
+        <code title="Cross-version compatible: code NOT affected by the change">
+        <![CDATA[
+// func_get_args() called BEFORE change of $a.
+function foo($a, $b = null) {
+    <em>$args = func_get_args()</em>;
+    if (isset($b)) {
+        $a *= $b;
+    }
+    return <em>$args</em>;
 }
-        ]]></code>
-        <code title="Invalid: will return the new value"><![CDATA[
-function myFunction($email) {
-    $email = 'New value';
-    saveEmail($email);
-    return func_get_arg(0);
+
+/* func_get_arg() retrieving the
+   unchanged argument $b. */
+function bar($a, $b) {
+    if (isset($b)) {
+        $a *= $b;
+    }
+    return func_get_arg(<em>1</em>);
 }
-        ]]></code>
+
+/* Calling debug_backtrace
+   with DEBUG_BACKTRACE_IGNORE_ARGS. */
+function foo($a) {
+    $a = 'foo';
+    debug_backtrace(
+        <em>DEBUG_BACKTRACE_IGNORE_ARGS</em>
+    );
+}
+
+// Function declared without arguments.
+$closure = <em>function()</em> {
+    $abc = 'abc';
+    var_dump(<em>func_get_args()</em>);
+};
+        ]]>
+        </code>
+        <code title="Cross-version INcompatible: code affected by the change">
+        <![CDATA[
+// func_get_args() called AFTER change of $a.
+function foo($a, $b = null) {
+
+    if (isset($b)) {
+        $a *= $b;
+    }
+    return <em>func_get_args()</em>;
+}
+
+/* func_get_arg() retrieving the
+   changed argument $a. */
+function bar($a, $b) {
+    if (isset($b)) {
+        $a *= $b;
+    }
+    return func_get_arg(<em>0</em>);
+}
+
+/* Calling debug_backtrace
+   without DEBUG_BACKTRACE_IGNORE_ARGS. */
+function foo($a) {
+    $a = 'foo';
+    <em>debug_backtrace()</em>;
+}
+
+
+
+// Value of defined parameter is changed.
+$closure = function(<em>$abc</em>) {
+    <em>$abc += 'abc';</em>
+    var_dump(<em>func_get_args()</em>);
+};
+        ]]>
+        </code>
     </code_comparison>
-    <link>https://www.zend.com/php-migration/function-use/inspecting-arguments</link>
+
+    <standard>
+    <![CDATA[
+    In some cases the sniff cannot reliably determine whether the argument which is used in the code, is actually being changed (potentially by reference).
+    In those situations, the sniff will throw a warning to manually inspect the code.
+
+    If, after close scrutiny, it is determined that the code is not affected by this change, an ignore annotation can be used to prevent the warning from showing in future code inspections.
+
+    It is recommended to use the most specific ignore annotation possible, like so:
+    // phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: original value of $array is not changed prior to call to func_get_args()">
+        <![CDATA[
+function foo($array) {
+    $args = <em>func_get_args()</em>;
+    \array_sort(<em>$array</em>);
+    return $args;
+}
+        ]]>
+        </code>
+        <code title="Cross-version INcompatible: original value of $array is changed by reference prior to call to func_get_args()">
+        <![CDATA[
+function foo($array) {
+    // Changes $array by reference.
+    \array_sort(<em>$array</em>);
+    return \<em>func_get_args()</em>;
+}
+        ]]>
+        </code>
+    </code_comparison>
+
+    <code_comparison>
+        <code title="Cross-version compatible: original value of $email is not changed prior to call to func_get_arg()">
+        <![CDATA[
+function myFunction($email) {
+    $newEmail = $email;
+    saveEmail($newEmail);
+    return func_get_arg(<em>0</em>);
+}
+        ]]>
+        </code>
+        <code title="Cross-version INcompatible: original value of $email is potentially be changed (by reference) prior to call to func_get_arg()">
+        <![CDATA[
+function myFunction($email) {
+    // Unclear: Is $email changed by reference?
+    saveEmail($email);
+    return func_get_arg(<em>0</em>);
+}
+        ]]>
+        </code>
+    </code_comparison>
 </documentation>


### PR DESCRIPTION
I'm not sure whether the `phpcs:ignore` comment should be part of the base example or not. I also didn't know how to split a non-splittable comment to fit within the narrow CLI block, so I improvised:

![image](https://user-images.githubusercontent.com/199835/129579137-f2990c88-bbc1-422b-9c46-45d4711346cf.png)

Related to #1285