### PR TITLE
OptionalToRequiredFunctionParameters: add support for named parameters + bug fix

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -38,56 +38,57 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
      *
      * The array lists : version number with true (required) and false (optional use deprecated).
      *
-     * The index is the location of the parameter in the parameter list, starting at 0 !
+     * The index is the 1-based parameter position of the parameter in the parameter list.
      * If's sufficient to list the last version in which the parameter was not yet required.
      *
      * @since 8.1.0
-     * @since 10.0.0 Parameter renamed from `$functionParameters` to `$targetFunctions` for
-     *               compatibility with the `AbstractFunctionCallParameterSniff` class.
+     * @since 10.0.0 - Parameter renamed from `$functionParameters` to `$targetFunctions` for
+     *                 compatibility with the `AbstractFunctionCallParameterSniff` class.
+     *               - The parameter offsets were changed from 0-based to 1-based.
      *
      * @var array
      */
     protected $targetFunctions = [
         'crypt' => [
-            1 => [
+            2 => [
                 'name' => 'salt',
                 '5.6'  => false,
                 '8.0'  => true,
             ],
         ],
         'gmmktime' => [
-            1 => [
+            2 => [
                 'name' => 'hour',
                 '8.0'  => true,
             ],
         ],
         'mb_parse_str' => [
-            1 => [
+            2 => [
                 'name' => 'result',
                 '8.0'  => true,
             ],
         ],
         'mktime' => [
-            0 => [
+            1 => [
                 'name' => 'hour',
                 '5.1'  => false,
                 '8.0'  => true,
             ],
         ],
         'openssl_seal' => [
-            4 => [
+            5 => [
                 'name' => 'method',
                 '8.0'  => true,
             ],
         ],
         'openssl_open' => [
-            4 => [
+            5 => [
                 'name' => 'method',
                 '8.0'  => true,
             ],
         ],
         'parse_str' => [
-            1 => [
+            2 => [
                 'name' => 'result',
                 '7.2'  => false,
                 '8.0'  => true,
@@ -124,12 +125,11 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $functionLc           = \strtolower($functionName);
-        $parameterCount       = \count($parameters);
-        $parameterOffsetFound = $parameterCount - 1;
+        $functionLc     = \strtolower($functionName);
+        $parameterCount = \count($parameters);
 
         foreach ($this->targetFunctions[$functionLc] as $offset => $parameterDetails) {
-            if ($offset > $parameterOffsetFound) {
+            if ($offset > $parameterCount) {
                 $itemInfo = [
                     'name'   => $functionName,
                     'nameLc' => $functionLc,

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\MessageHelper;
 
 /**
@@ -77,13 +78,13 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
         ],
         'openssl_seal' => [
             5 => [
-                'name' => 'method',
+                'name' => 'cipher_algo',
                 '8.0'  => true,
             ],
         ],
         'openssl_open' => [
             5 => [
-                'name' => 'method',
+                'name' => 'cipher_algo',
                 '8.0'  => true,
             ],
         ],
@@ -125,11 +126,12 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
      */
     public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $functionLc     = \strtolower($functionName);
-        $parameterCount = \count($parameters);
+        $functionLc = \strtolower($functionName);
 
         foreach ($this->targetFunctions[$functionLc] as $offset => $parameterDetails) {
-            if ($offset > $parameterCount) {
+            $targetParam = PassedParameters::getParameterFromStack($parameters, $offset, $parameterDetails['name']);
+
+            if ($targetParam === false) {
                 $itemInfo = [
                     'name'   => $functionName,
                     'nameLc' => $functionLc,

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -57,7 +57,7 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
             ],
         ],
         'gmmktime' => [
-            2 => [
+            1 => [
                 'name' => 'hour',
                 '8.0'  => true,
             ],

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
@@ -21,12 +21,20 @@ mktime();
 mb_parse_str($encoded_string, $result); // Ok.
 mb_parse_str($encoded_string); // Not ok.
 
-openssl_seal ( $data, $sealed_data, $env_keys, $pub_key_ids, $method, $iv ); // Ok.
+openssl_seal ( $data, $sealed_data, $env_keys, $pub_key_ids, $cipher_algo, $iv ); // Ok.
 openssl_seal ( $data, $sealed_data, $env_keys, $pub_key_ids ); // Not ok.
 
-openssl_open ( $sealed_data, $open_data, $env_key, $priv_key_id, $method, $iv ); // Ok.
+openssl_open ( $sealed_data, $open_data, $env_key, $priv_key_id, $cipher_algo, $iv ); // Ok.
 openssl_open ( $sealed_data, $open_data, $env_key, $priv_key_id ); // Not ok.
 
 // Prevent false positives on namespaced functions.
 \gmmktime(); // Not OK, global function.
 MyNameSpace\mktime(); // OK.
+
+// Safeguard support for PHP 8 named parameters.
+parse_str(string: $str, result: $output); // OK.
+parse_str(result: $output); // OK, well not really, the missing `string` parameter was always required, but that's not the concern of this sniff.
+parse_str(string: $str); // Error.
+
+openssl_seal( $data, $sealed_data, cipher_algo: $cipher_algo, iv: $iv, encrypted_keys: $encrypted_keys, public_key: $public_key, ); // Ok.
+openssl_seal( $data, $sealed_data, iv: $iv, encrypted_keys: $encrypted_keys, public_key: $public_key, ); // Error.

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -71,7 +71,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
         return [
             ['mktime', 'hour', '5.1', '8.0', [19], '5.0'],
             ['crypt', 'salt', '5.6', '8.0', [8], '5.5'],
-            ['parse_str', 'result', '7.2', '8.0', [7], '7.1'],
+            ['parse_str', 'result', '7.2', '8.0', [7, 37], '7.1'],
         ];
     }
 
@@ -115,8 +115,8 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
         return [
             ['gmmktime', 'hour', '8.0', [18, 31], '7.4'],
             ['mb_parse_str', 'result', '8.0', [22], '7.4'],
-            ['openssl_seal', 'method', '8.0', [25], '7.4'],
-            ['openssl_open', 'method', '8.0', [28], '7.4'],
+            ['openssl_seal', 'cipher_algo', '8.0', [25, 40], '7.4'],
+            ['openssl_open', 'cipher_algo', '8.0', [28], '7.4'],
         ];
     }
 


### PR DESCRIPTION
### OptionalToRequiredFunctionParameters: change the offsets from 0-based to 1-based

... to be in line with other sniffs and with the PassedParameters class.

### OptionalToRequiredFunctionParameters: bug fix for gmmktime()

From https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L192-L194 :
> `mktime()` and `gmmktime()` now require at least one argument. time() can be
used to get the current timestamp.

This commit fixes a bug for the offset being wrong for the `gmmktime()` function (introduced in
https://github.com/PHPCompatibility/PHPCompatibility/commit/610e79ccb07f185cc47d9e1324029e88299c08c9 ).

Note: as the change for `gmmktime()` and `mktime()` is actually "require at least one argument", if we combine that with named parameters, we may need to change how we sniff this as currently, as we'd report when the `hour` param is missing, even when one of the other parameters would be passed.

### OptionalToRequiredFunctionParameters: add support for named parameters

1. Adjusted the way the correct parameter is retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. Verified the parameter name used is in line with the name as per the PHP 8.0 release.
    PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* most functions: https://3v4l.org/rW0dJ
* `openssl_seal`: https://github.com/php/php-src/blob/9dc42b411433f25d37bb4c03ae1270fef8c0d062/ext/openssl/openssl.stub.php#L182
* `openssl_open`: https://github.com/php/php-src/blob/9dc42b411433f25d37bb4c03ae1270fef8c0d062/ext/openssl/openssl.stub.php#L188

Includes adding/adjusting the unit tests to include tests using named parameters.

Side-note: The sniff is based on the premise of positional parameters and does not report on missing _required_ parameters which were always required. This has not changed, even though with named parameters, the chance of that happening has increased.

Related to #1239