### PR TITLE
Numbers/ValidIntegers: account for PHP 8.1 explicit octal notation

### DIFF
--- a/PHPCompatibility/Tests/Numbers/ValidIntegersUnitTest.inc
+++ b/PHPCompatibility/Tests/Numbers/ValidIntegersUnitTest.inc
@@ -17,3 +17,13 @@ $invalidOctal = 03_8;
 
 // Intentional parse error.
 $invalidBinary = 0b012_3456; // Will still trigger a warning for invalid binary.
+
+// PHP 8.1: valid octal using explicit octal notation.
+$validOctal = 0o123;
+$validOctal = 0O321;
+
+// PHP 8.1: invalid octal using explicit octal notation.
+$invalidOctal = 0o91;
+$invalidOctal = 0O282;
+$invalidOctal = 0o28_2;
+$invalidOctal = 0o2_82;

--- a/PHPCompatibility/Tests/Numbers/ValidIntegersUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/ValidIntegersUnitTest.php
@@ -103,7 +103,7 @@ class ValidIntegersUnitTest extends BaseSniffTest
 
 
     /**
-     * testInvalidOctalInteger
+     * Test that invalid octals are correctly flagged.
      *
      * @dataProvider dataInvalidOctalInteger
      *
@@ -137,12 +137,16 @@ class ValidIntegersUnitTest extends BaseSniffTest
             [8, '038'],
             [9, '091'],
             [16, '03_8'],
+            [26, '0o91'],
+            [27, '0O282'],
+            [28, '0o28_2'],
+            [29, '0o2_82'],
         ];
     }
 
 
     /**
-     * testValidOctalInteger
+     * Verify that no false positives are thrown for valid octals.
      *
      * @dataProvider dataValidOctalInteger
      *
@@ -168,6 +172,8 @@ class ValidIntegersUnitTest extends BaseSniffTest
         return [
             [6],
             [15],
+            [22],
+            [23],
         ];
     }
 


### PR DESCRIPTION
Prevent the sniff from not reporting invalid octals when the octal uses PHP 8.1 explicit octal notation.

Includes unit tests.

Related to #1299