### PR TITLE
PHP 8.1 | RemovedFunctionParameters: account for PHP 8.1 changes

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -73,6 +73,28 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
                 '8.0'  => true,
             ],
         ],
+        /*
+         * For the below three functions, it's actually the 3rd (pos: 2) parameter which has been deprecated.
+         * However with positional arguments, this can only be detected by checking for the "old last" argument.
+         */
+        'imagepolygon' => [
+            3 => [
+                'name' => 'num_points',
+                '8.1'  => false,
+            ],
+        ],
+        'imageopenpolygon' => [
+            3 => [
+                'name' => 'num_points',
+                '8.1'  => false,
+            ],
+        ],
+        'imagefilledpolygon' => [
+            3 => [
+                'name' => 'num_points',
+                '8.1'  => false,
+            ],
+        ],
         'ldap_first_attribute' => [
             2 => [
                 'name'  => 'ber_identifier',

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -120,6 +120,12 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
                 '7.0'  => true,
             ],
         ],
+        'mysqli_get_client_info' => [
+            0 => [
+                'name' => 'mysql',
+                '8.1'  => false,
+            ],
+        ],
         'odbc_do' => [
             2 => [
                 'name' => 'flags',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -36,3 +36,5 @@ odbc_do($connection_id, $query_string, $flags); // Error.
 imagepolygon($image, $points, $num_points, $color); // Warning.
 imageopenpolygon($image, $points, $num_points, $color); // Warning.
 imagefilledpolygon($image, $points, $num_points, $color); // Warning.
+
+mysqli_get_client_info($mysql); // Warning.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -32,3 +32,7 @@ imap_headerinfo($imap_stream, $msg_number, $fromlength, $subjectlength, $default
 odbc_exec($connection_id, $query_string); // OK.
 odbc_exec($connection_id, $query_string, $flags); // Error.
 odbc_do($connection_id, $query_string, $flags); // Error.
+
+imagepolygon($image, $points, $num_points, $color); // Warning.
+imageopenpolygon($image, $points, $num_points, $color); // Warning.
+imagefilledpolygon($image, $points, $num_points, $color); // Warning.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -33,7 +33,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
      * @param string $functionName  Function name.
      * @param string $parameterName Parameter name.
      * @param string $removedIn     The PHP version in which the parameter was removed.
-     * @param array  $lines         The line numbers in the test file which apply to this class.
+     * @param array  $lines         The line numbers in the test file which apply to this parameter.
      * @param string $okVersion     A PHP version in which the parameter was ok to be used.
      * @param string $testVersion   Optional. A PHP version in which to test for the removal message.
      *
@@ -86,7 +86,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
      * @param string $parameterName Parameter name.
      * @param string $deprecatedIn  The PHP version in which the parameter was deprecated.
      * @param string $removedIn     The PHP version in which the parameter was removed.
-     * @param array  $lines         The line numbers in the test file which apply to this class.
+     * @param array  $lines         The line numbers in the test file which apply to this parameter.
      * @param string $okVersion     A PHP version in which the parameter was ok to be used.
      *
      * @return void
@@ -129,6 +129,52 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             ['curl_version', 'age', '7.4', '8.0', [19], '7.3'],
             ['curl_version', 'age', '7.4', '8.0', [20], '7.3'],
             ['curl_version', 'age', '7.4', '8.0', [21], '7.3'],
+        ];
+    }
+
+
+    /**
+     * Test that use of a deprecated parameter is detected correctly.
+     *
+     * @dataProvider dataDeprecatedParameter
+     *
+     * @param string $functionName  Function name.
+     * @param string $parameterName Parameter name.
+     * @param string $deprecatedIn  The PHP version in which the parameter was deprecated.
+     * @param array  $lines         The line numbers in the test file which apply to this parameter.
+     * @param string $okVersion     A PHP version in which the parameter was ok to be used.
+     * @param string $testVersion   Optional. A PHP version in which to test for the deprecation message.
+     *
+     * @return void
+     */
+    public function testDeprecatedParameter($functionName, $parameterName, $deprecatedIn, $lines, $okVersion, $testVersion = null)
+    {
+        $file = $this->sniffFile(__FILE__, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        $errorVersion = (isset($testVersion)) ? $testVersion : $deprecatedIn;
+        $file         = $this->sniffFile(__FILE__, $errorVersion);
+        $error        = "The \"{$parameterName}\" parameter for function {$functionName}() is deprecated since PHP {$deprecatedIn}";
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, $error);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDeprecatedParameter()
+     *
+     * @return array
+     */
+    public function dataDeprecatedParameter()
+    {
+        return [
+            ['imagepolygon', 'num_points', '8.1', [36], '8.0'],
+            ['imageopenpolygon', 'num_points', '8.1', [37], '8.0'],
+            ['imagefilledpolygon', 'num_points', '8.1', [38], '8.0'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -175,6 +175,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             ['imagepolygon', 'num_points', '8.1', [36], '8.0'],
             ['imageopenpolygon', 'num_points', '8.1', [37], '8.0'],
             ['imagefilledpolygon', 'num_points', '8.1', [38], '8.0'],
+            ['mysqli_get_client_info', 'mysql', '8.1', [40], '8.0'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.1 | RemovedFunctionParameters: handle deprecated $num_points parameter for `image*polygon()` functions

> GD:
> The `$num_points` parameter of `image(open|filled)polygon` has been deprecated.

Includes unit tests.

Refs:
* https://github.com/php/php-src/blob/f67986a9218f4889d9352a87c29337a5b6eaa4bd/UPGRADING#L397-L398
* https://wiki.php.net/rfc/deprecations_php_8_1#num_points_parameter_of_image_open_filled_polygon
* https://github.com/php/php-src/pull/6789
* https://github.com/php/php-src/commit/e1285c4aa5eba7d1cc2865400c0c165201f9e5f8

### PHP 8.1 | RemovedFunctionParameters: handle deprecated $mysql parameter for `mysqli_get_client_info()`

> Calling `mysqli::get_client_info()` or `mysqli_get_client_info()` with the `mysqli` argument has been deprecated. Call `mysqli_get_client_info()` without any arguments to obtain the version information of the client library.

Includes unit tests.

Refs:
* https://github.com/php/php-src/blob/3a71fcf5caf042a4ce8a586a6b554fd70432e1e2/UPGRADING#L423-L426
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.mysqli
* https://github.com/php/php-src/pull/6777
* https://github.com/php/php-src/commit/7e9f6d2a48f8ff6ae458252d395eec1b1d9e6f14


Related to #1299