### PR TITLE
NewNegativeStringOffset: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Detect negative string offsets as parameters passed to functions where this
@@ -38,7 +39,7 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
             4 => 'offset',
         ],
         'grapheme_extract'      => [
-            4 => 'start',
+            4 => 'offset',
         ],
         'grapheme_stripos'      => [
             3 => 'offset',
@@ -50,7 +51,7 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
             3 => 'offset',
         ],
         'mb_ereg_search_setpos' => [
-            1 => 'position',
+            1 => 'offset',
         ],
         'mb_strimwidth'         => [
             2 => 'start',
@@ -104,11 +105,10 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
     {
         $functionLC = \strtolower($functionName);
         foreach ($this->targetFunctions[$functionLC] as $pos => $name) {
-            if (isset($parameters[$pos]) === false) {
+            $targetParam = PassedParameters::getParameterFromStack($parameters, $pos, $name);
+            if ($targetParam === false) {
                 continue;
             }
-
-            $targetParam = $parameters[$pos];
 
             if ($this->isNegativeNumber($phpcsFile, $targetParam['start'], $targetParam['end']) === false) {
                 continue;

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.inc
@@ -8,9 +8,9 @@ mb_ereg_search_setpos();
 mb_ereg_search_setpos( 0 );
 mb_ereg_search_setpos( /* Some comment. */ );
 mb_ereg_search_setpos(
-	// Some comment.
-	0
-	// phpcs:ignore Standard.Category.Sniff -- for reasons.
+    // Some comment.
+    offset: 0
+    // phpcs:ignore Standard.Category.Sniff -- for reasons.
 );
 mb_ereg_search_setpos($position);
 mb_ereg_search_setpos( -1 + 10 );
@@ -46,3 +46,7 @@ $a = strpos($haystack, $needle, -30 );
 $a = substr_count($haystack, $needle, -20, -10 );
 $a = Substr_Count($haystack, $needle, -20, 10 );
 $a = substr_count($haystack, $needle, 20, -+-+-10 );
+
+// Safeguard support for PHP 8 named parameters.
+$a = mb_strimwidth(trim_marker: '', width: 5, start: -2, string: $str, ); // Error x 1.
+$a = mb_strimwidth(start: -2, width: -10, string: $str, trim_marker: ''); // Error x 2.

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
@@ -57,10 +57,10 @@ class NewNegativeStringOffsetUnitTest extends BaseSniffTest
     public function dataNegativeStringOffset()
     {
         return [
-            [28, 'position', 'mb_ereg_search_setpos'],
-            [34, 'position', 'MB_ereg_search_setpos'],
+            [28, 'offset', 'mb_ereg_search_setpos'],
+            [34, 'offset', 'MB_ereg_search_setpos'],
             [36, 'offset', 'file_get_contents'],
-            [37, 'start', 'grapheme_extract'],
+            [37, 'offset', 'grapheme_extract'],
             [38, 'offset', 'grapheme_stripos'],
             [39, 'offset', 'grapheme_strpos'],
             [40, 'offset', 'iconv_strpos'],
@@ -74,6 +74,9 @@ class NewNegativeStringOffsetUnitTest extends BaseSniffTest
             [46, 'length', 'substr_count'],
             [47, 'offset', 'Substr_Count'],
             [48, 'length', 'substr_count'],
+            [51, 'start', 'mb_strimwidth'],
+            [52, 'start', 'mb_strimwidth'],
+            [52, 'width', 'mb_strimwidth'],
         ];
     }
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `file_get_contents`: https://3v4l.org/nTVi2
* `grapheme_extract`: https://3v4l.org/dXIPV
* `grapheme_stripos`: https://3v4l.org/FPYdo
* `grapheme_strpos`: https://3v4l.org/bUIFV
* `iconv_strpos`: https://3v4l.org/6eS32
* `mb_ereg_search_setpos`: https://3v4l.org/8hOBl
* `mb_strimwidth`: https://3v4l.org/K0nEE
* `mb_stripos`: https://3v4l.org/fISc3
* `mb_strpos`: https://3v4l.org/Xtr5N
* `stripos`: https://3v4l.org/VnpWF
* `strpos`: https://3v4l.org/WoZlN
* `substr_count`: https://3v4l.org/7GSrB

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239