### PR TITLE
:sparkles: PHP 8.1 | New `PHPCompatibility.Numbers.NewExplicitOctalNotation` sniff

### DIFF
--- a/PHPCompatibility/Docs/Numbers/NewExplicitOctalNotationStandard.xml
+++ b/PHPCompatibility/Docs/Numbers/NewExplicitOctalNotationStandard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Explicit Octal Notation"
+    >
+    <standard>
+    <![CDATA[
+    Since PHP 8.1, octal integers can use an explicit 0o/0O prefix in integer literals, similarly to binary and hexadecimal integer literals.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: octal integer without the explicit octal prefix.">
+        <![CDATA[
+$octal = <em>014</em>;
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.1: octal integer using the explicit octal prefix.">
+        <![CDATA[
+$octal = <em>0o14</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Numbers;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Utils\Numbers;
+
+/**
+ * Support for octal integers using an explicit "0o"/"0O" prefix in integer literals is available since PHP 8.1.
+ *
+ * PHP version 8.1
+ *
+ * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.octal-literal-prefix
+ * @link https://wiki.php.net/rfc/explicit_octal_notation
+ *
+ * @since 10.0.0
+ */
+class NewExplicitOctalNotationSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_LNUMBER];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('8.0') === false) {
+            return;
+        }
+
+        $numberInfo = Numbers::getCompleteNumber($phpcsFile, $stackPtr);
+        if (\stripos($numberInfo['content'], '0o') !== 0) {
+            // Not using explicit octal notation.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'The explicit integer octal literal prefix "0o" is not supported in PHP 8.0 or lower. Found: %s',
+            $stackPtr,
+            'Found',
+            [$numberInfo['orig_content']]
+        );
+
+        // Skip past the parts we've already taken into account to prevent double reporting.
+        return ($numberInfo['last_token'] + 1);
+    }
+}

--- a/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.inc
+++ b/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.inc
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Okay cross-version: literal octal notation.
+ */
+$octal = 052;
+
+// PHP 7.4 octal with numeric literal separator. Not the concern of this sniff.
+$octal = 0137_041;
+
+// Invalid octal. Parse error. Not the concern of this sniff.
+$octal = 0o_;
+
+// Invalid octal. Parse error. Not the concern of this sniff.
+$octal = 0o9;
+
+/*
+ * PHP 8.1 explicit octal notation.
+ */
+$octal = 0o137041;
+$octal = 0O137041; // Testing uppercase O.
+$octal = 0o137_041; // Explicit notation with separator.

--- a/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Numbers;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCSUtils\BackCompat\Helper;
+
+/**
+ * Tests for the NewExplicitOctalNotationSniff sniff.
+ *
+ * @group newExplicitOctalNotation
+ * @group numbers
+ *
+ * @covers \PHPCompatibility\Sniffs\Numbers\NewExplicitOctalNotationSniff
+ *
+ * @since 10.0.0
+ */
+class NewExplicitOctalNotationUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test recognizing the explicit octal notation correctly.
+     *
+     * @dataProvider dataExplicitOctalNotation
+     *
+     * @param array $line The line number on which the error should occur.
+     *
+     * @return void
+     */
+    public function testExplicitOctalNotation($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'The explicit integer octal literal prefix "0o" is not supported in PHP 8.0 or lower. Found:');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testExplicitOctalNotation()
+     *
+     * @return array
+     */
+    public function dataExplicitOctalNotation()
+    {
+        return [
+            [20],
+            [21],
+            [22],
+        ];
+    }
+
+
+    /**
+     * Verify there are no false positives for valid code with a PHP version on which this sniff throws errors.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No issues expected on the first 16 lines.
+        for ($i = 1; $i <= 16; $i++) {
+            $data[] = [$i];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> **Integer Octal Literal Prefix**
>
> Octal integers can now use an explicit `0o`/`0O` prefix in integer literals, similarly to binary and hexadecimal integer literals.

Includes unit tests.
Includes documentation.

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.octal-literal-prefix
* https://wiki.php.net/rfc/explicit_octal_notation
* https://github.com/php/php-src/pull/6360
* https://github.com/php/php-src/commit/589bdf30b2bea10172a49bcad26d44b18f192556

Related to #1299