### PR TITLE
RemovedPCREModifiers: add support for named parameters

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.inc
@@ -226,3 +226,7 @@ preg_filter(<<<EOD
 `xe
 EOD
     , $replace, $source); // Bad.
+
+// Safeguard support for PHP 8 named parameters.
+preg_replace( subject: '/pattern/e', pattern: '/pattern/', count: $count, replacement: $replacement, limit: $limit ); // OK.
+preg_replace( limit: $limit, count: $count, pattern: '/some text/emS', replacement: $replacement, subject: $subject ); // Error.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -115,6 +115,9 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTest
 
             // Heredoc/Nowdoc.
             [228, 'preg_filter'],
+
+            // Named parameters.
+            [232],
         ];
     }
 
@@ -186,6 +189,9 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTest
 
             // Heredoc/Nowdoc.
             [220],
+
+            // Named parameters.
+            [231],
         ];
     }
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* https://3v4l.org/oocMn

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239