### PR TITLE
PHP 8.1 | NewIniDirectives: account for PHP 8.1 changes

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -894,6 +894,10 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '8.1'       => true,
             'extension' => 'mysqli',
         ],
+        'pm.max_spawn_rate' => [
+            '8.0' => false,
+            '8.1' => true,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -884,6 +884,11 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '7.4' => false,
             '8.0' => true,
         ],
+
+        'fiber.stack_size' => [
+            '8.0' => false,
+            '8.1' => true,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -889,6 +889,11 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             '8.0' => false,
             '8.1' => true,
         ],
+        'mysqli.local_infile_directory' => [
+            '8.0'       => false,
+            '8.1'       => true,
+            'extension' => 'mysqli',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -541,3 +541,6 @@ $test = ini_get('fiber.stack_size');
 
 ini_set('mysqli.local_infile_directory', 10);
 $test = ini_get('mysqli.local_infile_directory');
+
+ini_set('pm.max_spawn_rate', 10);
+$test = ini_get('pm.max_spawn_rate');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -538,3 +538,6 @@ $test = ini_get('com.dotnet_version');
 
 ini_set('fiber.stack_size', 10);
 $test = ini_get('fiber.stack_size');
+
+ini_set('mysqli.local_infile_directory', 10);
+$test = ini_get('mysqli.local_infile_directory');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -535,3 +535,6 @@ $test = ini_get('pm.status_listen');
 
 ini_set('com.dotnet_version', 'v4.0.30319');
 $test = ini_get('com.dotnet_version');
+
+ini_set('fiber.stack_size', 10);
+$test = ini_get('fiber.stack_size');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -265,6 +265,8 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             ['com.dotnet_version', '8.0', [536, 537], '7.4'],
             ['pm.status_listen', '8.0', [533, 534], '7.4'],
             ['zend.exception_string_param_max_len', '8.0', [530, 531], '7.4'],
+
+            ['fiber.stack_size', '8.1', [539, 540], '8.0'],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -267,6 +267,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             ['zend.exception_string_param_max_len', '8.0', [530, 531], '7.4'],
 
             ['fiber.stack_size', '8.1', [539, 540], '8.0'],
+            ['mysqli.local_infile_directory', '8.1', [542, 543], '8.0'],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -268,6 +268,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
 
             ['fiber.stack_size', '8.1', [539, 540], '8.0'],
             ['mysqli.local_infile_directory', '8.1', [542, 543], '8.0'],
+            ['pm.max_spawn_rate', '8.1', [545, 546], '8.0'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.1 | NewIniDirectives: add support for Fibers

> Support for Fibers has been added.

I've gone through all PRs I could find related to this and this was the only in directive I could find to account for.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.fibers
* https://wiki.php.net/rfc/fibers
* https://www.php.net/manual/en/language.fibers.php
* https://github.com/php/php-src/pull/6875
* https://github.com/php/php-src/commit/c276c16b6627222c40bd43907475d664734b9abe

### PHP 8.1 | NewIniDirectives: handle new `mysqli.local_infile_directory` ini

> New INI directive `mysqli.local_infile_directory`
>
> The `mysqli.local_infile_directory` INI directive has been added, which can be used to specify a directory from which files are allowed to be loaded. It is > only meaningful if `mysqli.allow_local_infile` is not enabled, as all directories are allowed in that case.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.mysqli.local_infile_directory
* https://github.com/php/php-src/pull/6448
* https://github.com/php/php-src/commit/da011a312a6c6cd7ff12fe1aa0de1e33fba2f167

### PHP 8.1 | NewIniDirectives: handle new pm.max_spawn_rate ini

> - FPM:
>   . Added new pool option for the dynamic process manager called
>     `pm.max_spawn_rate`. It allows to start number of children in a faster rate
>     when dynamic pm is selected. The default value is 32 which was the previous
>     hard coded value.

Includes unit tests.

Refs:
* https://github.com/php/php-src/blob/f67986a9218f4889d9352a87c29337a5b6eaa4bd/UPGRADING#L240-L243
* https://github.com/php/php-src/blob/33cd61c9045ae8675448456cdda6fb244b2efa01/NEWS#L280-L281
* https://github.com/php/php-src/pull/6753
* https://github.com/php/php-src/commit/eac1609a847f7cca45c9c14e1b9c4d72cea04fd6

Related to #1299