### PR TITLE
Classes/NewConstVisibility: account for PHP 8.1 final class constants

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -57,8 +57,11 @@ class NewConstVisibilitySniff extends Sniff
             return;
         }
 
-        $tokens    = $phpcsFile->getTokens();
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $tokens = $phpcsFile->getTokens();
+        $skip   = Tokens::$emptyTokens;
+        $skip[] = \T_FINAL;
+
+        $prevToken = $phpcsFile->findPrevious($skip, ($stackPtr - 1), null, true, null, true);
 
         // Is the previous token a visibility indicator ?
         if ($prevToken === false || isset(Tokens::$scopeModifiers[$tokens[$prevToken]['code']]) === false) {

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.inc
@@ -33,7 +33,7 @@ $a = new class
     public const PUBLIC_CONST_B = 2;
     protected const PROTECTED_CONST = 3;
     private const PRIVATE_CONST = 4;
-}
+};
 
 /*
  * Test against some false positives.
@@ -47,4 +47,14 @@ class NotAClassConstant {
     public function something() {
         public const GLOBAL_CONSTANT = 'not valid';
     }
+}
+
+/*
+ * Make sure the sniff will still work correctly when PHP 8.1 final constants are declared.
+ */
+class FinalConstDemo
+{
+    public final const FINAL_PUBLIC_CONST_B = 4;
+    protected final const FINAL_PROTECTED_CONST_B = 6;
+    private final const FINAL_PRIVATE_CONST_B = 8;
 }

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
@@ -26,7 +26,7 @@ class NewConstVisibilityUnitTest extends BaseSniffTest
 {
 
     /**
-     * testConstVisibility
+     * Test that an error is thrown for class constants declared with visibility.
      *
      * @dataProvider dataConstVisibility
      *
@@ -61,12 +61,16 @@ class NewConstVisibilityUnitTest extends BaseSniffTest
             [33],
             [34],
             [35],
+
+            [57],
+            [58],
+            [59],
         ];
     }
 
 
     /**
-     * testNoFalsePositives
+     * Verify that there are no false positives for valid code.
      *
      * @dataProvider dataNoFalsePositives
      *


### PR DESCRIPTION
Prevent the sniff from not reporting on this issue when PHP 8.1 `final` class constants are used with the `final` keyword between the visibility modifier and the `const` keyword.

Includes unit tests.
Includes fixing a parse error in the test case file.
Includes touching up the documentation of the test file.

Related to #1299