### PR TITLE
Sniff: start using PHPCSUtils MessageHelper

### DIFF
--- a/PHPCompatibility/AbstractNewFeatureSniff.php
+++ b/PHPCompatibility/AbstractNewFeatureSniff.php
@@ -101,7 +101,7 @@ abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
         $itemName = $this->getItemName($itemInfo, $errorInfo);
         $error    = $this->getErrorMsgTemplate();
 
-        $errorCode = $this->stringToErrorCode($itemName) . 'Found';
+        $errorCode = MessageHelper::stringToErrorCode($itemName, true) . 'Found';
         $data      = [
             $itemName,
             $errorInfo['not_in_version'],

--- a/PHPCompatibility/AbstractNewFeatureSniff.php
+++ b/PHPCompatibility/AbstractNewFeatureSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility;
 
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Base class for new feature sniffs.
@@ -109,6 +110,6 @@ abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
         $error = $this->filterErrorMsg($error, $itemInfo, $errorInfo);
         $data  = $this->filterErrorData($data, $itemInfo, $errorInfo);
 
-        $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
+        MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
     }
 }

--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -127,7 +127,7 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
         $itemName = $this->getItemName($itemInfo, $errorInfo);
         $error    = $this->getErrorMsgTemplate();
 
-        $errorCode = $this->stringToErrorCode($itemName);
+        $errorCode = MessageHelper::stringToErrorCode($itemName, true);
         $data      = [$itemName];
 
         if ($errorInfo['deprecated'] !== '') {

--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility;
 
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Base class for removed feature sniffs.
@@ -152,6 +153,6 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
         $error = $this->filterErrorMsg($error, $itemInfo, $errorInfo);
         $data  = $this->filterErrorData($data, $itemInfo, $errorInfo);
 
-        $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
+        MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
     }
 }

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -43,34 +43,6 @@ abstract class Sniff implements PHPCS_Sniff
     const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';
 
     /**
-     * Add a PHPCS message to the output stack as either a warning or an error.
-     *
-     * @since 7.1.0
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file the message applies to.
-     * @param string                      $message   The message.
-     * @param int                         $stackPtr  The position of the token
-     *                                               the message relates to.
-     * @param bool                        $isError   Whether to report the message as an
-     *                                               'error' or 'warning'. Defaults to
-     *                                               true (error).
-     * @param string                      $code      The error code for the message.
-     *                                               Defaults to 'Found'.
-     * @param array                       $data      Optional input for the data replacements.
-     *
-     * @return void
-     */
-    public function addMessage(File $phpcsFile, $message, $stackPtr, $isError, $code = 'Found', $data = [])
-    {
-        if ($isError === true) {
-            $phpcsFile->addError($message, $stackPtr, $code, $data);
-        } else {
-            $phpcsFile->addWarning($message, $stackPtr, $code, $data);
-        }
-    }
-
-
-    /**
      * Convert an arbitrary string to an alphanumeric string with underscores.
      *
      * Pre-empt issues with arbitrary strings being used as error codes in XML and PHP.

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -43,23 +43,6 @@ abstract class Sniff implements PHPCS_Sniff
     const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';
 
     /**
-     * Convert an arbitrary string to an alphanumeric string with underscores.
-     *
-     * Pre-empt issues with arbitrary strings being used as error codes in XML and PHP.
-     *
-     * @since 7.1.0
-     *
-     * @param string $baseString Arbitrary string.
-     *
-     * @return string
-     */
-    public function stringToErrorCode($baseString)
-    {
-        return \preg_replace('`[^a-z0-9_]`i', '_', \strtolower($baseString));
-    }
-
-
-    /**
      * Strip variables from an arbitrary double quoted string.
      *
      * Intended for use with the contents of a T_DOUBLE_QUOTED_STRING.

--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Classes;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\Conditions;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Using `parent` inside a class without parent is deprecated since PHP 7.4 and removed in PHP 8.0.
@@ -101,6 +102,6 @@ class RemovedOrphanedParentSniff extends Sniff
             $isError = true;
         }
 
-        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
+        MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
     }
 }

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ControlStructures;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\Conditions;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Detect using `break` and/or `continue` statements outside of a looping structure.
@@ -90,6 +91,6 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
             $errorCode = 'FatalError';
         }
 
-        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
+        MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
     }
 }

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ControlStructures;
 use PHPCompatibility\AbstractNewFeatureSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -263,7 +264,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
             parent::addError($phpcsFile, $stackPtr, $itemInfo, $errorInfo);
         } elseif ($errorInfo['conditional_version'] !== '') {
             $error     = 'Directive %s is present in PHP version %s but will be disregarded unless PHP is compiled with %s';
-            $errorCode = $this->stringToErrorCode($itemInfo['name']) . 'WithConditionFound';
+            $errorCode = MessageHelper::stringToErrorCode($itemInfo['name'], true) . 'WithConditionFound';
             $data      = [
                 $itemInfo['name'],
                 $errorInfo['conditional_version'],
@@ -311,7 +312,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 
         if ($isError === true) {
             $error     = 'The execution directive %s does not seem to have a valid value. Please review. Found: %s';
-            $errorCode = $this->stringToErrorCode($directive) . 'InvalidValueFound';
+            $errorCode = MessageHelper::stringToErrorCode($directive, true) . 'InvalidValueFound';
             $data      = [
                 $directive,
                 $value,

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Variables;
 
 /**
@@ -73,7 +74,7 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
         foreach ($parameters as $param) {
             if (Variables::isSuperglobalName($param['name']) === true) {
                 $error     = 'Parameter shadowing super global (%s) causes a fatal error since PHP 5.4';
-                $errorCode = $this->stringToErrorCode(\substr($param['name'], 1)) . 'Found';
+                $errorCode = MessageHelper::stringToErrorCode(\substr($param['name'], 1), true) . 'Found';
                 $data      = [$param['name']];
 
                 $phpcsFile->addError($error, $param['token'], $errorCode, $data);

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Scopes;
 
 /**
@@ -160,7 +161,7 @@ class NonStaticMagicMethodsSniff extends Sniff
         }
 
         $methodProperties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
-        $errorCodeBase    = $this->stringToErrorCode($methodNameLc);
+        $errorCodeBase    = MessageHelper::stringToErrorCode($methodNameLc);
 
         if (isset($this->magicMethods[$methodNameLc]['visibility'])
             && $this->magicMethods[$methodNameLc]['visibility'] !== $methodProperties['scope']

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\UseStatements;
@@ -201,7 +202,7 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
         }
 
         foreach ($exits as $ptr) {
-            $this->addMessage($phpcsFile, $error, $ptr, $isError, $errorCode, [$tokens[$ptr]['content']]);
+            MessageHelper::addMessage($phpcsFile, $error, $ptr, $isError, $errorCode, [$tokens[$ptr]['content']]);
         }
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\Scopes;
 
@@ -103,6 +104,6 @@ class RemovedMagicAutoloadSniff extends Sniff
             $isError = true;
         }
 
-        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
+        MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\Scopes;
 
@@ -91,6 +92,6 @@ class RemovedNamespacedAssertSniff extends Sniff
             $isError = true;
         }
 
-        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
+        MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\NamingConventions;
 use PHPCSUtils\Utils\ObjectDeclarations;
@@ -153,7 +154,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
                 $isError = true;
             }
 
-            $this->addMessage($phpcsFile, $error, $oldConstructorPos, $isError, $code);
+            MessageHelper::addMessage($phpcsFile, $error, $oldConstructorPos, $isError, $code);
         }
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\FunctionUse;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Detect usage of `func_get_args()`, `func_get_arg()` and `func_num_args()` in invalid context.
@@ -119,7 +120,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
                 $message .= ' As of PHP 5.3, it is no longer supported at all.';
             }
 
-            $this->addMessage($phpcsFile, $message, $stackPtr, $isError, 'OutsideFunctionScope', $data);
+            MessageHelper::addMessage($phpcsFile, $message, $stackPtr, $isError, 'OutsideFunctionScope', $data);
         }
 
         /*

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Detect missing required function parameters in calls to native PHP functions.
@@ -265,6 +266,6 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
         $error      = \substr($error, 0, (\strlen($error) - 5));
         $errorCode .= $codeSuffix . 'Required';
 
-        $this->addMessage($phpcsFile, $error, $stackPtr, $versionInfo['error'], $errorCode, $data);
+        MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $versionInfo['error'], $errorCode, $data);
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -243,7 +243,7 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
     protected function addError(File $phpcsFile, $stackPtr, array $itemInfo, array $itemArray, array $versionInfo)
     {
         $error      = 'The "%s" parameter for function %s() is missing. Passing this parameter is no longer optional. The optional nature of the parameter is ';
-        $errorCode  = $this->stringToErrorCode($itemInfo['name'] . '_' . $itemArray['name']);
+        $errorCode  = MessageHelper::stringToErrorCode($itemInfo['name'] . '_' . $itemArray['name'], true);
         $codeSuffix = '';
         $data       = [
             $itemArray['name'],

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Detect missing required function parameters in calls to native PHP functions.
@@ -473,7 +474,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractFunctionCallPara
     protected function addError(File $phpcsFile, $stackPtr, array $itemInfo, array $itemArray, array $versionInfo)
     {
         $error     = 'The "%s" parameter for function %s() is missing, but was required for PHP version %s and lower';
-        $errorCode = $this->stringToErrorCode($itemInfo['name'] . '_' . $itemArray['name']) . 'Missing';
+        $errorCode = MessageHelper::stringToErrorCode($itemInfo['name'] . '_' . $itemArray['name'], true) . 'Missing';
         $data      = [
             $itemArray['name'],
             $itemInfo['name'],

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\Scopes;
 
@@ -499,7 +500,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
         $errorCode = 'Found';
 
         if (isset($this->errorPhrases[$type]) === true) {
-            $errorCode = $this->stringToErrorCode($type) . 'Found';
+            $errorCode = MessageHelper::stringToErrorCode($type) . 'Found';
             $phrase    = $this->errorPhrases[$type];
         }
 

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Interfaces;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
@@ -87,7 +88,7 @@ class InternalInterfacesSniff extends Sniff
             $interfaceLc = \strtolower($interface);
             if (isset($this->internalInterfaces[$interfaceLc]) === true) {
                 $error     = 'The interface %s %s';
-                $errorCode = $this->stringToErrorCode($interfaceLc) . 'Found';
+                $errorCode = MessageHelper::stringToErrorCode($interfaceLc) . 'Found';
                 $data      = [
                     $interface,
                     $this->internalInterfaces[$interfaceLc],

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -16,6 +16,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ControlStructures;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Variables;
 
@@ -300,7 +301,7 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
                         && isset($this->unsupportedMethods[$interfaceLc][$funcNameLc]) === true
                     ) {
                         $error     = $phrase . ' interface %s do not support the method %s(). See %s';
-                        $errorCode = $this->stringToErrorCode($interface) . 'UnsupportedMethod';
+                        $errorCode = MessageHelper::stringToErrorCode($interfaceLc) . 'UnsupportedMethod';
                         $data      = [
                             $interface,
                             $funcName,

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -180,7 +180,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
         // Build up the error message.
         $error     = "'%s' is a";
         $isError   = null;
-        $errorCode = $this->stringToErrorCode($nameLc) . 'Found';
+        $errorCode = MessageHelper::stringToErrorCode($nameLc) . 'Found';
         $data      = [
             $nameLc,
         ];

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsDeclaredSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Keywords;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Namespaces;
 
@@ -207,7 +208,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
             $error .= ' and should not be used to name a class, interface or trait or as part of a namespace (%s)';
             $data[] = $tokens[$stackPtr]['type'];
 
-            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
+            MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
         }
     }
 }

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Keywords;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Prohibits the use of reserved keywords invoked as functions.
@@ -175,7 +176,7 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
 
         if ($this->supportsAbove($version)) {
             $error     = "'%s' is a reserved keyword introduced in PHP version %s and cannot be invoked as a function (%s)";
-            $errorCode = $this->stringToErrorCode($tokenContentLc) . 'Found';
+            $errorCode = MessageHelper::stringToErrorCode($tokenContentLc) . 'Found';
             $data      = [
                 $tokenContentLc,
                 $version,

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Keywords;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\TextStrings;
@@ -407,7 +408,7 @@ class ForbiddenNamesSniff extends Sniff
     protected function addError(File $phpcsFile, $stackPtr, $content, $data)
     {
         $error     = "Function name, class name, namespace name or constant name can not be reserved keyword '%s' (since version %s)";
-        $errorCode = $this->stringToErrorCode($content) . 'Found';
+        $errorCode = MessageHelper::stringToErrorCode($content, true) . 'Found';
         $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
     }
 

--- a/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Numbers;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Numbers;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -67,7 +68,7 @@ class RemovedHexadecimalNumericStringsSniff extends Sniff
 
         $isError = $this->supportsAbove('7.0');
 
-        $this->addMessage(
+        MessageHelper::addMessage(
             $phpcsFile,
             'The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7. Found: %s',
             $stackPtr,

--- a/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Numbers;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Numbers;
 
 /**
@@ -88,7 +89,7 @@ class ValidIntegersSniff extends Sniff
         $isError = $this->supportsAbove('7.0');
 
         if ($this->isInvalidOctalInteger($numberInfo['content']) === true) {
-            $this->addMessage(
+            MessageHelper::addMessage(
                 $phpcsFile,
                 'Invalid octal integer detected. Prior to PHP 7 this would lead to a truncated number. From PHP 7 onwards this causes a parse error. Found: %s',
                 $stackPtr,

--- a/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Operators;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Operators;
 
 /**
@@ -195,6 +196,6 @@ class ChangedConcatOperatorPrecedenceSniff extends Sniff
             $isError  = true;
         }
 
-        $this->addMessage($phpcsFile, $message, $i, $isError);
+        MessageHelper::addMessage($phpcsFile, $message, $i, $isError);
     }
 }

--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Operators;
 
 /**
@@ -154,7 +155,7 @@ class RemovedTernaryAssociativitySniff extends Sniff
 
             $message .= '. Multiple consecutive ternaries detected. Use parenthesis to clarify the order in which the operations should be executed';
 
-            $this->addMessage($phpcsFile, $message, $stackPtr, $isError, $code);
+            MessageHelper::addMessage($phpcsFile, $message, $stackPtr, $isError, $code);
         }
     }
 }

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Detect calls to functions where the expected type of a parameter has been changed from integer to boolean.
@@ -109,7 +110,7 @@ class ChangedIntToBoolParamTypeSniff extends AbstractFunctionCallParameterSniff
             }
 
             $error = 'The $%s parameter of %s() expects a boolean value instead of an integer since PHP %s. Found: %s';
-            $code  = $this->stringToErrorCode($functionName . '_' . $paramInfo['name']) . 'NumericFound';
+            $code  = MessageHelper::stringToErrorCode($functionLC . '_' . $paramInfo['name'], true) . 'NumericFound';
             $data  = [
                 $paramInfo['name'],
                 $functionLC,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Detect the use of assertions passed as a string.
@@ -128,6 +129,6 @@ class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSni
             $code    = 'Removed';
         }
 
-        $this->addMessage($phpcsFile, $error, $targetParam['start'], $isError, $code, $data);
+        MessageHelper::addMessage($phpcsFile, $error, $targetParam['start'], $isError, $code, $data);
     }
 }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Passing the `$glue` and `$pieces` parameters to `implode()` in reverse order has
@@ -312,6 +313,6 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
 
         $message .= '; $glue should be the first parameter and $pieces the second';
 
-        $this->addMessage($phpcsFile, $message, $stackPtr, $isError, $errorCode, $data);
+        MessageHelper::addMessage($phpcsFile, $message, $stackPtr, $isError, $errorCode, $data);
     }
 }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Detect passing `$encoding` to `mb_strrpos()` as 3rd argument.
@@ -135,6 +136,6 @@ class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParame
 
         $error .= '. Use an explicit 0 as the offset in the third parameter.';
 
-        $this->addMessage($phpcsFile, $error, $targetParam['start'], $isError, $code);
+        MessageHelper::addMessage($phpcsFile, $error, $targetParam['start'], $isError, $code);
     }
 }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -140,7 +141,7 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
                 $error .= ' Use mb_ereg_replace_callback() instead (PHP 5.4.1+).';
             }
 
-            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
+            MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $isError, $code);
         }
     }
 }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -100,7 +101,8 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        if (\strtolower($functionName) === 'hash_init'
+        $functionLC = \strtolower($functionName);
+        if ($functionLC === 'hash_init'
             && (isset($parameters[2]) === false
             || ($parameters[2]['clean'] !== 'HASH_HMAC'
                 && $parameters[2]['clean'] !== (string) \HASH_HMAC))
@@ -112,7 +114,7 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
         $phpcsFile->addError(
             'Non-cryptographic hashes are no longer accepted by function %s() since PHP 7.2. Found: %s',
             $targetParam['start'],
-            $this->stringToErrorCode($functionName),
+            MessageHelper::stringToErrorCode($functionLC),
             [
                 $functionName,
                 $targetParam['clean'],

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\PCRERegexTrait;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Check for the use of deprecated and removed regex modifiers for PCRE regex functions.
@@ -132,7 +133,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
                 $errorCode = 'Removed';
             }
 
-            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
+            MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
         }
     }
 }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Detect passing a string literal as `$category` to `setlocale()`.
@@ -103,7 +104,7 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
 
             $message .= '; Pass one of the LC_* constants instead. Found: %s';
 
-            $this->addMessage($phpcsFile, $message, $i, $isError, $errorCode, $data);
+            MessageHelper::addMessage($phpcsFile, $message, $i, $isError, $errorCode, $data);
             break;
         }
     }

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -134,7 +135,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
                     $errorCode = 'NotAllowed';
                 }
 
-                $this->addMessage($phpcsFile, $error, $parameter['start'], $isError, $errorCode);
+                MessageHelper::addMessage($phpcsFile, $error, $parameter['start'], $isError, $errorCode);
             }
         }
     }

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Syntax;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Detect the use of assigning the return value of `new` by reference.
@@ -75,6 +76,6 @@ class RemovedNewReferenceSniff extends Sniff
             $errorCode = 'Removed';
         }
 
-        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode);
+        MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode);
     }
 }

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -122,7 +122,7 @@ class LowPHPCSSniff extends Sniff
         if (\version_compare($phpcsVersion, self::MIN_SUPPORTED_VERSION, '<')) {
             $isError      = true;
             $message      = 'IMPORTANT: Please be advised that the minimum PHP_CodeSniffer version the PHPCompatibility standard supports is %s. You are currently using PHP_CodeSniffer %s. Please upgrade your PHP_CodeSniffer installation. The recommended version of PHP_CodeSniffer for PHPCompatibility is %s or higher.';
-            $errorCode    = 'Unsupported_' . $this->stringToErrorCode(self::MIN_SUPPORTED_VERSION);
+            $errorCode    = 'Unsupported_' . MessageHelper::stringToErrorCode(self::MIN_SUPPORTED_VERSION);
             $replacements = [
                 self::MIN_SUPPORTED_VERSION,
                 $phpcsVersion,
@@ -131,7 +131,7 @@ class LowPHPCSSniff extends Sniff
         } else {
             $isError      = false;
             $message      = 'IMPORTANT: Please be advised that for the most reliable PHPCompatibility results, PHP_CodeSniffer %s or higher should be used. Support for lower versions will be dropped in the foreseeable future. You are currently using PHP_CodeSniffer %s. Please upgrade your PHP_CodeSniffer installation to version %s or higher.';
-            $errorCode    = 'BelowRecommended_' . $this->stringToErrorCode(self::MIN_RECOMMENDED_VERSION);
+            $errorCode    = 'BelowRecommended_' . MessageHelper::stringToErrorCode(self::MIN_RECOMMENDED_VERSION);
             $replacements = [
                 self::MIN_RECOMMENDED_VERSION,
                 $phpcsVersion,

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Helpers\DisableSniffMsgTrait;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Add a notification for users of low PHPCS versions.
@@ -140,7 +141,7 @@ class LowPHPCSSniff extends Sniff
 
         $message .= $this->createDisableSniffNotice($phpcsFile, 'PHPCompatibility.Upgrade.LowPHPCS', $errorCode);
 
-        $this->addMessage($phpcsFile, $message, 0, $isError, $errorCode, $replacements);
+        MessageHelper::addMessage($phpcsFile, $message, 0, $isError, $errorCode, $replacements);
 
         $this->examine = false;
     }

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -113,7 +113,7 @@ class LowPHPSniff extends Sniff
         if (\version_compare($phpVersion, self::MIN_SUPPORTED_VERSION, '<')) {
             $isError      = true;
             $message      = 'IMPORTANT: Please be advised that the minimum PHP version the PHPCompatibility standard supports is %s. You are currently using PHP %s. Please upgrade your PHP installation. The recommended version of PHP for PHPCompatibility is %s or higher.';
-            $errorCode    = 'Unsupported_' . $this->stringToErrorCode(self::MIN_SUPPORTED_VERSION);
+            $errorCode    = 'Unsupported_' . MessageHelper::stringToErrorCode(self::MIN_SUPPORTED_VERSION);
             $replacements = [
                 self::MIN_SUPPORTED_VERSION,
                 $phpVersion,
@@ -122,7 +122,7 @@ class LowPHPSniff extends Sniff
         } else {
             $isError      = false;
             $message      = 'IMPORTANT: Please be advised that for the most reliable PHPCompatibility results, PHP %s or higher should be used. Support for lower versions will be dropped in the foreseeable future. You are currently using PHP %s. Please upgrade your PHP installation to version %s or higher.';
-            $errorCode    = 'BelowRecommended_' . $this->stringToErrorCode(self::MIN_RECOMMENDED_VERSION);
+            $errorCode    = 'BelowRecommended_' . MessageHelper::stringToErrorCode(self::MIN_RECOMMENDED_VERSION);
             $replacements = [
                 self::MIN_RECOMMENDED_VERSION,
                 $phpVersion,

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Upgrade;
 use PHPCompatibility\Helpers\DisableSniffMsgTrait;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\MessageHelper;
 
 /**
  * Add a notification for users of low PHP versions.
@@ -131,7 +132,7 @@ class LowPHPSniff extends Sniff
 
         $message .= $this->createDisableSniffNotice($phpcsFile, 'PHPCompatibility.Upgrade.LowPHP', $errorCode);
 
-        $this->addMessage($phpcsFile, $message, 0, $isError, $errorCode, $replacements);
+        MessageHelper::addMessage($phpcsFile, $message, 0, $isError, $errorCode, $replacements);
 
         $this->examine = false;
     }

--- a/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/FunctionsUnitTest.php
@@ -56,41 +56,6 @@ class FunctionsUnitTest extends TestCase
     }
 
     /**
-     * testStringToErrorCode
-     *
-     * @dataProvider dataStringToErrorCode
-     *
-     * @covers \PHPCompatibility\Sniff::stringToErrorCode
-     *
-     * @param string $input    The input string.
-     * @param string $expected The expected error code.
-     *
-     * @return void
-     */
-    public function testStringToErrorCode($input, $expected)
-    {
-        $this->assertSame($expected, $this->helperClass->stringToErrorCode($input));
-    }
-
-    /**
-     * dataStringToErrorCode
-     *
-     * @see testStringToErrorCode()
-     *
-     * @return array
-     */
-    public function dataStringToErrorCode()
-    {
-        return [
-            ['dir_name', 'dir_name'], // No change.
-            ['soap.wsdl_cache', 'soap_wsdl_cache'], // No dot.
-            ['arbitrary-string with space', 'arbitrary_string_with_space'], // No dashes, no spaces.
-            ['^%*&%*€à?', '____________'], // No non alpha-numeric characters.
-        ];
-    }
-
-
-    /**
      * testStripVariables
      *
      * @dataProvider dataStripVariables


### PR DESCRIPTION
### Sniff: remove addMessage() method in favour of PHPCSUtils

Includes adjusting all uses of the method in the repo.

### Sniff: remove stringToErrorCode() method in favour of PHPCSUtils

Includes adjusting all uses of the method in the repo.