### PR TITLE
ForbiddenNames: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -538,12 +538,12 @@ class ForbiddenNamesSniff extends Sniff
         }
 
         // Retrieve the define(d) constant name.
-        $firstParam = PassedParameters::getParameter($phpcsFile, $stackPtr, 1);
-        if ($firstParam === false) {
+        $constantName = PassedParameters::getParameter($phpcsFile, $stackPtr, 1, 'constant_name');
+        if ($constantName === false) {
             return;
         }
 
-        $defineName = TextStrings::stripQuotes($firstParam['clean']);
+        $defineName = TextStrings::stripQuotes($constantName['clean']);
         $this->checkName($phpcsFile, $stackPtr, $defineName);
     }
 

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
@@ -312,3 +312,6 @@ use const MyCONSTANT;
 
 // Closure use should be ignored.
 $closure = function () use ($a) {};
+
+// Test call to define() using named parameters.
+define(value: 'class', constant_name: 'BAR');

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.3.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.3.inc
@@ -73,9 +73,12 @@ trait FooTrait {
 }
 
 // Test function delared to return by reference.
-function &trait() {}
+function &trait() {} // Error.
 
 // Test "namespace" keyword at start of namespace name. Forbidden, even in PHP 8.
-namespace NAMEspace;
+namespace NAMEspace; // Error.
 
-namespace NameSpace\Foo;
+namespace NameSpace\Foo; // Error.
+
+// Test call to define() using named parameters.
+define(value: 'class', constant_name: 'class'); // Error.

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -327,6 +327,7 @@ class ForbiddenNamesUnitTest extends BaseSniffTest
             [76, 'trait'],
             [79, 'namespace'],
             [81, 'namespace'],
+            [84, 'class'],
         ];
     }
 


### PR DESCRIPTION
1. Add support for function calls using named parameters by passing the parameter name to the PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameter()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification references:
* `define`: https://3v4l.org/JLsqC

Includes adding tests to the "specific situations" test case files using named parameters.

Related to #1239