### PR TITLE
New/RemovedHashAlgorithms: add support for named parameters

### DIFF
--- a/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
+++ b/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
@@ -40,12 +40,30 @@ trait HashAlgorithmsTrait
      * @var array
      */
     protected $hashAlgoFunctions = [
-        'hash_file'      => 1,
-        'hash_hmac_file' => 1,
-        'hash_hmac'      => 1,
-        'hash_init'      => 1,
-        'hash_pbkdf2'    => 1,
-        'hash'           => 1,
+        'hash_file' => [
+            'position' => 1,
+            'name'     => 'algo',
+        ],
+        'hash_hmac_file' => [
+            'position' => 1,
+            'name'     => 'algo',
+        ],
+        'hash_hmac' => [
+            'position' => 1,
+            'name'     => 'algo',
+        ],
+        'hash_init' => [
+            'position' => 1,
+            'name'     => 'algo',
+        ],
+        'hash_pbkdf2' => [
+            'position' => 1,
+            'name'     => 'algo',
+        ],
+        'hash' => [
+            'position' => 1,
+            'name'     => 'algo',
+        ],
     ];
 
     /**
@@ -78,7 +96,8 @@ trait HashAlgorithmsTrait
         }
 
         // Get the parameter from the function call which should contain the algorithm name.
-        $algoParam = PassedParameters::getParameter($phpcsFile, $stackPtr, $this->hashAlgoFunctions[$functionNameLc]);
+        $paramInfo = $this->hashAlgoFunctions[$functionNameLc];
+        $algoParam = PassedParameters::getParameter($phpcsFile, $stackPtr, $paramInfo['position'], $paramInfo['name']);
         if ($algoParam === false) {
             return false;
         }

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.inc
@@ -3,7 +3,7 @@
 /**
  * These should all be fine.
  */
-hash_file("something"); // Not one of the targetted algorithms.
+hash_file(algo: "something"); // Not one of the targetted algorithms.
 hash("1st param", "md2"); // Not the right parameter.
 hash_init; // Not a function call.
 
@@ -23,7 +23,7 @@ hash("joaat");
 hash("fnv132", "2nd param", 3, false);
 hash("fnv164");
 
-hash_pbkdf2('gost-crypto');
+hash_pbkdf2(algo: 'gost-crypto');
 
 hash_file('sha512/224');
 hash_hmac_file('sha512/256');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.inc
@@ -4,7 +4,7 @@
  * These should all be fine.
  */
 hash_file("something"); // Not one of the targetted algorithms.
-hash("1st param", "salsa10"); // Not the right parameter.
+hash(algo: "1st param", "salsa10"); // Not the right parameter.
 hash_hmac; // Not a function call.
 
 /**
@@ -15,7 +15,7 @@ hash_file("salsa20");
 hash_file('salsa10');
 hash_file('salsa20');
 
-hash_hmac_file("salsa10");
+hash_hmac_file(algo: "salsa10");
 hash_hmac( "salsa20" );
 hash_init(   'salsa10'  );
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method in the `HashAlgorithmsTrait`.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `hash_file`: https://3v4l.org/7JNic
* `hash_hmac_file`: https://3v4l.org/XDWMd
* `hash_hmac`: https://3v4l.org/jJBV1
* `hash_init`: https://3v4l.org/DeFge
* `hash_pbkdf2`: https://3v4l.org/SDNeL
* `hash`: https://3v4l.org/6PfKM

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239