### PR TITLE
ChangedObStartEraseFlags: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Detect incompatible use of the third parameter for `ob_start()`.
@@ -69,11 +70,11 @@ class ChangedObStartEraseFlagsSniff extends AbstractFunctionCallParameterSniff
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[3]) === false) {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 3, 'flags');
+        if ($targetParam === false) {
             return;
         }
 
-        $targetParam  = $parameters[3];
         $cleanValueLc = \strtolower($targetParam['clean']);
 
         $error = 'The third parameter of ob_start() changed from the boolean $erase to the integer $flags in PHP 5.4. Found: %s';

--- a/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.inc
@@ -21,3 +21,8 @@ ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS);
 ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS | PHP_OUTPUT_HANDLER_FLUSHABLE);
 ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS ^ PHP_OUTPUT_HANDLER_FLUSHABLE);
 ob_start($output_callback, $chunk_size, 10);
+
+// Safeguard support for PHP 8 named parameters.
+ob_start(flags: false);
+ob_start(flags: 20);
+ob_start(flags: $flags); // OK.

--- a/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
@@ -57,6 +57,7 @@ class ChangedObStartEraseFlagsUnitTest extends BaseSniffTest
         return [
             [13],
             [14],
+            [26],
         ];
     }
 
@@ -98,6 +99,7 @@ class ChangedObStartEraseFlagsUnitTest extends BaseSniffTest
             [21],
             [22],
             [23],
+            [27],
         ];
     }
 
@@ -105,17 +107,39 @@ class ChangedObStartEraseFlagsUnitTest extends BaseSniffTest
     /**
      * Verify there are no false positives on code this sniff should ignore.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.3-5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 11 lines.
         for ($line = 1; $line <= 11; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        $data[] = [28];
+
+        return $data;
     }
+
 
     /*
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification references:
* `ob_start`: https://3v4l.org/ktMV3

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239