### PR TITLE
RemovedMbStrrposEncodingThirdParam: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\MessageHelper;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Detect passing `$encoding` to `mb_strrpos()` as 3rd argument.
@@ -95,19 +96,20 @@ class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParame
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[3]) === false) {
-            // Optional third parameter not set.
-            return;
-        }
-
-        if (isset($parameters[4]) === true) {
+        $encodingParam = PassedParameters::getParameterFromStack($parameters, 4, 'encoding');
+        if ($encodingParam !== false) {
             // Encoding set as fourth parameter.
             return;
         }
 
-        $targetParam = $parameters[3];
-        $targets     = $this->numberTokens + Tokens::$emptyTokens;
-        $nonNumber   = $phpcsFile->findNext($targets, $targetParam['start'], ($targetParam['end'] + 1), true);
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 3, 'offset');
+        if ($targetParam === false) {
+            // Optional third parameter not set.
+            return;
+        }
+
+        $targets   = $this->numberTokens + Tokens::$emptyTokens;
+        $nonNumber = $phpcsFile->findNext($targets, $targetParam['start'], ($targetParam['end'] + 1), true);
         if ($nonNumber === false) {
             return;
         }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.inc
@@ -22,3 +22,7 @@ mb_strrpos('abc abc abc', 'abc', $encoding);
 mb_strrpos('abc abc abc', 'abc', 'UTF-8');
 mb_strrpos('abc abc abc', 'abc', "utf-$utfType");
 mb_strrpos('abc abc abc', 'abc', 'utf-' . $utfType);
+
+// Safeguard support for PHP 8 named parameters.
+mb_strrpos(haystack: 'abc abc abc', needle: 'abc', encoding: 'UTF-8'); // OK.
+mb_strrpos(offset: 'UTF-8', haystack: 'abc abc abc', needle: 'abc',); // Error, not that it would make sense to pass this.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
@@ -62,23 +62,45 @@ class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTest
             [22],
             [23],
             [24],
+            [28],
         ];
     }
 
 
     /**
-     * testNoFalsePositives
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
      *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 20 lines.
         for ($line = 1; $line <= 20; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        $data[] = [27];
+
+        return $data;
     }
 
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `mb_strrpos`: https://3v4l.org/kDrJP

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239