### PR TITLE
GH Actions: automate some label management

### DIFF
--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -1,0 +1,52 @@
+name: Remove outdated labels
+
+on:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    types:
+      - closed
+  issues:
+    types:
+      - closed
+
+jobs:
+  on-pr-merge:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCompatibility' && github.event.pull_request.merged == true
+
+    name: Clean up labels on PR merge
+
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            PR: quick merge
+            PR: ready for review
+
+  on-pr-close:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCompatibility' && github.event_name == 'pull_request_target' && github.event.pull_request.merged == false
+
+    name: Clean up labels on PR close
+
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            PR: quick merge
+            PR: ready for review
+
+  on-issue-close:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'PHPCompatibility' && github.event.issue.state == 'closed'
+
+    name: Clean up labels on issue close
+
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            good first issue


### PR DESCRIPTION
This is a quite straight-forward workflow to just remove some labels which should only be on open issues/open PRs and which should be removed once an issue or PR has been closed/merged.

Just attempting to reduce yet some more manual labour.

**_Note: this is the first time I'm using this particular action runner, so consider this experimental and tweaks may be needed still._**