### PR TITLE
ForbiddenEmptyListAssignment: add extra test

### DIFF
--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.inc
@@ -30,5 +30,8 @@ if (true) {}
 list(,(),) = $infoArray;
 [,(),] = $infoArray;
 
+// Issue #1341, safeguard against a false positive.
+foreach(["a"=>[]] as $v){}
+
 // Don't trigger on unfinished code during live code review.
 list(

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
@@ -98,6 +98,7 @@ class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTest
             [30],
             [31],
             [34],
+            [37],
         ];
     }
 


### PR DESCRIPTION
The sniff would previously throw a false positive for the added example code, but this has been fixed automagically by the improvements made in PHPCSUtils.

Adding the test just to safeguard against regressions.

Closes #1341