### PR TITLE
:sparkles: PHP 8.1: New `PHPCompatibility.ParameterValues.NewHTMLEntitiesFlagsDefault` sniff

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/NewHTMLEntitiesFlagsDefaultStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/NewHTMLEntitiesFlagsDefaultStandard.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New htmlentities() Flags Default"
+    >
+    <standard>
+    <![CDATA[
+    Prior to PHP 8.1, the default value for the `$flags` parameter for the `htmlspecialchars()`, `htmlentities()`, `htmlspecialchars_decode()`, `html_entitity_decode()` and `get_html_translation_table()` functions was `ENT_COMPAT`.
+
+    As of PHP 8.1, the default value of the `$flags` parameters has been changed to
+    `ENT_QUOTES | ENT_SUBSTITUTE`.
+    This means that, as of PHP 8.1, a single quote `'` is escaped to `&#039`; while previously it was left alone.
+    Additionally, malformed UTF-8 will be replaced by a Unicode substitution character, instead of resulting in an empty string.
+
+    When any of these functions are used in code which needs to be PHP cross-version compatible, with both PHP < 8.1, as well as PHP 8.1+, the `$flags` parameter should be explicitly set to ensure the function return value will be consistent cross-version.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: passing the $flags parameter when calling these functions.">
+        <![CDATA[
+echo htmlentities($text, <em>ENT_COMPAT</em>, 'UTF-8');
+
+$decoded = htmlspecialchars_decode(
+    $string,
+    <em>ENT_QUOTES | ENT_SUBSTITUTE</em>
+);
+        ]]>
+        </code>
+        <code title="Invalid: calling these functions without passing the $flags parameter.">
+        <![CDATA[
+echo htmlspecialchars($string);
+
+$decoded = html_entity_decode(
+    string:   $string,
+    encoding: $encoding,
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesFlagsDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesFlagsDefaultSniff.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * As of PHP 8.1, the default value for the $flags parameters for `htmlspecialchars()`, `htmlentities()`
+ * `htmlspecialchars_decode()`, `html_entity_decode()` and `get_html_translation_table()` is
+ * now `ENT_QUOTES | ENT_SUBSTITUTE`, instead of `ENT_COMPAT`.
+ *
+ * PHP version 8.1
+ *
+ * @link https://github.com/php/php-src/blob/28a1a6be0873a109cb02ba32784bf046b87a02e4/UPGRADING#L149-L154
+ * @link https://github.com/php/php-src/commit/50eca61f68815005f3b0f808578cc1ce3b4297f0
+ *
+ * @since 10.0.0
+ */
+class NewHTMLEntitiesFlagsDefaultSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * Key is the function name, value an array containing the 1-based parameter position
+     * and the official name of the parameter.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = [
+        'get_html_translation_table' => [
+            'position' => 2,
+            'name'     => 'flags',
+        ],
+        'html_entity_decode'         => [
+            'position' => 2,
+            'name'     => 'flags',
+        ],
+        'htmlentities'               => [
+            'position' => 2,
+            'name'     => 'flags',
+        ],
+        'htmlspecialchars_decode'    => [
+            'position' => 2,
+            'name'     => 'flags',
+        ],
+        'htmlspecialchars'           => [
+            'position' => 2,
+            'name'     => 'flags',
+        ],
+    ];
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * Note: This sniff should only trigger errors when both PHP 8.0 or lower,
+     * as well as PHP 8.1 or higher need to be supported within the application.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('8.0') === false || $this->supportsAbove('8.1') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $functionLC  = \strtolower($functionName);
+        $paramInfo   = $this->targetFunctions[$functionLC];
+        $targetParam = PassedParameters::getParameterFromStack($parameters, $paramInfo['position'], $paramInfo['name']);
+        if ($targetParam !== false) {
+            // Parameter is set, not an issue.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'The default value of the $%1$s parameter for %2$s() was changed from ENT_COMPAT to ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 in PHP 8.1. For cross-version compatibility, the $%1$s parameter should be explicitly set.',
+            $stackPtr,
+            'NotSet',
+            [$paramInfo['name'], $functionName]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.inc
@@ -1,0 +1,15 @@
+<?php
+
+// OK cross-version.
+echo htmlentities( $string, ENT_QUOTES, 'UTF-8' );
+echo htmlspecialchars( $string, $flags);
+echo html_entity_decode( string: $string, encoding: 'ISO-8859-1', flags: ENT_COMPAT );
+echo htmlspecialchars_decode($string, ENT_COMPAT | ENT_XHTML);
+echo get_html_translation_table( $table, ENT_NOQUOTES, $encoding );
+
+// Not OK - error when both PHP < 8.1 and PHP 8.1+ need to be supported.
+echo htmlentities( $string );
+echo htmlspecialchars($string);
+echo HTML_entity_decode( string: $string, encoding: $encoding );
+echo htmlspecialchars_decode($string);
+echo get_html_translation_table( $table );

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewHTMLEntitiesFlagsDefault sniff.
+ *
+ * @group newHTMLEntitiesFlagsDefault
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewHTMLEntitiesFlagsDefaultSniff
+ *
+ * @since 10.0.0
+ */
+class NewHTMLEntitiesFlagsDefaultUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify that an error gets thrown when the $flags parameter is not set and both PHP < 8.1
+     * as well as PHP 8.1+ needs to be supported.
+     *
+     * @dataProvider dataNewHTMLEntitiesFlagsDefault
+     *
+     * @param int    $line         Line number where the error should occur.
+     * @param string $functionName The name of the function called.
+     *
+     * @return void
+     */
+    public function testNewHTMLEntitiesFlagsDefault($line, $functionName)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.0-8.1');
+        $error = "The default value of the \$flags parameter for {$functionName}() was changed from ENT_COMPAT to ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 in PHP 8.1";
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewHTMLEntitiesFlagsDefault()
+     *
+     * @return array
+     */
+    public function dataNewHTMLEntitiesFlagsDefault()
+    {
+        return [
+            [11, 'htmlentities'],
+            [12, 'htmlspecialchars'],
+            [13, 'HTML_entity_decode'],
+            [14, 'htmlspecialchars_decode'],
+            [15, 'get_html_translation_table'],
+        ];
+    }
+
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0-8.1');
+
+        // No errors expected on the first 9 lines.
+        for ($line = 1; $line <= 9; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @dataProvider dataNoViolationsInFileOnValidVersion
+     *
+     * @param string $testVersion The testVersion to use.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion($testVersion)
+    {
+        $file = $this->sniffFile(__FILE__, $testVersion);
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolationsInFileOnValidVersion()
+     *
+     * @return array
+     */
+    public function dataNoViolationsInFileOnValidVersion()
+    {
+        return [
+            ['5.6-8.0'],
+            ['8.1-'],
+        ];
+    }
+}


### PR DESCRIPTION
> htmlspecialchars(), htmlentities(), htmlspecialchars_decode(),
> html_entitity_decode() and get_html_translation_table() now use
> ENT_QUOTES | ENT_SUBSTITUTE rather than ENT_COMPAT by default. This means
> that ' is escaped to &#039; while previously it was left alone.
> Additionally, malformed UTF-8 will be replaced by a Unicode substitution
> character, instead of resulting in an empty string.

Refs:
* https://github.com/php/php-src/blob/28a1a6be0873a109cb02ba32784bf046b87a02e4/UPGRADING#L149-L154
* https://github.com/php/php-src/commit/50eca61f68815005f3b0f808578cc1ce3b4297f0

This new sniff will detect and flag use of these function without explicitly passing the `$flags` parameter when `testVersion` includes both PHP < 8.1 as well as PHP 8.1+.

Note: the extra `ENT_HTML401` addition is a documentation-only change as the value of the constant is `0`, so has no effect on the bitwise value of the flag.

Includes unit tests.
Includes sniff documentation.

Related to #1299