### PR TITLE
CI: run code coverage on PHPUnit 9.3+ and against PHP 8.1

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -62,13 +62,6 @@ jobs:
       - name: 'Composer: set PHPCS version for tests'
         run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
-      - name: 'Composer: tweak PHPUnit version'
-        if: ${{ matrix.php == 'latest' || startsWith( matrix.php, '8' ) }}
-        run: |
-          # Temporary fix - PHPUnit 9.3 is buggy when used for code coverage, so not allowed "normally".
-          # As the quick tests don't run code coverage, we can safely install it for PHP 8.
-          composer require --no-update --dev phpunit/phpunit:"^9.3" --no-interaction
-
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
         # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.1']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
         phpcs_version: ['3.7.1', 'dev-master']
         experimental: [false]
 
@@ -141,12 +141,6 @@ jobs:
       - name: 'Composer: set PHPCS version for tests'
         run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
-      - name: 'Composer: conditionally tweak PHPUnit version'
-        if: ${{ startsWith( matrix.php, '8' ) }}
-        # Temporary fix - PHPUnit 9.3+ is buggy when used for code coverage, so not allowed "normally".
-        # For tests which don't run code coverage, we can safely install it for PHP 8 though.
-        run: composer require --no-update phpunit/phpunit:"^9.3" --no-interaction
-
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
@@ -180,10 +174,10 @@ jobs:
       #   code conditions.
       matrix:
         include:
-          - php: '8.0'
+          - php: '8.1'
             phpcs_version: 'dev-master'
             custom_ini: true
-          - php: '8.0'
+          - php: '8.1'
             phpcs_version: '3.7.1'
 
           - php: '5.4'
@@ -228,19 +222,31 @@ jobs:
       - name: 'Composer: set PHPCS version for tests'
         run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
-      - name: Install Composer dependencies - normal
-        if: ${{ startsWith( matrix.php, '8' ) == false  }}
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
 
-      - name: Install Composer dependencies - with ignore platform
-        # For PHP 8+, we need to install with ignore platform reqs as we're using PHPUnit < 9.3.
-        if: ${{ startsWith( matrix.php, '8' ) }}
-        uses: "ramsey/composer-install@v2"
-        with:
-          composer-options: --ignore-platform-req=php
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo ::set-output name=VERSION::$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')
 
-      - name: Run the unit tests with code coverage
+      - name: "DEBUG: Show grabbed version"
+        run: echo ${{ steps.phpunit_version.outputs.VERSION }}
+
+      # PHPUnit 9.3 started using PHP-Parser for code coverage causing some of our coverage builds to fail.
+      # As of PHPUnit 9.3.4, a cache warming option is available.
+      # Using that option prevents issues with PHP-Parser backfilling PHP tokens when PHPCS does not (yet),
+      # which would otherwise cause tests to fail on tokens being available when they shouldn't be.
+      - name: "Warm the PHPUnit cache (PHPUnit 9.3+)"
+        if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
+        run: vendor/bin/phpunit --coverage-cache ./build/phpunit-cache --warm-coverage-cache
+
+      - name: "Run the unit tests with code coverage (PHPUnit < 9.3)"
+        if: ${{ steps.phpunit_version.outputs.VERSION < '9.3' }}
         run: vendor/bin/phpunit
+
+      - name: "Run the unit tests with code coverage (PHPUnit 9.3+)"
+        if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
+        run: vendor/bin/phpunit --coverage-cache ./build/phpunit-cache
 
       # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
       # Also PHP Coveralls itself (still) isn't fully compatible with PHP 8.0+.

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   "require-dev" : {
     "php-parallel-lint/php-parallel-lint": "^1.3.2",
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
-    "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
+    "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4",
     "phpcsstandards/phpcsdevcs": "^1.1.3",
     "phpcsstandards/phpcsdevtools": "^1.2.0",
     "yoast/phpunit-polyfills": "^1.0"

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -25,22 +25,6 @@ if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
     define('PHP_CODESNIFFER_VERBOSITY', 0);
 }
 
-/*
- * PHPUnit 9.3 is the first version which supports Xdebug 3, but we're using PHPUnit 9.2
- * for code coverage due to PHP_Parser interfering with our tests.
- *
- * For now, until a fix is pulled to allow us to use PHPUnit 9.3, this will allow
- * PHPUnit 9.2 to run with Xdebug 3 for code coverage.
- */
-if (\extension_loaded('xdebug') && \version_compare(\phpversion('xdebug'), '3', '>=')) {
-    if (defined('XDEBUG_CC_UNUSED') === false) {
-        define('XDEBUG_CC_UNUSED', null);
-    }
-    if (defined('XDEBUG_CC_DEAD_CODE') === false) {
-        define('XDEBUG_CC_DEAD_CODE', null);
-    }
-}
-
 // Get the PHPCS dir from an environment variable.
 $phpcsDir = getenv('PHPCS_DIR');
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,7 @@
     </filter>
 
     <logging>
+        <log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
### PHPUnit config: show code coverage summary

... at the end of test runs run with code coverage.

### CI: run code coverage on PHPUnit 9.3+

As of PHPUnit 9.3, PHPUnit started using PHP-Parser as a basis to calculate code coverage. This prevented this repo from using PHPUnit 9.3 (see PR PHPCSStandards/PHPCSUtils#304 for more details) as PHP Parser also backfills tokens and that interfered with the sniffs.

Now support for PHPCS < 3.7.1 has been dropped though, all tokens should exist in PHPCS.
And if in the future we would need to do "does this token exist ?" checks again, PHPCSUtils will provide a `TokenHelper::tokenExists()` method (as of version 1.0.0-alpha4), which will allow us to distinguish between tokens backfilled by PHPCS and tokens backfilled by PHP-Parser.

PHPUnit itself has also added a new feature in PHPUnit 9.3.4 to warm the code cache ahead of running tests recording code coverage. Using that feature should prevent the token interference completely, but implementing it was a bit of an experiment as the feature is barely documented.

Either way, the combination of the above, allows us to:
* Remove the tweaking of the PHPUnit version in `test` jobs in GH Actions.
* Run code coverage on the latest PHP version (8.1).

Notes regarding cache-warming:
* The `--coverage-cache` and `--warm-coverage-cache` options are available since PHPUnit 9.3.4 and if these are used on older PHPUnit versions, PHPUnit will error out with an "unrecognized CLI argument" error.
* In other words: these options can only be used with PHPUnit 9.3+, which is why the PHPUnit version is checked and remembered and subsequently used in the conditions.
* Also: running PHPUnit with the `--warm-coverage-cache` option _does not run the tests_. It literally only warms the cache, which is why this is implemented as a separate step in the workflow.
* The cache directory can be configured in the `phpunit.xml[.dist]` file, but only when using the PHPUnit 9.3+ `coverage` XML tag.
    As the PHPUnit config used by PHPCompatibility needs to stay cross-version compatible with older PHPUnit versions, the CLI option is used for now.
    If, at some point in the future, two config files would be used (one for PHPUnit < 9.3 and one for PHPUnit >= 9.3), the cache directory could be added to the config instead of passing it on the command-line.

Refs:
* https://github.com/sebastianbergmann/php-code-coverage/issues/798#issuecomment-678922065
* https://github.com/sebastianbergmann/phpunit/compare/9.3.3...9.3.4