### PR TITLE
Fix improper pluralization using apostrophes

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
@@ -17,7 +17,7 @@ use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
- * Detect trailing comma's in function declarations and closure use lists as allowed since PHP 8.
+ * Detect trailing commas in function declarations and closure use lists as allowed since PHP 8.
  *
  * PHP version 8.0
  *
@@ -78,13 +78,13 @@ class NewTrailingCommaSniff extends Sniff
         }
 
         /*
-         * Check for trailing comma's in a function declaration parameter list.
+         * Check for trailing commas in a function declaration parameter list.
          */
         $lastInParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), null, true);
 
         if ($tokens[$lastInParenthesis]['code'] === \T_COMMA) {
             $phpcsFile->addError(
-                'Trailing comma\'s are not allowed in function declaration parameter lists in PHP 7.4 or earlier',
+                'Trailing commas are not allowed in function declaration parameter lists in PHP 7.4 or earlier',
                 $lastInParenthesis,
                 'InParameterList'
             );
@@ -92,7 +92,7 @@ class NewTrailingCommaSniff extends Sniff
 
         /*
          * From this point forward, we're only interested in closures to check for
-         * trailing comma's in closure use lists.
+         * trailing commas in closure use lists.
          * Bow out for any of the other tokens.
          */
         if ($tokens[$stackPtr]['code'] !== \T_CLOSURE) {
@@ -119,7 +119,7 @@ class NewTrailingCommaSniff extends Sniff
 
         if ($tokens[$lastInParenthesis]['code'] === \T_COMMA) {
             $phpcsFile->addError(
-                'Trailing comma\'s are not allowed in closure use lists in PHP 7.4 or earlier',
+                'Trailing commas are not allowed in closure use lists in PHP 7.4 or earlier',
                 $lastInParenthesis,
                 'InClosureUseList'
             );

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -540,7 +540,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
             return $tokens[$endPtr]['bracket_closer'];
         }
 
-        // Skip past comma's at a lower nesting level.
+        // Skip past commas at a lower nesting level.
         if ($tokens[$endPtr]['code'] === \T_COMMA) {
             // Check if a comma is at the nesting level we're targetting.
             $nestingLevel = 0;

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
- * Detect trailing comma's in function calls, `isset()` and `unset()` as allowed since PHP 7.3.
+ * Detect trailing commas in function calls, `isset()` and `unset()` as allowed since PHP 7.3.
  *
  * PHP version 7.3
  *
@@ -112,7 +112,7 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
         }
 
         $phpcsFile->addError(
-            'Trailing comma\'s are not allowed in %s in PHP 7.2 or earlier',
+            'Trailing commas are not allowed in %s in PHP 7.2 or earlier',
             $lastInParenthesis,
             $errorCode,
             $data

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -19,7 +19,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * Checks for:
  * - Group use statements as introduced in PHP 7.0.
- * - Trailing comma's in group use statements as allowed since PHP 7.2.
+ * - Trailing commas in group use statements as allowed since PHP 7.2.
  *
  * PHP version 7.0
  * PHP version 7.2
@@ -31,7 +31,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * @link https://www.php.net/manual/en/language.namespaces.importing.php#language.namespaces.importing.group
  *
  * @since 7.0.0
- * @since 8.0.1 Now also checks for trailing comma's in group `use` declarations.
+ * @since 8.0.1 Now also checks for trailing commas in group `use` declarations.
  */
 class NewGroupUseDeclarationsSniff extends Sniff
 {
@@ -84,7 +84,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closeCurly - 1), null, true);
         if ($tokens[$prevToken]['code'] === \T_COMMA) {
             $phpcsFile->addError(
-                'Trailing comma\'s are not allowed in group use statements in PHP 7.1 or earlier',
+                'Trailing commas are not allowed in group use statements in PHP 7.1 or earlier',
                 $prevToken,
                 'TrailingCommaFound'
             );

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.inc
@@ -32,7 +32,7 @@ class LotsOfParams7 {
 }
 
 /*
- * PHP 8.0 trailing comma's in function declarations.
+ * PHP 8.0 trailing commas in function declarations.
  */
 function Foo8(
     $foo,
@@ -63,7 +63,7 @@ class LotsOfParams8 {
 }
 
 /*
- * PHP 8.0 trailing comma's in closure use lists.
+ * PHP 8.0 trailing commas in closure use lists.
  */
 $closure = function ($foo, $bar) use ($baz, $booboo,) {
     return ($foo + $bar) * $baz / $booboo;
@@ -90,7 +90,7 @@ $c = function(,) {}; // Parse error, but throw an error anyway.
 
 $c = function($foo) use(,) {}; // Parse error, but throw an error anyway.
 
-// Multiple trailing comma's.
+// Multiple trailing commas.
 $a = fn($foo, $bar,,) => $bar; // Parse error, but throw an error anyway.
 
 // Leading comma.

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
@@ -37,7 +37,7 @@ class NewTrailingCommaUnitTest extends BaseSniffTest
     public function testTrailingComma($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
-        $this->assertError($file, $line, "Trailing commas are not allowed in function declaration parameter lists in PHP 7.4 or earlier");
+        $this->assertError($file, $line, 'Trailing commas are not allowed in function declaration parameter lists in PHP 7.4 or earlier');
     }
 
     /**
@@ -73,7 +73,7 @@ class NewTrailingCommaUnitTest extends BaseSniffTest
     public function testTrailingCommaClosureUse($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
-        $this->assertError($file, $line, "Trailing commas are not allowed in closure use lists in PHP 7.4 or earlier");
+        $this->assertError($file, $line, 'Trailing commas are not allowed in closure use lists in PHP 7.4 or earlier');
     }
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
@@ -26,7 +26,7 @@ class NewTrailingCommaUnitTest extends BaseSniffTest
 {
 
     /**
-     * Test correctly identifying trailing comma's in function declarations.
+     * Test correctly identifying trailing commas in function declarations.
      *
      * @dataProvider dataTrailingComma
      *
@@ -37,7 +37,7 @@ class NewTrailingCommaUnitTest extends BaseSniffTest
     public function testTrailingComma($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
-        $this->assertError($file, $line, "Trailing comma's are not allowed in function declaration parameter lists in PHP 7.4 or earlier");
+        $this->assertError($file, $line, "Trailing commas are not allowed in function declaration parameter lists in PHP 7.4 or earlier");
     }
 
     /**
@@ -62,7 +62,7 @@ class NewTrailingCommaUnitTest extends BaseSniffTest
 
 
     /**
-     * Test correctly identifying trailing comma's in closure use lists.
+     * Test correctly identifying trailing commas in closure use lists.
      *
      * @dataProvider dataTrailingCommaClosureUse
      *
@@ -73,7 +73,7 @@ class NewTrailingCommaUnitTest extends BaseSniffTest
     public function testTrailingCommaClosureUse($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
-        $this->assertError($file, $line, "Trailing comma's are not allowed in closure use lists in PHP 7.4 or earlier");
+        $this->assertError($file, $line, "Trailing commas are not allowed in closure use lists in PHP 7.4 or earlier");
     }
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
@@ -9,7 +9,7 @@ myFunction($foo, $bar);
 $myClosure($foo, $bar);
 
 /*
- * PHP 7.3 trailing comma's in function calls + isset + unset.
+ * PHP 7.3 trailing commas in function calls + isset + unset.
  */
 // Isset & unset.
 unset($foo, $bar,);
@@ -61,7 +61,7 @@ $closure = function ($a, $b,) {} // Parse error, but not our concern.
 // Free-standing comma.
 foo(,); // Parse error, but throw an error anyway.
 
-// Multiple trailing comma's.
+// Multiple trailing commas.
 foo('function', 'bar',,); // Parse error, but throw an error anyway.
 
 // Leading comma.

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -38,7 +38,7 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
     public function testTrailingComma($line, $type = 'function calls')
     {
         $file = $this->sniffFile(__FILE__, '7.2');
-        $this->assertError($file, $line, 'Trailing commas are not allowed in {$type} in PHP 7.2 or earlier');
+        $this->assertError($file, $line, "Trailing commas are not allowed in {$type} in PHP 7.2 or earlier");
     }
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -38,7 +38,7 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
     public function testTrailingComma($line, $type = 'function calls')
     {
         $file = $this->sniffFile(__FILE__, '7.2');
-        $this->assertError($file, $line, "Trailing commas are not allowed in {$type} in PHP 7.2 or earlier");
+        $this->assertError($file, $line, 'Trailing commas are not allowed in {$type} in PHP 7.2 or earlier');
     }
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -38,7 +38,7 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
     public function testTrailingComma($line, $type = 'function calls')
     {
         $file = $this->sniffFile(__FILE__, '7.2');
-        $this->assertError($file, $line, "Trailing comma's are not allowed in {$type} in PHP 7.2 or earlier");
+        $this->assertError($file, $line, "Trailing commas are not allowed in {$type} in PHP 7.2 or earlier");
     }
 
     /**

--- a/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
@@ -74,7 +74,7 @@ class NewGroupUseDeclarationsUnitTest extends BaseSniffTest
     public function testGroupUseTrailingComma($line)
     {
         $file = $this->sniffFile(__FILE__, '7.1');
-        $this->assertError($file, $line, 'Trailing comma\'s are not allowed in group use statements in PHP 7.1 or earlier');
+        $this->assertError($file, $line, 'Trailing commas are not allowed in group use statements in PHP 7.1 or earlier');
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Installation via a git check-out to an arbitrary directory (method 2)
    ```
    I.e. if you placed the `PHPCompatibility` repository in the `/my/custom/standards/PHPCompatibility` directory, you will need to add that directory to the PHP CodeSniffer [`installed_paths` configuration variable](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
 
-   **Warning**: :warning: The `installed_paths` command overwrites any previously set `installed_paths`. If you have previously set `installed_paths` for other external standards, run `phpcs --config-show` first and then run the `installed_paths` command with all the paths you need separated by comma's, i.e.:
+   **Warning**: :warning: The `installed_paths` command overwrites any previously set `installed_paths`. If you have previously set `installed_paths` for other external standards, run `phpcs --config-show` first and then run the `installed_paths` command with all the paths you need separated by commas, i.e.:
    ```bash
    phpcs --config-set installed_paths /path/1,/path/2,/path/3
    ```


### PR DESCRIPTION
The package consistently pluralized "comma" as "comma's" (e.g. possessive) instead of "commas".

This PR updates all instances within the repo except for the CHANGELOG.md file (in the release notes for versions 8.0.1 and 8.2.0).