### PR TITLE
RemovedSetlocaleString: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Detect passing a string literal as `$category` to `setlocale()`.
@@ -72,13 +73,12 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[1]) === false) {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 1, 'category');
+        if ($targetParam === false) {
             return;
         }
 
-        $tokens      = $phpcsFile->getTokens();
-        $targetParam = $parameters[1];
-
+        $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
             if ($tokens[$i]['code'] === \T_STRING
                 || $tokens[$i]['code'] === \T_VARIABLE

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.inc
@@ -12,3 +12,7 @@ setlocale('LC_'.$category, $lang);
 // Issue #1043 - ignore function calls, constants etc.
 setlocale(getMyLocale('text'), 'nl_NL');
 setlocale($array['LC_ALL'], 'nl_NL');
+
+// Safeguard support for PHP 8 named parameters.
+setlocale(locales: 'nl_NL', category: $category); // Can't be determined.
+setlocale(category: 'LC_ALL', locales: 'nl_NL'); // Error.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
@@ -55,6 +55,7 @@ class RemovedSetlocaleStringUnitTest extends BaseSniffTest
         return [
             [9],
             [10],
+            [18],
         ];
     }
 
@@ -92,6 +93,7 @@ class RemovedSetlocaleStringUnitTest extends BaseSniffTest
 
         $data[] = [13];
         $data[] = [14];
+        $data[] = [17];
 
         return $data;
     }


### PR DESCRIPTION
1. Adjusted the way the correct parameter is retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `setlocale`: https://3v4l.org/XU4ja

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239