### PR TITLE
RemovedIniDirectives: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -36,7 +36,8 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
     /**
      * List of functions which take an ini directive as parameter (always the first parameter).
      *
-     * Key is the function name, value is the 1-based parameter position in the function call.
+     * Key is the function name, value an array containing the 1-based parameter position
+     * and the official name of the parameter.
      *
      * @since 7.1.0
      * @since 10.0.0 Moved from the base `Sniff` class to this sniff.
@@ -44,8 +45,14 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
      * @var array
      */
     protected $iniFunctions = [
-        'ini_get' => 1,
-        'ini_set' => 1,
+        'ini_get' => [
+            'position' => 1,
+            'name'     => 'option',
+        ],
+        'ini_set' => [
+            'position' => 1,
+            'name'     => 'option',
+        ],
     ];
 
     /**
@@ -674,7 +681,8 @@ class RemovedIniDirectivesSniff extends AbstractRemovedFeatureSniff
             return;
         }
 
-        $iniToken = PassedParameters::getParameter($phpcsFile, $stackPtr, $this->iniFunctions[$functionLc]);
+        $paramInfo = $this->iniFunctions[$functionLc];
+        $iniToken  = PassedParameters::getParameter($phpcsFile, $stackPtr, $paramInfo['position'], $paramInfo['name']);
         if ($iniToken === false) {
             return;
         }

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -1,7 +1,7 @@
 <?php
 
-ini_set('define_syslog_variables', 'a');
-$a = ini_get('define_syslog_variables');
+ini_set(option: 'define_syslog_variables', value: 'a');
+$a = ini_get(option: 'define_syslog_variables');
 
 ini_set('register_globals', 'a');
 $a = ini_get('register_globals');


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `ini_get`: https://3v4l.org/eF198
* `ini_set`: https://3v4l.org/XDWMd

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239