### PR TITLE
Tests: drop support for PHPCS 2.x from the BaseSniffTest class

### DIFF
--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -41,8 +41,6 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
      */
     protected function setUpPHPCS()
     {
-        parent::setUpPHPCS();
-
         // Sniff file without testVersion for testing the version independent sniff features.
         $this->sniffResult = $this->sniffFile(__FILE__);
     }

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -52,8 +52,6 @@ class InternalInterfacesUnitTest extends BaseSniffTest
      */
     protected function setUpPHPCS()
     {
-        parent::setUpPHPCS();
-
         // Sniff file without testVersion as all checks run independently of testVersion being set.
         $this->sniffResult = $this->sniffFile(__FILE__);
     }

--- a/PHPCompatibility/Tests/Upgrade/LowPHPCSUnitTest.php
+++ b/PHPCompatibility/Tests/Upgrade/LowPHPCSUnitTest.php
@@ -51,8 +51,6 @@ class LowPHPCSUnitTest extends BaseSniffTest
      */
     protected function setUpPHPCS()
     {
-        parent::setUpPHPCS();
-
         // Sniff file without testVersion as all checks run independently of testVersion being set.
         $this->sniffResult  = $this->sniffFile(__FILE__);
         $this->phpcsVersion = Helper::getVersion();

--- a/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
+++ b/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
@@ -50,8 +50,6 @@ class LowPHPUnitTest extends BaseSniffTest
      */
     protected function setUpPHPCS()
     {
-        parent::setUpPHPCS();
-
         // Sniff file without testVersion as all checks run independently of testVersion being set.
         $this->sniffResult = $this->sniffFile(__FILE__);
         $this->phpVersion  = \phpversion();


### PR DESCRIPTION
Just realized I'd forgotten to remove the PHPCS 2.x code from the test base class.

Note: dropping the `parent::setUpPHPCS()` calls is fine, the methods run due to the `@before` annotations and no longer need to overload a non-existent parent method.