### PR TITLE
PHP 8.1 | RemovedIniDirectives: account for PHP 8.1 changes

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -600,6 +600,9 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         'auto_detect_line_endings' => [
             '8.1' => false,
         ],
+        'log_errors_max_len' => [
+            '8.1' => true,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -615,6 +615,14 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             '8.1'       => false,
             'extension' => 'date',
         ],
+        'filter.default' => [
+            '8.1'       => false,
+            'extension' => 'filter',
+        ],
+        'filter.default_options' => [
+            '8.1'       => false,
+            'extension' => 'filter',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -603,6 +603,18 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         'log_errors_max_len' => [
             '8.1' => true,
         ],
+        'date.default_latitude' => [
+            '8.1'       => false,
+            'extension' => 'date',
+        ],
+        'date.default_longitude' => [
+            '8.1'       => false,
+            'extension' => 'date',
+        ],
+        'date.sunset_zenith' => [
+            '8.1'       => false,
+            'extension' => 'date',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -596,6 +596,10 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         'assert.quiet_eval' => [
             '8.0' => true,
         ],
+
+        'auto_detect_line_endings' => [
+            '8.1' => false,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -623,6 +623,10 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             '8.1'       => false,
             'extension' => 'filter',
         ],
+        'oci8.old_oci_close_semantics' => [
+            '8.1'       => false,
+            'extension' => 'oci8',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -441,3 +441,9 @@ $test = ini_get('date.default_longitude');
 
 ini_set('date.sunset_zenith', 0);
 $test = ini_get('date.sunset_zenith');
+
+ini_set('filter.default', 0);
+$test = ini_get('filter.default');
+
+ini_set('filter.default_options', 0);
+$test = ini_get('filter.default_options');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -447,3 +447,6 @@ $test = ini_get('filter.default');
 
 ini_set('filter.default_options', 0);
 $test = ini_get('filter.default_options');
+
+ini_set('oci8.old_oci_close_semantics', 0);
+$test = ini_get('oci8.old_oci_close_semantics');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -426,3 +426,6 @@ $test = ini_get('sybase.compatability_mode');
 
 ini_set('assert.quiet_eval', 0);
 $test = ini_get('assert.quiet_eval');
+
+ini_set('auto_detect_line_endings', 0);
+$test = ini_get('auto_detect_line_endings');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -429,3 +429,6 @@ $test = ini_get('assert.quiet_eval');
 
 ini_set('auto_detect_line_endings', 0);
 $test = ini_get('auto_detect_line_endings');
+
+ini_set('log_errors_max_len', 0);
+$test = ini_get('log_errors_max_len');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -432,3 +432,12 @@ $test = ini_get('auto_detect_line_endings');
 
 ini_set('log_errors_max_len', 0);
 $test = ini_get('log_errors_max_len');
+
+ini_set('date.default_latitude', 0);
+$test = ini_get('date.default_latitude');
+
+ini_set('date.default_longitude', 0);
+$test = ini_get('date.default_longitude');
+
+ini_set('date.sunset_zenith', 0);
+$test = ini_get('date.sunset_zenith');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -160,6 +160,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             ['date.default_latitude', '8.1', [436, 437], '8.0'],
             ['date.default_longitude', '8.1', [439, 440], '8.0'],
             ['date.sunset_zenith', '8.1', [442, 443], '8.0'],
+            ['filter.default', '8.1', [445, 446], '8.0'],
+            ['filter.default_options', '8.1', [448, 449], '8.0'],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -162,6 +162,7 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             ['date.sunset_zenith', '8.1', [442, 443], '8.0'],
             ['filter.default', '8.1', [445, 446], '8.0'],
             ['filter.default_options', '8.1', [448, 449], '8.0'],
+            ['oci8.old_oci_close_semantics', '8.1', [451, 452], '8.0'],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -157,6 +157,9 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             ['allow_url_include', '7.4', [238, 239], '7.3'],
 
             ['auto_detect_line_endings', '8.1', [430, 431], '8.0'],
+            ['date.default_latitude', '8.1', [436, 437], '8.0'],
+            ['date.default_longitude', '8.1', [439, 440], '8.0'],
+            ['date.sunset_zenith', '8.1', [442, 443], '8.0'],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -358,6 +358,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             ['ibase.timeformat', '7.4', [214, 215], '7.3'],
 
             ['assert.quiet_eval', '8.0', [427, 428], '7.4'],
+
+            ['log_errors_max_len', '8.1', [433, 434], '8.0'],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -155,6 +155,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             ['mbstring.internal_encoding', '5.6', [77, 78], '5.5'],
 
             ['allow_url_include', '7.4', [238, 239], '7.3'],
+
+            ['auto_detect_line_endings', '8.1', [430, 431], '8.0'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.1 | RemovedIniDirectives: handle deprecated `auto_detect_line_endings` ini directive

> The `auto_detect_line_endings` INI directive is deprecated. If necessary, handle "\r" line breaks manually instead.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.standard
* https://wiki.php.net/rfc/deprecations_php_8_1#auto_detect_line_endings_ini_setting
* https://github.com/php/php-src/commit/232aa34b9f01ee33fe0fa73ec7a6521a00dd0cc8

### PHP 8.1 | RemovedIniDirectives: handle removed log_errors_max_len ini directive

> The `log_errors_max_len` ini setting has been removed. It no longer had an effect since PHP 8.0.

Includes unit tests.

Refs:
* https://github.com/php/php-src/blob/3a71fcf5caf042a4ce8a586a6b554fd70432e1e2/UPGRADING#L622-L623
* https://github.com/php/php-src/pull/6838
* https://github.com/php/php-src/commit/3ccc0409ceb6d187b9fa5a3b599327ed3e59ff0a

### PHP 8.1 | RemovedIniDirectives: handle deprecated date ini directives

> The ini settings `date.default_latitude`, `date.default_longitude` and `date.sunset_zenith` are marked as deprecated in the documentation. In the next major version, ... the ini settings will be removed.

Note: these ini settings are "soft" deprecated in PHP (i.e. without notice).

Includes unit tests.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_1#date_sunrise_and_date_sunset
* https://github.com/php/php-src/pull/7222
* https://github.com/php/php-src/commit/5bb83b3778db3eece47207f4b4b5d8331e839cd5

### PHP 8.1 | RemovedIniDirectives: handle deprecated filter.default ini directive

> The `filter.default` INI directive is deprecated.

Note: the `filter.default_options` ini directive is "soft" deprecated, i.e. PHP will not throw a deprecation notice, but the RFC covers that the ini directive _will_ be removed in PHP 9.0.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.filter
* https://wiki.php.net/rfc/deprecations_php_8_1#filterdefault_ini_setting
* https://github.com/php/php-src/commit/aa733e8ac884db7c3d8fcde376074f2627668199

### PHP 8.1 | RemovedIniDirectives: handle deprecated oci8 ini directive

> The `oci8.old_oci_close_semantics` INI directive is deprecated.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.oci8
* https://wiki.php.net/rfc/deprecations_php_8_1#oci8old_oci_close_semantics_ini_setting
* https://github.com/php/php-src/pull/7258
* https://github.com/php/php-src/commit/e120d5269a31cb40d422e8617428a430bcda78c1


Related to #1299