### PR TITLE
ForbiddenSessionModuleNameUser: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -98,11 +99,10 @@ class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallParameterS
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[1]) === false) {
+        $param = PassedParameters::getParameterFromStack($parameters, 1, 'module');
+        if ($param === false) {
             return;
         }
-
-        $param = $parameters[1];
 
         $firstNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, $param['start'], ($param['end'] + 1), true);
         $hasNonTextToken = $phpcsFile->findNext($this->targetTokens, $firstNonEmpty, ($param['end'] + 1), true);

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.inc
@@ -4,7 +4,7 @@
  */
 
 // OK.
-session_module_name($module);
+session_module_name(module: $module);
 session_module_name();
 session_module_name('user' . $something);
 session_module_name(<<<EOD
@@ -14,7 +14,7 @@ EOD
 
 // Not OK.
 session_module_name('user');
-session_module_name("USER");
+session_module_name(module: "USER");
 session_module_name(<<<'EOD'
 user
 EOD


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `session_module_name`: https://3v4l.org/aTuiE

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239