### PR TITLE
PHP 8.1: New `PHPCompatibility.FunctionDeclarations.RemovedReturnByReferenceFromVoid` sniff

### DIFF
--- a/PHPCompatibility/Docs/FunctionDeclarations/RemovedReturnByReferenceFromVoidStandard.xml
+++ b/PHPCompatibility/Docs/FunctionDeclarations/RemovedReturnByReferenceFromVoidStandard.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<documentation title="Removed Return By Reference From Void Functions">
+    <standard>
+    <![CDATA[
+    Returning by reference from a void function is deprecated since PHP 8.1.
+
+    Such a function is contradictory, and already emits the following E_NOTICE when called: Only variable references should be returned by reference.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: not returning by reference with void.">
+        <![CDATA[
+// Not returning by reference.
+function foo(): void {}
+
+// Returning by reference, no return type.
+function &foo() {}
+
+// Returning by reference
+// without a void return type.
+function &foo(): array {}
+        ]]>
+        </code>
+        <code title="Invalid: returning by reference from a void function.">
+        <![CDATA[
+function <em>&</em>foo(): <em>void</em> {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Returning by reference from a void function is deprecated since PHP 8.1.
+ *
+ * PHP version 8.1
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_1#return_by_reference_with_void_type
+ * @link https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.void-by-ref
+ *
+ * @since 10.0.0
+ */
+class RemovedReturnByReferenceFromVoidSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return Collections::functionDeclarationTokensBC();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('8.1') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset(Collections::arrowFunctionTokensBC()[$tokens[$stackPtr]['code']])
+            && \strtolower($tokens[$stackPtr]['content']) !== 'fn'
+        ) {
+            // Not a function declaration.
+            return;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false
+            || ($tokens[$nextNonEmpty]['code'] !== \T_BITWISE_AND
+            // Deal with PHP 8.1 tokenization when using PHPCS < 3.6.1.
+            && $tokens[$nextNonEmpty]['type'] !== 'T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG'
+            && $tokens[$nextNonEmpty]['type'] !== 'T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG')
+        ) {
+            // Not a function declared to return by reference.
+            return;
+        }
+
+        try {
+            $functionProps = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
+        } catch (RuntimeException $e) {
+            // Most likely a T_STRING which wasn't an arrow function.
+            return;
+        }
+
+        if ($functionProps['return_type'] !== 'void') {
+            // Not a void function.
+            return;
+        }
+
+        $phpcsFile->addWarning(
+            'Returning by reference from a void function is deprecated since PHP 8.1.',
+            $stackPtr,
+            'Deprecated'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.inc
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Valid cross-version.
+ */
+
+// Not returning by reference.
+function noReference() : void {}
+
+$closure = function(): void {};
+
+class Foo {
+    function test(): void {}
+}
+
+$anon = new class() {
+    function test(): void {}
+};
+
+abstract class AbstractFoo {
+    abstract function test(): void;
+}
+
+interface FooInterface {
+    function test(): void;
+}
+
+trait FooTrait {
+    function test(): void {}
+}
+
+// No return type.
+function &noReturnType() {}
+
+$closure = function &() {};
+
+class FooNoReturn {
+    function &test() {}
+}
+
+// Different return type.
+function &differentReturnType(): array {}
+
+$closure = function &() : string {};
+
+class FooDifferentReturn {
+    function &test(): int {}
+}
+
+
+/*
+ * PHP 8.1: Returning by reference from a void function is deprecated.
+ */
+function &referenceWithVoidReturnType() : void {}
+
+$closure = function &(): void {};
+
+class Bar {
+    function &test(): void {}
+}
+
+$anon = new class() {
+    function &test(): void {}
+};
+
+abstract class AbstractBar {
+    abstract function &test(): void;
+}
+
+interface BarInterface {
+    function &test(): void;
+}
+
+trait BarTrait {
+    function &test(): void {}
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedReturnByReferenceFromVoid sniff.
+ *
+ * @group removedReturnByReferenceFromVoid
+ * @group functiondeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\RemovedReturnByReferenceFromVoidSniff
+ *
+ * @since 10.0.0
+ */
+class RemovedReturnByReferenceFromVoidUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test that returning by reference from a void function is detected correctly.
+     *
+     * @dataProvider dataReturnByReferenceFromVoid
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testReturnByReferenceFromVoid($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertWarning($file, $line, 'Returning by reference from a void function is deprecated since PHP 8.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testReturnByReferenceFromVoid()
+     *
+     * @return array
+     */
+    public function dataReturnByReferenceFromVoid()
+    {
+        return [
+            [54],
+            [56],
+            [59],
+            [63],
+            [67],
+            [71],
+            [75],
+        ];
+    }
+
+
+    /**
+     * Verify that there are no false positives for valid code.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+
+        // No errors expected on the first 50 lines.
+        for ($line = 1; $line <= 50; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Returning by reference from a void function
> ```php
> <?php
> function &test(): void {}
> ```
> Such a function is contradictory, and already emits the following `E_NOTICE` when called: `Only variable references should be returned by reference`.

New sniff to detect this deprecation.

Includes unit tests.
Includes docs.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_1#return_by_reference_with_void_type
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.void-by-ref
* https://github.com/php/php-src/commit/f0b190c32d41e03c94905f16eed269fba7d827c3

Related to #1299