### PR TITLE
ChangedIntToBoolParamType: add support for named parameters

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.inc
@@ -23,5 +23,6 @@ sem_get( $key, $max_acquire, $perm, 1 );
 sem_get( $key, $max_acquire, $perm, -1 );
 Sem_Get( $key, $max_acquire, $perm, 0 );
 sem_get( $key, $max_acquire, $perm, 1.0 );
-sem_get( $key, $max_acquire, $perm, 1 * 1);
+sem_get( $key, auto_release: 1 * 1);
 ob_implicit_flush(0);
+ob_implicit_flush(enable: 1);

--- a/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
@@ -61,7 +61,8 @@ class ChangedIntToBoolParamTypeUnitTest extends BaseSniffTest
             [24, '8.0', '$auto_release', 'sem_get'],
             [25, '8.0', '$auto_release', 'sem_get'],
             [26, '8.0', '$auto_release', 'sem_get'],
-            [27, '8.0', '$flag', 'ob_implicit_flush'],
+            [27, '8.0', '$enable', 'ob_implicit_flush'],
+            [28, '8.0', '$enable', 'ob_implicit_flush'],
         ];
     }
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter names used are in line with the names as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification references:
* `ob_implicit_flush`: https://3v4l.org/SVXD2
* `sem_get`: https://github.com/php/php-src/blob/5aaffc8095eeb69407855b33d1939dd5ebd619ca/ext/sysvsem/sysvsem.stub.php#L9

Includes adding/adjusting the unit tests to include tests using named parameters.

Note: this is changes the error code for the `ob_implicit_flush` violation, but as this is a new sniff which is being introduced in PHPCompatibility 10.0.0, this is not an issue.

Related to #1239