### PR TITLE
RemovedIconvEncoding: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Detect passing deprecated `$type` values to `iconv_get_encoding()`.
@@ -72,15 +73,16 @@ class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[1]) === false) {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 1, 'type');
+        if ($targetParam === false) {
             return;
         }
 
         $phpcsFile->addWarning(
             'All previously accepted values for the $type parameter of iconv_set_encoding() have been deprecated since PHP 5.6. Found %s',
-            $parameters[1]['start'],
+            $targetParam['start'],
             'DeprecatedValueFound',
-            [$parameters[1]['clean']]
+            [$targetParam['clean']]
         );
     }
 }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.inc
@@ -6,7 +6,7 @@ iconv_set_encoding();
 
 MyNS\iconv_set_encoding('internal_encoding', 'UTF-8');
 
-$a = iconv_get_encoding('internal_encoding');
+$a = iconv_get_encoding(type: 'internal_encoding');
 
 /*
  * Test iconv_set_encoding() PHP 5.6 change in accepted values.
@@ -14,5 +14,5 @@ $a = iconv_get_encoding('internal_encoding');
 iconv_set_encoding('internal_encoding', 'UTF-8');
 \iconv_set_encoding( 'input_encoding', 'ISO-8859-1' );
 iconv_set_encoding("output_encoding", "ISO-8859-1");
-iconv_set_encoding( $type, "ISO-8859-1");
+iconv_set_encoding( encoding: "ISO-8859-1", type: $type );
 iconv_set_encoding('all', 'UTF-8'); // Not a valid $type value.


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `iconv_get_encoding`: https://3v4l.org/MHJav

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239