### PR TITLE
NewNumberFormatMultibyteSeparators: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
@@ -13,10 +13,11 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
- * Detect: Passing multi-byte separators to the `$dec_point` and `$thousands_sep` parameters
+ * Detect: Passing multi-byte separators to the `$decimal_separator` and `$thousands_separator` parameters
  * for `number_format()` which was not supported prior to PHP 5.4.
  *
  * Previously, only the first byte of each separator was used.
@@ -98,12 +99,14 @@ class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCallParame
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[3]) === true) {
-            $this->examineParameter($phpcsFile, $parameters[3], 'dec_point');
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 3, 'decimal_separator');
+        if ($targetParam !== false) {
+            $this->examineParameter($phpcsFile, $targetParam, 'decimal_separator');
         }
 
-        if (isset($parameters[4]) === true) {
-            $this->examineParameter($phpcsFile, $parameters[4], 'thousands_sep');
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 4, 'thousands_separator');
+        if ($targetParam !== false) {
+            $this->examineParameter($phpcsFile, $targetParam, 'thousands_separator');
         }
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.inc
@@ -9,7 +9,7 @@
 number_format();
 number_format($number);
 number_format($number, $decimals);
-number_format($number, $decimals, $dec_point, $thousands_sep); // Undetermined.
+number_format($number, decimal_separator: $dec_point, thousands_separator: $thousands_sep, decimals: $decimals); // Undetermined.
 // Variables passed in a double quoted string are presumed to be single-byte.
 number_format($number, $decimals, "$dec_point", "$thousands_sep");
 number_format($number, $decimals, '.', ','); // Single-byte.
@@ -19,9 +19,9 @@ number_format($number, $decimals, '.', ','); // Single-byte.
  */
 number_format($number, $decimals, '.', '::'); // Thousand-sep multi-byte.
 
-// Note: this is an invalid function call, as when the third param is passed, the fourth has to be passed too,
-// but that's not the concern of this sniff.
-number_format($number, $decimals, "-$a",); // Dec point multi-byte (most probably, depends on contents of the variable).
+// Note: this is an invalid function call, as when the $decimal_separator is passed, the $thousands_separator
+// has to be passed too, but that's not the concern of this sniff.
+number_format(num: $number, decimal_separator: "-$a", decimals: $decimals,); // Dec point multi-byte (most probably, depends on contents of the variable).
 
 number_format(
     $number,

--- a/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.php
@@ -51,10 +51,10 @@ class NewNumberFormatMultibyteSeparatorsUnitTest extends BaseSniffTest
     public function dataNewNumberFormatMultibyteSeparators()
     {
         return [
-            [20, 'thousands_sep'],
-            [24, 'dec_point'],
-            [29, 'dec_point'],
-            [33, 'thousands_sep'],
+            [20, 'thousands_separator'],
+            [24, 'decimal_separator'],
+            [29, 'decimal_separator'],
+            [33, 'thousands_separator'],
         ];
     }
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `number_format`: https://3v4l.org/R7DRe

Includes adding/adjusting the unit tests to include tests using named parameters.

Note: this is changes the error code for both violations, but as this is a new sniff which is being introduced in PHPCompatibility 10.0.0, this is not an issue.

Related to #1239