### PR TITLE
PHPUnit: update configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,10 @@
         backupGlobals="true"
         colors="true"
         verbose="false"
+        convertErrorsToExceptions="true"
         convertWarningsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertDeprecationsToExceptions="true"
         forceCoversAnnotation="true"
     >
     <testsuites>


### PR DESCRIPTION
PHPUnit just released version 9.5.10 and 8.5.21.

This contains a particular (IMO breaking) change:

> * PHPUnit no longer converts PHP deprecations to exceptions by default (configure `convertDeprecationsToExceptions="true"` to enable this)

Let's unpack this:

Previously (PHPUnit < 9.5.10/8.5.21), if PHPUnit would encounter a PHP native deprecation notice, it would:
1. Show a test which causes a deprecation notice to be thrown as **"errored"**,
2. Show the **first** deprecation notice it encountered and
3. PHPUnit would exit with a **non-0 exit code** (2), which will fail a CI build.

As of PHPUnit 9.5.10/8.5.21, if PHPUnit encounters a PHP native deprecation notice, it will no longer do so. Instead PHPUnit will:
1. Show a test which causes a PHP deprecation notice to be thrown as **"risky"**,
2. Show the **all** deprecation notices it encountered and
3. PHPUnit will exit with a **0 exit code**, which will show a CI build as passing.

This commit reverts PHPUnit to the previous behaviour by adding `convertDeprecationsToExceptions="true"` to the PHPUnit configuration.
It also adds the other "missing" settings from the same series for consistency.

Refs:
* https://github.com/sebastianbergmann/phpunit/blob/9.5/ChangeLog-8.5.md
* https://github.com/sebastianbergmann/phpunit/blob/9.5/ChangeLog-9.5.md