### PR TITLE
NewStripTagsAllowableTagsArray: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -17,7 +17,7 @@ use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
- * As of PHP 7.4, `strip_tags()` now also accepts an array of `$allowable_tags`.
+ * As of PHP 7.4, `strip_tags()` now also accepts an array of `$allowed_tags`.
  *
  * PHP version 7.4
  *
@@ -69,12 +69,12 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[2]) === false) {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 2, 'allowed_tags');
+        if ($targetParam === false) {
             return;
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $targetParam  = $parameters[2];
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], $targetParam['end'], true);
 
         if ($nextNonEmpty === false) {
@@ -91,7 +91,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
 
         if ($this->supportsBelow('7.3') === true) {
             $phpcsFile->addError(
-                'The strip_tags() function did not accept $allowable_tags to be passed in array format in PHP 7.3 and earlier.',
+                'The strip_tags() function did not accept $allowed_tags to be passed in array format in PHP 7.3 and earlier.',
                 $nextNonEmpty,
                 'Found'
             );
@@ -122,7 +122,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
                         && \strpos($tokens[$i]['content'], '>') !== false
                     ) {
                         $phpcsFile->addWarning(
-                            'When passing strip_tags() the $allowable_tags parameter as an array, the tags should not be enclosed in <> brackets. Found: %s',
+                            'When passing strip_tags() the $allowed_tags parameter as an array, the tags should not be enclosed in <> brackets. Found: %s',
                             $i,
                             'Invalid',
                             [$item['clean']]

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.inc
@@ -2,7 +2,7 @@
 
 // OK.
 $str = strip_tags($str);
-$str = strip_tags($input, '<a><p>');
+$str = strip_tags($input, allowed_tags: '<a><p>');
 
 // Undetermined. Ignore.
 $str = strip_tags($str, $allowable_tags);
@@ -20,7 +20,7 @@ $str = strip_tags(
 );
 
 // PHP 7.4: Warning. Incorrectly passing $allowable_tags as an array.
-$str = strip_tags($input, ['<a>', '<p>']);
+$str = strip_tags(allowed_tags: ['<a>', '<p>'], string: $input);
 $str = strip_tags(
     $input,
     array(

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
@@ -37,7 +37,7 @@ class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTest
     public function testNewStripTagsAllowableTagsArray($line)
     {
         $file  = $this->sniffFile(__FILE__, '7.3');
-        $error = 'The strip_tags() function did not accept $allowable_tags to be passed in array format in PHP 7.3 and earlier.';
+        $error = 'The strip_tags() function did not accept $allowed_tags to be passed in array format in PHP 7.3 and earlier.';
 
         $this->assertError($file, $line, $error);
     }
@@ -75,7 +75,7 @@ class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTest
     public function testInvalidStripTagsAllowableTagsArray($line, $paramValue)
     {
         $file  = $this->sniffFile(__FILE__, '7.4');
-        $error = 'When passing strip_tags() the $allowable_tags parameter as an array, the tags should not be enclosed in <> brackets. Found: ' . $paramValue;
+        $error = 'When passing strip_tags() the $allowed_tags parameter as an array, the tags should not be enclosed in <> brackets. Found: ' . $paramValue;
 
         $this->assertWarning($file, $line, $error);
     }


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `strip_tags`: https://3v4l.org/dBJP1

Includes adding/adjusting the unit tests to include tests using named parameters.