### PR TITLE
PHP 8.0 | ForbiddenNames: don't report reserved names in namespace declarations

### DIFF
--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/namespace.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/namespace.inc
@@ -46,7 +46,6 @@ namespace insteadof;
 namespace interface;
 namespace isset;
 namespace list;
-namespace namespace;
 namespace new;
 namespace or;
 namespace print;

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.3.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.3.inc
@@ -5,7 +5,7 @@
  */
 
 // Test multiple errors for multiple incorrect namespace parts, as well as tolerance for comments and whitespace.
-namespace For\ List /*comment*/ \Foreach ?><?php // Error x3.
+namespace For\ List /*comment*/ \Foreach ?><?php // Error x3 with testVersion which includes PHP < 8.
 
 // Test multi-use line precision, including `as` as alias.
 use My\Foo as As, // Error.
@@ -74,3 +74,8 @@ trait FooTrait {
 
 // Test function delared to return by reference.
 function &trait() {}
+
+// Test "namespace" keyword at start of namespace name. Forbidden, even in PHP 8.
+namespace NAMEspace;
+
+namespace NameSpace\Foo;

--- a/bin/generate-forbidden-names-test-files
+++ b/bin/generate-forbidden-names-test-files
@@ -133,9 +133,15 @@ $tests = [
     /*
      * Reserved names being used in a declaration.
      */
+    // Only pre-PHP 8!
     'namespace'                              => function ($name) {
-        return "namespace $name;\n";
+        if ($name === 'namespace') {
+            return '';
+        } else {
+            return "namespace $name;\n";
+        }
     },
+    // Only pre-PHP 8!
     'nested-namespace'                       => function ($name) {
         $name = ucfirst($name);
         return "namespace Foo\\{$name}\\Bar;\n";


### PR DESCRIPTION
As of PHP 8.0, reserved keywords can be used in namespace declarations, with the exception of the `namespace` keyword at the start of a namespace name.

>  In the interest of consistency, the namespace declaration will accept any name, including isolated reserved keywords:
>
>  ```php
>  namespace iter\fn; // Legal
>  namespace fn;      // Legal
>  ```
>  This is to avoid a discrepancy where defining symbols like `iter\fn\operator` is allowed, but `fn\operator` is not. The only restriction is that the namespace name cannot start with a `namespace` segment:
>
>  ```php
>  namespace namespace;   // Illegal
>  namespace namespace\x; // Illegal
>  ```

This commit:
* Adjusts the `ForbiddenNames` sniff to prevent triggering an error for reserved keywords being used in a namespace name when the `testVersion` has a minimum version of PHP  `8.0` or higher.
* The code handling this has been written to be compatible with PHP 8.0 "namespaced names as single token" tokens. This addresses issue #1226 for this part of the sniff (but not yet for the complete sniff).
* Adjusts the testcase generation file to exclude the testcase with a namespace declaration using `namespace` at the start of the name, including a regenerated test case file as the behaviour is different compared to the other keywords.
* Special cases the "namespace declaration" tests. These will now trigger an error when PHP < 8.0 needs to be supported, but will no longer trigger an error when PHP 8.0 is the minimum supported version according to the `testVersion` setting.
* Adds separate test cases to the `ForbiddenNamesUnitTest.3.inc` test file to verify the correct handling of a namespace name starting with `namespace`.
* Annotates that the testcase on line 8 in the `ForbiddenNamesUnitTest.3.inc` test case file will only trigger errors when PHP < 8 is part of the `testVersion` setting and adjusts the unit test to make sure a `testVersion` is passed for that test.

Ref:
* https://wiki.php.net/rfc/namespaced_names_as_token
* https://github.com/php/php-src/pull/5827
* https://github.com/php/php-src/commit/7a3dcc3e339cde2177ba4fe8fc45f78c94dfbb29