### PR TITLE
PHPCSUtils: implement use of the Collections::phpOpenTags() method

### DIFF
--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Miscellaneous;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Check for use of alternative PHP tags, support for which was removed in PHP 7.0.
@@ -52,11 +53,10 @@ class RemovedAlternativePHPTagsSniff extends Sniff
             $this->aspTags = (bool) \ini_get('asp_tags');
         }
 
-        return [
-            \T_OPEN_TAG,
-            \T_OPEN_TAG_WITH_ECHO,
-            \T_INLINE_HTML,
-        ];
+        $targets                 = Collections::phpOpenTags();
+        $targets[\T_INLINE_HTML] = \T_INLINE_HTML;
+
+        return $targets;
     }
 
 
@@ -85,7 +85,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
             return;
         }
 
-        if ($openTag['code'] === \T_OPEN_TAG || $openTag['code'] === \T_OPEN_TAG_WITH_ECHO) {
+        if (isset(Collections::phpOpenTags()[$openTag['code']]) === true) {
 
             if ($content === '<%' || $content === '<%=') {
                 $data      = [

--- a/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Operators;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Operators;
 
@@ -102,11 +103,10 @@ class ChangedConcatOperatorPrecedenceSniff extends Sniff
 
             if ($tokens[$i]['code'] === \T_SEMICOLON
                 || $tokens[$i]['code'] === \T_OPEN_CURLY_BRACKET
-                || $tokens[$i]['code'] === \T_OPEN_TAG
-                || $tokens[$i]['code'] === \T_OPEN_TAG_WITH_ECHO
                 || $tokens[$i]['code'] === \T_COMMA
                 || $tokens[$i]['code'] === \T_COLON
                 || $tokens[$i]['code'] === \T_CASE
+                || isset(Collections::phpOpenTags()[$tokens[$i]['code']]) === true
             ) {
                 // If we reached any of the above tokens, we've reached the end of
                 // the statement without encountering a concatenation operator.

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Helpers\DisableSniffMsgTrait;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 
 /**
@@ -87,9 +88,7 @@ class LowPHPCSSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_OPEN_TAG,
-        ];
+        return Collections::phpOpenTags();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Upgrade;
 use PHPCompatibility\Helpers\DisableSniffMsgTrait;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 
 /**
@@ -78,9 +79,7 @@ class LowPHPSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_OPEN_TAG,
-        ];
+        return Collections::phpOpenTags();
     }
 
     /**

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.inc
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.inc
@@ -24,3 +24,5 @@ echo $var;
 <p>Some text <%= $var %> and some more text</p>
 
 </div>
+
+<?= $var ?><!-- OK -->

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -167,6 +167,7 @@ class RemovedAlternativePHPTagsUnitTest extends BaseSniffTest
     {
         return [
             [3],
+            [28],
         ];
     }
 

--- a/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.inc
+++ b/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.inc
@@ -124,3 +124,7 @@ return $number.($number === 1 ? 'd' : $number % 10 === 2 ? 'na' : 'mh');
 
 // (BUG!) /home/nikic/package-analysis/sources/respect/validation/library/Rules/Cnh.php:59
 $check = $dv2 < 0 ? $dv2 + 11 : $dv2 > 9 ? 0 : $dv2;
+
+?>
+<div class="<?= $a ? $b : $c ? $d : $e ? $f : $g ?>"></div><!-- Deprecated x2-->
+<?php

--- a/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
@@ -62,6 +62,7 @@ class RemovedTernaryAssociativityUnitTest extends BaseSniffTest
         120,
         123,
         126,
+        129, // x2.
     ];
 
 


### PR DESCRIPTION
### PHPCSUtils: implement use of the Collections::phpOpenTags() method

Token-wise, PHP has two PHP open tag tokens to take into account.

Some sniffs were only taking one of these into account. By switching use of `T_OPEN_TAG` to the `Collections::phpOpenTags()` method, both will now be handled.

Where this constitutes a functional change, unit tests have been added. In all other cases, it has been verified that the existing unit tests cover this sufficiently.

### RemovedTernaryAssociativity: add test with short open tag

.. to confirm this is already handled correctly.