### PR TITLE
ForbiddenGetClassNull: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Detect: Passing `null` to `get_class()` is no longer allowed as of PHP 7.2.
@@ -67,17 +68,18 @@ class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[1]) === false) {
+        $target = PassedParameters::getParameterFromStack($parameters, 1, 'object');
+        if ($target === false) {
             return;
         }
 
-        if ($parameters[1]['clean'] !== 'null') {
+        if ($target['clean'] !== 'null') {
             return;
         }
 
         $phpcsFile->addError(
             'Passing "null" as the $object to get_class() is not allowed since PHP 7.2.',
-            $parameters[1]['start'],
+            $target['start'],
             'Found'
         );
     }

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.inc
@@ -12,3 +12,4 @@ get_class(null);
 get_class(
     null // Comment.
 );
+get_class(object:null);

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
@@ -52,6 +52,7 @@ class ForbiddenGetClassNullUnitTest extends BaseSniffTest
         return [
             [11],
             [12],
+            [15],
         ];
     }
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification references:
* `get_class`: https://3v4l.org/NCRga

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239