### PR TITLE
Sniffs: remove work-arounds for PHPCS < 3.7.1

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -401,7 +401,7 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         $hasColon = $phpcsFile->findNext(
-            [\T_COLON, \T_INLINE_ELSE],
+            [\T_COLON],
             ($tokens[$stackPtr]['parenthesis_closer'] + 1),
             $endOfFunctionDeclaration
         );
@@ -453,9 +453,9 @@ abstract class Sniff implements PHPCS_Sniff
         $tokens = $phpcsFile->getTokens();
 
         // In older PHPCS versions, the nullable indicator will turn a return type colon into a T_INLINE_ELSE.
-        $colon = $phpcsFile->findPrevious([\T_COLON, \T_INLINE_ELSE, \T_FUNCTION, \T_CLOSE_PARENTHESIS], ($stackPtr - 1));
+        $colon = $phpcsFile->findPrevious([\T_COLON, \T_FUNCTION, \T_CLOSE_PARENTHESIS], ($stackPtr - 1));
         if ($colon === false
-            || ($tokens[$colon]['code'] !== \T_COLON && $tokens[$colon]['code'] !== \T_INLINE_ELSE)
+            || ($tokens[$colon]['code'] !== \T_COLON)
         ) {
             // Shouldn't happen, just in case.
             return '';
@@ -469,12 +469,7 @@ abstract class Sniff implements PHPCS_Sniff
                 continue;
             }
 
-            if ($tokens[$i]['type'] === 'T_NULLABLE') {
-                continue;
-            }
-
-            if (\defined('T_NULLABLE') === false && $tokens[$i]['code'] === \T_INLINE_THEN) {
-                // PHPCS < 2.8.0.
+            if ($tokens[$i]['code'] === \T_NULLABLE) {
                 continue;
             }
 
@@ -629,9 +624,7 @@ abstract class Sniff implements PHPCS_Sniff
         if ($firstOnLine !== false && $tokens[$firstOnLine]['code'] === \T_USE) {
             $nextOnLine = $phpcsFile->findNext(Tokens::$emptyTokens, ($firstOnLine + 1), null, true);
             if ($nextOnLine !== false) {
-                if (($tokens[$nextOnLine]['code'] === \T_STRING && $tokens[$nextOnLine]['content'] === 'const')
-                    || $tokens[$nextOnLine]['code'] === \T_CONST // Happens in some PHPCS versions.
-                ) {
+                if (($tokens[$nextOnLine]['code'] === \T_STRING && $tokens[$nextOnLine]['content'] === 'const')) {
                     $hasNsSep = $phpcsFile->findNext(\T_NS_SEPARATOR, ($nextOnLine + 1), $stackPtr);
                     if ($hasNsSep !== false) {
                         // Namespaced const (group) use statement.
@@ -923,10 +916,6 @@ abstract class Sniff implements PHPCS_Sniff
     protected function isNumericCalculation(File $phpcsFile, $start, $end)
     {
         $arithmeticTokens = Tokens::$arithmeticTokens;
-
-        // T_POW was not added to the arithmetic array until PHPCS 2.9.0.
-        // phpcs:ignore PHPCompatibility.Constants.NewConstants.t_powFound
-        $arithmeticTokens[\T_POW] = \T_POW;
 
         $skipTokens   = Tokens::$emptyTokens;
         $skipTokens[] = \T_MINUS;

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -44,15 +44,7 @@ class NewAttributesSniff extends Sniff
      */
     public function register()
     {
-        $targets = [\T_COMMENT];
-
-        if (\defined('T_ATTRIBUTE') === true) {
-            // PHP 8.0 or PHPCS >= 3.6.0.
-            $targets[] = \T_ATTRIBUTE;
-
-        }
-
-        return $targets;
+        return [\T_ATTRIBUTE];
     }
 
     /**
@@ -74,161 +66,16 @@ class NewAttributesSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['type'] === 'T_ATTRIBUTE') {
-            /*
-             * Either PHP 8.0 or PHPCS 3.6.0+.
-             * PHP 8.0 tokenizes the start marker of the attribute as `T_ATTRIBUTE` and the
-             * end marker as `T_CLOSE_SQUARE_BRACKET.
-             * In PHPCS 3.6.0+ the end marker will be tokenized as `T_ATTRIBUTE_END` and
-             * the start marker will have an 'attribute_closer' token array index.
-             */
-            if (isset($tokens[$stackPtr]['attribute_closer']) === true) {
-                // This is PHPCS >= 3.6.0.
-                $this->throwError(
-                    $phpcsFile,
-                    $stackPtr,
-                    GetTokensAsString::compact($phpcsFile, $stackPtr, $tokens[$stackPtr]['attribute_closer'], true)
-                );
-                return;
-            }
-
-            // This must be PHP 8.0 in combination with PHPCS < 3.6.0.
-            $nestedBrackets = 1;
-            for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
-                if ($tokens[$i]['code'] === \T_OPEN_SQUARE_BRACKET) {
-                    ++$nestedBrackets;
-                    continue;
-                }
-
-                if ($tokens[$i]['code'] === \T_CLOSE_SQUARE_BRACKET) {
-                    --$nestedBrackets;
-
-                    if ($nestedBrackets === 0) {
-                        // Found the end of the attribute.
-                        break;
-                    }
-                }
-
-                if ($tokens[$i]['code'] === \T_CLOSE_TAG) {
-                    /*
-                     * Prevent looping to the end of the file for a particular edge case which
-                     * breaks the tokenizer 8.0.
-                     */
-                    break;
-                }
-            }
-
-            $this->throwError($phpcsFile, $stackPtr, GetTokensAsString::compact($phpcsFile, $stackPtr, $i, true));
-            return;
+        if (isset($tokens[$stackPtr]['attribute_closer']) === false) {
+            // Live coding or parse error. Shouldn't be possible as shouldn't have retokenized in that case.
+            return; // @codeCoverageIgnore
         }
 
-        /*
-         * PHP < 8.0 in combination with PHPCS < 3.6.0 will tokenize attributes as comments.
-         * This comment can contain multiple attributes on the same line or can be followed
-         * by actual code.
-         * The attribute closer can also be on a later line.
-         */
-        $contents = $tokens[$stackPtr]['content'];
-
-        if (\substr($contents, 0, 2) !== '#[') {
-            // Bow out early if we already know this is not an attribute.
-            return;
-        }
-
-        $expectedErrors = \substr_count($contents, '#[');
-        $actualErrors   = 0;
-
-        while (empty($contents) === false && \substr($contents, 0, 2) === '#[') {
-            $length         = \strlen($contents);
-            $nestedBrackets = 1;
-
-            for ($i = 2; $i < $length; $i++) {
-                if ($contents[$i] === '[') {
-                    ++$nestedBrackets;
-                    continue;
-                }
-
-                if ($contents[$i] === ']') {
-                    --$nestedBrackets;
-
-                    if ($nestedBrackets === 0) {
-                        // Found the end of the attribute.
-                        $this->throwError($phpcsFile, $stackPtr, \substr($contents, 0, ($i + 1)));
-                        ++$actualErrors;
-
-                        if (($i + 1) === $length) {
-                            $contents = '';
-                        } else {
-                            $contents = \trim(\substr($contents, ($i + 1)));
-                        }
-                        break;
-                    }
-                }
-            }
-
-            if ($i === $length) {
-                // Reached the end of the content without finding a closing bracket.
-                break;
-            }
-        }
-
-        if ($expectedErrors === $actualErrors) {
-            // This was a single-line attribute, closer found.
-            return;
-        }
-
-        // This must be a multi-line attribute.
-        $nestedBrackets = 1;
-        for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
-            if ($tokens[$i]['code'] === \T_OPEN_SQUARE_BRACKET) {
-                ++$nestedBrackets;
-                continue;
-            }
-
-            if ($tokens[$i]['code'] === \T_CLOSE_SQUARE_BRACKET) {
-                --$nestedBrackets;
-
-                if ($nestedBrackets === 0) {
-                    // Found the end of the attribute.
-                    break;
-                }
-            }
-
-            if ($tokens[$i]['code'] === \T_CLOSE_TAG) {
-                /*
-                 * Prevent looping to the end of the file for a particular edge case which
-                 * breaks the tokenizer on PHP < 8.0.
-                 */
-                break;
-            }
-        }
-
-        $this->throwError(
-            $phpcsFile,
-            $stackPtr,
-            \rtrim($contents, "\r\n") . GetTokensAsString::compact($phpcsFile, $stackPtr, $i, true)
-        );
-    }
-
-    /**
-     * Throw an error when an attribute is encountered.
-     *
-     * @since 10.0.0
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
-     * @param string                      $content   Attribute content for use in the error message.
-     *
-     * @return void
-     */
-    protected function throwError($phpcsFile, $stackPtr, $content)
-    {
         $phpcsFile->addError(
             'Attributes are not supported in PHP 7.4 or earlier. Found: %s',
             $stackPtr,
             'Found',
-            [$content]
+            [GetTokensAsString::compact($phpcsFile, $stackPtr, $tokens[$stackPtr]['attribute_closer'], true)]
         );
     }
 }

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1013,15 +1013,16 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 5.5
-     * @since 7.0.3 - Now also targets the `class` keyword to detect extended classes.
-     *              - Now also targets double colons to detect static class use.
-     * @since 7.1.4 - Now also targets anonymous classes to detect extended classes.
-     *              - Now also targets functions/closures to detect new classes used
-     *                as parameter type declarations.
-     *              - Now also targets the `catch` control structure to detect new
-     *                exception classes being caught.
-     * @since 8.2.0 Now also targets the `T_RETURN_TYPE` token to detect new classes used
-     *              as return type declarations.
+     * @since 7.0.3  - Now also targets the `class` keyword to detect extended classes.
+     *               - Now also targets double colons to detect static class use.
+     * @since 7.1.4  - Now also targets anonymous classes to detect extended classes.
+     *               - Now also targets functions/closures to detect new classes used
+     *                 as parameter type declarations.
+     *               - Now also targets the `catch` control structure to detect new
+     *                 exception classes being caught.
+     * @since 8.2.0  Now also targets the `T_RETURN_TYPE` token to detect new classes used
+     *               as return type declarations.
+     * @since 10.0.0 `T_RETURN_TYPE` token removed after PHPCS < 3.7.1 version drop.
      *
      * @return array
      */
@@ -1042,7 +1043,6 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             \T_FUNCTION,
             \T_CLOSURE,
             \T_CATCH,
-            \T_RETURN_TYPE,
         ];
     }
 
@@ -1077,10 +1077,6 @@ class NewClassesSniff extends AbstractNewFeatureSniff
 
             case 'T_CATCH':
                 $this->processCatchToken($phpcsFile, $stackPtr);
-                break;
-
-            case 'T_RETURN_TYPE':
-                $this->processReturnTypeToken($phpcsFile, $stackPtr);
                 break;
 
             default:

--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -224,7 +224,6 @@ class RemovedClassesSniff extends AbstractRemovedFeatureSniff
             \T_FUNCTION,
             \T_CLOSURE,
             \T_CATCH,
-            \T_RETURN_TYPE,
         ];
     }
 
@@ -259,10 +258,6 @@ class RemovedClassesSniff extends AbstractRemovedFeatureSniff
 
             case 'T_CATCH':
                 $this->processCatchToken($phpcsFile, $stackPtr);
-                break;
-
-            case 'T_RETURN_TYPE':
-                $this->processReturnTypeToken($phpcsFile, $stackPtr);
                 break;
 
             default:

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -46,16 +46,7 @@ class NewMagicClassConstantSniff extends Sniff
      */
     public function register()
     {
-        /*
-         * In PHPCS < 3.4.1, the class keyword after a double colon + comment may be tokenized as
-         * `T_CLASS` instead of as `T_STRING`, so registering both.
-         *
-         * @link https://github.com/squizlabs/php_codesniffer/issues/2431
-         */
-        return [
-            \T_STRING,
-            \T_CLASS,
-        ];
+        return [\T_STRING];
     }
 
     /**
@@ -89,7 +80,7 @@ class NewMagicClassConstantSniff extends Sniff
         $subjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true, null, true);
         if ($subjectPtr === false) {
             // Shouldn't be possible.
-            return;
+            return; // @codeCoverageIgnore
         }
 
         $preSubjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($subjectPtr - 1), null, true, null, true);

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewArrowFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewArrowFunctionSniff.php
@@ -12,8 +12,6 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHP_CodeSniffer\Files\File;
 use PHPCompatibility\Sniff;
-use PHPCSUtils\Tokens\Collections;
-use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
  * The arrow function syntax for short functions is available since PHP 7.4.
@@ -37,7 +35,7 @@ class NewArrowFunctionSniff extends Sniff
      */
     public function register()
     {
-        return Collections::arrowFunctionTokensBC();
+        return [\T_FN];
     }
 
     /**
@@ -54,10 +52,6 @@ class NewArrowFunctionSniff extends Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('7.3') === false) {
-            return;
-        }
-
-        if (FunctionDeclarations::isArrowFunction($phpcsFile, $stackPtr) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
-use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
  * Detect trailing commas in function declarations and closure use lists as allowed since PHP 8.
@@ -38,7 +37,7 @@ class NewTrailingCommaSniff extends Sniff
      */
     public function register()
     {
-        return Collections::functionDeclarationTokensBC();
+        return Collections::functionDeclarationTokens();
     }
 
     /**
@@ -60,22 +59,12 @@ class NewTrailingCommaSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        if (isset(Collections::arrowFunctionTokensBC()[$tokens[$stackPtr]['code']]) === true) {
-            $arrowInfo = FunctionDeclarations::getArrowFunctionOpenClose($phpcsFile, $stackPtr);
-            if ($arrowInfo === false) {
-                // Not an arrow function.
-                return;
-            }
-
-            $closer = $arrowInfo['parenthesis_closer'];
-        } else {
-            if (isset($tokens[$stackPtr]['parenthesis_closer']) === false) {
-                // Live coding or parse error.
-                return;
-            }
-
-            $closer = $tokens[$stackPtr]['parenthesis_closer'];
+        if (isset($tokens[$stackPtr]['parenthesis_closer']) === false) {
+            // Live coding or parse error.
+            return;
         }
+
+        $closer = $tokens[$stackPtr]['parenthesis_closer'];
 
         /*
          * Check for trailing commas in a function declaration parameter list.

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -44,8 +44,7 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
      * The callback function should return `true` if the condition is met and the
      * error should *not* be thrown.
      *
-     * {@internal This list does not contain `T_FN` as that token is not reliably
-     * sniffable in a PHP/PHPCS cross-version compatible manner.
+     * {@internal This list does not contain `T_FN`.
      * The separate `Syntax.NewArrowFunction` sniff reports on that token.}
      *
      * @since 5.5
@@ -72,37 +71,31 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
             '5.3'         => false,
             '5.4'         => true,
             'description' => '"callable" keyword',
-            'content'     => 'callable',
         ],
         'T_DIR' => [
             '5.2'         => false,
             '5.3'         => true,
             'description' => '__DIR__ magic constant',
-            'content'     => '__DIR__',
         ],
         'T_GOTO' => [
             '5.2'         => false,
             '5.3'         => true,
             'description' => '"goto" keyword',
-            'content'     => 'goto',
         ],
         'T_INSTEADOF' => [
             '5.3'         => false,
             '5.4'         => true,
             'description' => '"insteadof" keyword (for traits)',
-            'content'     => 'insteadof',
         ],
         'T_NAMESPACE' => [
             '5.2'         => false,
             '5.3'         => true,
             'description' => '"namespace" keyword',
-            'content'     => 'namespace',
         ],
         'T_NS_C' => [
             '5.2'         => false,
             '5.3'         => true,
             'description' => '__NAMESPACE__ magic constant',
-            'content'     => '__NAMESPACE__',
         ],
         'T_USE' => [
             '5.2'         => false,
@@ -129,34 +122,26 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
             '5.3'         => false,
             '5.4'         => true,
             'description' => '"trait" keyword',
-            'content'     => 'trait',
         ],
         'T_TRAIT_C' => [
             '5.3'         => false,
             '5.4'         => true,
             'description' => '__TRAIT__ magic constant',
-            'content'     => '__TRAIT__',
         ],
-        // The specifics for distinguishing between 'yield' and 'yield from' are dealt
-        // with in the translation logic.
-        // This token has to be placed above the `T_YIELD` token in this array to allow for this.
         'T_YIELD_FROM' => [
             '5.6'         => false,
             '7.0'         => true,
             'description' => '"yield from" keyword (for generators)',
-            'content'     => 'yield',
         ],
         'T_YIELD' => [
             '5.4'         => false,
             '5.5'         => true,
             'description' => '"yield" keyword (for generators)',
-            'content'     => 'yield',
         ],
         'T_FINALLY' => [
             '5.4'         => false,
             '5.5'         => true,
             'description' => '"finally" keyword (in exception handling)',
-            'content'     => 'finally',
         ],
     ];
 
@@ -234,29 +219,6 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
             }
 
             $tokenType = $this->translateContentToToken[$content];
-        }
-
-        /*
-         * Special case: distinguish between `yield` and `yield from`.
-         *
-         * PHPCS did not backfill for the `yield` nor the `yield from` keywords prior to PHPCS 3.1.0.
-         * See: https://github.com/squizlabs/PHP_CodeSniffer/issues/1524
-         *
-         * In PHP < 5.5, both `yield` as well as `from` are tokenized as T_STRING.
-         * In PHP 5.5 - 5.6, `yield` is tokenized as T_YIELD and `from` as T_STRING,
-         * but the `T_YIELD_FROM` token *is* defined in PHP.
-         * In PHP 7.0+ both are tokenized as their respective token, however,
-         * a multi-line "yield from" is tokenized as two tokens.
-         */
-        if ($tokenType === 'T_YIELD') {
-            $nextToken = $phpcsFile->findNext(\T_WHITESPACE, ($end + 1), null, true);
-            if ($tokens[$nextToken]['code'] === \T_STRING
-                && $tokens[$nextToken]['content'] === 'from'
-            ) {
-                $tokenType = 'T_YIELD_FROM';
-                $end       = $nextToken;
-            }
-            unset($nextToken);
         }
 
         if ($tokenType === 'T_YIELD_FROM' && $tokens[($stackPtr - 1)]['type'] === 'T_YIELD_FROM') {

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -82,10 +82,7 @@ class NewArrayStringDereferencingSniff extends Sniff
         $supports54 = $this->supportsBelow('5.4');
 
         foreach ($dereferencing['braces'] as $openBrace => $closeBrace) {
-            if ($supports54 === true
-                && ($tokens[$openBrace]['type'] === 'T_OPEN_SQUARE_BRACKET'
-                    || $tokens[$openBrace]['type'] === 'T_OPEN_SHORT_ARRAY') // Work around bug #1381 in PHPCS 2.8.1 and lower.
-            ) {
+            if ($supports54 === true && $tokens[$openBrace]['code'] === \T_OPEN_SQUARE_BRACKET) {
                 $phpcsFile->addError(
                     'Direct array dereferencing of %s is not present in PHP version 5.4 or earlier',
                     $openBrace,
@@ -97,7 +94,7 @@ class NewArrayStringDereferencingSniff extends Sniff
             }
 
             // PHP 7.0 Array/string dereferencing using curly braces.
-            if ($tokens[$openBrace]['type'] === 'T_OPEN_CURLY_BRACKET') {
+            if ($tokens[$openBrace]['code'] === \T_OPEN_CURLY_BRACKET) {
                 $phpcsFile->addError(
                     'Direct array dereferencing of %s using curly braces is not present in PHP version 5.6 or earlier',
                     $openBrace,
@@ -166,9 +163,8 @@ class NewArrayStringDereferencingSniff extends Sniff
                 break;
             }
 
-            if ($tokens[$nextNonEmpty]['type'] === 'T_OPEN_SQUARE_BRACKET'
-                || $tokens[$nextNonEmpty]['type'] === 'T_OPEN_CURLY_BRACKET' // PHP 7.0+.
-                || $tokens[$nextNonEmpty]['type'] === 'T_OPEN_SHORT_ARRAY' // Work around bug #1381 in PHPCS 2.8.1 and lower.
+            if ($tokens[$nextNonEmpty]['code'] === \T_OPEN_SQUARE_BRACKET
+                || $tokens[$nextNonEmpty]['code'] === \T_OPEN_CURLY_BRACKET // PHP 7.0+.
             ) {
                 if (isset($tokens[$nextNonEmpty]['bracket_closer']) === false) {
                     // Live coding or parse error.

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -226,12 +226,6 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
                 && $tokens[$stackPtr]['scope_closer'] === $stackPtr
             ) {
                 $opener = $tokens[$stackPtr]['scope_opener'];
-            } else {
-                // PHPCS < 3.0.2 did not add scope_* values for Nowdocs.
-                $opener = $phpcsFile->findPrevious(\T_START_NOWDOC, ($stackPtr - 1));
-                if ($opener === false) {
-                    return;
-                }
             }
 
             $quotedIdentifier = \preg_quote($tokens[$stackPtr]['content'], '`');

--- a/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
@@ -75,9 +75,6 @@ class NewInterpolatedStringDereferencingSniff extends Sniff
         $nextNonEmptyCode = $tokens[$nextNonEmpty]['code'];
         if ($nextNonEmptyCode !== \T_OPEN_SQUARE_BRACKET
             && $nextNonEmptyCode !== \T_OBJECT_OPERATOR
-            // Work-around for a bug in PHPCS < 3.6.0.
-            // @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3172
-            && $nextNonEmptyCode !== \T_OPEN_SHORT_ARRAY
         ) {
             return $endOfQuote;
         }

--- a/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
@@ -63,10 +63,7 @@ class NewMagicConstantDereferencingSniff extends Sniff
             return;
         }
 
-        if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_SQUARE_BRACKET
-            // Work around bug #3013 in PHPCS 3.5.5 and lower.
-            && $tokens[$nextNonEmpty]['code'] !== \T_OPEN_SHORT_ARRAY
-        ) {
+        if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_SQUARE_BRACKET) {
             return;
         }
 
@@ -104,9 +101,7 @@ class NewMagicConstantDereferencingSniff extends Sniff
             }
 
             // Check if this is an multi-access array assignment, e.g., `__FILE__[1][2] = 'val';` .
-            if (($tokens[$nextNext]['code'] === \T_OPEN_SQUARE_BRACKET
-                // Work around for nested array access being incorrectly tokenized in PHPCS 2.8.x.
-                || $tokens[$nextNext]['code'] === \T_OPEN_SHORT_ARRAY)
+            if ($tokens[$nextNext]['code'] === \T_OPEN_SQUARE_BRACKET
                 && isset($tokens[$nextNext]['bracket_closer']) === true
             ) {
                 $nextNext = $tokens[$nextNext]['bracket_closer'];

--- a/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
+++ b/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
@@ -11,7 +11,6 @@
 namespace PHPCompatibility\Tests\Attributes;
 
 use PHPCompatibility\Tests\BaseSniffTest;
-use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Test the NewAttributes sniff.
@@ -93,17 +92,8 @@ class NewAttributesUnitTest extends BaseSniffTest
             [96, '#[Assert\Email(["message" => "text"])]'],
             [96, '#[Assert\Text(["message" => "text"]), Assert\Domain(["message" => "text"]), Assert\Id(Assert\Id::REGEX[10]), ]'],
             [104],
+            [109],
         ];
-
-        /*
-         * In PHP < 8.0 in combination with PHPCS < 3.6.1, anything after the test case on
-         * line 104 will be tokenized as `T_INLINE_HTML` and undetectable.
-         */
-        if (version_compare(Helper::getVersion(), '3.6.1', '>=') === true
-            || version_compare(PHP_VERSION_ID, '80000', '>=') === true
-        ) {
-            $data[] = [109];
-        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
@@ -11,7 +11,6 @@
 namespace PHPCompatibility\Tests\ControlStructures;
 
 use PHPCompatibility\Tests\BaseSniffTest;
-use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Test the DiscouragedSwitchContinue sniff.
@@ -68,6 +67,8 @@ class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
             [149],
             [174],
             [210],
+            [212],
+            [218],
 
             /*
             @todo: False negatives. Unscoped control structure within case.
@@ -77,11 +78,6 @@ class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
             array(184),
             */
         ];
-
-        if (\version_compare(Helper::getVersion(), '3.5.3', '!=')) {
-            $data[] = [212];
-            $data[] = [218];
-        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -11,7 +11,6 @@
 namespace PHPCompatibility\Tests\ControlStructures;
 
 use PHPCompatibility\Tests\BaseSniffTest;
-use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Test the ForbiddenBreakContinueVariableArguments sniff.
@@ -85,11 +84,8 @@ class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
             [133, self::ERROR_TYPE_ZERO],
             [141, self::ERROR_TYPE_ZERO],
             [149, self::ERROR_TYPE_ZERO],
+            [160, self::ERROR_TYPE_ZERO],
         ];
-
-        if (\version_compare(Helper::getVersion(), '3.5.3', '!=')) {
-            $data[] = [160, self::ERROR_TYPE_ZERO];
-        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
@@ -11,7 +11,6 @@
 namespace PHPCompatibility\Tests\Miscellaneous;
 
 use PHPCompatibility\Tests\BaseSniffTest;
-use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Test the NewPHPOpenTagEOF sniff.
@@ -170,15 +169,11 @@ class NewPHPOpenTagEOFUnitTest extends BaseSniffTest
             [1],
             [2],
             [3],
+            [4],
             [5],
             [6],
             [7],
         ];
-
-        // In PHPCS 2.x, the `Internal.NoCodeFound` error will come through, even when unit testing.
-        if (\version_compare(Helper::getVersion(), '3.0.0', '>')) {
-            $data[] = [4];
-        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
@@ -69,7 +69,7 @@ class NewNumericLiteralSeparatorUnitTest extends BaseSniffTest
 
         // The test case on line 39 is half a valid numeric literal with underscore, half parse error.
         // The sniff will behave differently on PHP 7.4 vs PHP < 7.4.
-        if (\version_compare(\PHP_VERSION_ID, '70399', '>') || \version_compare(Helper::getVersion(), '3.5.3', '<')) {
+        if (\version_compare(\PHP_VERSION_ID, '70399', '>')) {
             $data[] = [41];
         }
 
@@ -120,7 +120,7 @@ class NewNumericLiteralSeparatorUnitTest extends BaseSniffTest
 
         // The test case on line 39 is half a valid numeric literal with underscore, half parse error.
         // The sniff will behave differently on PHP 7.4 vs PHP < 7.4.
-        if (\version_compare(\PHP_VERSION_ID, '70399', '<=') && \version_compare(Helper::getVersion(), '3.5.3', '>')) {
+        if (\version_compare(\PHP_VERSION_ID, '70399', '<=')) {
             $data[] = [41];
         }
 


### PR DESCRIPTION
Removes various work-around/back compat layers from the sniffs. (This should raise the code coverage back to "normal" levels)

Closes #1347