### PR TITLE
NewConstantArraysUsingDefine: add tests with named parameters

### DIFF
--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
@@ -34,3 +34,7 @@ define('WPDIRAUTH_LDAP_RETURN_KEYS',serialize(['sn', 'givenname', 'mail']));
 // Array dereferencing.
 define('DEREF', OTHER['key']);
 define('DEREF', 'string'[2]);
+
+// PHP 8.0: calling define() using named parameters.
+define(value: array('bird'), constant_name: 'ANIMALS' ); // Error.
+define(value: 'not an array', constant_name: 'NOTANARRAY' ); // OK.

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -52,6 +52,7 @@ class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
         return [
             [3],
             [9],
+            [39],
         ];
     }
 
@@ -92,6 +93,7 @@ class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
             [32],
             [35],
             [36],
+            [40],
         ];
     }
 


### PR DESCRIPTION
PHPCSUtils `1.0.0-alpha4` adds support for named parameters.

PR #1249 already added the parameter name to the function call to `PassedParameters::getParameter()`.

This now adds some unit tests to safeguard the support for named parameters in this sniff.

Related to #1239