### PR TITLE
ForbiddenStripTagsSelfClosingXHTML: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Since PHP 5.3.4, `strip_tags()` ignores self-closing XHTML tags in allowable_tags
@@ -66,12 +67,12 @@ class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCallParame
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[2]) === false) {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 2, 'allowed_tags');
+        if ($targetParam === false) {
             return;
         }
 
-        $tokens      = $phpcsFile->getTokens();
-        $targetParam = $parameters[2];
+        $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
             if ($tokens[$i]['code'] === \T_STRING
                 || $tokens[$i]['code'] === \T_VARIABLE
@@ -84,7 +85,7 @@ class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCallParame
                 && \strpos($tokens[$i]['content'], '/>') !== false
             ) {
                 $phpcsFile->addError(
-                    'Self-closing XHTML tags are ignored. Only non-self-closing tags should be used in the strip_tags() $allowable_tags parameter since PHP 5.3.4. Found: %s',
+                    'Self-closing XHTML tags are ignored. Only non-self-closing tags should be used in the strip_tags() $allowed_tags parameter since PHP 5.3.4. Found: %s',
                     $i,
                     'Found',
                     [$targetParam['clean']]

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.inc
@@ -3,13 +3,13 @@
 // OK.
 $str = strip_tags($str);
 $str = strip_tags($input, '<br>');
-$str = strip_tags($input, '<img><br><meta><input>');
+$str = strip_tags($input, allowed_tags: '<img><br><meta><input>');
 
 // Undetermined. Ignore.
 $str = strip_tags($str, $allowable_tags);
 $str = strip_tags($str, self::ALLOWABLE_TAGS);
-$str = strip_tags($str, MyClass::get_allowable_tags('<br/>'));
+$str = strip_tags($str, allowed_tags: MyClass::get_allowable_tags('<br/>'));
 
 // Not OK - warning.
 $str = strip_tags($input, '<br/>');
-$str = strip_tags($input, '<img/><br/>' . '<meta/><input/>');
+$str = strip_tags(allowed_tags: '<img/><br/>' . '<meta/><input/>', string: $input);

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
@@ -38,7 +38,7 @@ class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTest
     public function testForbiddenStripTagsSelfClosingXHTML($line, $paramValue)
     {
         $file  = $this->sniffFile(__FILE__, '5.4');
-        $error = 'Self-closing XHTML tags are ignored. Only non-self-closing tags should be used in the strip_tags() $allowable_tags parameter since PHP 5.3.4. Found: ' . $paramValue;
+        $error = 'Self-closing XHTML tags are ignored. Only non-self-closing tags should be used in the strip_tags() $allowed_tags parameter since PHP 5.3.4. Found: ' . $paramValue;
 
         $this->assertError($file, $line, $error);
     }


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `strip_tags`: https://3v4l.org/dBJP1

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239