### PR TITLE
RemovedGetDefinedFunctionsExcludeDisabledFalse: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Detect: Passing `false` to `get_defined_functions()` is deprecated as of PHP 8.0.
@@ -66,17 +67,18 @@ class RemovedGetDefinedFunctionsExcludeDisabledFalseSniff extends AbstractFuncti
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[1]) === false) {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 1, 'exclude_disabled');
+        if ($targetParam === false) {
             return;
         }
 
-        if ($parameters[1]['clean'] !== 'false') {
+        if ($targetParam['clean'] !== 'false') {
             return;
         }
 
         $phpcsFile->addWarning(
             'Explicitly passing "false" as the value for $exclude_disabled to get_defined_functions() is deprecated since PHP 8.0.',
-            $parameters[1]['start'],
+            $targetParam['start'],
             'Deprecated'
         );
     }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.inc
@@ -5,7 +5,7 @@
 
 // OK.
 get_defined_functions();
-get_defined_functions($exclude_disabled);
+get_defined_functions(exclude_disabled: $exclude_disabled);
 
 // Not OK.
 get_defined_functions(false);


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `get_defined_functions`: https://3v4l.org/fsgQl

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239