### PR TITLE
Update for PHPCSUtils 1.0.0-alpha4

### DIFF
--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -81,7 +81,7 @@ trait PCRERegexTrait
         }
 
         $tokens = $phpcsFile->getTokens();
-        if (isset(Collections::$arrayTokensBC[$tokens[$nextNonEmpty]['code']]) === false) {
+        if (isset(Collections::arrayOpenTokensBC()[$tokens[$nextNonEmpty]['code']]) === false) {
             // Parameter not passed as an array, treat it as a string pattern.
             return [$paramInfo];
         }
@@ -159,7 +159,7 @@ trait PCRERegexTrait
          * and function calls. We are only concerned with the strings.
          */
         for ($i = $patternInfo['start']; $i <= $patternInfo['end']; $i++) {
-            if (isset(Collections::$textStingStartTokens[$tokens[$i]['code']]) === false) {
+            if (isset(Collections::textStringStartTokens()[$tokens[$i]['code']]) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -84,9 +84,9 @@ class NewMagicClassConstantSniff extends Sniff
         }
 
         $preSubjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($subjectPtr - 1), null, true, null, true);
-        if (isset(Collections::$OOHierarchyKeywords[$tokens[$subjectPtr]['code']]) === true
+        if (isset(Collections::ooHierarchyKeywords()[$tokens[$subjectPtr]['code']]) === true
             || ($tokens[$subjectPtr]['code'] === \T_STRING
-                && isset(Collections::$objectOperators[$tokens[$preSubjectPtr]['code']]) === false)
+                && isset(Collections::objectOperators()[$tokens[$preSubjectPtr]['code']]) === false)
         ) {
             // This is a syntax which is supported on PHP 5.5 and higher.
             if ($this->supportsBelow('5.4') === true) {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -40,7 +40,7 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
      */
     public function register()
     {
-        return Collections::functionDeclarationTokensBC();
+        return Collections::functionDeclarationTokens();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -39,7 +39,7 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
      */
     public function register()
     {
-        return Collections::functionDeclarationTokensBC();
+        return Collections::functionDeclarationTokens();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -251,7 +251,7 @@ class NewClosureSniff extends Sniff
         }
 
         $tokens   = $phpcsFile->getTokens();
-        $classRef = $phpcsFile->findNext(Collections::$OOHierarchyKeywords, $startToken, $endToken);
+        $classRef = $phpcsFile->findNext(Collections::ooHierarchyKeywords(), $startToken, $endToken);
 
         if ($classRef === false || $tokens[$classRef]['code'] !== \T_STATIC) {
             return $classRef;

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -45,7 +45,7 @@ class NewNullableTypesSniff extends Sniff
      */
     public function register()
     {
-        return Collections::functionDeclarationTokensBC();
+        return Collections::functionDeclarationTokens();
     }
 
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -139,7 +139,7 @@ class NewParamTypeDeclarationsSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        return Collections::functionDeclarationTokensBC();
+        return Collections::functionDeclarationTokens();
     }
 
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -127,7 +127,7 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        return Collections::functionDeclarationTokensBC();
+        return Collections::functionDeclarationTokens();
     }
 
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -100,7 +100,7 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
 
             // Skip over nested closed scopes as possible for efficiency.
             // Ignore arrow functions as they aren't closed scopes.
-            if (isset(Collections::$closedScopes[$tokens[$current]['code']]) === true
+            if (isset(Collections::closedScopes()[$tokens[$current]['code']]) === true
                 && isset($tokens[$current]['scope_closer']) === true
             ) {
                 $current = $tokens[$current]['scope_closer'];

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -58,7 +58,7 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
     {
         $this->allowedInDefault += Tokens::$emptyTokens;
 
-        return Collections::functionDeclarationTokensBC();
+        return Collections::functionDeclarationTokens();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -60,7 +60,7 @@ class NewConstantArraysUsingConstSniff extends Sniff
         }
 
         $tokens = $phpcsFile->getTokens();
-        $find   = Collections::$arrayTokens;
+        $find   = Collections::arrayOpenTokensBC();
 
         while (($hasArray = $phpcsFile->findNext($find, ($stackPtr + 1), null, false, null, true)) !== false) {
             if ($tokens[$hasArray]['code'] === \T_ARRAY

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -90,7 +90,7 @@ class NewConstantArraysUsingDefineSniff extends Sniff
             $targetNestingLevel = \count($tokens[$secondParam['start']]['nested_parenthesis']);
         }
 
-        $array = $phpcsFile->findNext(Collections::$arrayTokensBC, $secondParam['start'], ($secondParam['end'] + 1));
+        $array = $phpcsFile->findNext(Collections::arrayOpenTokensBC(), $secondParam['start'], ($secondParam['end'] + 1));
         if ($array !== false
             && ($tokens[$array]['code'] === \T_ARRAY
                 || Arrays::isShortArray($phpcsFile, $array) === true)

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -158,7 +158,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
             \T_CATCH,
         ];
 
-        $targets += Collections::functionDeclarationTokensBC();
+        $targets += Collections::functionDeclarationTokens();
 
         return $targets;
     }
@@ -198,7 +198,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
                 break;
         }
 
-        if (isset(Collections::functionDeclarationTokensBC()[$tokens[$stackPtr]['code']]) === true) {
+        if (isset(Collections::functionDeclarationTokens()[$tokens[$stackPtr]['code']]) === true) {
             $this->processFunctionToken($phpcsFile, $stackPtr);
         }
     }

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -38,7 +38,7 @@ class CaseSensitiveKeywordsSniff extends Sniff
      */
     public function register()
     {
-        return Collections::$OOHierarchyKeywords;
+        return Collections::ooHierarchyKeywords();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -92,7 +92,7 @@ class NewDirectCallsToCloneSniff extends Sniff
 
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevNonEmpty === false
-            || isset(Collections::$OOHierarchyKeywords[$tokens[$prevNonEmpty]['code']])
+            || isset(Collections::ooHierarchyKeywords()[$tokens[$prevNonEmpty]['code']])
         ) {
             // Class internal call to __clone().
             return;

--- a/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
@@ -122,7 +122,7 @@ class ValidIntegersSniff extends Sniff
         }
 
         if ($next['code'] === \T_STRING
-            && \preg_match(Numbers::REGEX_NUMLIT_STRING, $next['content'])
+            && \preg_match('`^((?<![\.e])_[0-9][0-9e\.]*)+$`iD', $next['content'])
         ) {
             return true;
         }

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -95,7 +95,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
             true
         );
 
-        if ($prevNonEmpty !== false && isset(Collections::$closedScopes[$tokens[$prevNonEmpty]['code']]) === true) {
+        if ($prevNonEmpty !== false && isset(Collections::closedScopes()[$tokens[$prevNonEmpty]['code']]) === true) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
@@ -14,7 +14,6 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\BackCompat\BCTokens;
-use PHPCSUtils\Tokens\Collections;
 
 /**
  * Detect dereferencing of magic constants as allowed per PHP 8.0.
@@ -37,7 +36,7 @@ class NewMagicConstantDereferencingSniff extends Sniff
      */
     public function register()
     {
-        return Collections::$magicConstants;
+        return Tokens::$magicConstants;
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -38,7 +38,7 @@ class NewShortArraySniff extends Sniff
      */
     public function register()
     {
-        return Collections::$shortArrayTokensBC;
+        return Collections::shortArrayListOpenTokensBC();
     }
 
 
@@ -63,18 +63,12 @@ class NewShortArraySniff extends Sniff
             return;
         }
 
-        $tokens = $phpcsFile->getTokens();
-        $token  = $tokens[$stackPtr];
-
-        $error = '%s is not supported in PHP 5.3 or lower';
-        $data  = [];
-
-        if ($token['code'] === \T_OPEN_SHORT_ARRAY || $token['code'] === \T_OPEN_SQUARE_BRACKET) {
-            $data[] = 'Short array syntax (open)';
-        } elseif ($token['code'] === \T_CLOSE_SHORT_ARRAY || $token['code'] === \T_CLOSE_SQUARE_BRACKET) {
-            $data[] = 'Short array syntax (close)';
-        }
-
+        $error = 'Short array syntax (%s) is not supported in PHP 5.3 or lower';
+        $data  = ['open'];
         $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+
+        $tokens = $phpcsFile->getTokens();
+        $data   = ['close'];
+        $phpcsFile->addError($error, $tokens[$stackPtr]['bracket_closer'], 'Found', $data);
     }
 }


### PR DESCRIPTION
**_Note: this is a minimal update to get rid of some deprecations and such. Once this has been merged, a lot more PRs will follow which will actually implement the new functionality from PHPCSUtils 1.0.0-alpha4._**

### PHPCSUtils 1.0.0-alpha4: ValidIntegers: remove use of `Numbers::REGEX_NUMLIT_STRING`

This constant has been removed from PHPCSUtils as it is no longer needed there. The regex which was previously contained in PHPCSUtils has now been copied into this sniff.

### PHPCSUtils 1.0.0-alpha4: replace deprecated Collections properties and methods

The direct use of the static properties in the `PHPCSUtils\Tokens\Collections` class has been deprecated.
Additionally, a number of methods in the same class have been deprecated as they are no longer needed now PHPCS < 3.7.1 is no longer supported.

This updates the sniffs to no longer use this deprecated functionality.

Includes switching to more appropriate (new) token collection when possible.

Includes a small change in the `NewShortArray` sniff to only determine whether something is a short array once, while still showing the same error notices. (efficiency tweak)

See: https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.0-alpha4