### PR TITLE
:sparkles: PHP 8.1: New `PHPCompatibility.ParameterValues.RemovedVersionCompareOperators` sniff

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedVersionCompareOperatorsStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedVersionCompareOperatorsStandard.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed version_compare() Operators"
+    >
+    <standard>
+    <![CDATA[
+    Prior to PHP 8.1, the `version_compare()` function did not verify the passed `$operator` parameter sufficiently, which meant that arbitrary abbreviations of the supported operators were accepted and - by accident - supported.
+    This behaviour was undocumented and could lead to subtle bugs.
+
+    As of PHP 8.1, these abbreviations of the supported operators are not longer supported and using these will fail the `version_compare()` comparison.
+
+    The following operators are supported cross-version:
+    '<', 'lt', '<=', 'le', '>', 'gt', '>=', 'ge', '==', '=', 'eq', '!=', '<>', 'ne'.
+
+    Support for the following unofficially supported operators has been removed in PHP 8.1:
+    '', 'l', 'g', 'e', '!', 'n'.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: using officially supported comparison operators.">
+        <![CDATA[
+version_compare($v1, $v2, <em>'<'</em>);
+version_compare($v1, $v2, <em>'ge'</em>);
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.1: using accidentally supported comparison operators.">
+        <![CDATA[
+version_compare($v1, $v2, <em>'!'</em>);
+version_compare($v1, $v2, <em>'e'</em>);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedVersionCompareOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedVersionCompareOperatorsSniff.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\PassedParameters;
+use PHPCSUtils\Utils\TextStrings;
+
+/**
+ * Detect undocumented operator abbreviations being passed to `version_compare()`.
+ *
+ * Support for these undocumented operator abbreviation has been removed in PHP 8.1.
+ *
+ * PHP version 8.1
+ *
+ * @link https://github.com/php/php-src/blob/28a1a6be0873a109cb02ba32784bf046b87a02e4/UPGRADING#L148
+ * @link https://github.com/php/php-src/commit/2b7eb0e26a1816a3c5ddb28dd53f98ae0ecef047
+ *
+ * @since 10.0.0
+ */
+class RemovedVersionCompareOperatorsSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = [
+        'version_compare' => true,
+    ];
+
+    /**
+     * The operators which are no longer supported.
+     *
+     * Note: operators are case-sensitive, values should be lowercase.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    private $unsupportedOperators = [
+        ''  => true,
+        'l' => true,
+        'g' => true,
+        'e' => true,
+        '!' => true,
+        'n' => true,
+    ];
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('8.1') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 3, 'operator');
+        if ($targetParam === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $textStartTokens  = Tokens::$stringTokens;
+        $textStartTokens += Tokens::$heredocTokens;
+
+        $accepted  = $textStartTokens;
+        $accepted += Tokens::$emptyTokens;
+
+        $hasNonText = $phpcsFile->findNext($accepted, $targetParam['start'], ($targetParam['end'] + 1), true);
+        if ($hasNonText !== false) {
+            // Found a non text-string token. Ignore as undetermined.
+            return;
+        }
+
+        $textStringStart = $phpcsFile->findNext($textStartTokens, $targetParam['start'], ($targetParam['end'] + 1));
+        if ($textStringStart === false) {
+            // Shouldn't be able to happen, but just in case.
+            return; // @codeCoverageIgnore
+        }
+
+        $contents = TextStrings::getCompleteTextString($phpcsFile, $textStringStart);
+        if (isset($this->unsupportedOperators[$contents]) === false) {
+            // Either never supported or still supported.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'version_compare() no longer supports operator abbreviations since PHP 8.1. Found: %s',
+            $textStringStart,
+            'Found',
+            [$targetParam['clean']]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.inc
@@ -1,0 +1,53 @@
+<?php
+
+// OK cross-version.
+version_compare($version1, $version2);
+version_compare($version1, $version2, /*comment*/ );
+version_compare($version1, $version2, '<');
+version_compare($version1, $version2, 'lt');
+version_compare($version1, $version2, '<=');
+version_compare($version1, $version2, <<<'EOD'
+le
+EOD
+);
+version_compare($version1, $version2, '>');
+version_compare($version1, $version2, 'gt');
+version_compare($version1, $version2, ">=");
+version_compare(operator: 'ge', version1: $version1, version2: $version2);
+version_compare($version1, $version2, '==');
+version_compare($version1, $version2, '=');
+version_compare($version1, $version2, 'eq' /*comment*/);
+version_compare($version1, $version2, '!=');
+version_compare($version1, $version2, <<<EOD
+<>
+EOD
+);
+version_compare($version1, $version2, 'ne');
+
+// Ignore as undetermined.
+version_compare($version1, $version2, "$operator"); // Can't be determined.
+version_compare($version1, $version2, $operator); // Can't be determined.
+version_compare($version1, $version2, getOperator('e')); // Can't be determined.
+version_compare($version1, $version2, $operators['e']); // Can't be determined.
+version_compare($version1, $version2, g); // Lowercase constant. Can't be determined.
+
+// Ignore as never supported.
+version_compare($version1, $version2, 'GE');
+version_compare($version1, $version2, 'E');
+version_compare($version1, $version2, <<<'EOD'
+g
+e
+EOD
+);
+
+// PHP 8.1: operators for which support has been removed.
+version_compare($version1, $version2, '');
+version_compare($version1, $version2, "");
+version_compare(version1: $version1, operator: 'l', version2: $version2, );
+version_compare($version1, $version2, /*comment*/ 'g');
+version_compare($version1, $version2, <<<EOD
+e
+EOD
+);
+version_compare($version1, $version2, "!");
+version_compare($version1, $version2, 'n');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedVersionCompareOperators sniff.
+ *
+ * @group removedVersionCompareOperators
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedVersionCompareOperatorsSniff
+ *
+ * @since 10.0.0
+ */
+class RemovedVersionCompareOperatorsUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify that version compare operators for which support has been removed, get flagged when used.
+     *
+     * @dataProvider dataRemovedVersionCompareOperators
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedVersionCompareOperators($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertError($file, $line, 'version_compare() no longer supports operator abbreviations since PHP 8.1.');
+    }
+
+    /**
+     * Data Provider
+     *
+     * @see testRemovedVersionCompareOperators()
+     *
+     * @return array
+     */
+    public function dataRemovedVersionCompareOperators()
+    {
+        return [
+            [44],
+            [45],
+            [46],
+            [47],
+            [48],
+            [52],
+            [53],
+        ];
+    }
+
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 42 lines.
+        for ($line = 1; $line <= 42; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> version_compare() no longer accepts undocumented operator abbreviations.

Refs:
* https://github.com/php/php-src/blob/28a1a6be0873a109cb02ba32784bf046b87a02e4/UPGRADING#L148
* https://github.com/php/php-src/commit/2b7eb0e26a1816a3c5ddb28dd53f98ae0ecef047

This new sniff will detect and flag use of these undocumented operator abbreviations.

Includes unit tests.
Includes sniff documentation.

Related to #1299