### PR TITLE
NewPasswordAlgoConstantValues: add support for named parameters

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
@@ -5,10 +5,10 @@ $hash = password_hash( $password, PASSWORD_DEFAULT, $options );
 $hash = password_hash( $password, PASSWORD_BCRYPT, $options );
 $hash = password_needs_rehash( $password, PASSWORD_ARGON2I, $options );
 $hash = password_hash(
-	$password,
+	password: $password,
+	options: $options
 	// comment.
-	PASSWORD_ARGON2ID,
-	$options
+	algo: PASSWORD_ARGON2ID,
 );
 
 // Undetermined. Ignore.
@@ -20,7 +20,7 @@ $hash = password_hash( $password, static::ALGO, $options );
 $hash = PassWord_hash( $password, null, $options );
 $hash = password_hash( $password, +1, $options );
 $hash = password_needs_rehash( $password, 2, $options );
-$hash = password_hash( $password, 3, $options );
+$hash = password_hash( algo: 3, password: $password, options: $options );
 $hash = password_hash( $password, '2y', $options );
 $hash = password_HASH( $password, "argon{$type}" /*comment*/, $options );
 $hash = password_needs_rehash( $password, 'argon2id', $options );


### PR DESCRIPTION
1. Adjusted the way the correct parameter is retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `password_hash`: https://3v4l.org/3poVd
* `password_needs_rehash`: https://3v4l.org/nnoF7

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239