### PR TITLE
:sparkles: PHP 8.1: New `PHPCompatibility.Classes.NewReadonlyProperties` sniff

### DIFF
--- a/PHPCompatibility/Docs/Classes/NewReadonlyPropertiesStandard.xml
+++ b/PHPCompatibility/Docs/Classes/NewReadonlyPropertiesStandard.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Readonly Properties"
+    >
+    <standard>
+    <![CDATA[
+    Properties can be declared as readonly since PHP 8.1.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: properties declared without the readonly keyword.">
+        <![CDATA[
+class NonReadonly
+{
+    public $foo;
+    protected ClassName $baz;
+    private static ?string $bar;
+    var bool $flag;
+}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.1: properties declared with the readonly keyword.">
+        <![CDATA[
+class ReadonlyProperties
+{
+    public <em>readonly</em> int $foo;
+    <em>readonly</em> protected ClassName $bar;
+    private <em>readonly</em> ?string $baz;
+    <em>readonly</em> bool $flag;
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\Variables;
+
+/**
+ * Detects declarations of readonly properties, as introduced in PHP 8.1.
+ *
+ * PHP version 8.1
+ *
+ * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.readonly
+ * @link https://wiki.php.net/rfc/readonly_properties_v2
+ *
+ * @since 10.0.0
+ */
+final class NewReadonlyPropertiesSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_VARIABLE,
+            \T_FUNCTION,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('8.0') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $error  = 'Readonly properties are not supported in PHP 8.0 or earlier. Property %s was declared as readonly.';
+
+        if ($tokens[$stackPtr]['code'] === \T_VARIABLE) {
+            try {
+                $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
+            } catch (RuntimeException $e) {
+                // Not a class property.
+                return;
+            }
+
+            if ($properties['is_readonly'] === false) {
+                // Not a readonly property.
+                return;
+            }
+
+            $phpcsFile->addError($error, $stackPtr, 'Found', [$tokens[$stackPtr]['content']]);
+
+            $endOfStatement = $phpcsFile->findNext(\T_SEMICOLON, ($stackPtr + 1));
+            if ($endOfStatement !== false) {
+                // Don't throw the same error multiple times for multi-property declarations.
+                return ($endOfStatement + 1);
+            }
+
+            return;
+        }
+
+        /*
+         * This must be a function declaration. Let's check for constructor property promotion.
+         */
+        if (Scopes::isOOMethod($phpcsFile, $stackPtr) === false) {
+            // Global function.
+            return;
+        }
+
+        $functionName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
+        if (\strtolower($functionName) !== '__construct') {
+            // Not a class constructor.
+            return;
+        }
+
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        foreach ($parameters as $param) {
+            if (empty($param['readonly_token']) === true) {
+                // Not property promotion with readonly.
+                continue;
+            }
+
+            $phpcsFile->addError($error, $param['readonly_token'], 'FoundInConstructor', [$param['name']]);
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.inc
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * OK: Non-readonly properties.
+ */
+class NonReadonly {
+    public $public;
+    protected /* comment */ $protected;
+    private static $private;
+    static public $publicStatic;
+    var $oldStyle;
+
+    public int $scalarType;
+    protected ClassName $classType;
+    private ?ClassName $nullableClassType;
+    public static Iterable $staticProp;
+    var bool $flag;
+
+    public string $str = "foo";
+    public ?STRING $nullableStr = null;
+
+	// Multi-property declarations.
+    public float $a, $b;
+    public int $x,
+        /**
+         * Docblock
+         */
+        $y,
+        // comment.
+        $z = 15;
+
+    protected \MyNamespace\InterfaceName $namespacedInterfaceType;
+    static bool $bool = true;
+    static public inT $int = 0;
+
+    // Intentional parse error.
+    $invalidProperty;
+
+
+	// Constructor property promotion.
+    public function __construct(
+        protected float|int $promotedProtected,
+        public ?string &$promotedPublic = 'test',
+        private mixed $promotedPrivate,
+        callable $normalParamIgnore1,
+        mixed $normalParamIgnore2,
+    ) {}
+
+    // Function parameter and function local var, not property.
+    public function method(?int $param) {
+        $localVar = 'abc';
+    }
+}
+
+// Ignore. Not a constructor, so no property promotion.
+function __construct(float|int $x, callable $callMe) {}
+
+
+/*
+ * PHP 8.1: readonly properies.
+ */
+class PHP81Example {
+    readonly protected ClassName $classType;
+    private readonly ?ClassName $nullableClassType;
+
+    // Readonly properties do not need to explicitly declare their visibility.
+    readonly bool $flag;
+
+	// Readonly properties cannot have a default value, but that's not the concern of this sniff.
+    public readonly int $scalarType = 0;
+
+    // Readonly can only be applied to typed properties, but that's not the concern of this sniff.
+    public readonly $prop;
+
+    // Readonly is not allowed on static properties, but that's not the concern of this sniff.
+    public static readonly Iterable $staticProp;
+
+    // Readonly can not be applied to old-style "var" properties, but that's not the concern of this sniff.
+    var readonly bool $flag;
+
+	// Multi-property declarations.
+    public readonly float $a, $b;
+    readonly public int $x,
+        /**
+         * Docblock
+         */
+        $y,
+        // comment.
+        $z;
+
+	// Constructor property promotion.
+    public function __construct(
+        protected readonly float|int $promotedProtected,
+        // Default values are allowed when combined with constructor property promotion.
+        readonly public ?string &$promotedPublic = 'test',
+        private readonly mixed $promotedPrivate,
+        callable $normalParamIgnore1,
+        mixed $normalParamIgnore2,
+    ) {}
+}
+
+// Parse error. This has to be the last test in the file.
+class ParseError {
+	public readonly $propertyWithoutSemiColon
+}

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewReadonlyProperties sniff.
+ *
+ * @group newReadonlyProperties
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewReadonlyPropertiesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewReadonlyPropertiesUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify that first class callables are correctly detected.
+     *
+     * @dataProvider dataFirstClassCallables
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testFirstClassCallables($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Readonly properties are not supported in PHP 8.0 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testFirstClassCallables()
+     *
+     * @return array
+     */
+    public function dataFirstClassCallables()
+    {
+        return [
+            [63],
+            [64],
+            [67],
+            [70],
+            [73],
+            [76],
+            [79],
+            [82],
+            [83],
+            [93],
+            [95],
+            [96],
+            [104],
+        ];
+    }
+
+
+    /**
+     * Verify there are no false positives for similar syntaxes.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 58 lines.
+        for ($line = 1; $line <= 58; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Readonly properties
>
> Support for `readonly` has been added.

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.readonly
* https://wiki.php.net/rfc/readonly_properties_v2
* https://github.com/php/php-src/pull/7089
* https://github.com/php/php-src/commit/6780aaa53266a19c4d0116329c163a8fe65b5413

Includes unit tests.
Includes sniff documentation.

Related to #1299