### PR TITLE
RemovedFunctionParameters: add support for named parameters

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -36,7 +36,7 @@ class RemovedFunctionParametersSniff extends Sniff
      * A list of removed function parameters, which were present in older versions.
      *
      * The array lists : version number with false (deprecated) and true (removed).
-     * The index is the location of the parameter in the parameter list, starting at 0 !
+     * The index is the 1-based parameter position of the parameter in the parameter list.
      * If's sufficient to list the first version where the function parameter was deprecated/removed.
      *
      * The optional `callback` key can be used to pass a method name which should be called for an
@@ -44,115 +44,116 @@ class RemovedFunctionParametersSniff extends Sniff
      * if the notice should be thrown or false otherwise.
      *
      * @since 7.0.0
-     * @since 7.0.2 Visibility changed from `public` to `protected`.
-     * @since 9.3.0 Optional `callback` key.
+     * @since 7.0.2  Visibility changed from `public` to `protected`.
+     * @since 9.3.0  Optional `callback` key.
+     * @since 10.0.0 The parameter offsets were changed from 0-based to 1-based.
      *
      * @var array
      */
     protected $removedFunctionParameters = [
         'curl_version' => [
-            0 => [
+            1 => [
                 'name' => 'age',
                 '7.4'  => false,
                 '8.0'  => true,
             ],
         ],
         'define' => [
-            2 => [
+            3 => [
                 'name' => 'case_insensitive',
                 '7.3'  => false,
                 '8.0'  => true,
             ],
         ],
         'gmmktime' => [
-            6 => [
+            7 => [
                 'name' => 'is_dst',
                 '5.1'  => false,
                 '7.0'  => true,
             ],
         ],
         'imap_headerinfo' => [
-            4 => [
+            5 => [
                 'name' => 'defaulthost',
                 '8.0'  => true,
             ],
         ],
         /*
-         * For the below three functions, it's actually the 3rd (pos: 2) parameter which has been deprecated.
+         * For the below three functions, it's actually the 3rd parameter which has been deprecated.
          * However with positional arguments, this can only be detected by checking for the "old last" argument.
          */
         'imagepolygon' => [
-            3 => [
+            4 => [
                 'name' => 'num_points',
                 '8.1'  => false,
             ],
         ],
         'imageopenpolygon' => [
-            3 => [
+            4 => [
                 'name' => 'num_points',
                 '8.1'  => false,
             ],
         ],
         'imagefilledpolygon' => [
-            3 => [
+            4 => [
                 'name' => 'num_points',
                 '8.1'  => false,
             ],
         ],
         'ldap_first_attribute' => [
-            2 => [
+            3 => [
                 'name'  => 'ber_identifier',
                 '5.2.4' => true,
             ],
         ],
         'ldap_next_attribute' => [
-            2 => [
+            3 => [
                 'name'  => 'ber_identifier',
                 '5.2.4' => true,
             ],
         ],
         'mb_decode_numericentity' => [
-            3 => [
+            4 => [
                 'name' => 'is_hex',
                 '8.0'  => true,
             ],
         ],
         'mktime' => [
-            6 => [
+            7 => [
                 'name' => 'is_dst',
                 '5.1'  => false,
                 '7.0'  => true,
             ],
         ],
         'mysqli_get_client_info' => [
-            0 => [
+            1 => [
                 'name' => 'mysql',
                 '8.1'  => false,
             ],
         ],
         'odbc_do' => [
-            2 => [
+            3 => [
                 'name' => 'flags',
                 '8.0'  => true,
             ],
         ],
         'odbc_exec' => [
-            2 => [
+            3 => [
                 'name' => 'flags',
                 '8.0'  => true,
             ],
         ],
         'pg_connect' => [
             // These were already deprecated before, but version in which deprecation took place is unclear.
-            2 => [
+            3 => [
                 'name' => 'options',
                 '8.0'  => true,
             ],
-            3 => [
+            4 => [
                 'name' => 'tty',
                 '8.0'  => true,
             ],
-            4 => [
+            5 => [
                 'name' => 'dbname',
                 '8.0'  => true,
             ],
@@ -233,11 +234,10 @@ class RemovedFunctionParametersSniff extends Sniff
         }
 
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        $openParenthesis      = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
-        $parameterOffsetFound = $parameterCount - 1;
+        $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
 
         foreach ($this->removedFunctionParameters[$functionLc] as $offset => $parameterDetails) {
-            if ($offset <= $parameterOffsetFound) {
+            if ($offset <= $parameterCount) {
                 if (isset($parameterDetails['callback']) && \method_exists($this, $parameterDetails['callback'])) {
                     if ($this->{$parameterDetails['callback']}($phpcsFile, $parameters[($offset + 1)]) === false) {
                         continue;

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -38,3 +38,10 @@ imageopenpolygon($image, $points, $num_points, $color); // Warning.
 imagefilledpolygon($image, $points, $num_points, $color); // Warning.
 
 mysqli_get_client_info($mysql); // Warning.
+
+// Safeguard support for PHP 8 named parameters.
+define(constant_name: 'CONSTANT', value : 'foo'); // OK.
+define( case_insensitive : true, value : 'foo', constant_name: 'CONSTANT' ); // Error.
+
+imagepolygon($image, color: $color, points: $points); // OK, well not really as this function sig doesn't support named params, but that's not the concern of this sniff.
+imagepolygon($image, color: $color, points: $points, num_points: $num_points); // Warning.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -121,9 +121,9 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
     public function dataDeprecatedRemovedParameter()
     {
         return [
-            ['mktime', 'is_dst', '5.1', '7.0', [8], '5.0'],
-            ['gmmktime', 'is_dst', '5.1', '7.0', [9], '5.0'],
-            ['define', 'case_insensitive', '7.3', '8.0', [15], '7.2'],
+            ['mktime', 'isDST', '5.1', '7.0', [8], '5.0'],
+            ['gmmktime', 'isDST', '5.1', '7.0', [9], '5.0'],
+            ['define', 'case_insensitive', '7.3', '8.0', [15, 44], '7.2'],
 
             ['curl_version', 'age', '7.4', '8.0', [18], '7.3'],
             ['curl_version', 'age', '7.4', '8.0', [19], '7.3'],
@@ -172,7 +172,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
     public function dataDeprecatedParameter()
     {
         return [
-            ['imagepolygon', 'num_points', '8.1', [36], '8.0'],
+            ['imagepolygon', 'num_points', '8.1', [36, 47], '8.0'],
             ['imageopenpolygon', 'num_points', '8.1', [37], '8.0'],
             ['imagefilledpolygon', 'num_points', '8.1', [38], '8.0'],
             ['mysqli_get_client_info', 'mysql', '8.1', [40], '8.0'],


### PR DESCRIPTION
### RemovedFunctionParameters: change the offsets from 0-based to 1-based

... to be in line with other sniffs and with the PassedParameters class.

### RemovedFunctionParameters: add support for named parameters

1. Adjusted the way the correct parameter is retrieved to use the new PHPCSUtils 1.0.0-alpha4 `PassedParameters::getParameterFromStack()` method.
2. ~~Verified the parameter name used is in line with the name as per the PHP 8.0 release.~~
    PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.
    **_As most of these parameters have all been removed either before or in PHP 8.0, their name won't have undergone any changes (other than documentation-wise)._**

Name verification reference:
* most functions: https://3v4l.org/QLt1l

Includes adding/adjusting the unit tests to include tests using named parameters.

Related to #1239