### PR TITLE
NewProcOpenCmdArray: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -71,12 +71,12 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[1]) === false) {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 1, 'command');
+        if ($targetParam === false) {
             return;
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $targetParam  = $parameters[1];
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], $targetParam['end'], true);
 
         if ($nextNonEmpty === false) {
@@ -93,7 +93,7 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
 
         if ($this->supportsBelow('7.3') === true) {
             $phpcsFile->addError(
-                'The proc_open() function did not accept $cmd to be passed in array format in PHP 7.3 and earlier.',
+                'The proc_open() function did not accept $command to be passed in array format in PHP 7.3 and earlier.',
                 $nextNonEmpty,
                 'Found'
             );
@@ -122,7 +122,7 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
                     // @todo Potential future enhancement: check if it's a call to the PHP native function.
 
                     $phpcsFile->addWarning(
-                        'When passing the $cmd parameter to proc_open() as an array, PHP will take care of any necessary argument escaping. Found: %s',
+                        'When passing the $command parameter to proc_open() as an array, PHP will take care of any necessary argument escaping. Found: %s',
                         $i,
                         'Invalid',
                         [$item['clean']]

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.inc
@@ -37,3 +37,26 @@ $proc = proc_open(
     $descriptors,
     $pipes
 );
+
+// Safeguard support for PHP 8 named parameters.
+$proc = proc_open(
+    descriptor_spec: array(
+        0 => array("pipe", "r"),
+        1 => array("pipe", "w"),
+        2 => array("file", "/tmp/error-output.txt", "a"),
+    ),
+    command: '"findstr" "search" "filename.txt"',
+    pipes: $pipes,
+    env_vars: $env_vars
+); // OK.
+
+$proc = proc_open(
+    pipes: $pipes,
+    env_vars: $env_vars,
+    descriptor_spec: array(
+        0 => array("pipe", "r"),
+        1 => array("pipe", "w"),
+        2 => array("file", "/tmp/error-output.txt", "a"),
+    ),
+    command: array('php', '-r', escapeshellarg($echo)),
+); // Error + Warning.

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
@@ -37,7 +37,7 @@ class NewProcOpenCmdArrayUnitTest extends BaseSniffTest
     public function testNewProcOpenCmdArray($line)
     {
         $file  = $this->sniffFile(__FILE__, '7.3');
-        $error = 'The proc_open() function did not accept $cmd to be passed in array format in PHP 7.3 and earlier.';
+        $error = 'The proc_open() function did not accept $command to be passed in array format in PHP 7.3 and earlier.';
 
         $this->assertError($file, $line, $error);
     }
@@ -56,6 +56,7 @@ class NewProcOpenCmdArrayUnitTest extends BaseSniffTest
             [20],
             [30],
             [32],
+            [61],
         ];
     }
 
@@ -73,7 +74,7 @@ class NewProcOpenCmdArrayUnitTest extends BaseSniffTest
     public function testInvalidProcOpenCmdArray($line, $itemValue)
     {
         $file  = $this->sniffFile(__FILE__, '7.4');
-        $error = 'When passing the $cmd parameter to proc_open() as an array, PHP will take care of any necessary argument escaping. Found: ' . $itemValue;
+        $error = 'When passing the $command parameter to proc_open() as an array, PHP will take care of any necessary argument escaping. Found: ' . $itemValue;
 
         $this->assertWarning($file, $line, $error);
     }
@@ -91,6 +92,7 @@ class NewProcOpenCmdArrayUnitTest extends BaseSniffTest
             [30, 'escapeshellarg($echo)'],
             [34, '\'--standard=\' . escapeshellarg($standard)'],
             [35, '\'./path/to/\' . escapeshellarg($file)'],
+            [61, 'escapeshellarg($echo)'],
         ];
     }
 
@@ -110,6 +112,11 @@ class NewProcOpenCmdArrayUnitTest extends BaseSniffTest
 
         // No errors expected on the first 16 lines.
         for ($line = 1; $line <= 16; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        // Nor on line 41 to 51.
+        for ($line = 41; $line <= 51; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `proc_open`: https://github.com/php/php-src/blob/9dda22bd1e4568cde1114e0d80c39ce211e15025/ext/standard/basic_functions.stub.php#L1156

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239