### PR TITLE
GH Actions: fix coverage not running on `develop`

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -1,7 +1,7 @@
 name: Quicktest
 
 on:
-  # Run on pushes, including merges, to all branches except `master`.
+  # Run on pushes, including merges, to all branches except `master` and `develop`.
   push:
     branches-ignore:
       - master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,7 +226,7 @@ jobs:
     # No use running the coverage builds if there are failing test builds.
     needs: test
     # The default condition is success(), but this is false when one of the previous jobs is skipped (but don't run on forks).
-    if: github.repository_owner == 'PHPCompatibility' && (needs.test.result == 'success' || needs.test.result == 'skipped')
+    if: always() && github.repository_owner == 'PHPCompatibility' && (needs.test.result == 'success' || needs.test.result == 'skipped')
 
     runs-on: ubuntu-latest
 
@@ -329,7 +329,7 @@ jobs:
   coveralls-finish:
     needs: coverage
     # Don't run on forks.
-    if: github.repository_owner == 'PHPCompatibility' && needs.coverage.result == 'success'
+    if: always() && github.repository_owner == 'PHPCompatibility' && needs.coverage.result == 'success'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Follow up on #1307 which broke the running of code coverage on the `develop` branch.

Apparently, an `if` conditional combined with a `needs`, MUST force the `if` to be read by calling `always()`, otherwise, if the `needs` was skipped (like we do for builds on `develop`), the condition will always return `false`.

With thanks to Arthur from GH support for pointing this out.