### PR TITLE
PHP 8.1 | RemovedFunctions: account for PHP 8.1 changes

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4910,6 +4910,26 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '8.1'         => false,
             'alternative' => 'date() or IntlDateFormatter::format()',
         ],
+        'mhash_count' => [
+            '8.1'         => false,
+            'alternative' => 'the hash_*() functions',
+        ],
+        'mhash_get_block_size' => [
+            '8.1'         => false,
+            'alternative' => 'the hash_*() functions',
+        ],
+        'mhash_get_hash_name' => [
+            '8.1'         => false,
+            'alternative' => 'the hash_*() functions',
+        ],
+        'mhash_keygen_s2k' => [
+            '8.1'         => false,
+            'alternative' => 'the hash_*() functions',
+        ],
+        'mhash' => [
+            '8.1'         => false,
+            'alternative' => 'the hash_*() functions',
+        ],
     ];
 
 

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4889,6 +4889,27 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '8.0'         => false,
             'alternative' => 'ZipArchive',
         ],
+
+        'date_sunrise' => [
+            '8.1'         => false,
+            'alternative' => 'date_sun_info()',
+        ],
+        'date_sunset' => [
+            '8.1'         => false,
+            'alternative' => 'date_sun_info()',
+        ],
+        'strptime' => [
+            '8.1'         => false,
+            'alternative' => 'date_parse_from_format() or IntlDateFormatter::parse()',
+        ],
+        'strftime' => [
+            '8.1'         => false,
+            'alternative' => 'date() or IntlDateFormatter::format()',
+        ],
+        'gmstrftime' => [
+            '8.1'         => false,
+            'alternative' => 'date() or IntlDateFormatter::format()',
+        ],
     ];
 
 

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4930,6 +4930,9 @@ class RemovedFunctionsSniff extends AbstractRemovedFeatureSniff
             '8.1'         => false,
             'alternative' => 'the hash_*() functions',
         ],
+        'odbc_result_all' => [
+            '8.1' => false,
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1221,3 +1221,8 @@ date_sunset();
 strptime();
 strftime();
 gmstrftime();
+mhash_count();
+mhash_get_block_size();
+mhash_get_hash_name();
+mhash_keygen_s2k();
+mhash();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1226,3 +1226,4 @@ mhash_get_block_size();
 mhash_get_hash_name();
 mhash_keygen_s2k();
 mhash();
+odbc_result_all();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1216,4 +1216,8 @@ pg_setclientencoding();
 imap_header();
 shmop_close();
 openssl_free_key();
-
+date_sunrise();
+date_sunset();
+strptime();
+strftime();
+gmstrftime();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -73,6 +73,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             ['openssl_pkey_free', '8.0', [1190], '7.4'],
             ['shmop_close', '8.0', [1217], '7.4'],
             ['openssl_free_key', '8.0', [1218], '7.4'],
+            ['odbc_result_all', '8.1', [1229], '8.0'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -212,6 +212,11 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             ['strptime', '8.1', 'date_parse_from_format() or IntlDateFormatter::parse()', [1221], '8.0'],
             ['strftime', '8.1', 'date() or IntlDateFormatter::format()', [1222], '8.0'],
             ['gmstrftime', '8.1', 'date() or IntlDateFormatter::format()', [1223], '8.0'],
+            ['mhash_count', '8.1', 'the hash_*() functions', [1224], '8.0'],
+            ['mhash_get_block_size', '8.1', 'the hash_*() functions', [1225], '8.0'],
+            ['mhash_get_hash_name', '8.1', 'the hash_*() functions', [1226], '8.0'],
+            ['mhash_keygen_s2k', '8.1', 'the hash_*() functions', [1227], '8.0'],
+            ['mhash', '8.1', 'the hash_*() functions', [1228], '8.0'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -206,6 +206,12 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             ['pg_numrows', '8.0', 'pg_num_rows()', [1213], '7.4'],
             ['pg_result', '8.0', 'pg_fetch_result()', [1214], '7.4'],
             ['pg_setclientencoding', '8.0', 'pg_set_client_encoding()', [1215], '7.4'],
+
+            ['date_sunrise', '8.1', 'date_sun_info()', [1219], '8.0'],
+            ['date_sunset', '8.1', 'date_sun_info()', [1220], '8.0'],
+            ['strptime', '8.1', 'date_parse_from_format() or IntlDateFormatter::parse()', [1221], '8.0'],
+            ['strftime', '8.1', 'date() or IntlDateFormatter::format()', [1222], '8.0'],
+            ['gmstrftime', '8.1', 'date() or IntlDateFormatter::format()', [1223], '8.0'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.1 | RemovedFunctions: handle deprecated DateTime functions

> `date_sunrise()` and `date_sunset()` have been deprecated in favor of `date_sun_info()`.
>
> `strptime()` has been deprecated. Use `date_parse_from_format()` instead (for locale-independent parsing), or `IntlDateFormatter::parse()` (for locale-dependent parsing).
>
> `strftime()` and `gmstrftime()` have been deprecated. Use `date()` instead (for locale-independent formatting), or `IntlDateFormatter::format()` (for locale-dependent formatting).

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.date
* https://wiki.php.net/rfc/deprecations_php_8_1#date_sunrise_and_date_sunset
* https://github.com/php/php-src/commit/5bb83b3778db3eece47207f4b4b5d8331e839cd5
* https://wiki.php.net/rfc/deprecations_php_8_1#strptime
* https://github.com/php/php-src/commit/bed71393755a84b29eed89327f36e3b6f487ba2b
* https://wiki.php.net/rfc/deprecations_php_8_1#strftime_and_gmstrftime
* https://github.com/php/php-src/commit/4b3615a33ff376281ddd1e228237b435a9738521

### PHP 8.1 | RemovedFunctions: handle deprecated mhash_*() functions

> The `mhash()`, `mhash_keygen_s2k()`, `mhash_count()`, `mhash_get_block_size()`, and `mhash_get_hash_name()` have been deprecated. Use the `hash_*()` functions instead.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.hash
* https://wiki.php.net/rfc/deprecations_php_8_1#mhash_function_family
* https://github.com/php/php-src/commit/bf0c1ce1a0d3418f2f436af09380d6928e0a0dfd

### PHP 8.1 | RemovedFunctions: handle deprecated odbc_result_all() function

> `odbc_result_all()` has been deprecated.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.odbc
* https://wiki.php.net/rfc/deprecations_php_8_1#odbc_result_all
* https://github.com/php/php-src/commit/1c07b11b1c25294e368a647ec74e5c09f9b2ed68

Related to #1299