### PR TITLE
NewIniDirectives: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -34,7 +34,8 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * List of functions which take an ini directive as parameter (always the first parameter).
      *
-     * Key is the function name, value is the 1-based parameter position in the function call.
+     * Key is the function name, value an array containing the 1-based parameter position
+     * and the official name of the parameter.
      *
      * @since 7.1.0
      * @since 10.0.0 Moved from the base `Sniff` class to this sniff.
@@ -42,8 +43,14 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
      * @var array
      */
     protected $iniFunctions = [
-        'ini_get' => 1,
-        'ini_set' => 1,
+        'ini_get' => [
+            'position' => 1,
+            'name'     => 'option',
+        ],
+        'ini_set' => [
+            'position' => 1,
+            'name'     => 'option',
+        ],
     ];
 
     /**
@@ -945,7 +952,8 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
             return;
         }
 
-        $iniToken = PassedParameters::getParameter($phpcsFile, $stackPtr, $this->iniFunctions[$functionLc]);
+        $paramInfo = $this->iniFunctions[$functionLc];
+        $iniToken  = PassedParameters::getParameter($phpcsFile, $stackPtr, $paramInfo['position'], $paramInfo['name']);
         if ($iniToken === false) {
             return;
         }

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -2,10 +2,10 @@
 function some_random_function() {} // Verify sniff doesn't flag this line.
 some_random_function(); // Verify sniff doesn't flag this line.
 ini_set('display_errors', 1); // Verify sniff doesn't flag this ini directive.
-ini_set($iniName, 'filter.default'); // Verify sniff doesn't flag on second parameter.
+ini_set(value: 'filter.default', option: $iniName); // Verify sniff doesn't flag on the value parameter.
 
-ini_set('allow_url_include', 1);
-$test = ini_get('allow_url_include');
+ini_set(option: 'allow_url_include', value: 1);
+$test = ini_get(option: 'allow_url_include');
 
 
 ini_set('pcre.backtrack_limit', 1);


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `ini_get`: https://3v4l.org/eF198
* `ini_set`: https://3v4l.org/XDWMd

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239