### PR TITLE
FunctionNameRestrictions/NewMagicMethods: special case the magic __[un]serialize() methods

### DIFF
--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.inc
@@ -97,3 +97,27 @@ trait MyTrait
     public function __construct() {}
     public function __destruct() {}
 }
+
+/*
+ * Don't show warning for the PHP 7.4+ serialization magic methods when the class/interface
+ * also implements/extends Serializable.
+ */
+class ImplementingSerializableANDMagicMethods extends ArrayIterator implements Serializable {
+    public function serialize() {
+        return serialize($this->data);
+    }
+    public function unserialize( $data) {
+        $this->data = unserialize($data);
+    }
+    public function __serialize() {
+        return $this->data;
+    }
+    public function __unserialize($data) {
+        $this->data = $data;
+    }
+}
+
+interface SerializableExtendedInterface extends Iterator, Serializable, ArrayAccess {
+    public function __serialize();
+    public function __unserialize($data);
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -196,6 +196,12 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
             [54],
             [74],
             [75],
+
+            // Magic serialization methods in a class implementing Serializable.
+            [112],
+            [115],
+            [121],
+            [122],
         ];
     }
 


### PR DESCRIPTION
... in light of the PHP 8.1 deprecation of the `Serializable` interface.

For classes which implement the `Serializable` interface and need to support both PHP < 7.4 as well as PHP >= 8.1, the only way to avoid a deprecation warning is by implementing both the `Serializable` interface as well as the PHP 7.4 magic `__[un]serialize()` methods.

In that case, the sniff should stay silent as the code is cross-version compatible, as for PHP < 7.4, the `Serializable` interface methods will be used to serialize the object, while for PHP 7.4 and higher, the magic methods will be used.

Includes unit tests.

Fixes #1310

Related to #1299