### PR TITLE
Drop support for PHPCS < 3.7.1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To start contributing, fork the repository, create a new branch in your fork, ma
 
 Please make sure that your pull request contains unit tests covering what's being addressed by it.
 
-* All code should be compatible with PHPCS >= 2.6.0 and PHPCS >= 3.1.0.
+* All code should be compatible with PHPCS >= 3.7.1.
 * All code should be compatible with PHP 5.4 to PHP nightly.
 * All code should comply with the PHPCompatibility coding standards.
     The [ruleset used by PHPCompatibility](https://github.com/PHPCSStandards/PHPCSDevCS) is largely based on PSR-12 with minor variations and some additional checks for array layout and documentation and such.
@@ -129,7 +129,7 @@ If you are running the PHPCS native unit tests or the unit tests for another sni
 
 This will generally only happen if you have both PHPCompatibility as well as another custom sniff library in your PHPCS `installed_paths` setting.
 
-To fix these errors, make sure you are running PHPCS 2.7.1 or higher and add the following to the `phpunit.xml` file for the sniff library you are testing:
+To fix these errors, add the following to the `phpunit.xml` file for the sniff library you are testing:
 ```xml
     <php>
         <env name="PHPCS_IGNORE_TESTS" value="PHPCompatibility"/>

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -41,9 +41,6 @@ jobs:
         run: |
           # Using PHPCS `master` as an early detection system for bugs upstream.
           composer require --no-update squizlabs/php_codesniffer:"dev-master" --no-interaction
-          # Add PHPCSDevCS - this is the CS ruleset we use.
-          # This is not in the composer.json as it has different minimum PHPCS reqs and would conflict.
-          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.3" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -29,25 +29,9 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', 'latest']
-        phpcs_version: ['dev-master']
-        lint: [true]
+        phpcs_version: ['3.7.1', 'dev-master']
 
-        include:
-          - php: '7.3'
-            phpcs_version: '2.6.0'
-            lint: false
-          # PHP 7.3+ is only fully supported icw PHPCS 2.9.2 and 3.3.1+.
-          - php: '7.2'
-            phpcs_version: '3.1.0'
-            lint: true
-          - php: '5.4'
-            phpcs_version: '>=2.6,<3.0'
-            lint: false
-          - php: '5.4'
-            phpcs_version: '2.6.0'
-            lint: false
-
-    name: "QTest${{ matrix.lint && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
+    name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
     steps:
       - name: Checkout code
@@ -72,10 +56,7 @@ jobs:
           coverage: none
 
       - name: 'Composer: set PHPCS version for tests'
-        run: |
-          # Remove devtools as it would block install on old PHPCS versions (< 3.0).
-          composer remove --no-update --dev phpcsstandards/phpcsdevtools --no-interaction
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
+        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
       - name: 'Composer: tweak PHPUnit version'
         if: ${{ matrix.php == 'latest' || startsWith( matrix.php, '8' ) }}
@@ -90,7 +71,7 @@ jobs:
         uses: "ramsey/composer-install@v2"
 
       - name: Lint against parse errors
-        if: ${{ matrix.lint }}
+        if: ${{ matrix.phpcs_version == 'dev-master' }}
         run: composer lint
 
       - name: Run the unit tests

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -26,6 +26,10 @@ jobs:
   quicktest:
     runs-on: ubuntu-latest
 
+    env:
+      # - COMPOSER_ROOT_VERSION is needed to get round the recursive dependency when using CI.
+      COMPOSER_ROOT_VERSION: '10.99.99'
+
     strategy:
       matrix:
         php: ['5.4', 'latest']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,72 +79,15 @@ jobs:
         # as well as add extra jobs in `include`.
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
-        # IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
-        # - PHPCS will run without errors on PHP 5.4 - 7.2 on any version.
-        # - PHP 7.3 needs PHPCS 2.9.2 and 3.3.1+ to run without errors.
-        #   On PHPCS 2.x our tests won't fail though, but on PHPCS 3.x < 3.3.1 they will.
-        # - PHP 7.4 needs PHPCS 3.5.0+ to run without errors.
-        #   On PHPCS 2.x our tests won't fail though, but on PHPCS 3.x < 3.5.0 they will.
-        # - PHP 8.0 needs PHPCS 3.5.7+ to run without errors.
-        # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
-        #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.4']
-        phpcs_version: ['2.6.0', 'dev-master']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.1']
+        phpcs_version: ['3.7.1', 'dev-master']
         experimental: [false]
 
         include:
-          # Complement the builds run in code coverage to complete the matrix.
-          - php: '8.1'
-            phpcs_version: 'dev-master'
-            experimental: false
-          - php: '8.1'
-            phpcs_version: '3.6.1'
-            experimental: false
-
-          - php: '8.0'
-            phpcs_version: '~3.5.7'
-            experimental: false
-
-          - php: '7.3'
-            phpcs_version: 'dev-master'
-            experimental: false
-
-          # In addition to the matrix, test against a variation of PHPCS 2.x and 3.x versions.
-          - php: '7.4'
-            phpcs_version: '>=2.6,<3.0'
-            experimental: false
-
-          - php: '7.3'
-            phpcs_version: '3.4.*'
-            experimental: false
-
           - php: '7.2'
-            phpcs_version: '3.3.*'
+            phpcs_version: '^3.7.1'
             custom_ini: true
-            experimental: false
-
-          - php: '7.1'
-            phpcs_version: '3.1.*'
-            experimental: false
-
-          - php: '7.0'
-            phpcs_version: '2.6.*'
-            experimental: false
-
-          - php: '5.6'
-            phpcs_version: '2.8.*'
-            experimental: false
-
-          - php: '5.5'
-            phpcs_version: '3.2.*'
-            experimental: false
-          - php: '5.5'
-            phpcs_version: '2.7.*'
-            experimental: false
-
-          - php: '5.4'
-            phpcs_version: '3.1.0'
             experimental: false
 
           # Experimental builds. These are allowed to fail.
@@ -191,11 +134,8 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: 'Composer: adjust dependencies'
-        run: |
-          # Remove devtools as it would block install on old PHPCS versions (< 3.0).
-          composer remove --no-update --dev phpcsstandards/phpcsdevtools --no-interaction
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
+      - name: 'Composer: set PHPCS version for tests'
+        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
       - name: 'Composer: conditionally tweak PHPUnit version'
         if: ${{ startsWith( matrix.php, '8' ) }}
@@ -239,18 +179,14 @@ jobs:
           - php: '8.0'
             phpcs_version: 'dev-master'
             custom_ini: true
-          - php: '7.3'
-            phpcs_version: '2.6.0'
-          - php: '7.2'
-            phpcs_version: '3.1.0'
+          - php: '8.0'
+            phpcs_version: '3.7.1'
 
           - php: '5.4'
             phpcs_version: 'dev-master'
           - php: '5.4'
-            phpcs_version: '>=2.6,<3.0'
+            phpcs_version: '3.7.1'
             custom_ini: true
-          - php: '5.4'
-            phpcs_version: '2.6.0'
 
     name: "Coverage: PHP ${{ matrix.php }}${{ matrix.custom_ini && ' (ini)' || '' }} - PHPCS ${{ matrix.phpcs_version }}"
 
@@ -285,12 +221,8 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
 
-      - name: 'Composer: adjust dependencies'
-        run: |
-          # Remove devtools as it would block install on old PHPCS versions (< 3.0).
-          composer remove --no-update --dev phpcsstandards/phpcsdevtools --no-interaction
-          # Set a specific PHPCS version.
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
+      - name: 'Composer: set PHPCS version for tests'
+        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
       - name: Install Composer dependencies - normal
         if: ${{ startsWith( matrix.php, '8' ) == false  }}
@@ -307,6 +239,7 @@ jobs:
         run: vendor/bin/phpunit
 
       # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
+      # Also PHP Coveralls itself (still) isn't fully compatible with PHP 8.0+.
       - name: Switch to PHP 7.4
         if: ${{ success() && matrix.php != '7.4' }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # - COMPOSER_ROOT_VERSION is needed to get round the recursive dependency when using CI.
+  COMPOSER_ROOT_VERSION: '10.99.99'
+
 jobs:
   #### PHP LINT STAGE ####
   # Linting against high/low of each PHP major should catch everything.

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -20,7 +20,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * Originally PHPCompatibility supported PHPCS 1.5.x, 2.x and since PHPCompatibility 8.0.0, 3.x.
  * Support for PHPCS < 2.3.0 has been dropped in PHPCompatibility 9.0.0.
- * Support for PHPCS < 2.6.0 has been dropped in PHPCompatibility 10.0.0.
+ * Support for PHPCS < 3.7.1 has been dropped in PHPCompatibility 10.0.0.
  *
  * The standard will - up to a point - still work for users of lower
  * PHPCS versions, but will give less accurate results and may throw
@@ -31,6 +31,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/688
  * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/835
+ * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/1347
  *
  * @since 8.2.0
  */
@@ -48,7 +49,7 @@ class LowPHPCSSniff extends Sniff
      *
      * @var string
      */
-    const MIN_SUPPORTED_VERSION = '2.6.0';
+    const MIN_SUPPORTED_VERSION = '3.7.1';
 
     /**
      * The minimum recommended PHPCS version.
@@ -60,7 +61,7 @@ class LowPHPCSSniff extends Sniff
      *
      * @var string
      */
-    const MIN_RECOMMENDED_VERSION = '3.1.0';
+    const MIN_RECOMMENDED_VERSION = '3.7.1';
 
     /**
      * Keep track of whether this sniff needs to actually run.

--- a/PHPCompatibility/ruleset.xml
+++ b/PHPCompatibility/ruleset.xml
@@ -4,7 +4,4 @@
 
     <autoload>./../PHPCSAliases.php</autoload>
 
-    <!-- Make the utility functions available in PHPCS 2.x -->
-    <rule ref="PHPCS23Utils"/>
-
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -43,19 +43,13 @@ Requirements
 -------
 
 * PHP 5.4+
-* PHP CodeSniffer: 2.6.0+ or 3.1.0+.
+* PHP CodeSniffer: 3.7.1+.
 
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP CodeSniffer. You should get consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on a recent PHP version in combination with a recent PHP_CodeSniffer version.
 
-For running the sniffs on PHP 7.3, it is recommended to use PHP_CodeSniffer 3.3.1+, or, if needs be, PHP_CodeSniffer 2.9.2.
-PHP_CodeSniffer < 2.9.2/3.3.1 is not fully compatible with PHP 7.3, which effectively means that PHPCompatibility can't be either.
-While the sniffs will still work in _most_ cases, you can expect PHP warnings to be thrown.
-
-For running the sniffs on PHP 7.4, it is recommended to use PHP_CodeSniffer 3.5.0+ for the same reasons.
-
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP CodeSniffer 3.x.
 As of version 9.0.0, support for PHP CodeSniffer 1.5.x and low 2.x versions < 2.3.0 has been dropped.
-As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 2.6.0 has been dropped.
+As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 3.7.1 has been dropped.
 
 
 Thank you
@@ -102,7 +96,7 @@ Installation in a Composer project (method 1)
        * [DealerDirect/phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.6.0"
        * [higidi/composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin)
        * [SimplyAdmire/ComposerPlugins](https://github.com/SimplyAdmire/ComposerPlugins). This plugin *might* still work, but appears to be abandoned.
-    - As a last alternative in case you use a custom ruleset, _and only if you use PHP CodeSniffer version 2.6.0 or higher_, you can tell PHP CodeSniffer the path to the PHPCompatibility standard by adding the following snippet to your custom ruleset:
+    - As a last alternative in case you use a custom ruleset, you can tell PHP CodeSniffer the path to the PHPCompatibility standard by adding the following snippet to your custom ruleset:
         ```xml
         <config name="installed_paths" value="vendor/phpcompatibility/php-compatibility" />
         ```
@@ -135,7 +129,7 @@ Installation via a git check-out to an arbitrary directory (method 2)
    phpcs --config-set installed_paths /path/1,/path/2,/path/3
    ```
 
-   **Pro-tip:** Alternatively, in case you use a custom ruleset _and only if you use PHP CodeSniffer version 2.6.0 or higher_, you can tell PHP CodeSniffer the path to the PHPCompatibility standard(s) by adding the following snippet to your custom ruleset:
+   **Pro-tip:** Alternatively, in case you use a custom ruleset, you can tell PHP CodeSniffer the path to the PHPCompatibility standard(s) by adding the following snippet to your custom ruleset:
    ```xml
    <config name="installed_paths" value="/path/to/PHPCompatibility" />
    ```

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "require" : {
     "php" : ">=5.4",
-    "squizlabs/php_codesniffer" : "^2.6 || ^3.1.0",
+    "squizlabs/php_codesniffer" : "^3.7.1",
     "phpcsstandards/phpcsutils" : "^1.0"
   },
   "require-dev" : {
@@ -38,9 +38,6 @@
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
     "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
     "phpcsstandards/phpcsdevtools": "^1.2.0"
-  },
-  "conflict": {
-    "squizlabs/php_codesniffer": "2.6.2"
   },
   "replace": {
     "wimg/php-compatibility": "*"

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     "php-parallel-lint/php-parallel-lint": "^1.3.2",
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
     "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
+    "phpcsstandards/phpcsdevcs": "^1.1.3",
     "phpcsstandards/phpcsdevtools": "^1.2.0"
   },
   "replace": {
@@ -72,21 +73,11 @@
     "check-complete-strict": [
       "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./PHPCompatibility"
     ],
-    "install-devcs": [
-      "composer require --dev phpcsstandards/phpcsdevcs:\"^1.1.3\" --no-suggest"
-    ],
-    "remove-devcs": [
-      "composer remove --dev phpcsstandards/phpcsdevcs"
-    ],
     "checkcs": [
-      "@install-devcs",
-      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
-      "@remove-devcs"
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
     ],
     "fixcs": [
-      "@install-devcs",
-      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
-      "@remove-devcs"
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
     ]
   }
 }

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -82,13 +82,6 @@ if ($phpcsDir !== false && file_exists($phpcsDir . $ds . 'autoload.php')) {
     // Pre-load the token back-fills to prevent undefined constant notices.
     require_once $phpcsDir . '/src/Util/Tokens.php';
 
-} elseif ($phpcsDir !== false && file_exists($phpcsDir . $ds . 'CodeSniffer.php')) {
-    // PHPCS 2.x.
-    require_once $phpcsDir . $ds . 'CodeSniffer.php';
-
-    if (isset($vendorDir) && file_exists($vendorDir . $ds . 'autoload.php')) {
-        require_once $vendorDir . $ds . 'autoload.php';
-    }
 } else {
     echo 'Uh oh... can\'t find PHPCS.
 


### PR DESCRIPTION
### Drop support for PHPCS < 3.7.1

This:
* Updates the minimum PHPCS requirement in `composer.json`, the `README` and the `CONTRIBUTING` docs.
    Includes removing some phrases which referenced use of older PHPCS versions.
* Updates the GH Actions scripts to no longer test against PHPCS < 3.7.1.
    Includes:
    - Removing a work-around which was in place for a dependency which isn't compatible with PHPCS 2.x.
    - Minor simplification for the `quicktest` script regarding whether or not to run linting.
* Updates the `LowPHPCS` sniff to reflect the new minimum and recommended PHPCS version.
    This sniff will now not trigger any errors anymore, however, I recommend leaving the sniff in place for now for future "resurrection".
* No need to include the `PHPCSUtils23` ruleset anymore (which added aliases for PHPCS 2.x classes).

### Composer: add PHPCSDevCS to the dependencies

PHPCSDevCS was previously not added to the `require-dev` dependencies as the minimum supported PHPCS version conflicted with the minimum supported PHPCS version of this package.

Now this is no longer the case, the package can be safely added to `require-dev` and work-arounds can be removed.

Note: includes declaring a `COMPOSER_ROOT_VERSION` environment variable in the test workflows as PHPCompatibility is a dependency of PHPCSDevCS and having the `COMPOSER_ROOT_VERSION` environment variable prevents a conflict due to the circular dependency.


### Test bootstrap: remove condition related to PHPCS 2.x


Related #1347

👉🏻 **Note**: this PR does not remove any existing work-arounds for old PHPCS support which may exist in sniffs. This will be done in a separate follow-up PR.