### PR TITLE
PHP 8.1: New `PHPCompatibility.ParameterValues.RemovedMbCheckEncodingNoArgs` sniff

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedMbCheckEncodingNoArgsStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedMbCheckEncodingNoArgsStandard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<documentation title="Removed mb_check_encoding() without arguments">
+    <standard>
+    <![CDATA[
+    Calling the mb_check_encoding() function without passing any arguments is deprecated since PHP 8.1 and support will be removed in PHP 9.0.
+
+    Pass either the $value and/or the $encoding parameter for PHP cross-version compatible code.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: calling mb_check_encoding() with at least one argument.">
+        <![CDATA[
+$check = <em>mb_check_encoding($value, $encoding)</em>;
+$check = <em>mb_check_encoding(encoding: $charset)</em>;
+        ]]>
+        </code>
+        <code title="Invalid: calling mb_check_encoding() without any arguments.">
+        <![CDATA[
+$check = <em>mb_check_encoding()</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbCheckEncodingNoArgsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbCheckEncodingNoArgsSniff.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Detect: Calling mb_check_encoding() without any arguments is deprecated as of PHP 8.1.
+ * This will become a fatal error as of PHP 9.0.
+ *
+ * PHP version 8.1
+ * PHP version 9.0
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_1#mb_check_encoding_without_argument
+ * @link https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.mbstring
+ * @link https://www.php.net/manual/en/function.mb-check-encoding.php
+ *
+ * @since 10.0.0
+ */
+class RemovedMbCheckEncodingNoArgsSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = [
+        'mb_check_encoding' => true,
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('8.1') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return void
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        // Nothing to do. Function called with one or more parameters.
+    }
+
+    /**
+     * Process the function if no parameters were found.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     *
+     * @return void
+     */
+    public function processNoParameters(File $phpcsFile, $stackPtr, $functionName)
+    {
+        $phpcsFile->addWarning(
+            'Calling %s() without arguments is deprecated since PHP 8.1.',
+            $stackPtr,
+            'Found',
+            [$functionName]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.inc
@@ -1,0 +1,13 @@
+<?php
+/*
+ * Test mb_check_encoding() should no longer be called without arguments since PHP 8.1.
+ */
+
+//OK.
+mb_check_encoding($value, $encoding);
+mb_check_encoding($value);
+mb_check_encoding(encoding: $encoding);
+
+// Not OK.
+mb_check_encoding();
+Mb_Check_Encoding( /* comment */ );

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedMbCheckEncodingNoArgs sniff.
+ *
+ * @group removedMbCheckEncodingNoArgs
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedMbCheckEncodingNoArgsSniff
+ *
+ * @since 10.0.0
+ */
+class RemovedMbCheckEncodingNoArgsUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test receiving an expected warning for calling mb_check_encoding() without arguments.
+     *
+     * @dataProvider dataRemovedMbCheckEncodingNoArgs
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedMbCheckEncodingNoArgs($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertWarning($file, $line, 'without arguments is deprecated since PHP 8.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedMbCheckEncodingNoArgs()
+     *
+     * @return array
+     */
+    public function dataRemovedMbCheckEncodingNoArgs()
+    {
+        return [
+            [12],
+            [13],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for valid code.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+
+        // No errors expected on the first 11 lines.
+        for ($line = 1; $line <= 11; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Calling mb_check_encoding() without any arguments is deprecated.

New sniff to detect this deprecation.

Includes unit tests.
Includes docs.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_1#mb_check_encoding_without_argument
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.mbstring
* https://www.php.net/manual/en/function.mb-check-encoding.php
* https://github.com/php/php-src/commit/639015845fff43fe45feeecbf57635b0cbdc8efc

Related to #1299