### PR TITLE
NewArrayReduceInitialType: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * In PHP 5.2 and lower, the `$initial` parameter for `array_reduce()` had to be an integer.
@@ -83,11 +84,11 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[3]) === false) {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 3, 'initial');
+        if ($targetParam === false) {
             return;
         }
 
-        $targetParam = $parameters[3];
         if ($this->isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], true) !== false) {
             return;
         }

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.inc
@@ -10,7 +10,7 @@ array_reduce( $array, $callback, /*initial*/ -100 /*initial*/ );
 array_reduce( $array, $callback, 'string' ); // Will be typecast by PHP.
 array_reduce( $array, $callback, 20.5 ); // Will be typecast by PHP.
 array_reduce( $array, $callback, false ); // Will be typecast by PHP.
-array_reduce( $array, $callback, null ); // Will be typecast by PHP.
+array_reduce( $array, $callback, initial: null ); // Will be typecast by PHP.
 
 // Not OK - error.
 array_reduce( $array, $callback, array() );
@@ -21,3 +21,6 @@ array_reduce( $array, $callback, $this->initial );
 array_reduce( $array, $callback, self::INITIAL );
 array_reduce( $array, $callback, 15 * $initial );
 array_reduce( $array, $callback, new stdClass );
+
+// Safeguard support for PHP 8 named parameters.
+array_reduce( $array, initial: array(), callback: $callback ); // Error.

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
@@ -65,6 +65,8 @@ class NewArrayReduceInitialTypeUnitTest extends BaseSniffTest
             [21, false],
             [22, false],
             [23, false],
+
+            [26],
         ];
     }
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `array_reduce`: https://3v4l.org/FDrWM

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239