### PR TITLE
:sparkles: PHP 8.0 | New `NewNamedParameters` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionUse;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Detect the use of named function call parameters as supported since PHP 8.0.
+ *
+ * PHP version 8.0
+ *
+ * @link https://wiki.php.net/rfc/named_params
+ *
+ * @since 10.0.0
+ */
+class NewNamedParametersSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return Collections::functionCallTokens();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
+            || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
+        ) {
+            return;
+        }
+
+        if ($tokens[$stackPtr]['code'] === \T_STRING) {
+            $ignore = [
+                \T_FUNCTION => true,
+                \T_CONST    => true,
+                \T_USE      => true,
+            ];
+
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
+                // Not a function call.
+                return;
+            }
+        }
+
+        $params = PassedParameters::getParameters($phpcsFile, $stackPtr);
+        if (empty($params) === true) {
+            // No parameters found.
+            return;
+        }
+
+        foreach ($params as $param) {
+            if (isset($param['name']) === false) {
+                continue;
+            }
+
+            $phpcsFile->addError(
+                'Using named arguments in function calls is not supported in PHP 7.4 or earlier. Found: "%s"',
+                $param['name_token'],
+                'Found',
+                [$param['name'] . ': ' . $param['raw']]
+            );
+
+        }
+    }
+}

--- a/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.inc
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * No parameters, no issue.
+ */
+do_something();
+
+/*
+ * Allowed pre-PHP 8.0.
+ */
+array_fill(0, 100, 50);
+array_fill(START_INDEX, \COUNT, MyNS\VALUE);
+
+/*
+ * PHP 8.0 named parameters in function calls.
+ */
+array_fill(start_index: 0, count: 100, value: 50);
+
+array_fill(
+    start_index : 0,
+    count       : 100,
+    value       : 50,
+);
+
+// Test whitespace and comment tolerance.
+array_fill ( start_index : 0, /*comment */ count /*comment*/ : 100, value: 50);
+
+htmlspecialchars($string, double_encode: false);
+
+array_fill(
+    start_index: $obj->getPos(skip: false),
+    count: count(array_or_countable: $array),
+    value: 50
+);
+
+namespace\function_name(label:$string, more: false);
+Partially\Qualified\function_name(label:$string, more: false);
+\Fully\Qualified\function_name(label: $string, more:false);
+$fn(label: $string, more:false);
+$obj->methodName(label: $foo, more: $bar);
+$obj = new MyClass(label: $string, more:false);
+$obj = new self(label: $string, more:true);
+$obj = new static(label: $string, more:false);
+
+$anon = new class(label: $string, more: false) {
+    public function __construct($label, $more) {}
+};
+
+// Syntaxes not yet supported by PHPCSUtils.
+${$fn}(label: $string, more:false); // False negative.
+$obj->{$var}(label: $foo, more: $bar); // False negative.
+
+// Non-ascii names.
+foo(💩💩💩: [], Пасха: 'text', _valid: 123);
+
+foo( label: $cond ? true : false, more: $cond ? CONSTANT_A : CONSTANT_B );
+
+echo $cond ? foo( label: $something ) : foo( more: $something_else );
+
+// Reserved keywords are allowed.
+foobar(
+    abstract: $value,
+    function: $value,
+    protected: $value,
+    object: $value,
+    parent: $value,
+);
+
+// Compile error: named param before positional. Report anyway.
+test(param: $bar, $foo);
+
+// Error Exception: duplicate parameter passed. Report anyway.
+test(param: 1, /* testDuplicateName2 */ param: 2);
+
+// Error Exception: named params cannot be used with variadic. Report anyway.
+array_fill(start_index: 0, ...[100, 50]);
+
+// Compile error: named params cannot be used after variadic. Report anyway.
+test(...$values, param: $value); // Compile-time error
+
+/*
+ * Still not allowed.
+ */
+// Parse error: dynamic name. Ignore.
+function_name($variableStoringParamName: $value);
+
+// Parse error: exit is a language construct, not a function. Named params not supported.
+exit(status: $value);
+
+// Parse error: empty is a language construct, not a function. Named params not supported.
+empty(variable: $value);
+
+// Parse error: eval is a language construct, not a function. Named params not supported.
+eval(code: $value);
+
+// Parse error: "named param" in arbitrary parentheses.
+$calc = (something: $value / $other);

--- a/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionUse;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewNamedParameters sniff.
+ *
+ * @group newNamedParameters
+ * @group functionuse
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionUse\NewNamedParametersSniff
+ *
+ * @since 10.0.0
+ */
+class NewNamedParametersUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify that function calls using named parameters are detected correctly.
+     *
+     * @dataProvider dataNewNamedParameters
+     *
+     * @param int    $line The line number.
+     * @param string $name The parameter name detected.
+     *
+     * @return void
+     */
+    public function testNewNamedParameters($line, $name)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, "Using named arguments in function calls is not supported in PHP 7.4 or earlier. Found: \"$name");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewNamedParameters()
+     *
+     * @return array
+     */
+    public function dataNewNamedParameters()
+    {
+        return [
+            [17, 'start_index'],
+            [17, 'count'],
+            [17, 'value'],
+            [20, 'start_index'],
+            [21, 'count'],
+            [22, 'value'],
+            [26, 'start_index'],
+            [26, 'count'],
+            [26, 'value'],
+            [28, 'double_encode'],
+            [31, 'start_index'],
+            [31, 'skip'],
+            [32, 'count'],
+            [32, 'array_or_countable'],
+            [33, 'value'],
+
+            [36, 'label'],
+            [36, 'more'],
+            [37, 'label'],
+            [37, 'more'],
+            [38, 'label'],
+            [38, 'more'],
+            [39, 'label'],
+            [39, 'more'],
+            [40, 'label'],
+            [40, 'more'],
+            [41, 'label'],
+            [41, 'more'],
+            [42, 'label'],
+            [42, 'more'],
+            [43, 'label'],
+            [43, 'more'],
+            [45, 'label'],
+            [45, 'more'],
+
+            // Temporarily disabled. These are currently false negatives.
+            // Not (yet) supported by PHPCSUtils. Uncomment once support has been added.
+            // [50, 'label'],
+            // [50, 'more'],
+            // [51, 'label'],
+            // [51, 'more'],
+
+            [54, '💩💩💩'],
+            [54, 'Пасха'],
+            [54, '_valid'],
+
+            [56, 'label'],
+            [56, 'more'],
+
+            [58, 'label'],
+            [58, 'more'],
+
+            [62, 'abstract'],
+            [63, 'function'],
+            [64, 'protected'],
+            [65, 'object'],
+            [66, 'parent'],
+
+            [70, 'param'],
+            [73, 'param'], // Same error for duplicate label.
+            [76, 'start_index'],
+            [79, 'param'],
+        ];
+    }
+
+
+    /**
+     * Verify no false positives are thrown for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 13 lines.
+        for ($line = 1; $line <= 13; $line++) {
+            $data[] = [$line];
+        }
+
+        $data[] = [85];
+        $data[] = [88];
+        $data[] = [91];
+        $data[] = [94];
+        $data[] = [97];
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
PHP 8.0 introduces named function call parameters:
```php
array_fill(start_index: 0, count: 100, value: 50);

// Using reserved keywords as names is allowed.
array_foobar(array: $array, switch: $switch, class: $class);
```

Ref: https://wiki.php.net/rfc/named_params

This new sniff will detect the use of named parameters based on the support for this in PHPCSUtils as added in PHPCSStandards/PHPCSUtils#235 and PHPCSStandards/PHPCSUtils#383.

Includes unit tests.

Related to #809

**Open question**: should this sniff live in the `FunctionUse` category or in the `Syntax` category ?