### PR TITLE
QA: don't use reserved keywords as parameter names

### DIFF
--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -30,13 +30,13 @@ if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
      *
      * @since 8.0.0
      */
-    spl_autoload_register(function ($class) {
+    spl_autoload_register(function ($className) {
         // Only try & load our own classes.
-        if (stripos($class, 'PHPCompatibility') !== 0) {
+        if (stripos($className, 'PHPCompatibility') !== 0) {
             return;
         }
 
-        $file = realpath(__DIR__) . DIRECTORY_SEPARATOR . strtr($class, '\\', DIRECTORY_SEPARATOR) . '.php';
+        $file = realpath(__DIR__) . DIRECTORY_SEPARATOR . strtr($className, '\\', DIRECTORY_SEPARATOR) . '.php';
 
         if (file_exists($file)) {
             include_once $file;

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
@@ -30,15 +30,15 @@ class NewHTMLEntitiesEncodingDefaultUnitTest extends BaseSniffTest
      *
      * @dataProvider dataNewHTMLEntitiesEncodingDefault
      *
-     * @param int    $line     Line number where the error should occur.
-     * @param string $function The name of the function called.
+     * @param int    $line         Line number where the error should occur.
+     * @param string $functionName The name of the function called.
      *
      * @return void
      */
-    public function testNewHTMLEntitiesEncodingDefault($line, $function)
+    public function testNewHTMLEntitiesEncodingDefault($line, $functionName)
     {
         $file  = $this->sniffFile(__FILE__, '5.3-5.4');
-        $error = "The default value of the \$encoding parameter for {$function}() was changed from ISO-8859-1 to UTF-8 in PHP 5.4";
+        $error = "The default value of the \$encoding parameter for {$functionName}() was changed from ISO-8859-1 to UTF-8 in PHP 5.4";
 
         $this->assertError($file, $line, $error);
     }

--- a/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
@@ -30,15 +30,15 @@ class NewIDNVariantDefaultUnitTest extends BaseSniffTest
      *
      * @dataProvider dataNewIDNVariantDefault
      *
-     * @param int    $line     Line number where the error should occur.
-     * @param string $function Function name.
+     * @param int    $line         Line number where the error should occur.
+     * @param string $functionName Function name.
      *
      * @return void
      */
-    public function testNewIDNVariantDefault($line, $function)
+    public function testNewIDNVariantDefault($line, $functionName)
     {
         $file  = $this->sniffFile(__FILE__, '7.3-');
-        $error = 'The default value of the ' . $function . '() $variant parameter has changed from INTL_IDNA_VARIANT_2003 to INTL_IDNA_VARIANT_UTS46 in PHP 7.4.';
+        $error = 'The default value of the ' . $functionName . '() $variant parameter has changed from INTL_IDNA_VARIANT_2003 to INTL_IDNA_VARIANT_UTS46 in PHP 7.4.';
 
         $this->assertError($file, $line, $error);
     }

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -30,17 +30,17 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
      *
      * @dataProvider dataNewIconvMbstringCharsetDefault
      *
-     * @param int    $line      Line number where the error should occur.
-     * @param string $function  The name of the function called.
-     * @param string $paramName The name of parameter which is missing.
-     *                          Defaults to `$encoding`.
+     * @param int    $line         Line number where the error should occur.
+     * @param string $functionName The name of the function called.
+     * @param string $paramName    The name of parameter which is missing.
+     *                             Defaults to `$encoding`.
      *
      * @return void
      */
-    public function testNewIconvMbstringCharsetDefault($line, $function, $paramName = '$encoding')
+    public function testNewIconvMbstringCharsetDefault($line, $functionName, $paramName = '$encoding')
     {
         $file  = $this->sniffFile(__FILE__, '5.4-7.0');
-        $error = "The default value of the {$paramName} parameter for {$function}() was changed from ISO-8859-1 to UTF-8 in PHP 5.6";
+        $error = "The default value of the {$paramName} parameter for {$functionName}() was changed from ISO-8859-1 to UTF-8 in PHP 5.6";
 
         $this->assertError($file, $line, $error);
     }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
@@ -30,18 +30,18 @@ class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTest
      *
      * @dataProvider dataRemovedImplodeFlexibleParamOrder
      *
-     * @param int    $line     Line number where the error should occur.
-     * @param string $function The function name.
+     * @param int    $line         Line number where the error should occur.
+     * @param string $functionName The function name.
      *
      * @return void
      */
-    public function testRemovedImplodeFlexibleParamOrder($line, $function)
+    public function testRemovedImplodeFlexibleParamOrder($line, $functionName)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
-        $this->assertWarning($file, $line, 'Passing the $glue and $pieces parameters in reverse order to ' . $function . ' has been deprecated since PHP 7.4; $glue should be the first parameter and $pieces the second');
+        $this->assertWarning($file, $line, 'Passing the $glue and $pieces parameters in reverse order to ' . $functionName . ' has been deprecated since PHP 7.4; $glue should be the first parameter and $pieces the second');
 
         $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertError($file, $line, 'Passing the $glue and $pieces parameters in reverse order to ' . $function . ' has been deprecated since PHP 7.4 and is removed since PHP 8.0; $glue should be the first parameter and $pieces the second');
+        $this->assertError($file, $line, 'Passing the $glue and $pieces parameters in reverse order to ' . $functionName . ' has been deprecated since PHP 7.4 and is removed since PHP 8.0; $glue should be the first parameter and $pieces the second');
     }
 
     /**


### PR DESCRIPTION
While reserved keywords can be used as parameter names without issue, it makes for very confusing code when the PHP 8.0 "named arguments in function calls" feature would be used. With this in mind, I'm proposing to rename parameters mirroring reserved keywords pre-emptively.