### PR TITLE
NewIDNVariantDefault: add support for named parameters

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.inc
@@ -1,7 +1,7 @@
 <?php
 
 // OK.
-echo idn_to_ascii('täst.de', $options, $variant, $idna_info);
+echo idn_to_ascii('täst.de', idna_info: $idna_info, variant: $variant);
 echo idn_to_ascii( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
 echo idn_to_utf8('xn--tst-qla.de', $options, $variant, $idna_info);
 echo idn_to_utf8( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003 );
@@ -11,3 +11,5 @@ echo idn_to_ascii('täst.de');
 echo idn_to_ascii( $domain, IDNA_DEFAULT);
 echo IDN_to_utf8('xn--tst-qla.de');
 echo idn_to_utf8( $domain, IDNA_DEFAULT);
+echo idn_to_ascii(idna_info: $idna_info, domain: 'täst.de');
+echo idn_to_utf8( flags: IDNA_DEFAULT, domain: $domain);

--- a/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
@@ -57,6 +57,8 @@ class NewIDNVariantDefaultUnitTest extends BaseSniffTest
             [11, 'idn_to_ascii'],
             [12, 'IDN_to_utf8'],
             [13, 'idn_to_utf8'],
+            [14, 'idn_to_ascii'],
+            [15, 'idn_to_utf8'],
         ];
     }
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `idn_to_ascii`: https://3v4l.org/IsYhA
* `idn_to_utf8`: https://3v4l.org/HigvC

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239