### PR TITLE
RemovedSplAutoloadRegisterThrowFalse: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Detect: Passing `false` to `spl_autoload_register()` is deprecated as of PHP 8.0.
@@ -67,17 +68,18 @@ class RemovedSplAutoloadRegisterThrowFalseSniff extends AbstractFunctionCallPara
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if (isset($parameters[2]) === false) {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 2, 'throw');
+        if ($targetParam === false) {
             return;
         }
 
-        if ($parameters[2]['clean'] !== 'false') {
+        if ($targetParam['clean'] !== 'false') {
             return;
         }
 
         $phpcsFile->addWarning(
             'Explicitly passing "false" as the value for $throw to spl_autoload_register() is deprecated since PHP 8.0.',
-            $parameters[2]['start'],
+            $targetParam['start'],
             'Deprecated'
         );
     }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.inc
@@ -8,6 +8,8 @@ spl_autoload_register();
 spl_autoload_register($autoload_function);
 spl_autoload_register($autoload_function, true, false);
 spl_autoload_register($autoload_function, $throw, $prepend);
+spl_autoload_register(callback: $autoload_function, prepend: false);
 
 // Not OK.
 spl_autoload_register($autoload_function, false);
+spl_autoload_register(prepend: false, callback: $autoload_function, throw: false);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
@@ -50,7 +50,8 @@ class RemovedSplAutoloadRegisterThrowFalseUnitTest extends BaseSniffTest
     public function dataRemovedSplAutoloadRegisterThrowFalse()
     {
         return [
-            [13],
+            [14],
+            [15],
         ];
     }
 
@@ -64,8 +65,8 @@ class RemovedSplAutoloadRegisterThrowFalseUnitTest extends BaseSniffTest
     {
         $file = $this->sniffFile(__FILE__, '8.0');
 
-        // No errors expected on the first 11 lines.
-        for ($line = 1; $line <= 11; $line++) {
+        // No errors expected on the first 12 lines.
+        for ($line = 1; $line <= 12; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }


### PR DESCRIPTION
1. Adjusted the way the correct parameter is retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `spl_autoload_register`: https://3v4l.org/47KmF

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239