### PR TITLE
NewFopenModes: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Check for valid values for the `fopen()` `$mode` parameter.
@@ -67,13 +68,13 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[2]) === false) {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 2, 'mode');
+        if ($targetParam === false) {
             return;
         }
 
-        $tokens      = $phpcsFile->getTokens();
-        $targetParam = $parameters[2];
-        $errors      = [];
+        $tokens = $phpcsFile->getTokens();
+        $errors = [];
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
             if ($tokens[$i]['code'] === \T_STRING

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.inc
@@ -2,13 +2,13 @@
 
 // OK.
 $handle = fopen("/home/rasmus/file.txt", "r");
-$handle = fopen("/home/rasmus/file.gif", 'wb');
+$handle = fopen("/home/rasmus/file.gif", mode: 'wb');
 $handle = fopen("/home/rasmus/file.gif", 'a' . $additional_modes);
 
 // Not OK.
 $handle = fopen("/home/rasmus/file.txt", "re"); // PHP 7.0.16+
 $handle = fopen("/home/rasmus/file.gif", 'c+'); // PHP 5.2.6+
-$handle = fopen("/home/rasmus/file.gif", 'c'); // PHP 5.2.6+
+$handle = fopen(mode: 'c', filename: "/home/rasmus/file.gif"); // PHP 5.2.6+
 $handle = fopen("/home/rasmus/file.gif", 'c'./*comment*/'e'); // PHP 5.2.6+ and PHP 7.0.16+
 
 // Issue #1043 - ignore function calls, constants etc.


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `fopen`: https://3v4l.org/Y5tif

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239