### PR TITLE
Variables/ForbiddenThisUseContexts: add test with $this in enums

### DIFF
--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.inc
@@ -152,6 +152,22 @@ class StaticMethodsClass {
     }
 }
 
+// Issue  #1343 - $this in enums.
+enum Suit: string implements Colorful
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+
+    public function color(): string {
+        return match($this) {
+            Suit::Hearts, Suit::Diamonds => 'Red',
+            Suit::Clubs, Suit::Spades => 'Black',
+        };
+    }
+}
+
 
 /*
  * ====================================================================

--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
@@ -435,7 +435,8 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTest
             [126],
             [133],
             [138],
-            [202], // Exception to the rule / static __call() magic method.
+            [164],
+            [219], // Exception to the rule / static __call() magic method.
         ];
     }
 
@@ -449,8 +450,8 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTest
     {
         $file = $this->sniffFile(__FILE__, '7.1');
 
-        // No errors expected on the first 14 lines.
-        for ($line = 156; $line <= 205; $line++) {
+        // No errors expected on the last group of lines.
+        for ($line = 172; $line <= 226; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }


### PR DESCRIPTION
This is now automatically fixed after the update of PHPCSUtils to 1.0.0-alpha4.

This sniff uses a couple of token arrays which previously did not contain the `T_ENUM` token, but that token has been added to the relevant arrays as of PHPCSUtils 1.0.0-alpha4.

Report also contains similar unit test.

Closes #1343