### PR TITLE
Numbers/RemovedHexadecimalNumericStrings: prevent some false positives

### DIFF
--- a/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
@@ -12,8 +12,12 @@ namespace PHPCompatibility\Sniffs\Numbers;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Numbers;
+use PHPCSUtils\Utils\Parentheses;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -32,6 +36,70 @@ use PHPCSUtils\Utils\TextStrings;
  */
 class RemovedHexadecimalNumericStringsSniff extends Sniff
 {
+
+    /**
+     * Names of global/PHP native functions which still accept hexadecimal numeric strings
+     * as numeric input.
+     *
+     * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/1345
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, array|true> True if all arguments in the function call accept hex numeric
+     *                                strings. An array with 1-based parameter position (key) and
+     *                                names (value) for those functions which only accept
+     *                                hex numeric strings for select parameters.
+     */
+    private $excludedFunctions = [
+        'gmp_abs'            => true,
+        'gmp_add'            => true,
+        'gmp_and'            => true,
+        'gmp_binomial'       => [1 => 'n'],
+        'gmp_cmp'            => true,
+        'gmp_com'            => true,
+        'gmp_div_q'          => [1 => 'num1', 2 => 'num2'],
+        'gmp_div_qr'         => [1 => 'num1', 2 => 'num2'],
+        'gmp_div_r'          => [1 => 'num1', 2 => 'num2'],
+        'gmp_div'            => [1 => 'num1', 2 => 'num2'],
+        'gmp_divexact'       => true,
+        'gmp_export'         => [1 => 'num'],
+        'gmp_fact'           => true,
+        'gmp_gcd'            => true,
+        'gmp_gcdext'         => true,
+        'gmp_hamdist'        => true,
+        'gmp_init'           => [1 => 'num'],
+        'gmp_intval'         => true,
+        'gmp_invert'         => true,
+        'gmp_jacobi'         => true,
+        'gmp_kronecker'      => true,
+        'gmp_lcm'            => true,
+        'gmp_legendre'       => true,
+        'gmp_mod'            => true,
+        'gmp_mul'            => true,
+        'gmp_neg'            => true,
+        'gmp_nextprime'      => true,
+        'gmp_or'             => true,
+        'gmp_perfect_power'  => true,
+        'gmp_perfect_square' => true,
+        'gmp_popcount'       => true,
+        'gmp_pow'            => [1 => 'num'],
+        'gmp_powm'           => true,
+        'gmp_prob_prime'     => [1 => 'num'],
+        'gmp_random_range'   => true,
+        'gmp_random_seed'    => true,
+        'gmp_root'           => [1 => 'num'],
+        'gmp_rootrem'        => [1 => 'num'],
+        'gmp_scan0'          => [1 => 'num'],
+        'gmp_scan1'          => [1 => 'num'],
+        'gmp_sign'           => true,
+        'gmp_sqrt'           => true,
+        'gmp_sqrtrem'        => true,
+        'gmp_strval'         => [1 => 'num'],
+        'gmp_sub'            => true,
+        'gmp_testbit'        => [1 => 'num'],
+        'gmp_xor'            => true,
+        'hexdec'             => true,
+    ];
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -66,6 +134,38 @@ class RemovedHexadecimalNumericStringsSniff extends Sniff
             return;
         }
 
+        /*
+         * Prevent false positives if the text string is used within a function call to a function
+         * which still accepts hexadecimal numeric strings.
+         */
+        $nested = Parentheses::getLastOpener($phpcsFile, $stackPtr);
+        if ($nested !== false) {
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nested - 1), null, true);
+            $contentLc    = \strtolower($tokens[$prevNonEmpty]['content']);
+            if ($tokens[$prevNonEmpty]['code'] === \T_STRING
+                && isset($this->excludedFunctions[$contentLc]) === true
+                && $this->isCallToGlobalFunction($phpcsFile, $prevNonEmpty) === true
+            ) {
+                /*
+                 * Okay, so the string is apparently used in a function call to a function which still supports it.
+                 * Now verify it is used in a valid parameter position.
+                 */
+                if ($this->excludedFunctions[$contentLc] === true) {
+                    // All parameters support hex numeric strings. Bow out.
+                    return;
+                }
+
+                $parameters = PassedParameters::getParameters($phpcsFile, $prevNonEmpty);
+                foreach ($this->excludedFunctions[$contentLc] as $paramOffset => $paramName) {
+                    $param = PassedParameters::getParameterFromStack($parameters, $paramOffset, $paramName);
+                    if ($stackPtr >= $param['start'] && $stackPtr <= $param['end']) {
+                        // Parameter used in a position which supports hex numeric strings. Bow out.
+                        return;
+                    }
+                }
+            }
+        }
+
         $isError = $this->supportsAbove('7.0');
 
         MessageHelper::addMessage(
@@ -76,5 +176,48 @@ class RemovedHexadecimalNumericStringsSniff extends Sniff
             'Found',
             [$tokens[$stackPtr]['content']]
         );
+    }
+
+    /**
+     * Check if a `T_STRING` token represents a function call to a global function.
+     *
+     * Note: not 100% precise, but should be sufficient for now. At a later point in
+     * time there will probably be a PHPCSUtils function for this.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the potential function call
+     *                                               token in the stack.
+     *
+     * @return bool
+     */
+    private function isCallToGlobalFunction(File $phpcsFile, $stackPtr)
+    {
+        $tokens       = $phpcsFile->getTokens();
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+        if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === true) {
+            // Method call.
+            return false;
+        }
+
+        if ($tokens[$prevNonEmpty]['code'] === \T_NEW
+            || $tokens[$prevNonEmpty]['code'] === \T_FUNCTION
+        ) {
+            return false;
+        }
+
+        if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
+            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+            if ($tokens[$prevPrevToken]['code'] === \T_STRING
+                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
+            ) {
+                // Namespaced function.
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/PHPCompatibility/Tests/Numbers/RemovedHexadecimalNumericStringsUnitTest.inc
+++ b/PHPCompatibility/Tests/Numbers/RemovedHexadecimalNumericStringsUnitTest.inc
@@ -4,3 +4,25 @@ $hex = 'aa78b5'; // Ok.
 
 $hex = '0xaa78b5';
 $hexUpper = '0Xbb99EF';
+
+// Issue 1345: prevent false positives when used with the GMP extension/functions which still support hex numeric strings.
+$test = hexdec('aa78b5'); // Ok.
+$test = gmp_and($n, '0x7ff0000000'); // Ok.
+$test = \Gmp_Div('0xfffffffff', $n); // Ok.
+
+// But don't ignore the issue when in other function calls or non-function calls.
+$test = bcadd($n, '0x7ff000000');
+$test = gmp_import($data, '0x7', GMP_NATIVE_ENDIAN);
+$test = gmp_userland_function($n, '0x7fef');
+$test = MyNs\gmp_and($n, '0x7ff00');
+$test = $obj->gmp_and($n, '0x7ff00');
+$test = $obj?->gmp_and($n, '0x7ff00');
+$test = MyClass::gmp_and($n, '0x7ff00');
+$test = new GMP_And($n, '0x7ff00');
+class Foo {
+    public function gmp_and($param = '0x7ff00') {}
+}
+
+// Or when the hex numeric string is used in a parameter which doesn't support it.
+$test = gmp_init($num, '0x7ff00');
+$test = gmp_ROOT(nth: '0x7ff00', num: 10);

--- a/PHPCompatibility/Tests/Numbers/RemovedHexadecimalNumericStringsUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/RemovedHexadecimalNumericStringsUnitTest.php
@@ -60,6 +60,18 @@ class RemovedHexadecimalNumericStringsUnitTest extends BaseSniffTest
         return [
             [5, '0xaa78b5'],
             [6, '0Xbb99EF'],
+
+            [14, '0x7ff000000'],
+            [15, '0x7'],
+            [16, '0x7fef'],
+            [17, '0x7ff00'],
+            [18, '0x7ff00'],
+            [19, '0x7ff00'],
+            [20, '0x7ff00'],
+            [21, '0x7ff00'],
+            [23, '0x7ff00'],
+            [27, '0x7ff00'],
+            [28, '0x7ff00'],
         ];
         // phpcs:enable
     }
@@ -68,17 +80,37 @@ class RemovedHexadecimalNumericStringsUnitTest extends BaseSniffTest
     /**
      * Verify the sniff doesn't throw false positives.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.6');
-        $this->assertNoViolation($file, 3);
+        $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(__FILE__, '7.0');
-        $this->assertNoViolation($file, 3);
+        $this->assertNoViolation($file, $line);
     }
 
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return [
+            [3],
+            [9],
+            [10],
+            [11],
+        ];
+    }
 
     /*
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors


### PR DESCRIPTION
Apparently, hexadecimal numeric strings are still supported in a limited number of PHP functions. While if they are passed in as a variable, we're out of luck, if the text string is hard-coded in the function call, we can prevent a false positive.

This commit adds the logic necessary to prevent these false positives for a limited set of functions currently known to still support hexadecimal numeric strings.

Note: The logic takes function calls using PHP 8.0 named parameters into account.

Includes unit tests.

Fixes #1345