### PR TITLE
GH Actions: various updates

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -47,9 +47,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1'
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, zend.assertions=1'
+            echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
           fi
 
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,15 +119,15 @@ jobs:
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
           if [ ${{ matrix.custom_ini }} == "true" ]; then
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1, short_open_tag=On'
+              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1, short_open_tag=On' >> $GITHUB_OUTPUT
             else
-              echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, short_open_tag=On, zend.assertions=1'
+              echo 'PHP_INI=error_reporting=-1, display_errors=On, short_open_tag=On, zend.assertions=1' >> $GITHUB_OUTPUT
             fi
           else
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1'
+              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
             else
-              echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, zend.assertions=1'
+              echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
             fi
           fi
 
@@ -200,15 +200,15 @@ jobs:
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
           if [ ${{ matrix.custom_ini }} == "true" ]; then
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1, short_open_tag=On'
+              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1, short_open_tag=On' >> $GITHUB_OUTPUT
             else
-              echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, short_open_tag=On, zend.assertions=1'
+              echo 'PHP_INI=error_reporting=-1, display_errors=On, short_open_tag=On, zend.assertions=1' >> $GITHUB_OUTPUT
             fi
           else
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1'
+              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
             else
-              echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, zend.assertions=1'
+              echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
             fi
           fi
 


### PR DESCRIPTION
### GH Actions: fix use of deprecated set-output

GitHub has deprecated the use of `set-output` (and `set-state`) in favour of new environment files.

This commit updates workflows to use the new methodology.

Refs:
* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

### ~~GH Actions: update the xmllint-problem-matcher~~

~~The `xmllint-problem-matcher` action runner has released a new version which updates it to use node 16.
This gets rid of a warning which was shown in the action logs.~~

~~Note: I've [suggested to the author to use long-running branches for the action runner instead](https://github.com/korelstar/xmllint-problem-matcher/pull/7), which would make this update redundant, but no telling if or when they'll respond to that, let alone if they will follow my suggestion.~~

Refs:
* https://github.com/korelstar/xmllint-problem-matcher/releases/tag/v1.1