### PR TITLE
PHP 8.1: New `PHPCompatibility.Classes.NewFinalClassConstants` sniff

### DIFF
--- a/PHPCompatibility/Docs/Classes/NewFinalClassConstantsStandard.xml
+++ b/PHPCompatibility/Docs/Classes/NewFinalClassConstantsStandard.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<documentation title="New final class constants">
+    <standard>
+    <![CDATA[
+    Class constants can be declared as final since PHP 8.1.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: not using the final modifier.">
+        <![CDATA[
+class Foo {
+    const BAR = 10;
+}
+        ]]>
+        </code>
+        <code title="PHP >= 8.1: using the final modifier.">
+        <![CDATA[
+class Foo {
+    <em>final</em> const BAR = 10;
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Classes/NewFinalClassConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewFinalClassConstantsSniff.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Using the "final" modifier for class constants is available since PHP 8.1.
+ *
+ * PHP version 8.1
+ *
+ * @link https://wiki.php.net/rfc/final_class_const
+ * @link https://www.php.net/manual/en/language.oop5.final.php#language.oop5.final.example.php81
+ *
+ * @since 10.0.0
+ */
+class NewFinalClassConstantsSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_CONST];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('8.0') === false) {
+            return;
+        }
+
+        // Is this a class constant ?
+        if (Scopes::isOOConstant($phpcsFile, $stackPtr) === false) {
+            return;
+        }
+
+        $tokens    = $phpcsFile->getTokens();
+        $skip      = Tokens::$emptyTokens + Tokens::$scopeModifiers;
+        $prevToken = $phpcsFile->findPrevious($skip, ($stackPtr - 1), null, true, null, true);
+
+        // Is the previous token the final keyword ?
+        if ($prevToken === false || $tokens[$prevToken]['code'] !== \T_FINAL) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'The final modifier for class constants is not supported in PHP 8.0 or earlier.',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewFinalClassConstantsUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewFinalClassConstantsUnitTest.inc
@@ -1,0 +1,68 @@
+<?php
+
+const NONCLASSCONST = 'foo';
+
+class ConstDemo
+{
+    const MY_CONST = 1;
+
+    // PHP 8.1+.
+    final const FINAL_A = 2;
+    final public const FINAL_PUBLIC_CONST_A = 3;
+    public final const FINAL_PUBLIC_CONST_B = 4;
+    final protected const FINAL_PROTECTED_CONST_A = 5;
+    protected final const FINAL_PROTECTED_CONST_B = 6;
+
+    // Fatal error as final with private is an oxymoron.
+    final private const FINAL_PRIVATE_CONST_A = 7;
+    private final const FINAL_PRIVATE_CONST_B = 8;
+}
+
+interface InterfaceDemo
+{
+    const MY_CONST = 1;
+
+    // PHP 8.1+.
+    final const FINAL_A = 2;
+    final public /*comment*/ const FINAL_PUBLIC_CONST_A = 3;
+    public final const FINAL_PUBLIC_CONST_B = 4;
+
+    // Fatal error as interface constants must be public, but the check for which visibility indicator is used is outside the scope of this sniff.
+    final /*comment*/ protected const FINAL_PROTECTED_CONST_A = 5;
+    protected final const FINAL_PROTECTED_CONST_B = 6;
+
+    // Fatal error as final with private is an oxymoron.
+    final private const FINAL_PRIVATE_CONST_A = 7;
+    private final const FINAL_PRIVATE_CONST_B = 8;
+}
+
+// Test anonymous classes.
+$a = new class
+{
+    const MY_CONST = 1;
+
+    // PHP 8.1+.
+    final const FINAL_A = 2;
+    final public const FINAL_PUBLIC_CONST_A = 3;
+    public final const FINAL_PUBLIC_CONST_B = 4;
+    final protected const FINAL_PROTECTED_CONST_A = 5;
+    protected final const FINAL_PROTECTED_CONST_B = 6;
+
+    // Fatal error as final with private is an oxymoron.
+    final private const FINAL_PRIVATE_CONST_A = 7;
+    private final const FINAL_PRIVATE_CONST_B = 8;
+};
+
+/*
+ * Test against some false positives.
+ *
+ * Constants defined in the global namespace can not have the final modifier,
+ * but this is outside the scope of this library. Would cause a parse error anyway.
+ */
+final const GLOBAL_CONSTANT = 'not valid';
+
+class NotAClassConstant {
+    public function something() {
+        final const GLOBAL_CONSTANT = 'not valid';
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewFinalClassConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewFinalClassConstantsUnitTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewFinalClassConstants sniff.
+ *
+ * @group newFinalClassConstants
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewFinalClassConstantsSniff
+ *
+ * @since 10.0.0
+ */
+class NewFinalClassConstantsUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test that an error is thrown for class constants declared as final.
+     *
+     * @dataProvider dataFinalClassConstants
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testFinalClassConstants($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'The final modifier for class constants is not supported in PHP 8.0 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testFinalClassConstants()
+     *
+     * @return array
+     */
+    public function dataFinalClassConstants()
+    {
+        return [
+            [10],
+            [11],
+            [12],
+            [13],
+            [14],
+            [17],
+            [18],
+
+            [26],
+            [27],
+            [28],
+            [31],
+            [32],
+            [35],
+            [36],
+
+            [45],
+            [46],
+            [47],
+            [48],
+            [49],
+            [52],
+            [53],
+        ];
+    }
+
+
+    /**
+     * Verify that there are no false positives for valid code/code errors outside the scope of this sniff.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return [
+            [3],
+            [7],
+            [23],
+            [42],
+            [62],
+            [66],
+        ];
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Added support for the final modifier for class constants. Also, interface constants become overridable by default.

New sniff to detect this new feature.

Note: the sniff does not do anything special for non-final interface constants which previously were not overridable.

Includes unit tests.
Includes docs.

Refs:
* https://wiki.php.net/rfc/final_class_const
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.final-constants
* https://www.php.net/manual/en/language.oop5.final.php#language.oop5.final.example.php81
* https://github.com/php/php-src/pull/6878
* https://github.com/php/php-src/commit/a5360e80c27fcf2e1a3e4c4602940fd1d7a8ce89

Related to #1299