### PR TITLE
PHP 8.1 | NewClasses: account for PHP 8.1 changes

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -767,6 +767,11 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '7.4' => false,
             '8.0' => true,
         ],
+
+        'IntlDatePatternGenerator' => [
+            '8.0' => false,
+            '8.1' => true,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -781,6 +781,11 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '8.1'       => true,
             'extension' => 'reflection',
         ],
+        'CURLStringFile' => [
+            '8.0'       => false,
+            '8.1'       => true,
+            'extension' => 'curl',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -772,6 +772,15 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             '8.0' => false,
             '8.1' => true,
         ],
+        'Fiber' => [
+            '8.0' => false,
+            '8.1' => true,
+        ],
+        'ReflectionFiber' => [
+            '8.0'       => false,
+            '8.1'       => true,
+            'extension' => 'reflection',
+        ],
     ];
 
     /**
@@ -986,6 +995,11 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         'ValueError' => [
             '7.4' => false,
             '8.0' => true,
+        ],
+
+        'FiberError' => [
+            '8.0' => false,
+            '8.1' => true,
         ],
     ];
 

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -435,3 +435,4 @@ try {
 	$fiber = new Fiber();
 	$reflect = new ReflectionFiber($fiber);
 } catch( FiberError $e ) {}
+$file = new CURLStringFile($data, 'filename.txt', 'text/plain');

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -429,3 +429,5 @@ try {
 }
 
 class MyAttribute extends \Attribute {}
+
+$generator = new IntlDatePatternGenerator();

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -431,3 +431,7 @@ try {
 class MyAttribute extends \Attribute {}
 
 $generator = new IntlDatePatternGenerator();
+try {
+	$fiber = new Fiber();
+	$reflect = new ReflectionFiber($fiber);
+} catch( FiberError $e ) {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -215,6 +215,7 @@ class NewClassesUnitTest extends BaseSniffTest
             ['OCICollection', '7.4', [424], '8.0'],
             ['OCILob', '7.4', [425], '8.0'],
             ['Attribute', '7.4', [431], '8.0'],
+            ['IntlDatePatternGenerator', '8.0', [433], '8.1'],
 
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -218,6 +218,7 @@ class NewClassesUnitTest extends BaseSniffTest
             ['IntlDatePatternGenerator', '8.0', [433], '8.1'],
             ['Fiber', '8.0', [435], '8.1'],
             ['ReflectionFiber', '8.0', [436], '8.1'],
+            ['CURLStringFile', '8.0', [438], '8.1'],
 
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -216,6 +216,8 @@ class NewClassesUnitTest extends BaseSniffTest
             ['OCILob', '7.4', [425], '8.0'],
             ['Attribute', '7.4', [431], '8.0'],
             ['IntlDatePatternGenerator', '8.0', [433], '8.1'],
+            ['Fiber', '8.0', [435], '8.1'],
+            ['ReflectionFiber', '8.0', [436], '8.1'],
 
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],
@@ -262,6 +264,7 @@ class NewClassesUnitTest extends BaseSniffTest
             ['FFI\ParserException', '7.3', [349], '7.4'],
             ['UnhandledMatchError', '7.4', [428], '8.0'],
             ['ValueError', '7.4', [418, 419], '8.0'],
+            ['FiberError', '8.0', [437], '8.1'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.1 | NewClasses: handle new IntlDatePatternGenerator class

Note: in contrast to the original RFC proposal, [the procedural functions mentioned in the RFC were not included in the final implementation](https://github.com/php/php-src/pull/6771#issuecomment-1053656447).

Includes unit test.

Refs:
* https://www.php.net/manual/en/migration81.new-classes.php#migration81.new-classes.intl
* https://wiki.php.net/rfc/intldatetimepatterngenerator
* https://github.com/php/php-src/pull/6771
* https://github.com/php/php-src/commit/ae9f6e7a8f51b8c41a2267303f9e31aafafd2dd6

### PHP 8.1 | NewClasses: add support for Fibers

> Support for Fibers has been added.

I've gone through all PRs I could find related to this and these were the only classes I could find to account for.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.fibers
* https://wiki.php.net/rfc/fibers
* https://www.php.net/manual/en/language.fibers.php
* https://github.com/php/php-src/pull/6875
* https://github.com/php/php-src/commit/c276c16b6627222c40bd43907475d664734b9abe

### PHP 8.1 | NewClasses: handle new CURLStringFile class

> Added `CURLStringFile`, which can be used to post a file from a string rather
> than a file:
> ```php
> $file = new CURLStringFile($data, 'filename.txt', 'text/plain');
> curl_setopt($curl, CURLOPT_POSTFIELDS, ['file' => $file]);
> ```

Includes unit test.

Refs:
* https://github.com/php/php-src/blob/f67986a9218f4889d9352a87c29337a5b6eaa4bd/UPGRADING#L231-L235
* https://github.com/php/php-src/pull/6456
* https://github.com/php/php-src/commit/e727919b97c4baeca93cb7700d4adf2e35a3530f


Related to #1299