### PR TITLE
:sparkles: PHP 8.0: New `PHPCompatibility.Classes.NewConstructorPropertyPromotion` sniff

### DIFF
--- a/PHPCompatibility/Docs/Classes/NewConstructorPropertyPromotionStandard.xml
+++ b/PHPCompatibility/Docs/Classes/NewConstructorPropertyPromotionStandard.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Constructor Property Promotion"
+    >
+    <standard>
+    <![CDATA[
+    Constructor Property Promotion is available since PHP 8.0.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: assigning parameters received in the class constructor to properties.">
+        <![CDATA[
+class Foo
+{
+    <em>public float $x = 0.0</em>;
+    <em>protected $y = ''</em>;
+    <em>private $z = null</em>;
+
+    public function __construct($x, $y, $z) {
+        <em>$this->x = $x</em>;
+        <em>$this->y = $y</em>;
+        <em>$this->z = $z</em>;
+    }
+}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.0: using constructor property promotion.">
+        <![CDATA[
+class PropertyPromotion
+{
+    public function __construct(
+        <em>public float $x = 0.0</em>,
+        <em>protected $y = ''</em>,
+        <em>private $z = null</em>,
+    ) {}
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Detect constructor property promotion as supported since PHP 8.0.
+ *
+ * PHP version 8.0
+ *
+ * @link https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion
+ * @link https://wiki.php.net/rfc/constructor_promotion
+ *
+ * @since 10.0.0
+ */
+final class NewConstructorPropertyPromotionSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_FUNCTION];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.4') === false) {
+            return;
+        }
+
+        if (Scopes::isOOMethod($phpcsFile, $stackPtr) === false) {
+            // Global or namespaced function.
+            return;
+        }
+
+        $functionName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
+        if (\strtolower($functionName) !== '__construct') {
+            // Not a class constructor.
+            return;
+        }
+
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        if (empty($parameters)) {
+            // Nothing to do.
+            return;
+        }
+
+        foreach ($parameters as $param) {
+            if (empty($param['property_visibility']) === true) {
+                // Not property promotion.
+                continue;
+            }
+
+            $phpcsFile->addError(
+                'Constructor property promotion is not available in PHP version 7.4 or earlier. Found: %s',
+                $param['visibility_token'],
+                'Found',
+                [$param['content']]
+            );
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.inc
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * OK on all versions.
+ */
+class NoParams {
+    public function __construct() {}
+}
+
+class CrossVersion {
+    public function __construct(int $a, $b = true, &...$c) {}
+}
+
+/*
+ * Not valid, but not a class constructor either, so ignore.
+ *
+ * These will all generate a fatal error.
+ */
+function __construct(public $a) {}
+
+function globalFunction(private $x) {}
+
+class Invalid {
+    protected function thisIsNotAConstructor(protected mixed $foo = null) {}
+}
+
+/*
+ * PHP 8 Constructor Property Promotion.
+ */
+class ConstructorPropertyPromotionNoTypes {
+    public function __construct(
+        public $x = 0.0,
+        protected $y = '',
+        private $z = null,
+    ) {}
+}
+
+class ConstructorPropertyPromotionWithTypes {
+    public function __construct(protected float|int $x, public ?string &$y = 'test', private mixed $z) {}
+}
+
+class ConstructorPropertyPromotionAndNormalParams {
+    public function __construct(
+        public int $promotedProp,
+        ?int $normalArg
+    ) {}
+}
+
+abstract class ConstructorPropertyPromotionAbstractMethod {
+    // Intentional fatal error.
+    // 1. Property promotion not allowed in abstract method, but that's not the concern of this sniff.
+    // 2. Variadic arguments not allowed in property promotion, but that's not the concern of this sniff.
+    // 3. The callable type is not supported for properties, but that's not the concern of this sniff.
+    abstract public function __construct(public callable $y, private ...$x);
+}

--- a/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewConstructorPropertyPromotion sniff.
+ *
+ * @group newConstructorPropertyPromotion
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewConstructorPropertyPromotionSniff
+ *
+ * @since 10.0.0
+ */
+final class NewConstructorPropertyPromotionUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify that the sniff throws an error for constructor property promotion.
+     *
+     * @dataProvider dataNewConstructorPropertyPromotion
+     *
+     * @param int $line The line number where the error is expected.
+     *
+     * @return void
+     */
+    public function testNewConstructorPropertyPromotion($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, 'Constructor property promotion is not available in PHP version 7.4 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewConstructorPropertyPromotion()
+     *
+     * @return array
+     */
+    public function dataNewConstructorPropertyPromotion()
+    {
+        return [
+            [32],
+            [33],
+            [34],
+            [39], // x3.
+            [44],
+            [54], // x2.
+        ];
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = [];
+        // No errors expected on the first 26 lines.
+        for ($line = 1; $line <= 26; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [45];
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
PHP 8.0 introduced constructor property promotion.

Refs:
* https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion
* https://www.php.net/manual/en/migration80.new-features.php#migration80.new-features.core.property-promotion
* https://wiki.php.net/rfc/constructor_promotion
* https://github.com/php/php-src/pull/5291
* https://github.com/php/php-src/commit/064b4644484d38e9dce40aef7e8e0e8190e9d863

This commit adds a new sniff to detect this.

Includes unit tests.
Includes sniff documentation.

Related to #809