### PR TITLE
NewNumericLiteralSeparator: add test with explicit octal notation

### DIFF
--- a/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.inc
+++ b/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.inc
@@ -39,3 +39,6 @@ $a = 1e_2;   // next to e
 
 // More test cases.
 $a = 0xCAFE_F00D_.892;
+
+// PHP 8.1 explicit octal notation.
+$octal = 0o137_041;

--- a/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
@@ -65,6 +65,7 @@ class NewNumericLiteralSeparatorUnitTest extends BaseSniffTest
             [22],
             [23],
             [26],
+            [44],
         ];
 
         // The test case on line 39 is half a valid numeric literal with underscore, half parse error.


### PR DESCRIPTION
... to safeguard that this is handled correctly by the sniff as each sniff needs to act independently of other sniffs.


Related to #1299