### PR TITLE
NewExecutionDirectives: various bug fixes

### DIFF
--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -68,7 +68,7 @@ class NewExecutionDirectivesSniff extends Sniff
         'strict_types' => [
             '5.6'          => false,
             '7.0'          => true,
-            'valid_values' => [1],
+            'valid_values' => [0, 1],
         ],
     ];
 

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -68,7 +68,7 @@ class NewExecutionDirectivesSniff extends Sniff
         'strict_types' => [
             '5.6'          => false,
             '7.0'          => true,
-            'valid_values' => [0, 1],
+            'valid_values' => ['0', '1'],
         ],
     ];
 
@@ -292,13 +292,13 @@ class NewExecutionDirectivesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         $value = $tokens[$stackPtr]['content'];
-        if (isset(Tokens::$stringTokens[$tokens[$stackPtr]['code']]) === true) {
+        if ($directive === 'encoding' && isset(Tokens::$stringTokens[$tokens[$stackPtr]['code']]) === true) {
             $value = TextStrings::stripQuotes($value);
         }
 
         $isError = false;
         if (isset($this->newDirectives[$directive]['valid_values'])) {
-            if (\in_array($value, $this->newDirectives[$directive]['valid_values']) === false) {
+            if (\in_array($value, $this->newDirectives[$directive]['valid_values'], true) === false) {
                 $isError = true;
             }
         } elseif (isset($this->newDirectives[$directive]['valid_value_callback'])) {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -135,13 +135,13 @@ class NewExecutionDirectivesSniff extends Sniff
                 $directiveContent,
             ];
 
-            $phpcsFile->addError($error, $stackPtr, 'InvalidDirectiveFound', $data);
+            $phpcsFile->addError($error, $directivePtr, 'InvalidDirectiveFound', $data);
         } else {
             // Check for valid directive for version.
             $itemInfo = [
                 'name' => $directiveContentLC,
             ];
-            $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
+            $this->handleFeature($phpcsFile, $directivePtr, $itemInfo);
 
             // Check for valid directive value.
             $valuePtr = $phpcsFile->findNext($this->ignoreTokens, $directivePtr + 1, $closeParenthesis, true);

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -125,9 +125,10 @@ class NewExecutionDirectivesSniff extends Sniff
             return;
         }
 
-        $directiveContent = $tokens[$directivePtr]['content'];
+        $directiveContent   = $tokens[$directivePtr]['content'];
+        $directiveContentLC = \strtolower($directiveContent);
 
-        if (isset($this->newDirectives[$directiveContent]) === false) {
+        if (isset($this->newDirectives[$directiveContentLC]) === false) {
             $error = 'Declare can only be used with the directives %s. Found: %s';
             $data  = [
                 \implode(', ', \array_keys($this->newDirectives)),
@@ -138,7 +139,7 @@ class NewExecutionDirectivesSniff extends Sniff
         } else {
             // Check for valid directive for version.
             $itemInfo = [
-                'name' => $directiveContent,
+                'name' => $directiveContentLC,
             ];
             $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
 
@@ -148,7 +149,7 @@ class NewExecutionDirectivesSniff extends Sniff
                 return;
             }
 
-            $this->addWarningOnInvalidValue($phpcsFile, $valuePtr, $directiveContent);
+            $this->addWarningOnInvalidValue($phpcsFile, $valuePtr, $directiveContentLC);
         }
     }
 

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
@@ -21,5 +21,8 @@ declare(strict_types=false); // Invalid - only 1 is a valid value.
 // Invalid directive name.
 declare(invalid=true);
 
+// Strict types can have value 0.
+declare(strict_types=0);
+
 // Incomplete directive.
 declare(

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
@@ -4,8 +4,8 @@
  * The below directives are valid.
  */
 declare(ticks=1);
-declare ( ticks = 1 ) {} // Test with varying spacing.
-declare(encoding='ISO-8859-1');
+declare ( TICKS = 1 ) {} // Test with varying spacing and case-sensitivity.
+declare(Encoding='ISO-8859-1');
 declare(strict_types=1) {
     $var = false;
 }
@@ -15,7 +15,7 @@ declare(strict_types=1) {
  */
 declare(ticks=TICK_VALUE); // Invalid - only literals may be given as directive values.
 declare(encoding='invalid'); // Invalid - not a valid encoding.
-declare(strict_types=false); // Invalid - only 1 is a valid value.
+declare(Strict_Types=false); // Invalid - only 1 is a valid value.
 
 
 // Invalid directive name.

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
@@ -24,5 +24,9 @@ declare(invalid=true);
 // Strict types can have value 0.
 declare(strict_types=0);
 
+// Strict types does not type juggle the value.
+declare(strict_types='0');
+declare(strict_types='1');
+
 // Incomplete directive.
 declare(

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
@@ -17,16 +17,20 @@ declare(ticks=TICK_VALUE); // Invalid - only literals may be given as directive 
 declare(encoding='invalid'); // Invalid - not a valid encoding.
 declare(Strict_Types=false); // Invalid - only 1 is a valid value.
 
-
 // Invalid directive name.
-declare(invalid=true);
+declare(
+    invalid=true
+);
 
 // Strict types can have value 0.
 declare(strict_types=0);
 
 // Strict types does not type juggle the value.
 declare(strict_types='0');
-declare(strict_types='1');
+declare(
+    // Comment.
+    strict_types='1'
+);
 
 // Incomplete directive.
 declare(

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
@@ -32,5 +32,16 @@ declare(
     strict_types='1'
 );
 
+/*
+ * Testing multi-declare statements.
+ */
+declare(
+    ticks = 10.56,
+    encoding='UTF-8',
+    strict_types=0
+); // All valid.
+
+declare(ticks = new stdClass, encoding=$encoding, strict_types=false, unknown = 'invalid', ); // All invalid in one way or another; also: trailing comma not allowed.
+
 // Incomplete directive.
 declare(

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -46,7 +46,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
     }
 
     /**
-     * testNewExecutionDirective
+     * Test that execution directives which are not supported in certain PHP versions are correctly flagged.
      *
      * @dataProvider dataNewExecutionDirective
      *
@@ -99,7 +99,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
 
 
     /**
-     * testInvalidDirectiveValue
+     * Verify that execution directives with an invalid value are flagged.
      *
      * @dataProvider dataInvalidDirectiveValue
      *
@@ -116,7 +116,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
     }
 
     /**
-     * dataInvalidDirectiveValue
+     * Data provider.
      *
      * @see testInvalidDirectiveValue()
      *
@@ -132,7 +132,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
 
 
     /**
-     * testInvalidEncodingDirectiveValue
+     * Verify that "encoding" execution directives with an invalid value are flagged.
      *
      * @requires function mb_list_encodings
      *
@@ -151,7 +151,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
     }
 
     /**
-     * dataInvalidEncodingDirectiveValue
+     * Data provider.
      *
      * @see testInvalidEncodingDirectiveValue()
      *
@@ -166,7 +166,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
 
 
     /**
-     * testInvalidDirective
+     * Verify that directives which are not supported by PHP are flagged as such.
      *
      * @return void
      */
@@ -178,7 +178,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
 
 
     /**
-     * testIncompleteDirective
+     * Verify that the sniff stays silent for incomplete declare statements (live coding/parse error).
      *
      * @return void
      */

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -56,11 +56,19 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
      * @param string $okVersion          A PHP version in which the directive was ok to be used.
      * @param string $conditionalVersion Optional. A PHP version in which the directive was conditionaly available.
      * @param string $condition          The availability condition.
+     * @param bool   $skipNoViolation    Whether to skip the "no violation test".
      *
      * @return void
      */
-    public function testNewExecutionDirective($directive, $lastVersionBefore, $lines, $okVersion, $conditionalVersion = null, $condition = null)
-    {
+    public function testNewExecutionDirective(
+        $directive,
+        $lastVersionBefore,
+        $lines,
+        $okVersion,
+        $conditionalVersion = null,
+        $condition = null,
+        $skipNoViolation = false
+    ) {
         $file  = $this->sniffFile(__FILE__, $lastVersionBefore);
         $error = "Directive {$directive} is not present in PHP version {$lastVersionBefore} or earlier";
         foreach ($lines as $line) {
@@ -73,6 +81,10 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
             foreach ($lines as $line) {
                 $this->assertWarning($file, $line, $error);
             }
+        }
+
+        if ($skipNoViolation === true) {
+            return;
         }
 
         $file = $this->sniffFile(__FILE__, $okVersion);
@@ -92,8 +104,11 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
     {
         return [
             ['ticks', '3.1', [6, 7], '4.0'],
+            ['ticks', '3.1', [16], '4.0', null, null, true], // Test lines with an invalid value.
             ['encoding', '5.2', [8], '5.4', '5.3', '--enable-zend-multibyte'],
+            ['encoding', '5.2', [17], '5.4', '5.3', '--enable-zend-multibyte', true], // Test lines with an invalid value.
             ['strict_types', '5.6', [9], '7.0'],
+            ['strict_types', '5.6', [18], '7.0', null, null, true], // Test lines with an invalid value.
         ];
     }
 

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -107,8 +107,8 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
             ['ticks', '3.1', [16], '4.0', null, null, true], // Test lines with an invalid value.
             ['encoding', '5.2', [8], '5.4', '5.3', '--enable-zend-multibyte'],
             ['encoding', '5.2', [17], '5.4', '5.3', '--enable-zend-multibyte', true], // Test lines with an invalid value.
-            ['strict_types', '5.6', [9, 25], '7.0'],
-            ['strict_types', '5.6', [18, 28, 29], '7.0', null, null, true], // Test lines with an invalid value.
+            ['strict_types', '5.6', [9, 26], '7.0'],
+            ['strict_types', '5.6', [18, 29, 32], '7.0', null, null, true], // Test lines with an invalid value.
         ];
     }
 
@@ -142,8 +142,8 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
         return [
             ['ticks', 'TICK_VALUE', 16],
             ['strict_types', 'false', 18],
-            ['strict_types', "'0'", 28],
-            ['strict_types', "'1'", 29],
+            ['strict_types', "'0'", 29],
+            ['strict_types', "'1'", 32],
         ];
     }
 
@@ -201,7 +201,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
      */
     public function testIncompleteDirective()
     {
-        $this->assertNoViolation($this->sniffResult, 32);
+        $this->assertNoViolation($this->sniffResult, 36);
     }
 
 

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -108,7 +108,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
             ['encoding', '5.2', [8], '5.4', '5.3', '--enable-zend-multibyte'],
             ['encoding', '5.2', [17], '5.4', '5.3', '--enable-zend-multibyte', true], // Test lines with an invalid value.
             ['strict_types', '5.6', [9, 25], '7.0'],
-            ['strict_types', '5.6', [18], '7.0', null, null, true], // Test lines with an invalid value.
+            ['strict_types', '5.6', [18, 28, 29], '7.0', null, null, true], // Test lines with an invalid value.
         ];
     }
 
@@ -142,6 +142,8 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
         return [
             ['ticks', 'TICK_VALUE', 16],
             ['strict_types', 'false', 18],
+            ['strict_types', "'0'", 28],
+            ['strict_types', "'1'", 29],
         ];
     }
 
@@ -199,7 +201,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
      */
     public function testIncompleteDirective()
     {
-        $this->assertNoViolation($this->sniffResult, 28);
+        $this->assertNoViolation($this->sniffResult, 32);
     }
 
 

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -107,7 +107,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
             ['ticks', '3.1', [16], '4.0', null, null, true], // Test lines with an invalid value.
             ['encoding', '5.2', [8], '5.4', '5.3', '--enable-zend-multibyte'],
             ['encoding', '5.2', [17], '5.4', '5.3', '--enable-zend-multibyte', true], // Test lines with an invalid value.
-            ['strict_types', '5.6', [9], '7.0'],
+            ['strict_types', '5.6', [9, 25], '7.0'],
             ['strict_types', '5.6', [18], '7.0', null, null, true], // Test lines with an invalid value.
         ];
     }
@@ -199,7 +199,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
      */
     public function testIncompleteDirective()
     {
-        $this->assertNoViolation($this->sniffResult, 25);
+        $this->assertNoViolation($this->sniffResult, 28);
     }
 
 

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -103,12 +103,12 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
     public function dataNewExecutionDirective()
     {
         return [
-            ['ticks', '3.1', [6, 7], '4.0'],
-            ['ticks', '3.1', [16], '4.0', null, null, true], // Test lines with an invalid value.
-            ['encoding', '5.2', [8], '5.4', '5.3', '--enable-zend-multibyte'],
-            ['encoding', '5.2', [17], '5.4', '5.3', '--enable-zend-multibyte', true], // Test lines with an invalid value.
-            ['strict_types', '5.6', [9, 26], '7.0'],
-            ['strict_types', '5.6', [18, 29, 32], '7.0', null, null, true], // Test lines with an invalid value.
+            ['ticks', '3.1', [6, 7, 39], '4.0'],
+            ['ticks', '3.1', [16, 44], '4.0', null, null, true], // Test lines with an invalid value.
+            ['encoding', '5.2', [8, 40], '5.4', '5.3', '--enable-zend-multibyte'],
+            ['encoding', '5.2', [17, 44], '5.4', '5.3', '--enable-zend-multibyte', true], // Test lines with an invalid value.
+            ['strict_types', '5.6', [9, 26, 41], '7.0'],
+            ['strict_types', '5.6', [18, 29, 32, 44], '7.0', null, null, true], // Test lines with an invalid value.
         ];
     }
 
@@ -141,9 +141,11 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
     {
         return [
             ['ticks', 'TICK_VALUE', 16],
+            ['ticks', 'new', 44],
             ['strict_types', 'false', 18],
             ['strict_types', "'0'", 29],
             ['strict_types', "'1'", 32],
+            ['strict_types', 'false', 44],
         ];
     }
 
@@ -178,6 +180,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
     {
         return [
             ['encoding', 'invalid', 17],
+            ['encoding', '$encoding', 44],
         ];
     }
 
@@ -185,12 +188,32 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
     /**
      * Verify that directives which are not supported by PHP are flagged as such.
      *
+     * @dataProvider dataInvalidDirective
+     *
+     * @param string $directive Name of the execution directive.
+     * @param int    $line      Line number where the error should occur.
+     *
      * @return void
      */
-    public function testInvalidDirective()
+    public function testInvalidDirective($directive, $line)
     {
         // Message will be shown independently of testVersion.
-        $this->assertError($this->sniffResult, 22, 'Declare can only be used with the directives ticks, encoding, strict_types. Found: invalid');
+        $this->assertError($this->sniffResult, $line, "Declare can only be used with the directives ticks, encoding, strict_types. Found: {$directive}");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidDirective()
+     *
+     * @return array
+     */
+    public function dataInvalidDirective()
+    {
+        return [
+            ['invalid', 22],
+            ['unknown', 44],
+        ];
     }
 
 
@@ -201,7 +224,7 @@ class NewExecutionDirectivesUnitTest extends BaseSniffTest
      */
     public function testIncompleteDirective()
     {
-        $this->assertNoViolation($this->sniffResult, 36);
+        $this->assertNoViolation($this->sniffResult, 47);
     }
 
 


### PR DESCRIPTION
### NewExecutionDirectives: improve test documentation

### Tests/NewExecutionDirectives: allow for skipping the "no violations" check

This allows for testing the "not available in PHP x" error even when the directive has an invalid value (which is tested separately).

Includes adding existing "invalid value" tests to the "not available in PHP x" test data provider.

### NewExecutionDirectives: strict_types can have value 0

The `strict_types` execution directive allows for a value of `0` or `1`.

As things were, the sniff did not account for the `0` value.

Includes test.

### NewExecutionDirectives: strict_types does not type juggle

The `strict_types` execution directive allows for a value `0` or `1`. Declare statements do not type juggle, so a scalar value which could juggle to either of those types is not supported.

Also note that the representation of the token content in PHPCS is always a string, so the "valid values" to compare against need to be a text string, so we need to make sure that potential text string quotes are not stripped off.

Includes tests.

### NewExecutionDirectives: directives are case insensitive

The directive name are case-insensitive in PHP. See: https://3v4l.org/KDeaC

Tested via adjusting some existing tests.

### NewExecutionDirectives: improve message line precision

Previously, all messages would be thrown on the `T_DECLARE` token, while the actual directive token _could_ be on another line alltogether.

This changes the sniff to throw the messages on the actual execution directive instead of on the `declare` keyword.

Tested via adjusting an existing test.
Includes safeguarding the whitespace and comment tolerance in the sniff code (which is fine, but was insufficiently safeguarded).

### NewExecutionDirectives: handle multi-directive declare statements

As per https://www.php.net/manual/en/control-structures.declare.php#124553, a `declare` statement can contain multiple, comma-separated, directives in one statement.

The sniff did not take this into account so far. Fixed now.

Includes additional tests.