### PR TITLE
RemovedNonCryptoHash: add support for named parameters

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
@@ -6,13 +6,13 @@
 // OK.
 hash_init( 'fnv132');
 hash_init( 'sha1', HASH_HMAC);
-hash_init( 'gost-crypto', 1);
+hash_init( algo: 'gost-crypto', 1);
 
 // Not OK.
 hash_hmac('adler32');
 hash_hmac_file("crc32");
 hash_pbkdf2('crc32b');
-hash_init( 'fnv132', HASH_HMAC);
+hash_init( flags: HASH_HMAC, algo: 'fnv132' );
 hash_hmac('fnv1a32');
 hash_hmac_file("fnv164");
 hash_pbkdf2('fnv1a64');


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* https://3v4l.org/MPdLd (all functions)

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239