### PR TITLE
Comprehensive CI update

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -79,3 +79,24 @@ jobs:
       # At a later stage the documentation check can be activated.
       - name: Check sniff feature completeness
         run: composer check-complete
+
+  verify-tests:
+    name: 'Check test files are up to date'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          coverage: none
+
+      - name: Regenerate the test files for the forbidden names test
+        run: php "./bin/generate-forbidden-names-test-files"
+
+      # If the regeneration of the test files yielded changes, this will ensure we fail the build.
+      - name: Ensure version-controlled files are not modified or deleted
+        run: git diff --exit-code

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -40,10 +40,10 @@ jobs:
       - name: 'Composer: adjust dependencies'
         run: |
           # Using PHPCS `master` as an early detection system for bugs upstream.
-          composer require --no-update squizlabs/php_codesniffer:"dev-master"
+          composer require --no-update squizlabs/php_codesniffer:"dev-master" --no-interaction
           # Add PHPCSDevCS - this is the CS ruleset we use.
           # This is not in the composer.json as it has different minimum PHPCS reqs and would conflict.
-          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.3"
+          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.3" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -43,7 +43,7 @@ jobs:
           composer require --no-update squizlabs/php_codesniffer:"dev-master"
           # Add PHPCSDevCS - this is the CS ruleset we use.
           # This is not in the composer.json as it has different minimum PHPCS reqs and would conflict.
-          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.2"
+          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.3"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -48,7 +48,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: Install xmllint
         run: sudo apt-get install --no-install-recommends -y libxml2-utils

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkcs:
     name: 'Basic CS and QA checks'

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -74,15 +74,15 @@ jobs:
       - name: 'Composer: set PHPCS version for tests'
         run: |
           # Remove devtools as it would block install on old PHPCS versions (< 3.0).
-          composer remove --no-update --dev phpcsstandards/phpcsdevtools
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
+          composer remove --no-update --dev phpcsstandards/phpcsdevtools --no-interaction
+          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
       - name: 'Composer: tweak PHPUnit version'
         if: ${{ matrix.php == 'latest' || startsWith( matrix.php, '8' ) }}
         run: |
           # Temporary fix - PHPUnit 9.3 is buggy when used for code coverage, so not allowed "normally".
           # As the quick tests don't run code coverage, we can safely install it for PHP 8.
-          composer require --no-update --dev phpunit/phpunit:"^9.3"
+          composer require --no-update --dev phpunit/phpunit:"^9.3" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -87,7 +87,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: Lint against parse errors
         if: ${{ matrix.lint }}

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -11,6 +11,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### QUICK TEST STAGE ####
   # This is a much quicker test which only runs the unit tests and linting against the low/high

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -59,9 +59,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, zend.assertions=1'
           fi
 
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### PHP LINT STAGE ####
   # Linting against high/low of each PHP major should catch everything.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,8 +222,8 @@ jobs:
   coverage:
     # No use running the coverage builds if there are failing test builds.
     needs: test
-    # The default condition is success(), but this is false when one of the previous jobs is skipped
-    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
+    # The default condition is success(), but this is false when one of the previous jobs is skipped (but don't run on forks).
+    if: github.repository_owner == 'PHPCompatibility' && (needs.test.result == 'success' || needs.test.result == 'skipped')
 
     runs-on: ubuntu-latest
 
@@ -325,7 +325,8 @@ jobs:
 
   coveralls-finish:
     needs: coverage
-    if: always() && needs.coverage.result == 'success'
+    # Don't run on forks.
+    if: github.repository_owner == 'PHPCompatibility' && needs.coverage.result == 'success'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: error_reporting=E_ALL, display_errors=On
+          ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
           coverage: none
           tools: cs2pr
 
@@ -169,15 +169,15 @@ jobs:
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
           if [ ${{ matrix.custom_ini }} == "true" ]; then
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, short_open_tag=On'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1, short_open_tag=On'
             else
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On, short_open_tag=On'
+              echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, short_open_tag=On, zend.assertions=1'
             fi
           else
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1'
             else
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+              echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, zend.assertions=1'
             fi
           fi
 
@@ -263,15 +263,15 @@ jobs:
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
           if [ ${{ matrix.custom_ini }} == "true" ]; then
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, short_open_tag=On'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1, short_open_tag=On'
             else
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On, short_open_tag=On'
+              echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, short_open_tag=On, zend.assertions=1'
             fi
           else
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
+              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1'
             else
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+              echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, zend.assertions=1'
             fi
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
         # - PHP 7.4 needs PHPCS 3.5.0+ to run without errors.
         #   On PHPCS 2.x our tests won't fail though, but on PHPCS 3.x < 3.5.0 they will.
         # - PHP 8.0 needs PHPCS 3.5.7+ to run without errors.
+        # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.4']
@@ -94,6 +95,13 @@ jobs:
 
         include:
           # Complement the builds run in code coverage to complete the matrix.
+          - php: '8.1'
+            phpcs_version: 'dev-master'
+            experimental: false
+          - php: '8.1'
+            phpcs_version: '3.6.1'
+            experimental: false
+
           - php: '8.0'
             phpcs_version: '~3.5.7'
             experimental: false
@@ -144,7 +152,7 @@ jobs:
           #  phpcs_version: '4.0.x-dev@dev'
           #  experimental: true
 
-          - php: '8.1' # Nightly.
+          - php: '8.2' # Nightly.
             phpcs_version: 'dev-master'
             experimental: true
 
@@ -198,15 +206,15 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php < 8.1 }}
+        if: ${{ matrix.php < 8.2 }}
         uses: "ramsey/composer-install@v1"
 
       # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php >= 8.1 }}
+        if: ${{ matrix.php >= 8.2 }}
         uses: "ramsey/composer-install@v1"
         with:
-          composer-options: --ignore-platform-reqs
+          composer-options: --ignore-platform-req=php
 
       - name: Run the unit tests
         run: vendor/bin/phpunit --no-coverage
@@ -293,7 +301,7 @@ jobs:
         if: ${{ startsWith( matrix.php, '8' ) }}
         uses: "ramsey/composer-install@v1"
         with:
-          composer-options: --ignore-platform-reqs
+          composer-options: --ignore-platform-req=php
 
       - name: Run the unit tests with code coverage
         run: vendor/bin/phpunit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,15 +26,10 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.6', '7.0', '7.4', '8.0']
-        experimental: [false]
-
-        include:
-          - php: '8.1'
-            experimental: true
+        php: ['5.4', '5.6', '7.0', '7.4', '8.0', '8.1', '8.2']
 
     name: "Lint: PHP ${{ matrix.php }}"
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.php == '8.2' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: 'Composer: adjust dependencies'
         # Remove PHPUnit requirement to save some bandwidth.
-        run: composer remove --no-update phpunit/phpunit
+        run: composer remove --no-update phpunit/phpunit --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
@@ -194,14 +194,14 @@ jobs:
       - name: 'Composer: adjust dependencies'
         run: |
           # Remove devtools as it would block install on old PHPCS versions (< 3.0).
-          composer remove --no-update --dev phpcsstandards/phpcsdevtools
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
+          composer remove --no-update --dev phpcsstandards/phpcsdevtools --no-interaction
+          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
       - name: 'Composer: conditionally tweak PHPUnit version'
         if: ${{ startsWith( matrix.php, '8' ) }}
         # Temporary fix - PHPUnit 9.3+ is buggy when used for code coverage, so not allowed "normally".
         # For tests which don't run code coverage, we can safely install it for PHP 8 though.
-        run: composer require --no-update phpunit/phpunit:"^9.3"
+        run: composer require --no-update phpunit/phpunit:"^9.3" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
@@ -288,9 +288,9 @@ jobs:
       - name: 'Composer: adjust dependencies'
         run: |
           # Remove devtools as it would block install on old PHPCS versions (< 3.0).
-          composer remove --no-update --dev phpcsstandards/phpcsdevtools
+          composer remove --no-update --dev phpcsstandards/phpcsdevtools --no-interaction
           # Set a specific PHPCS version.
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
+          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
       - name: Install Composer dependencies - normal
         if: ${{ startsWith( matrix.php, '8' ) == false  }}
@@ -316,7 +316,7 @@ jobs:
 
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer require php-coveralls/php-coveralls:"^2.4.2"
+        run: composer require php-coveralls/php-coveralls:"^2.4.2" --no-interaction
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: Lint against parse errors
         if: ${{ matrix.php != '5.4' && startsWith( matrix.php, '8' ) == false }}
@@ -207,12 +207,12 @@ jobs:
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
         if: ${{ matrix.php < 8.2 }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
         if: ${{ matrix.php >= 8.2 }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-req=php
 
@@ -294,12 +294,12 @@ jobs:
 
       - name: Install Composer dependencies - normal
         if: ${{ startsWith( matrix.php, '8' ) == false  }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: Install Composer dependencies - with ignore platform
         # For PHP 8+, we need to install with ignore platform reqs as we're using PHPUnit < 9.3.
         if: ${{ startsWith( matrix.php, '8' ) }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-req=php
 

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
       "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./PHPCompatibility"
     ],
     "install-devcs": [
-      "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1.2\" --no-suggest"
+      "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1.3\" --no-suggest"
     ],
     "remove-devcs": [
       "composer remove --dev phpcsstandards/phpcsdevcs"

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
     "issues" : "https://github.com/PHPCompatibility/PHPCompatibility/issues",
     "source" : "https://github.com/PHPCompatibility/PHPCompatibility"
   },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  },
   "require" : {
     "php" : ">=5.4",
     "squizlabs/php_codesniffer" : "^2.6 || ^3.1.0",


### PR DESCRIPTION
### GH Actions: auto-cancel previous builds for same branch

Previously, in Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a `concurrency` configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

### GH Actions: further improve PHP ini settings

Follow up on #1290.

This commit builds onto and improves the previous changes made to the ini values:
* `E_ALL` does not really contain **ALL** PHP notices across all PHP versions, in some `E_STRICT`, for instance, is excluded from `E_ALL`, so using `-1` is the better choice as that will always contain everything.
* While assertions are (as far as I'm aware) not currently used in the code base, it's still a good idea to enable `zend_assertions` in case something would be changed in the test tooling used.
    This is one of the other ini settings which is not turned on by default in the `setup-php` action.
    Ref: https://www.php.net/manual/en/ini.core.php#ini.zend.assertions

### GH Actions: don't run code coverage on forks

As forks cannot register the code coverage with the report tooling used, we may as well skip running it on forks.

### GH Actions: add task to verify forbidden names test files are always up-to-date

This new job runs the script to regenerate the forbidden names sniff test case files and will fail the build if those are not up to date.

Note: Alternatively, I could set up the job to automatically update the files when needed and commit the updates to the current branch.

### GH Actions: start running lint against PHP 8.2 

... and don't allow linting errors against PHP 8.1 anymore.

Includes minor matrix simplification.

### GH Actions: update matrix for PHP 8.1 release 

Note: while "normally", a PHP 8.1 build would be added to the code coverage job and the PHP 8.0 build moved to the normal test job, this is not possible while we are still using PHPUnit < 9.5 for code coverage. Fixing that is still on the to do list.

Also: `--ignore-platform-reqs` is no longer needed for installing on PHP 8.1.

### Composer: allow the PHPCS plugin

The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution

### Composer: use PHPCSDevCS v 1.1.3

PHPCS 3.6.2 introduced a new sniff to the PSR12 standard, which enforces no blank line at the start of a class.

That sniff conflicts with the `Squiz.WhiteSpace.FunctionSpacing` sniff when the `spacingBeforeFirst` property is set to `1`.

The latest release of PHPCSDevCS removes the conflict and should allow the CS build to pass again.

Ref: https://github.com/PHPCSStandards/PHPCSDevCS/releases/tag/1.1.3

### GH Actions: version update for `ramsey/composer-install`

The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2

### GH Actions: always use --no-interaction for Composer

Adding `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

### ~~GH Actions: always use versioned actions~~