### PR TITLE
PHP 8.1: New PHPCompatibility.Interfaces.RemovedSerializable sniff

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
@@ -1,0 +1,396 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Interfaces;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Detect use of "only Serializable" classes which is deprecated as of PHP 8.1.0.
+ *
+ * A class is "only Serializable" if it is non-abstract, implements Serializable,
+ * and does not implement __serialize() and __unserialize().
+ *
+ * As of PHP 8.1, declaring an "only Serializable" class will throw a deprecation warning.
+ * Other implementations of Serializable will be accepted without a deprecation warning,
+ * because libraries supporting PHP < 7.4 will generally need to implement both the
+ * old and new mechanisms.
+ *
+ * If PHP < 7.4 does not need to be supported, the Serializable implementation can be removed
+ * in favour of only implementing the magic methods.
+ *
+ * As of PHP 9.0, the Serializable interface will be removed.
+ *
+ * PHP version 8.1
+ * PHP version 9.0
+ *
+ * @link https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.serialize-interface
+ * @link https://wiki.php.net/rfc/phase_out_serializable
+ * @link https://www.php.net/manual/en/class.serializable.php
+ * @link https://www.php.net/manual/en/language.oop5.magic.php#object.serialize
+ *
+ * @since 10.0.0
+ */
+class RemovedSerializableSniff extends Sniff
+{
+
+    /**
+     * Array of additional interface implementations to examine.
+     *
+     * This property can be provided via a custom ruleset.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    public $serializableInterfaces = [];
+
+    /**
+     * Array of additional interface implementations to examine.
+     *
+     * This is a cleaned up version of the property provided via a custom ruleset.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $customSerializableInterfaces = [];
+
+    /**
+     * Array of PHP native interfaces to look for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $phpSerializableInterfaces = [
+        'serializable',
+    ];
+
+    /**
+     * Array of interfaces extending a PHP native or "extra" interface seen along the way.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $collectedInterfaces = [];
+
+    /**
+     * Array of interface implementations to examine.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $interfaceList = [];
+
+    /**
+     * Cache of the last seen value of the $serializableInterfaces property
+     * to know whether the $interfaceList property needs updating.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $lastSeenSerializableInterfaces;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_CLASS,
+            \T_ANON_CLASS,
+            \T_INTERFACE,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('8.1') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $class  = $tokens[$stackPtr];
+
+        $this->updateInterfaceList();
+
+        if ($class['code'] === \T_INTERFACE) {
+            $extendedInterfaces = ObjectDeclarations::findExtendedInterfaceNames($phpcsFile, $stackPtr);
+            if (empty($extendedInterfaces)) {
+                // Interface doesn't extend other interfaces.
+                return;
+            }
+
+            $extendedInterfaces = $this->cleanInterfaceNames($extendedInterfaces);
+            $intersection       = \array_intersect($extendedInterfaces, $this->interfaceList);
+            if (empty($intersection) === true) {
+                // Interface doesn't extend a PHP native, collected or user provided serializable interface.
+                return;
+            }
+
+            /*
+             * Okay, so we have an interface which extends Serializable in one way or another.
+             */
+            if ($this->supportsBelow('7.3') === false) {
+                /*
+                 * Check if the interface requires implementation of the magic methods.
+                 */
+                $hasMagic = $this->findMagicMethods($phpcsFile, $stackPtr);
+
+                if ($hasMagic['__serialize'] === true && $hasMagic['__unserialize'] === true) {
+                    $message = 'When an interface enforces implementation of the magic __serialize() and __unserialize() methods and the code base does not need to support PHP < 7.4, the interface no longer needs to extend the Serializable interface.';
+                    $code    = 'RedundantSerializableExtension';
+
+                    $phpcsFile->addWarning($message, $stackPtr, $code);
+                }
+            }
+
+            /*
+             * - Check if the interface is already in the list of interfaces to check for.
+             * - If not, we should recommend to the user to add it to the $serializableInterfaces
+             *   property and to rescan the codebase.
+             * - And in the mean time, we add the interface to the "Collected" list.
+             */
+            $interfaceName   = ObjectDeclarations::getName($phpcsFile, $stackPtr);
+            $interfaceNameLC = (empty($interfaceName) === false) ? \strtolower($interfaceName) : '';
+
+            if (empty($this->customSerializableInterfaces) === false
+                && \in_array($interfaceNameLC, $this->customSerializableInterfaces, true) === true
+            ) {
+                // Interface has already been added to the list of additional interfaces to find.
+                return;
+            }
+
+            $this->collectedInterfaces[] = $interfaceNameLC;
+            $this->interfaceList[]       = $interfaceNameLC;
+
+            $message = 'The "%1$s" interface extends the serializable %2$s interface%3$s. For the PHPCompatibility.Interface.RemovedSerializable sniff to be reliable, the name of this interface needs to be added to the list of interface implementations to find. Please add the interface name "%1$s" to the "serializableInterfaces" property for this sniff in your custom ruleset and rescan the codebase.';
+            $code    = 'MissingInterface';
+            $data    = [
+                $interfaceName,
+                \implode(', ', $intersection),
+                (\count($intersection) > 1) ? 's' : '',
+            ];
+
+            $phpcsFile->addWarning($message, $stackPtr, $code, $data);
+
+            // Nothing more to do for interfaces.
+            return;
+        }
+
+        if ($class['code'] === \T_CLASS) {
+            // Anon classes cannot be abstract.
+            $classProps = ObjectDeclarations::getClassProperties($phpcsFile, $stackPtr);
+            if ($classProps['is_abstract'] === true) {
+                // We cannot determine compliance for abstract classes.
+                return;
+            }
+        }
+
+        if (isset($class['scope_opener'], $class['scope_closer']) === false) {
+            // If the scope cannot be determines, there is no way to find method declarations.
+            return;
+        }
+
+        $implementedInterfaces = ObjectDeclarations::findImplementedInterfaceNames($phpcsFile, $stackPtr);
+        if (empty($implementedInterfaces)) {
+            // Class doesn't implement any interface.
+            return;
+        }
+
+        $implementedInterfaces = $this->cleanInterfaceNames($implementedInterfaces);
+
+        $matchedInterfaces = \array_intersect($implementedInterfaces, $this->interfaceList);
+        if (empty($matchedInterfaces) === true) {
+            // Class doesn't implement any of the known Serializable interfaces.
+            return;
+        }
+
+        /*
+         * Okay, if we're still here, we know that this is a class which implements
+         * the Serializable interface.
+         */
+        $hasMagic = $this->findMagicMethods($phpcsFile, $stackPtr);
+
+        if ($hasMagic['__serialize'] === true && $hasMagic['__unserialize'] === true) {
+            /*
+             * If PHP < 7.4 does not need to be supported, recommend removing the Serializable implementation,
+             * but only for direct implementations of Serializable as other interfaces may provide additional functionality.
+             */
+            if ($this->supportsBelow('7.3') === false
+                && \array_intersect($matchedInterfaces, $this->phpSerializableInterfaces) !== []
+            ) {
+                $message = 'When the magic __serialize() and __unserialize() methods are available and the code base does not need to support PHP < 7.4, the implementation of the Serializable interface can be removed.';
+                $code    = 'RedundantSerializableImplementation';
+
+                $phpcsFile->addWarning($message, $stackPtr, $code);
+            }
+
+            // Both magic methods have been found, we're good.
+            return;
+        }
+
+        $methods = '';
+        if ($hasMagic['__serialize'] === false && $hasMagic['__unserialize'] === false) {
+            $methods = '__serialize() and __unserialize()';
+        } elseif ($hasMagic['__serialize'] === false) {
+            $methods = '__serialize()';
+        } elseif ($hasMagic['__unserialize'] === false) {
+            $methods = '__unserialize()';
+        }
+
+        $message = '"Only Serializable" classes are deprecated since PHP 8.1. The magic __serialize() and __unserialize() methods need to be implemented for cross-version compatibility. Missing implementation of: ' . $methods;
+        $code    = 'Deprecated';
+
+        $phpcsFile->addWarning($message, $stackPtr, $code);
+    }
+
+    /**
+     * Update the interface list to match against.
+     *
+     * @since 10.0.0
+     *
+     * @return void
+     */
+    private function updateInterfaceList()
+    {
+        // Allow for resetting the property in test files.
+        if ($this->serializableInterfaces === null || $this->serializableInterfaces === '') {
+            $this->serializableInterfaces = [];
+        }
+
+        if (isset($this->lastSeenSerializableInterfaces)
+            && $this->lastSeenSerializableInterfaces === $this->serializableInterfaces
+        ) {
+            // Nothing to do.
+            return;
+        }
+
+        // Make sure that all name comparisons against the extra list will be done in a case-insensitive manner.
+        $this->customSerializableInterfaces = $this->serializableInterfaces;
+        if (empty($this->customSerializableInterfaces) === false) {
+            $this->customSerializableInterfaces = $this->cleanInterfaceNames($this->customSerializableInterfaces);
+        }
+
+        // Overwrite any previously set list to clear out any "extras" no longer set.
+        $interfaceList       = \array_merge($this->phpSerializableInterfaces, $this->customSerializableInterfaces, $this->collectedInterfaces);
+        $this->interfaceList = \array_unique($interfaceList);
+
+        $this->lastSeenSerializableInterfaces = $this->serializableInterfaces;
+    }
+
+    /**
+     * Lowercase the interface names and remove leading namespace separators.
+     *
+     * @since 10.0.0
+     *
+     * @param array $interfaceNames List of interface names.
+     *
+     * @return array
+     */
+    private function cleanInterfaceNames($interfaceNames)
+    {
+        if (\is_string($interfaceNames) === true) {
+            // Probably received in old, pre-PHPCS 3.3.0 syntax.
+            $interfaceNames = \explode(',', $interfaceNames);
+        }
+
+        // Make double sure that this is an array.
+        $interfaceNames = (array) $interfaceNames;
+
+        $interfaceNames = \array_map('strtolower', $interfaceNames);
+        $interfaceNames = \array_map('ltrim', $interfaceNames, \array_fill(0, \count($interfaceNames), '\\'));
+
+        return $interfaceNames;
+    }
+
+    /**
+     * Check whether the magic methods have been declared within the class/interface.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return array Array with two keys: '__serialize' and '__unserialize'.
+     *               The values are boolean indicators of whether the method declarations were found.
+     */
+    private function findMagicMethods($phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $class  = $tokens[$stackPtr];
+
+        $scopeCloser           = $class['scope_closer'];
+        $nextFunc              = $class['scope_opener'];
+        $foundMagicSerialize   = false;
+        $foundMagicUnserialize = false;
+
+        while (($nextFunc = $phpcsFile->findNext([\T_FUNCTION, \T_DOC_COMMENT_OPEN_TAG], ($nextFunc + 1), $scopeCloser)) !== false) {
+            // Skip over docblocks.
+            if ($tokens[$nextFunc]['code'] === \T_DOC_COMMENT_OPEN_TAG
+                && isset($tokens[$nextFunc]['comment_closer'])
+            ) {
+                $nextFunc = $tokens[$nextFunc]['comment_closer'];
+                continue;
+            }
+
+            $functionScopeCloser = $nextFunc;
+            if (isset($tokens[$nextFunc]['scope_closer'])) {
+                // Normal (non-abstract, non-interface) method.
+                $functionScopeCloser = $tokens[$nextFunc]['scope_closer'];
+            }
+
+            $funcName = FunctionDeclarations::getName($phpcsFile, $nextFunc);
+            if (empty($funcName) || \is_string($funcName) === false) {
+                $nextFunc = $functionScopeCloser;
+                continue;
+            }
+
+            if (\strtolower($funcName) === '__serialize') {
+                $foundMagicSerialize = true;
+            } elseif (\strtolower($funcName) === '__unserialize') {
+                $foundMagicUnserialize = true;
+            }
+
+            // If both have been found, no need to continue looping through the functions.
+            if ($foundMagicSerialize === true && $foundMagicUnserialize === true) {
+                break;
+            }
+
+            $nextFunc = $functionScopeCloser;
+        }
+
+        return [
+            '__serialize'   => $foundMagicSerialize,
+            '__unserialize' => $foundMagicUnserialize,
+        ];
+    }
+}

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * Not what we're looking for.
+ */
+class DoesNotImplementAnyInterface {}
+
+class DoesNotImplementSerializable implements SomeInterface, SomeOtherInterface {}
+
+class DoesNotImplementPHPNativeSerializable implements \My\Custom\Serializable {}
+
+interface DoesNotExtendAnything {}
+
+interface DoesNotExtendSerializable extends SomeInterface, SomeOtherInterface {}
+
+/*
+ * This is okay for PHP 7.4 and higher only (not the concern of this sniff).
+ */
+class OnlyMagicMethods {
+    public function __serialize() {
+        return $this->data;
+    }
+    public function __unserialize($data) {
+        $this->data = $data;
+    }
+}
+
+// Ignore. Whether the required methods are implemented cannot be determined as the class is abstract.
+// Also: PHP itself does not regard abstract classes implementing Serializable as "Only Serializable".
+abstract class AbstractImplementingSerializable implements Serializable {}
+
+
+/*
+ * This is okay cross-version.
+ * These implementations can remove the Serializable implementation when the minimum PHP version is 7.4 or higher.
+ */
+
+// Includes testing with extends and multiple implemented interfaces.
+class ImplementingSerializableANDMagicMethods extends ArrayIterator implements Iterator, Serializable, ArrayAccess { // Redundant warning with PHP 7.4+.
+    public function serialize() {
+        return serialize($this->data);
+    }
+    public function unserialize( $data) {
+        $this->data = unserialize($data);
+    }
+    public function __serialize() {
+        return $this->data;
+    }
+    public function __unserialize($data) {
+        $this->data = $data;
+    }
+}
+
+$anon = new class() extends ArrayIterator implements Iterator, \Serializable, ArrayAccess { // Redundant warning with PHP 7.4+.
+    public function serialize() {}
+    public function unserialize( $data) {}
+    public function __serialize() {}
+    public function __unserialize($data) {}
+};
+
+class ImplementingSerializableANDMagicMethodsDifferentOrder implements SERIALIZABLE { // Redundant warning with PHP 7.4+.
+    public function __Serialize() {}
+    public function __UnSerialize($data) {}
+    public function Serialize() {}
+    public function Unserialize( $data) {}
+}
+
+// Parse error, class should be abstract, but that's not our concern.
+class HandleAbstractMagicMethods implements Serializable { // Redundant warning with PHP 7.4+.
+    abstract public function __serialize();
+    abstract public function __unserialize($data);
+}
+
+/*
+ * Test warning that interface needs to be added to the list of interfaces to scan for,
+ * as well as flagging redundant Serializable implementation
+ */
+interface SerializableExtendedInterface extends Iterator, Serializable, ArrayAccess { // Missing interface warning + redundant warning with PHP 7.4+.
+    public function __serialize();
+    public function __unserialize($data);
+}
+
+
+/*
+ * PHP 8.1: Implementing Serializable without also implementing the magic methods is deprecated.
+ */
+
+// Includes testing with extends and multiple implemented interfaces.
+class OnlySerializable extends ArrayIterator implements Iterator, Serializable, ArrayAccess { // Deprecation warning.
+    public function serialize() {
+        return serialize($this->data);
+    }
+    public function unserialize($data) {
+        $this->data = unserialize($data);
+    }
+}
+
+$anon = new class extends ArrayIterator implements Iterator, \Serializable, ArrayAccess { // Deprecation warning.
+    public function serialize() {}
+    public function unserialize($data) {}
+};
+
+class OnlySerializableOnlySerializeMagic implements serializable { // Deprecation warning.
+    public function serialize() {}
+    public function unserialize($data) {}
+    abstract public function __Serialize();
+}
+
+class OnlySerializableOnlyUnserializeMagic implements \Serializable { // Deprecation warning.
+    public function serialize() {}
+    public function unserialize($data) {}
+    public function __unSerialize();
+}
+
+// Simple test of the docblock skipping code.
+class SkipOverDocblocks implements Serializable, ArrayAccess{ // Deprecation warning.
+    /**
+     * This
+     * docblock
+     * should
+     * be
+     * skipped
+     * over.
+     */
+    public function serialize() {}
+
+    /**
+     * This
+     * docblock
+     * should
+     * be
+     * skipped
+     * over.
+     */
+    public function unserialize( $data) {}
+}
+
+
+// Test handling of property to search for additional interfaces.
+// @codingStandardsChangeSetting PHPCompatibility.Interfaces.RemovedSerializable serializableInterfaces SerializableInterface,ThisInterfaceIsInTheList
+interface ThisInterfaceisinTheList extends Serializable {}
+
+interface ThisInterfaceIsNOTInTheList extends ArrayAcces, \Serializable {} // Missing interface warning.
+
+interface ThisInterfaceIsNOTInTheListAndExtendOneInTheList extends \ThisInterfaceisinTheList { // Missing interface warning via user provided, NO redundant warning.
+    public function __serialize();
+    public function __unserialize($data);
+}
+
+interface ThisInterfaceIsNOTInTheListAndExtendCollected extends \ThisInterfaceIsNOTInTheList {} // Missing interface warning via collected.
+
+class OnlySerializableViaExtendedInterface extends ArrayIterator implements SerializableInterface { // Deprecation warning via user provided.
+    public function serialize() {}
+    public function unserialize( $data) {}
+}
+
+class OnlySerializableViaExtendedInterfaceCollected extends ArrayIterator implements Serializableextendedinterface { // Deprecation warning via collected.
+    public function serialize() {}
+    public function unserialize( $data) {}
+}
+
+$anon = new class extends ArrayIterator implements Iterator, \ThisInterfaceIsInTheList { // Deprecation warning via user provided.
+    public function Serialize() {
+        return serialize($this->data);
+    }
+    public function UnSerialize( $data) {
+        $this->data = unserialize($data);
+    }
+};
+
+// This should NOT generate the "redundant" warning as it is not the PHP native Serializable and the userland interface may do more.
+$anon = new class() implements \ThisInterfaceIsInTheList {
+    public function serialize() {}
+    public function unserialize( $data) {}
+    public function __serialize() {}
+    public function __unserialize($data) {}
+};
+
+// Reset property.
+// @codingStandardsChangeSetting PHPCompatibility.Interfaces.RemovedSerializable serializableInterfaces
+
+// Must be last test: testing class without scope closer.
+class Something implements Serializable {

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Interfaces;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedSerializable sniff.
+ *
+ * @group removedSerializable
+ * @group interfaces
+ *
+ * @covers \PHPCompatibility\Sniffs\Interfaces\RemovedSerializableSniff
+ *
+ * @since 10.0.0
+ */
+class RemovedSerializableUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test deprecated use of Serializable only classes is flagged.
+     *
+     * @dataProvider dataIsDeprecated
+     *
+     * @param int $line Line number where the warning should occur.
+     *
+     * @return void
+     */
+    public function testIsDeprecated($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.3-');
+        $this->assertWarning($file, $line, 'Only Serializable" classes are deprecated since PHP 8.1. The magic __serialize() and __unserialize() methods need to be implemented for cross-version compatibility');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsDeprecated()
+     *
+     * @return array
+     */
+    public function dataIsDeprecated()
+    {
+        return [
+            [89],
+            [98],
+            [103],
+            [109],
+            [116],
+            [152],
+            [157],
+            [162],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives when PHP < 7.4 and PHP 7.4+ both need to be supported.
+     *
+     * @dataProvider dataNoFalsePositivesDeprecated
+     *
+     * @param int $line Line number where no error should occur.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesDeprecated($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.3-');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesDeprecated()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesDeprecated()
+    {
+        $data = [];
+
+        // No errors expected on the first 75 lines.
+        for ($line = 1; $line <= 75; $line++) {
+            $data[] = [$line];
+        }
+
+        $data[] = [172];
+        $data[] = [183];
+
+        return $data;
+    }
+
+
+    /**
+     * Test that a warning is thrown when the Serializable interface implementation is not needed.
+     *
+     * @dataProvider dataRedundantImplementation
+     *
+     * @param int $line Line number where the warning should occur.
+     *
+     * @return void
+     */
+    public function testRedundantImplementation($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4-');
+        $this->assertWarning($file, $line, 'When the magic __serialize() and __unserialize() methods are available and the code base does not need to support PHP < 7.4, the implementation of the Serializable interface can be removed');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRedundantImplementation()
+     *
+     * @return array
+     */
+    public function dataRedundantImplementation()
+    {
+        return [
+            [39],
+            [54],
+            [61],
+            [69],
+        ];
+    }
+
+
+    /**
+     * Test that a warning is thrown when the Serializable interface extension is not needed.
+     *
+     * @dataProvider dataRedundantExtension
+     *
+     * @param int $line Line number where the warning should occur.
+     *
+     * @return void
+     */
+    public function testRedundantExtension($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4-');
+        $this->assertWarning($file, $line, 'When an interface enforces implementation of the magic __serialize() and __unserialize() methods and the code base does not need to support PHP < 7.4, the interface no longer needs to extend the Serializable interface.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRedundantExtension()
+     *
+     * @return array
+     */
+    public function dataRedundantExtension()
+    {
+        return [
+            [78],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for the "redundant" notice when only PHP 7.4+ need to be supported.
+     *
+     * @dataProvider dataNoFalsePositivesRedundant
+     *
+     * @param int $line Line number where no error should occur.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesRedundant($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4-');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesRedundant()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesRedundant()
+    {
+        $data = [];
+
+        // Also no errors expected on the first 37 lines.
+        for ($line = 1; $line <= 37; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Test that a warning is thrown an interface extending the Serializable interface is detected
+     * and the interface is not in the extra interfaces list.
+     *
+     * @dataProvider dataMissingInterface
+     *
+     * @param int $line Line number where the warning should occur.
+     *
+     * @return void
+     */
+    public function testMissingInterface($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertWarning($file, $line, 'For the PHPCompatibility.Interface.RemovedSerializable sniff to be reliable, the name of this interface needs to be added to the list of interface implementations to find');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testMissingInterface()
+     *
+     * @return array
+     */
+    public function dataMissingInterface()
+    {
+        return [
+            [78],
+            [143],
+            [145],
+            [150],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for the "missing interface" notice.
+     *
+     * @dataProvider dataNoFalsePositivesMissingInterface
+     *
+     * @param int $line Line number where no error should occur.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesMissingInterface($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesMissingInterface()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesMissingInterface()
+    {
+        return [
+            [12],
+            [14],
+            [141],
+        ];
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3-8.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ This allows for more flexibility when, for instance, your project needs to compl
 
 ### PHPCompatibility specific options
 
-At this moment, there is one sniff which has a property which can be set via the ruleset. More custom properties may become available in the future.
+At this moment, there are two sniffs which have a property which can be set via the ruleset. More custom properties may become available in the future.
 
 The `PHPCompatibility.Extensions.RemovedExtensions` sniff checks for removed extensions based on the function prefix used for these extensions.
 This might clash with userland functions using the same function prefix.
@@ -220,6 +220,21 @@ To whitelist userland functions, you can pass a comma-delimited list of function
     <rule ref="PHPCompatibility.Extensions.RemovedExtensions">
         <properties>
             <property name="functionWhitelist" type="array" value="mysql_to_rfc3339,mysql_another_function"/>
+        </properties>
+    </rule>
+```
+
+The `PHPCompatibility.Interfaces.RemovedSerializable` sniff needs to know about all interfaces which extend the `Serializable` interface to provide the most reliable results.
+The sniff will warn when it encounters an interface extending the `Serializable` interface which is unknown to the sniff and recommend for the interface name to be added to the property.
+
+To inform the sniff about additional interfaces providing the Serializable interface, add a snippet along the lines of the below to your custom ruleset:
+```xml
+    <rule ref="PHPCompatibility.Interfaces.RemovedSerializable">
+        <properties>
+            <property name="serializableInterfaces" type="array">
+                <element value="MyCustomSerializableInterface"/>
+                <element value="AnotherSerializableInterface"/>
+            </property>
         </properties>
     </rule>
 ```


### PR DESCRIPTION
New sniff which addresses the following deprecation in PHP 8.1:

> **Implementing Serializable without `__serialize()` and `__unserialize()`**
>
> Either only the new methods should be implemented, if no support for PHP prior to version 7.4 is provided, or both should be implemented.

This sniff will throw a warning when a class implements the `Serializable` interface, but does not implement the magic `__serialize()` and `__unserialize()` methods.

The sniff contains a `public` `$serializableInterfaces` property for users to provide their own list of additional interfaces (which extend the `Serializable` interface) to scan for.

If the sniff comes across an interface declaration extending the `Serializable` interface and the interface is not in the user provided `$serializableInterfaces` list, a warning will be thrown for the user to add the interface to the property via a custom ruleset.

Additionally, when the `testVersion` has a minimum PHP version of `7.4` or higher, an additional check is executed:
* For interfaces directly extending `Serializable` AND containing a declaration of both the `__serialize()` as well as the `__unserialize()` magic method, thus enforcing the implementation of these methods in classes implementing the interface, a warning will be thrown that the extension of the `Serializable` interface can be removed.
* For classes which implement the `Serializable` interface AND contain a declaration of both the `__serialize()` as well as the `__unserialize()` magic method, a warning will be thrown that the implementation of the `Serializable` interface can be removed.

Includes unit tests.
Includes updating the section about available custom properties in the README.

Refs:
 * https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.serialize-interface
 * https://wiki.php.net/rfc/phase_out_serializable
 * https://www.php.net/manual/en/class.serializable.php
 * https://www.php.net/manual/en/language.oop5.magic.php#object.serialize
 * https://github.com/php/php-src/pull/6494
 * https://github.com/php/php-src/commit/3e6b447979a2b1f351faf40bee9c6cf7e362d85a

Related #1299, #1310