### PR TITLE
:sparkles: PHP 8.1: New `PHPCompatibility.Syntax.NewFirstClassCallables` sniff

### DIFF
--- a/PHPCompatibility/Docs/Syntax/NewFirstClassCallablesStandard.xml
+++ b/PHPCompatibility/Docs/Syntax/NewFirstClassCallablesStandard.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New First Class Callable Syntax"
+    >
+    <standard>
+    <![CDATA[
+    First class callables using the CallableExpr(...) syntax are available since PHP 8.1.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: not using first class callables.">
+        <![CDATA[
+$fn = <em>Closure::fromCallable('strlen')</em>;
+$fn = <em>Closure::fromCallable([$this, 'method'])</em>;
+$fn = <em>Closure::fromCallable(['Foo', 'method'])</em>;
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.1: using first class callables.">
+        <![CDATA[
+$fn = <em>strlen(...)</em>;
+$fn = <em>$this->method(...)</em>;
+$fn = <em>Foo::method(...)</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Syntax;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Sniff;
+
+/**
+ * Detects the use of the first class callable syntax, as introduced in PHP 8.1.
+ *
+ * PHP version 8.1
+ *
+ * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.callable-syntax
+ * @link https://wiki.php.net/rfc/first_class_callable_syntax
+ *
+ * @since 10.0.0
+ */
+final class NewFirstClassCallablesSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_ELLIPSIS];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('8.0') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($tokens[$prev]['code'] !== \T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($next === false || $tokens[$next]['code'] !== \T_CLOSE_PARENTHESIS) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'First class callables using the CallableExpr(...) syntax are not supported in PHP 8.0 or earlier.',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewFirstClassCallablesUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFirstClassCallablesUnitTest.inc
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Using the spread operator for something other than first class callables.
+ */
+
+// PHP 5.6: function declarations using variadic arguments.
+function foo( $param, ...$variadic);
+$closure = function (&...$variadic) {};
+
+// PHP 5.6: argument unpacking in function calls.
+$return = function_call(...$array);
+$return = function_call(...$array, named: $param);
+test(...new ArrayIterator([1, 2, 3]));
+test(...$args1, ...$args2);
+
+// PHP 7.4: unpacking inside arrays.
+// PHP 8.1: unpacking inside arrays with string keys is now also supported.
+$fruits = ['banana', 'orange', ...$parts, 'watermelon'];
+$array = [...$array1, ...$array2];
+
+
+/*
+ * PHP 8.1: first class callables.
+ */
+$callable = strlen(...);
+return $closure(...);
+$invokableObject(...);
+$obj->method(  ...  );
+$obj->$methodStr(...);
+($obj->property)(... /*comment*/ );
+Foo::method(...);
+$classStr::$methodStr(
+    /*comment*/
+    ...
+    );
+self::{$complex . $expression}(...);
+'strlen'(...);
+[$obj, 'method'](...);
+[Foo::class, 'method'](...);

--- a/PHPCompatibility/Tests/Syntax/NewFirstClassCallablesUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFirstClassCallablesUnitTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewFirstClassCallables sniff.
+ *
+ * @group newFirstClassCallables
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewFirstClassCallablesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewFirstClassCallablesUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify that first class callables are correctly detected.
+     *
+     * @dataProvider dataFirstClassCallables
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testFirstClassCallables($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'First class callables using the CallableExpr(...) syntax are not supported in PHP 8.0 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testFirstClassCallables()
+     *
+     * @return array
+     */
+    public function dataFirstClassCallables()
+    {
+        return [
+            [26],
+            [27],
+            [28],
+            [29],
+            [30],
+            [31],
+            [32],
+            [35],
+            [37],
+            [38],
+            [39],
+            [40],
+        ];
+    }
+
+
+    /**
+     * Verify there are no false positives for similar syntaxes.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 22 lines.
+        for ($line = 1; $line <= 22; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Closures for callables can now be created using the syntax `myFunc(...)`, which is identical to `Closure::fromCallable('myFunc')`.

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.callable-syntax
* https://wiki.php.net/rfc/first_class_callable_syntax
* https://github.com/php/php-src/pull/7019
* https://github.com/php/php-src/commit/d0b09a7be484b2408066e7a9840567a7a7b9828c

Includes unit tests.
Includes sniff documentation.

Related to #1299