### PR TITLE
NewPCREModifiers: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\PCRERegexTrait;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 
 /**
  * Check for the use of newly added regex modifiers for PCRE functions.
@@ -36,18 +37,44 @@ class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
      * Functions to check for.
      *
      * @since 8.2.0
+     * @since 10.0.0 Value changed from an irrelevant value to an array.
      *
-     * @var array
+     * @var array Key is the function name, value an array containing the 1-based parameter position
+     *            and the official name of the parameter.
      */
     protected $targetFunctions = [
-        'preg_filter'                 => true,
-        'preg_grep'                   => true,
-        'preg_match_all'              => true,
-        'preg_match'                  => true,
-        'preg_replace_callback_array' => true,
-        'preg_replace_callback'       => true,
-        'preg_replace'                => true,
-        'preg_split'                  => true,
+        'preg_filter' => [
+            'position' => 1,
+            'name'     => 'pattern',
+        ],
+        'preg_grep' => [
+            'position' => 1,
+            'name'     => 'pattern',
+        ],
+        'preg_match_all' => [
+            'position' => 1,
+            'name'     => 'pattern',
+        ],
+        'preg_match' => [
+            'position' => 1,
+            'name'     => 'pattern',
+        ],
+        'preg_replace_callback_array' => [
+            'position' => 1,
+            'name'     => 'pattern',
+        ],
+        'preg_replace_callback' => [
+            'position' => 1,
+            'name'     => 'pattern',
+        ],
+        'preg_replace' => [
+            'position' => 1,
+            'name'     => 'pattern',
+        ],
+        'preg_split' => [
+            'position' => 1,
+            'name'     => 'pattern',
+        ],
     ];
 
     /**
@@ -96,12 +123,14 @@ class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        // Check the first parameter in the function call as that should contain the regex(es).
-        if (isset($parameters[1]) === false) {
+        $functionLC  = \strtolower($functionName);
+        $paramInfo   = $this->targetFunctions[$functionLC];
+        $targetParam = PassedParameters::getParameterFromStack($parameters, $paramInfo['position'], $paramInfo['name']);
+        if ($targetParam === false) {
             return;
         }
 
-        $patterns = $this->getRegexPatternsFromParameter($phpcsFile, $functionName, $parameters[1]);
+        $patterns = $this->getRegexPatternsFromParameter($phpcsFile, $functionName, $targetParam);
         if (empty($patterns) === true) {
             return;
         }

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
@@ -44,3 +44,7 @@ EOD
     '[$1]',
     $text
   );
+
+// Safeguard support for PHP 8 named parameters.
+preg_grep(array: $input, pattern: '#some text#i'); // OK.
+preg_grep(array: $input, pattern: '#some text#Ji', flags: $flags); // Error.

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -65,7 +65,7 @@ class NewPCREModifiersUnitTest extends BaseSniffTest
     public function dataPCRENewModifier()
     {
         return [
-            ['J', '7.1', [3, 4, 10, 17, 19, 25, 43], '7.2'],
+            ['J', '7.1', [3, 4, 10, 17, 19, 25, 43, 50], '7.2'],
         ];
     }
 
@@ -97,6 +97,7 @@ class NewPCREModifiersUnitTest extends BaseSniffTest
         return [
             [18],
             [28],
+            [49],
         ];
     }
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by implementing the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `preg_filter`: https://3v4l.org/eJNZe
* `preg_grep`: https://3v4l.org/Am8aX
* `preg_match_all`: https://3v4l.org/IoIJQ
* `preg_match`: https://3v4l.org/TfVDB
* `preg_replace_callback_array`: https://3v4l.org/Hp8rI
* `preg_replace_callback`: https://3v4l.org/BHj7T
* `preg_replace`: https://3v4l.org/0lr5d
* `preg_split`: https://3v4l.org/jJMg0

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239