### PR TITLE
:sparkles: PHP 8.2 | New `PHPCompatibility.TextStrings.RemovedDollarBraceStringEmbeds` sniff

### DIFF
--- a/PHPCompatibility/Docs/TextStrings/RemovedDollarBraceStringEmbedsStandard.xml
+++ b/PHPCompatibility/Docs/TextStrings/RemovedDollarBraceStringEmbedsStandard.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed Dollar Brace String Embeds"
+    >
+    <standard>
+    <![CDATA[
+    Detect use of select forms of variable embedding in double quoted texts strings and heredocs which are deprecated since PHP 8.2.
+
+    Until PHP 8.2, PHP allowed embedding variables in strings with double-quotes (") and heredocs in four different ways:
+    1. Directly embedding variables (`$foo`)
+    2. Braces outside the variable (`{$foo}`)
+    3. Braces after the dollar sign (`${foo}`)
+    4. Variable variables (`${expr}`, equivalent to `(string) ${expr}`)
+
+    As of PHP 8.2, embedding variables and expressions using the syntaxes as per option 3 and 4 is deprecated.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: Embedding simple variables and complex expressions in text strings using plain variables or the `{$...}` syntax.">
+        <![CDATA[
+echo <em>"hello $world"</em>;
+
+echo <em>"hello {$world['bar']}"</em>;
+
+echo <em>"hello {$world->bar}"</em>;
+
+echo <em>"hello {$world["${bar['baz']}"]}"</em>;
+
+echo <em>"hello {${world->{${'bar'}}}}"</em>;
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.2: Embedding simple variables and complex expressions in text strings using the `${...}` syntax">
+        <![CDATA[
+echo <em>"hello ${world}"</em>;
+
+echo <em>"hello ${world['bar']}"</em>;
+
+echo <em>"hello ${world->bar}"</em>;
+
+echo <em>"hello ${world["${bar['baz']}"]}"</em>;
+
+echo <em>"hello ${world->{${'bar'}}}"</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/TextStrings/RemovedDollarBraceStringEmbedsSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/RemovedDollarBraceStringEmbedsSniff.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\TextStrings;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\TextStrings;
+
+/**
+ * Detect use of select forms of variable embedding in heredocs and double strings as deprecated per PHP 8.2.
+ *
+ * > PHP allows embedding variables in strings with double-quotes (") and heredoc in various ways.
+ * > 1. Directly embedding variables (`$foo`)
+ * > 2. Braces outside the variable (`{$foo}`)
+ * > 3. Braces after the dollar sign (`${foo}`)
+ * > 4. Variable variables (`${expr}`, equivalent to `(string) ${expr}`)
+ * >
+ * > [...] to deprecate options 3 and 4 in PHP 8.2 and remove them in PHP 9.0.
+ *
+ * PHP version 8.2
+ * PHP version 9.0
+ *
+ * @link https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation
+ *
+ * @since 10.0.0
+ */
+class RemovedDollarBraceStringEmbedsSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_DOUBLE_QUOTED_STRING,
+            \T_START_HEREDOC,
+            \T_DOLLAR_OPEN_CURLY_BRACES,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void|int Void or a stack pointer to skip forward.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('8.2') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        /*
+         * Defensive coding, this code is not expected to ever actually be hit since PHPCS#3604
+         * (included in 3.7.0), but _will_ be hit if a file containing a PHP 7.3 indented heredoc/nowdocs
+         * is scanned with PHPCS on PHP < 7.3. People shouldn't do that, but hey, we can't stop them.
+         */
+        if ($tokens[$stackPtr]['code'] === \T_DOLLAR_OPEN_CURLY_BRACES) {
+            // @codeCoverageIgnoreStart
+            if ($tokens[($stackPtr - 1)]['code'] === \T_DOUBLE_QUOTED_STRING) {
+                --$stackPtr;
+            } else {
+                // Throw an error anyway, though it won't be very informative.
+                $message = 'Using ${} in strings is deprecated since PHP 8.2, use {$var} or {${expr}} instead.';
+                $code    = 'DeprecatedDollarBraceEmbed';
+                $phpcsFile->addWarning($message, $stackPtr, $code);
+                return;
+            }
+            // @codeCoverageIgnoreEnd
+        }
+
+        $endOfString   = TextStrings::getEndOfCompleteTextString($phpcsFile, $stackPtr);
+        $startOfString = $stackPtr;
+        if ($tokens[$stackPtr]['code'] === \T_START_HEREDOC) {
+            $startOfString = ($stackPtr + 1);
+        }
+
+        $contents = GetTokensAsString::normal($phpcsFile, $startOfString, $endOfString);
+        if (\strpos($contents, '${') === false) {
+            // No interpolation found or only interpolations which are still supported.
+            return ($endOfString + 1);
+        }
+
+        $embeds = TextStrings::getEmbeds($contents);
+        foreach ($embeds as $offset => $embed) {
+            if (\strpos($embed, '${') !== 0) {
+                continue;
+            }
+
+            // Figure out the stack pointer to throw the warning on.
+            $errorPtr = $startOfString;
+            $length   = 0;
+            while (($length + $tokens[$errorPtr]['length']) < $offset) {
+                $length += $tokens[$errorPtr]['length'];
+                ++$errorPtr;
+            }
+
+            // Type 4.
+            $message = 'Using %s (variable variables) in strings is deprecated since PHP 8.2, use {${expr}} instead.';
+            $code    = 'DeprecatedExpressionSyntax';
+            if (\preg_match('`^\$\{(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)(?:\[([\'"])?[^\$\{\}\]]+(?:\2)?\])?\}$`', $embed) === 1) {
+                // Type 3.
+                $message = 'Using ${var} in strings is deprecated since PHP 8.2, use {$var} instead. Found: %s';
+                $code    = 'DeprecatedVariableSyntax';
+            }
+
+            $phpcsFile->addWarning($message, $errorPtr, $code, [$embed]);
+
+        }
+
+        return ($endOfString + 1);
+    }
+}

--- a/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.1.inc
+++ b/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.1.inc
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Embedded variables which are supported cross-version.
+ */
+
+// Type 1: directly embedding variables.
+echo "$foo";
+echo "$$foo";
+echo "$foo[bar]";
+echo "$foo->bar";
+$text = "some text $var some text";
+
+$heredoc = <<<EOD
+some text $var some text
+EOD;
+
+// Type 2: Braces around the variable/expression.
+echo "{$foo}";
+echo "{$$foo}";
+echo "{$foo['bar']}";
+echo "{$foo->bar}";
+echo "{$foo->bar()}";
+echo "{$foo['bar']->baz()()}";
+echo "{${$bar}}";
+echo "{$foo()}";
+echo "{${$object->getMethod()}}"
+$text = "some text {$var} some text";
+
+$heredoc = <<<"EOD"
+some text {$var} some text
+EOD;
+
+/*
+ * Not our target.
+ */
+
+// Ordinary variable variables outside strings.
+$foo = ${'bar'};
+
+// Heredoc without embeds.
+echo <<<EOD
+Some text
+EOD;
+
+// Not actually interpolated - $ is escaped. The second $foo is to force T_DOUBLE_QUOTED_STRING tokenization.
+echo "\${foo} and $foo";
+echo "\${foo[\"bar\"]} and $foo";
+echo "$\{foo} and $foo";
+
+
+/*
+ * PHP 8.2: deprecated forms of embedding variables.
+ */
+
+// Type 3: Braces after the dollar sign.
+echo "${foo}";
+echo "${foo['bar']}";
+$text = "some text ${foo} some ${text}";
+
+$heredoc = <<<EOD
+some text ${foo} some text
+EOD;
+
+echo "\\${foo}"; // Not actually escaped, the backslash escapes the backslash, not the dollar sign.
+
+// Type 4: Variable variables.
+echo "${$bar}";
+echo "${(foo)}";
+echo "${foo->bar}";
+echo "${$object->getMethod()}"
+$text = "some text ${(foo)} some text";
+echo "${substr('laruence', 0, 2)}";
+
+echo "${foo["${bar}"]}";
+echo "${foo["${bar['baz']}"]}";
+echo "${foo->{$baz}}";
+echo "${foo->{${'a'}}}";
+echo "${foo->{"${'a'}"}}";
+
+// Verify correct handling of stack pointers in multi-token code.
+$text = "Line without embed
+some text ${foo["${bar}"]} some text
+some text ${foo["${bar['baz']}"]} some text
+some text ${foo->{${'a'}}} some text
+";
+
+$heredoc = <<<"EOD"
+some text ${(foo)} some text
+EOD;

--- a/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.2.inc
+++ b/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.2.inc
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * The tests involving PHP 7.3+ indented heredocs are in a separate test case file
+ * as any code after an indented heredoc will be tokenizer garbage on PHP < 7.3.
+ */
+
+// No embeds.
+$php73IndentedHeredoc = <<<"EOD"
+    some text some text
+    EOD;
+
+/*
+ * Embedded variables which are supported cross-version.
+ */
+
+// Type 1: directly embedding variables.
+$php73IndentedHeredoc = <<<"EOD"
+    some text $foo[bar] some text
+    EOD;
+
+// Type 2: Braces around the variable/expression.
+$php73IndentedHeredoc = <<<EOD
+    some text {${$bar}} some text
+    EOD;
+
+/*
+ * PHP 8.2: deprecated forms of embedding variables.
+ */
+
+// Type 3: Braces after the dollar sign.
+$php73IndentedHeredoc = <<<"EOD"
+    some text ${foo['bar']} some text
+    EOD;
+
+// Type 4: Variable variables.
+$php73IndentedHeredoc = <<<EOD
+    Line without embed
+    some text ${$object->getMethod()} some text
+    some text ${foo["${bar['baz']}"]} some text
+    some text ${foo->{${'a'}}} some text
+    EOD;

--- a/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.php
+++ b/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\TextStrings;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedDollarBraceStringEmbeds sniff.
+ *
+ * @group removedDollarBraceStringEmbeds
+ * @group textstrings
+ *
+ * @covers \PHPCompatibility\Sniffs\TextStrings\RemovedDollarBraceStringEmbedsSniff
+ *
+ * @since 10.0.0
+ */
+class RemovedDollarBraceStringEmbedsUnitTest extends BaseSniffTest
+{
+
+    /**
+     * The name of the primary test case file.
+     *
+     * @var string
+     */
+    const TEST_FILE = 'RemovedDollarBraceStringEmbedsUnitTest.1.inc';
+
+    /**
+     * The name of a secondary test case file containing PHP 7.3+ indented heredocs.
+     *
+     * @var string
+     */
+    const TEST_FILE_PHP73HEREDOCS = 'RemovedDollarBraceStringEmbedsUnitTest.2.inc';
+
+    /**
+     * Test that variable embeds of "type 3" - Braces after the dollar sign (“${foo}”) -
+     * are correctly detected.
+     *
+     * @dataProvider dataRemovedDollarBraceStringEmbedsType3
+     *
+     * @param int    $line  The line number.
+     * @param string $found The embedded variable found.
+     *
+     * @return void
+     */
+    public function testRemovedDollarBraceStringEmbedsType3($line, $found)
+    {
+        $file = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE, '8.2');
+        $this->assertWarning($file, $line, 'Using ${var} in strings is deprecated since PHP 8.2, use {$var} instead. Found: ' . $found);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedDollarBraceStringEmbedsType3()
+     *
+     * @return array
+     */
+    public function dataRemovedDollarBraceStringEmbedsType3()
+    {
+        return [
+            [57, '${foo}'],
+            [58, '${foo[\'bar\']}'],
+            [59, '${foo}'],
+            [59, '${text}'],
+            [62, '${foo}'],
+            [65, '${foo}'],
+        ];
+    }
+
+
+    /**
+     * Test that variable embeds of "type 4" - Variable variables (“${expr}”, equivalent to
+     * (string) ${expr}) - are correctly detected.
+     *
+     * @dataProvider dataRemovedDollarBraceStringEmbedsType4
+     *
+     * @param int    $line  The line number.
+     * @param string $found The embedded expression found.
+     *
+     * @return void
+     */
+    public function testRemovedDollarBraceStringEmbedsType4($line, $found)
+    {
+        $file = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE, '8.2');
+        $this->assertWarning($file, $line, "Using {$found} (variable variables) in strings is deprecated since PHP 8.2, use {\${expr}} instead.");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedDollarBraceStringEmbedsType4()
+     *
+     * @return array
+     */
+    public function dataRemovedDollarBraceStringEmbedsType4()
+    {
+        return [
+            [68, '${$bar}'],
+            [69, '${(foo)}'],
+            [70, '${foo->bar}'],
+            [71, '${$object->getMethod()}'],
+            [72, '${(foo)}'],
+            [73, '${substr(\'laruence\', 0, 2)}'],
+            [75, '${foo["${bar}"]}'],
+            [76, '${foo["${bar[\'baz\']}"]}'],
+            [77, '${foo->{$baz}}'],
+            [78, '${foo->{${\'a\'}}}'],
+            [79, '${foo->{"${\'a\'}"}}'],
+            [83, '${foo["${bar}"]}'],
+            [84, '${foo["${bar[\'baz\']}"]}'],
+            [85, '${foo->{${\'a\'}}}'],
+            [89, '${(foo)}'],
+        ];
+    }
+
+
+    /**
+     * Test that variable embeds of "type 3" - Braces after the dollar sign (“${foo}”) -
+     * are correctly detected in PHP 7.3+ indented heredocs.
+     *
+     * @dataProvider dataRemovedDollarBraceStringEmbedsType3InIndentedHeredoc
+     *
+     * @param int    $line  The line number.
+     * @param string $found The embedded variable found.
+     *
+     * @return void
+     */
+    public function testRemovedDollarBraceStringEmbedsType3InIndentedHeredoc($line, $found)
+    {
+        if (\PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('Test code involving PHP 7.3 heredocs will not tokenize correctly on PHP < 7.3');
+        }
+
+        $file = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE_PHP73HEREDOCS, '8.2');
+        $this->assertWarning($file, $line, 'Using ${var} in strings is deprecated since PHP 8.2, use {$var} instead. Found: ' . $found);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedDollarBraceStringEmbedsType3InIndentedHeredoc()
+     *
+     * @return array
+     */
+    public function dataRemovedDollarBraceStringEmbedsType3InIndentedHeredoc()
+    {
+        return [
+            [33, '${foo[\'bar\']}'],
+        ];
+    }
+
+
+    /**
+     * Test that variable embeds of "type 4" - Variable variables (“${expr}”, equivalent to
+     * (string) ${expr}) - are correctly detected in PHP 7.3+ indented heredocs.
+     *
+     * @dataProvider dataRemovedDollarBraceStringEmbedsType4InIndentedHeredoc
+     *
+     * @param int    $line  The line number.
+     * @param string $found The embedded expression found.
+     *
+     * @return void
+     */
+    public function testRemovedDollarBraceStringEmbedsType4InIndentedHeredoc($line, $found)
+    {
+        if (\PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('Test code involving PHP 7.3 heredocs will not tokenize correctly on PHP < 7.3');
+        }
+
+        $file = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE_PHP73HEREDOCS, '8.2');
+        $this->assertWarning($file, $line, "Using {$found} (variable variables) in strings is deprecated since PHP 8.2, use {\${expr}} instead.");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedDollarBraceStringEmbedsType4InIndentedHeredoc()
+     *
+     * @return array
+     */
+    public function dataRemovedDollarBraceStringEmbedsType4InIndentedHeredoc()
+    {
+        return [
+            [39, '${$object->getMethod()}'],
+            [40, '${foo["${bar[\'baz\']}"]}'],
+            [41, '${foo->{${\'a\'}}}'],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataTestFiles
+     *
+     * @param string $testFile File name for the test case file to use.
+     * @param int    $lines    Number of lines at the top of the file for which we don't expect errors.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($testFile, $lines)
+    {
+        if ($testFile === self::TEST_FILE_PHP73HEREDOCS && \PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('Test code involving PHP 7.3 heredocs will not tokenize correctly on PHP < 7.3');
+        }
+
+        $file = $this->sniffFile(__DIR__ . '/' . $testFile, '8.2');
+
+        // No errors expected on the first # lines.
+        for ($line = 1; $line <= $lines; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @dataProvider dataTestFiles
+     *
+     * @param string $testFile File name for the test case file to use.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion($testFile)
+    {
+        if ($testFile === self::TEST_FILE_PHP73HEREDOCS && \PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('Test code involving PHP 7.3 heredocs will not tokenize correctly on PHP < 7.3');
+        }
+
+        $file = $this->sniffFile(__DIR__ . '/' . $testFile, '8.1');
+        $this->assertNoViolation($file);
+    }
+
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataTestFiles()
+    {
+        return [
+            [self::TEST_FILE, 51],
+            [self::TEST_FILE_PHP73HEREDOCS, 26],
+        ];
+    }
+}


### PR DESCRIPTION
PHP 8.2 will be deprecating two out of the four ways to embed variables and expressions in text strings (heredocs and double quoted strings).

>  PHP allows embedding variables in strings with double-quotes (") and heredoc in various ways.
> 1. Directly embedding variables (“$foo”)
> 2. Braces outside the variable (“{$foo}”)
> 3. Braces after the dollar sign (“${foo}”)
> 4. Variable variables (“${expr}”, equivalent to (string) ${expr})
>
> Options 1 and 2 have their pros and cons. Options 3 and 4 are easily confused due to overlapping syntax, 3 is strictly less capable than 1 and 2, and 4 has completely different semantics (variable variables) that are rarely useful in string interpolation.
>
> This RFC proposes to deprecate options 3 and 4 in PHP 8.2 and remove them in PHP 9.0.

This commit introduces a new sniff to detect this deprecation.

Analyzing code for this deprecation was affected by a bug in the PHPCS Tokenizer discovered while writing this sniff. As of PHPCSUtils 1.0.0-alpha4, the utility methods in PHPCSUtils include a work-around for this bug and are stable for our purposes.

Also note that while the included unit tests should absolutely be sufficient for our purposes, the PHPCSUtils methods used to retrieve embedded variables and expressions are tested **_in-depth_** (> 1000 tests for that functionality alone), so we should be good ;-)

Last note: the tests are split in two files as any code after a PHP 7.3 heredoc/nowdoc will not tokenize correctly on PHP < 7.3. Splitting the tests into two files works as a work-around for that.

Includes unit tests.
Includes sniff documentation.

Refs:
* https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation
* php/php-src#8212
* https://www.php.net/manual/en/language.types.string.php#language.types.string.parsing
* https://gist.github.com/iluuu1994/72e2154fc4150f2258316b0255b698f2
* squizlabs/PHP_CodeSniffer#3604

Related to #1348