### PR TITLE
Tests: start using the PHPUnit Polyfills

### DIFF
--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Tests;
 use PHPUnit\Framework\TestCase;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\Helper;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 
 /**
  * Base sniff test class file.
@@ -31,6 +32,7 @@ use PHPCSUtils\BackCompat\Helper;
  */
 class BaseSniffTest extends TestCase
 {
+    use AssertStringContains;
 
     /**
      * The name of the standard as registered with PHPCS.
@@ -284,11 +286,6 @@ class BaseSniffTest extends TestCase
         $insteadMessagesString = \implode(', ', $insteadFoundMessages);
 
         $msg = "Expected $type message '$expectedMessage' on line $lineNumber not found. Instead found: $insteadMessagesString.";
-
-        if (\method_exists($this, 'assertStringContainsString') === false) {
-            // PHPUnit < 7.
-            return $this->assertContains($expectedMessage, $insteadMessagesString, $msg);
-        }
 
         return $this->assertStringContainsString($expectedMessage, $insteadMessagesString, $msg);
     }

--- a/PHPCompatibility/Util/Tests/Helpers/DisableSniffMsgTraitUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/DisableSniffMsgTraitUnitTest.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Util\Tests\Helpers;
 
 use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
 use PHPCompatibility\Helpers\DisableSniffMsgTrait;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 /**
  * Tests for the DisableSniffMsgTrait sniff helper.
@@ -24,6 +25,7 @@ use PHPCompatibility\Helpers\DisableSniffMsgTrait;
  */
 class DisableSniffMsgTraitUnitTest extends CoreMethodTestFrame
 {
+    use AssertionRenames;
     use DisableSniffMsgTrait;
 
     /**
@@ -41,12 +43,6 @@ class DisableSniffMsgTraitUnitTest extends CoreMethodTestFrame
 
         $result = $this->createDisableSniffNotice(self::$phpcsFile, 'Stnd.Cat.Sniff', 'Code');
 
-        if (\method_exists($this, 'assertMatchesRegularExpression') === true) {
-            // PHPUnit >= 9.1.0
-            $this->assertMatchesRegularExpression($expectedPattern, $result);
-        } else {
-            // PHPUnit < 9.1.0.
-            $this->assertRegExp($expectedPattern, $result);
-        }
+        $this->assertMatchesRegularExpression($expectedPattern, $result);
     }
 }

--- a/PHPCompatibility/Util/Tests/Helpers/TestVersionTraitUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/TestVersionTraitUnitTest.php
@@ -13,6 +13,8 @@ namespace PHPCompatibility\Util\Tests\Helpers;
 use PHPUnit\Framework\TestCase;
 use PHPCompatibility\Helpers\TestVersionTrait;
 use PHPCSUtils\BackCompat\Helper;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 /**
  * Tests for the TestVersionTrait sniff helper.
@@ -23,6 +25,8 @@ use PHPCSUtils\BackCompat\Helper;
  */
 class TestVersionTraitUnitTest extends TestCase
 {
+    use ExpectException;
+    use ExpectPHPException;
     use TestVersionTrait;
 
     /**
@@ -154,7 +158,9 @@ class TestVersionTraitUnitTest extends TestCase
     public function testGetTestVersionInvalidRange($testVersion)
     {
         $message = \sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion);
-        $this->phpWarningTestHelper($message);
+
+        $this->expectWarning();
+        $this->expectWarningMessage($message);
 
         $this->testGetTestVersion($testVersion, [null, null]);
     }
@@ -190,7 +196,9 @@ class TestVersionTraitUnitTest extends TestCase
     public function testGetTestVersionInvalidVersion($testVersion)
     {
         $message = \sprintf('Invalid testVersion setting: \'%s\'', \trim($testVersion));
-        $this->phpWarningTestHelper($message);
+
+        $this->expectWarning();
+        $this->expectWarningMessage($message);
 
         $this->testGetTestVersion($testVersion, [null, null]);
     }
@@ -311,37 +319,5 @@ class TestVersionTraitUnitTest extends TestCase
             'valid_testVersion_range_1'          => ['7.1', '5.1-5.4', true],
             'valid_testVersion_range_2'          => ['7.1', '5.3-7.0', true],
         ];
-    }
-
-
-    /**
-     * Helper function for testing PHP warnings.
-     *
-     * @since 10.0.0
-     *
-     * @param string $message The warning message to expect.
-     *
-     * @return void
-     */
-    public function phpWarningTestHelper($message)
-    {
-        if (\method_exists($this, 'expectWarning')) {
-            // PHPUnit 9.0+.
-            $this->expectWarning();
-            $this->expectWarningMessage($message);
-
-            return;
-        }
-
-        if (\method_exists($this, 'expectException') && \class_exists('PHPUnit\Framework\Error\Warning')) {
-            // PHPUnit 5.7/6/7/8.
-            $this->expectException('PHPUnit\Framework\Error\Warning');
-            $this->expectExceptionMessage($message);
-
-            return;
-        }
-
-        // PHPUnit 4/5.7.
-        $this->setExpectedException('PHPUnit_Framework_Error_Warning', $message);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
     "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
     "phpcsstandards/phpcsdevcs": "^1.1.3",
-    "phpcsstandards/phpcsdevtools": "^1.2.0"
+    "phpcsstandards/phpcsdevtools": "^1.2.0",
+    "yoast/phpunit-polyfills": "^1.0"
   },
   "replace": {
     "wimg/php-compatibility": "*"

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -41,23 +41,30 @@ if (\extension_loaded('xdebug') && \version_compare(\phpversion('xdebug'), '3', 
     }
 }
 
-$ds = DIRECTORY_SEPARATOR;
-
 // Get the PHPCS dir from an environment variable.
 $phpcsDir = getenv('PHPCS_DIR');
 
 // Get the PHPCSUtils dir from an environment variable.
 $phpcsUtilsDir = getenv('PHPCSUTILS_DIR');
 
-// This may be a Composer install.
-if (is_dir(__DIR__ . $ds . 'vendor')) {
-    $vendorDir = __DIR__ . $ds . 'vendor';
-    if ($phpcsDir === false && is_dir($vendorDir . $ds . 'squizlabs' . $ds . 'php_codesniffer')) {
-        $phpcsDir = $vendorDir . $ds . 'squizlabs' . $ds . 'php_codesniffer';
+// Make sure that `composer install` has always been run.
+if (is_dir(__DIR__ . '/vendor') && file_exists(__DIR__ . '/vendor/autoload.php')) {
+    $vendorDir = __DIR__ . '/vendor';
+    if ($phpcsDir === false && is_dir($vendorDir . '/squizlabs/php_codesniffer')) {
+        $phpcsDir = $vendorDir . '/squizlabs/php_codesniffer';
     }
-    if ($phpcsUtilsDir === false && is_dir($vendorDir . $ds . 'phpcsstandards' . $ds . 'phpcsutils')) {
-        $phpcsUtilsDir = $vendorDir . $ds . 'phpcsstandards' . $ds . 'phpcsutils';
+    if ($phpcsUtilsDir === false && is_dir($vendorDir . '/phpcsstandards/phpcsutils')) {
+        $phpcsUtilsDir = $vendorDir . '/phpcsstandards/phpcsutils';
     }
+} else {
+    echo 'Please run `composer install` before attempting to run the unit tests.
+You can still run the tests using a PHPUnit phar file, but some test dependencies need to be available.
+
+Please read the contributors guidelines for more information:
+https://is.gd/PHPCompatibilityContrib
+';
+
+    die(1);
 }
 
 if ($phpcsDir !== false) {
@@ -69,15 +76,15 @@ if ($phpcsUtilsDir !== false) {
 }
 
 // Try and load the PHPCS autoloader.
-if ($phpcsDir !== false && file_exists($phpcsDir . $ds . 'autoload.php')) {
+if ($phpcsDir !== false && file_exists($phpcsDir . '/autoload.php')) {
     // PHPCS 3.x.
-    require_once $phpcsDir . $ds . 'autoload.php';
+    require_once $phpcsDir . '/autoload.php';
 
     /*
      * Provide a custom autoloader for our abstract base classes as the PHPCS native autoloader
      * has trouble with them in combination with the PHPCompatibility custom unit test suite.
      */
-    require_once __DIR__ . $ds . 'PHPCSAliases.php';
+    require_once __DIR__ . '/PHPCSAliases.php';
 
     // Pre-load the token back-fills to prevent undefined constant notices.
     require_once $phpcsDir . '/src/Util/Tokens.php';
@@ -97,8 +104,8 @@ https://is.gd/PHPCompatibilityContrib
 }
 
 // Try and load the PHPCSUtils autoloader.
-if ($phpcsUtilsDir !== false && file_exists($phpcsUtilsDir . $ds . 'phpcsutils-autoload.php')) {
-    require_once $phpcsUtilsDir . $ds . 'phpcsutils-autoload.php';
+if ($phpcsUtilsDir !== false && file_exists($phpcsUtilsDir . '/phpcsutils-autoload.php')) {
+    require_once $phpcsUtilsDir . '/phpcsutils-autoload.php';
 } else {
     echo 'Uh oh... can\'t find PHPCSUtils.
 
@@ -113,6 +120,16 @@ https://is.gd/PHPCompatibilityContrib
     die(1);
 }
 
+if (defined('__PHPUNIT_PHAR__')) {
+    // Testing via a PHPUnit phar.
+
+    // Load the PHPUnit Polyfills autoloader.
+    require_once $vendorDir . '/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
+} else {
+    // Testing via a Composer setup.
+    require_once $vendorDir . '/autoload.php';
+}
+
 // PHPUnit cross version compatibility.
 if (class_exists('PHPUnit_Framework_TestCase') === true
     && class_exists('PHPUnit\Framework\TestCase') === false
@@ -120,6 +137,6 @@ if (class_exists('PHPUnit_Framework_TestCase') === true
     class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
 }
 
-require_once __DIR__ . $ds . 'PHPCompatibility' . $ds . 'Tests' . $ds . 'BaseSniffTest.php';
-require_once __DIR__ . $ds . 'PHPCompatibility' . $ds . 'Util' . $ds . 'Tests' . $ds . 'CoreMethodTestFrame.php';
-unset($ds, $phpcsDir, $vendorDir);
+require_once __DIR__ . '/PHPCompatibility/Tests/BaseSniffTest.php';
+require_once __DIR__ . '/PHPCompatibility/Util/Tests/CoreMethodTestFrame.php';
+unset($phpcsUtilsDir, $phpcsDir, $vendorDir);


### PR DESCRIPTION
(saw I had this branch lying around from quite a while ago and had forgotten to pull it, so may as well do so now)

### Composer: require-dev the PHPUnit Polyfills

... so we no longer have to have our own work-arounds for various PHPUnit versions in the test suite.

While generally speaking, the `require-dev` for PHPUnit should now be removed, I'm leaving it in place due to the PHPUnit >= 9.3.0 issue with PHP-Parser backfilling tokens.
If/when that issue is resolved in the future, the direct requirement for PHPUnit can be removed.

Ref: https://github.com/Yoast/PHPUnit-Polyfills

### Tests: update the bootstrap file

... to always check that a `composer install` has been run and to load the PHPUnit Polyfill autoloader directly when running PHPUnit via a Phar file as the Polyfill library needs to be installed and its autoload file loaded for the tests to work correctly.

Includes some minor tidying up:
* Remove redundant use of `DIRECTORY_SEPARATOR`.
* Remove use of FQN function names (as file is not namespaced).

### Tests: remove PHPUnit cross-version work-arounds

... in favour of using the PHPUnit Polyfills.