### PR TITLE
Composer/GH Actions: start using PHPCSDevTools 1.2.0

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -59,7 +59,7 @@ jobs:
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - uses: korelstar/xmllint-problem-matcher@v1
 
-      # Validate the XML file.
+      # Validate the Ruleset XML file.
       # @link http://xmlsoft.org/xmllint.html
       - name: Validate ruleset against schema
         run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd PHPCompatibility/ruleset.xml
@@ -67,6 +67,10 @@ jobs:
       # Check the code-style consistency of the XML file.
       - name: Check XML code style
         run: diff -B ./PHPCompatibility/ruleset.xml <(xmllint --format "./PHPCompatibility/ruleset.xml")
+
+      # Validate the Documentation XML files.
+      - name: Validate documentation against schema
+        run: xmllint --noout --schema vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd ./PHPCompatibility/Docs/*/*Standard.xml
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style

--- a/PHPCompatibility/Docs/Classes/NewConstVisibilityStandard.xml
+++ b/PHPCompatibility/Docs/Classes/NewConstVisibilityStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="New constant visibility">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Constant Visibility"
+    >
     <standard>
     <![CDATA[
     Class constants can be declared with visibility since PHP 7.1.

--- a/PHPCompatibility/Docs/Classes/NewFinalClassConstantsStandard.xml
+++ b/PHPCompatibility/Docs/Classes/NewFinalClassConstantsStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="New final class constants">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Final Class Constants"
+    >
     <standard>
     <![CDATA[
     Class constants can be declared as final since PHP 8.1.

--- a/PHPCompatibility/Docs/FunctionDeclarations/RemovedReturnByReferenceFromVoidStandard.xml
+++ b/PHPCompatibility/Docs/FunctionDeclarations/RemovedReturnByReferenceFromVoidStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Removed Return By Reference From Void Functions">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed Return By Reference From Void Functions"
+    >
     <standard>
     <![CDATA[
     Returning by reference from a void function is deprecated since PHP 8.1.

--- a/PHPCompatibility/Docs/ParameterValues/RemovedMbCheckEncodingNoArgsStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedMbCheckEncodingNoArgsStandard.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<documentation title="Removed mb_check_encoding() without arguments">
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed mb_check_encoding() Without Arguments"
+    >
     <standard>
     <![CDATA[
     Calling the mb_check_encoding() function without passing any arguments is deprecated since PHP 8.1 and support will be removed in PHP 9.0.

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "php-parallel-lint/php-parallel-lint": "^1.3.2",
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
     "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
-    "phpcsstandards/phpcsdevtools": "^1.0"
+    "phpcsstandards/phpcsdevtools": "^1.2.0"
   },
   "conflict": {
     "squizlabs/php_codesniffer": "2.6.2"


### PR DESCRIPTION
### Composer/GH Actions: start using PHPCSDevTools 1.2.0

PHPCSDevTools 1.2.0 introduces an XSD for the XML docs which can accompany sniffs.

This commit:
* Updates the PHPCSDevTools to version 1.2.0.
* Adds a new check against the XSD for all sniff XML Docs files.

Ref: https://github.com/PHPCSStandards/PHPCSDevTools/releases/tag/1.2.0

### Sniff XML docs: add schema to docs

Includes adding the `<?xml..?>` header if it didn't exist in the file.