### PR TITLE
Composer: update PHP Parallel Lint and Console Highlighter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
       "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/logs"
     ],
     "lint": [
-      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git --exclude PHPCompatibility/Tests/Keywords/ForbiddenNames"
+      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git --exclude PHPCompatibility/Tests/Keywords/ForbiddenNames"
     ],
     "check-complete": [
       "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./PHPCompatibility"

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     "phpcsstandards/phpcsutils" : "^1.0"
   },
   "require-dev" : {
-    "php-parallel-lint/php-parallel-lint": "^1.2.0",
-    "php-parallel-lint/php-console-highlighter": "^0.5",
+    "php-parallel-lint/php-parallel-lint": "^1.3.2",
+    "php-parallel-lint/php-console-highlighter": "^1.0.0",
     "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
     "phpcsstandards/phpcsdevtools": "^1.0"
   },


### PR DESCRIPTION
### Composer: update PHP Parallel Lint and Console Highlighter

PHP Console Highlighter has released version `1.0.0` and PHP Parallel Lint version `1.3.2` is the first PHP Parallel Lint version which supports PHP Console Highlighter `1.0.0`.

As the minimum supported PHP version is still PHP 5.3 for both, we can safely update both dependency requirements.

Refs:
* https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v1.0.0
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.2

### GH Actions: show deprecations when linting

While rare, there are some deprecations which PHP can show when a file is being linted.
By default these are ignored by PHP-Parallel-Lint.

Apparently though, there is an option to show them (wasn't documented until recently), so let's turn that option on.