### PR TITLE
Link to legacy docs

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Tokens\Collections;
  *
  * PHP version 5.5
  *
- * @link https://www.php.net/manual/en/migration55.incompatible.php#migration55.incompatible.self-parent-static
+ * @link https://php-legacy-docs.zend.com/manual/php5/en/migration55.incompatible#migration55.incompatible.self-parent-static
  *
  * @since 7.1.4
  */


### PR DESCRIPTION
The referenced PHP manual page was removed, but a version of it exists in the Zend legacy docs. This was permanently removed from the PHP manual, because the docs team only wants to maintain the last two major PHP versions.