### PR TITLE
NewHTMLEntitiesEncodingDefault: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * As of PHP 5.4, the default character set for `htmlspecialchars()`, `htmlentities()`
@@ -32,18 +33,30 @@ class NewHTMLEntitiesEncodingDefaultSniff extends AbstractFunctionCallParameterS
     /**
      * Functions to check for.
      *
-     * Key is the function name, value the 1-based parameter position of
-     * the $encoding parameter.
+     * Key is the function name, value an array containing the 1-based parameter position
+     * and the official name of the parameter.
      *
      * @since 9.3.0
      *
      * @var array
      */
     protected $targetFunctions = [
-        'html_entity_decode'         => 3,
-        'htmlentities'               => 3,
-        'htmlspecialchars'           => 3,
-        'get_html_translation_table' => 3,
+        'html_entity_decode' => [
+            'position' => 3,
+            'name'     => 'encoding',
+        ],
+        'htmlentities' => [
+            'position' => 3,
+            'name'     => 'encoding',
+        ],
+        'htmlspecialchars' => [
+            'position' => 3,
+            'name'     => 'encoding',
+        ],
+        'get_html_translation_table' => [
+            'position' => 3,
+            'name'     => 'encoding',
+        ],
     ];
 
 
@@ -78,16 +91,18 @@ class NewHTMLEntitiesEncodingDefaultSniff extends AbstractFunctionCallParameterS
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $functionLC = \strtolower($functionName);
-        if (isset($parameters[$this->targetFunctions[$functionLC]]) === true) {
+        $functionLC  = \strtolower($functionName);
+        $paramInfo   = $this->targetFunctions[$functionLC];
+        $targetParam = PassedParameters::getParameterFromStack($parameters, $paramInfo['position'], $paramInfo['name']);
+        if ($targetParam !== false) {
             return;
         }
 
         $phpcsFile->addError(
-            'The default value of the $encoding parameter for %s() was changed from ISO-8859-1 to UTF-8 in PHP 5.4. For cross-version compatibility, the $encoding parameter should be explicitly set.',
+            'The default value of the $%1$s parameter for %2$s() was changed from ISO-8859-1 to UTF-8 in PHP 5.4. For cross-version compatibility, the $%1$s parameter should be explicitly set.',
             $stackPtr,
             'NotSet',
-            [$functionName]
+            [$paramInfo['name'], $functionName]
         );
     }
 }

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.inc
@@ -2,12 +2,12 @@
 
 // OK.
 echo htmlentities( $string, ENT_QUOTES, 'UTF-8' );
-echo htmlspecialchars( $string, ENT_COMPAT, $encoding, false );
+echo htmlspecialchars( $string, encoding: $encoding, flags: ENT_COMPAT, double_encode: false );
 echo html_entity_decode( $string, ENT_COMPAT, $encoding );
 echo get_html_translation_table( $table, ENT_COMPAT, $encoding );
 
 // Not OK - error.
-echo htmlentities( $string, $flags );
+echo htmlentities( string: $string, flags: $flags, double_encode: false );
 echo htmlspecialchars($string);
 echo HTML_entity_decode( $string, ENT_COMPAT );
 echo get_html_translation_table( $table );


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter names used are in line with the names as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification references:
* `html_entity_decode`: https://3v4l.org/vJiUA
* `htmlentities`: https://3v4l.org/lNBbG
* `htmlspecialchars`: https://3v4l.org/WWbgG
* `get_html_translation_table`: https://3v4l.org/9f0Jn

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239