### PR TITLE
Sniff::isUseOfGlobalConstant(): various improvements and PHP 8.0+ support

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff as PHPCS_Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\TestVersionTrait;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\ObjectDeclarations;
@@ -463,26 +464,25 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         // Array of tokens which if found preceding the $stackPtr indicate that a T_STRING is not a global constant.
-        $tokensToIgnore = [
-            \T_NAMESPACE       => true,
-            \T_USE             => true,
-            \T_CLASS           => true,
-            \T_TRAIT           => true,
-            \T_INTERFACE       => true,
-            \T_EXTENDS         => true,
-            \T_IMPLEMENTS      => true,
-            \T_NEW             => true,
-            \T_FUNCTION        => true,
-            \T_DOUBLE_COLON    => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_INSTANCEOF      => true,
-            \T_INSTEADOF       => true,
-            \T_GOTO            => true,
-            \T_AS              => true,
-            \T_PUBLIC          => true,
-            \T_PROTECTED       => true,
-            \T_PRIVATE         => true,
+        $tokensToIgnore  = [
+            \T_NAMESPACE  => true,
+            \T_USE        => true,
+            \T_CLASS      => true,
+            \T_TRAIT      => true,
+            \T_INTERFACE  => true,
+            \T_EXTENDS    => true,
+            \T_IMPLEMENTS => true,
+            \T_NEW        => true,
+            \T_FUNCTION   => true,
+            \T_INSTANCEOF => true,
+            \T_INSTEADOF  => true,
+            \T_GOTO       => true,
+            \T_AS         => true,
+            \T_PUBLIC     => true,
+            \T_PROTECTED  => true,
+            \T_PRIVATE    => true,
         ];
+        $tokensToIgnore += Collections::objectOperators();
 
         $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prev !== false && isset($tokensToIgnore[$tokens[$prev]['code']]) === true) {

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -464,29 +464,28 @@ abstract class Sniff implements PHPCS_Sniff
 
         // Array of tokens which if found preceding the $stackPtr indicate that a T_STRING is not a global constant.
         $tokensToIgnore = [
-            'T_NAMESPACE'       => true,
-            'T_USE'             => true,
-            'T_CLASS'           => true,
-            'T_TRAIT'           => true,
-            'T_INTERFACE'       => true,
-            'T_EXTENDS'         => true,
-            'T_IMPLEMENTS'      => true,
-            'T_NEW'             => true,
-            'T_FUNCTION'        => true,
-            'T_DOUBLE_COLON'    => true,
-            'T_OBJECT_OPERATOR' => true,
-            'T_INSTANCEOF'      => true,
-            'T_INSTEADOF'       => true,
-            'T_GOTO'            => true,
-            'T_AS'              => true,
-            'T_PUBLIC'          => true,
-            'T_PROTECTED'       => true,
-            'T_PRIVATE'         => true,
+            \T_NAMESPACE       => true,
+            \T_USE             => true,
+            \T_CLASS           => true,
+            \T_TRAIT           => true,
+            \T_INTERFACE       => true,
+            \T_EXTENDS         => true,
+            \T_IMPLEMENTS      => true,
+            \T_NEW             => true,
+            \T_FUNCTION        => true,
+            \T_DOUBLE_COLON    => true,
+            \T_OBJECT_OPERATOR => true,
+            \T_INSTANCEOF      => true,
+            \T_INSTEADOF       => true,
+            \T_GOTO            => true,
+            \T_AS              => true,
+            \T_PUBLIC          => true,
+            \T_PROTECTED       => true,
+            \T_PRIVATE         => true,
         ];
 
         $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($prev !== false && isset($tokensToIgnore[$tokens[$prev]['type']]) === true
-        ) {
+        if ($prev !== false && isset($tokensToIgnore[$tokens[$prev]['code']]) === true) {
             // Not the use of a constant.
             return false;
         }

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -467,9 +467,6 @@ abstract class Sniff implements PHPCS_Sniff
         $tokensToIgnore  = [
             \T_NAMESPACE  => true,
             \T_USE        => true,
-            \T_CLASS      => true,
-            \T_TRAIT      => true,
-            \T_INTERFACE  => true,
             \T_EXTENDS    => true,
             \T_IMPLEMENTS => true,
             \T_NEW        => true,
@@ -482,6 +479,7 @@ abstract class Sniff implements PHPCS_Sniff
             \T_PROTECTED  => true,
             \T_PRIVATE    => true,
         ];
+        $tokensToIgnore += Tokens::$ooScopeTokens;
         $tokensToIgnore += Collections::objectOperators();
 
         $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -475,12 +475,10 @@ abstract class Sniff implements PHPCS_Sniff
             \T_INSTEADOF  => true,
             \T_GOTO       => true,
             \T_AS         => true,
-            \T_PUBLIC     => true,
-            \T_PROTECTED  => true,
-            \T_PRIVATE    => true,
         ];
         $tokensToIgnore += Tokens::$ooScopeTokens;
         $tokensToIgnore += Collections::objectOperators();
+        $tokensToIgnore += Tokens::$scopeModifiers;
 
         $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prev !== false && isset($tokensToIgnore[$tokens[$prev]['code']]) === true) {

--- a/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.inc
@@ -104,6 +104,9 @@ class MyClass2 {
 /* test 32 */
 echo $this?->PHP_VERSION_ID;
 
+/* test 33 */
+enum PHP_VERSION_ID: string {}
+
 /*
  * Make sure that global constants are correctly identified.
  *

--- a/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.inc
@@ -101,6 +101,9 @@ class MyClass2 {
     }
 }
 
+/* test 32 */
+echo $this?->PHP_VERSION_ID;
+
 /*
  * Make sure that global constants are correctly identified.
  *

--- a/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.php
@@ -83,6 +83,7 @@ class IsUseOfGlobalConstantUnitTest extends CoreMethodTestFrame
             ['/* test 29 */', false],
             ['/* test 30 */', false],
             ['/* test 31 */', false],
+            ['/* test 32 */', false],
 
             ['/* test A1 */', true],
             ['/* test A2 */', true],

--- a/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Core/IsUseOfGlobalConstantUnitTest.php
@@ -84,6 +84,7 @@ class IsUseOfGlobalConstantUnitTest extends CoreMethodTestFrame
             ['/* test 30 */', false],
             ['/* test 31 */', false],
             ['/* test 32 */', false],
+            ['/* test 33 */', false],
 
             ['/* test A1 */', true],
             ['/* test A2 */', true],


### PR DESCRIPTION
### Sniff::isUseOfGlobalConstant(): use code instead of type

The use of `type` is no longer needed as all tokens listed will be defined now support for PHPCS < 3.7.1 has been dropped.

### Sniff::isUseOfGlobalConstant(): allow for PHP 8.0+ nullsafe object operator

... as an indicator that a `T_STRING` is not a global constant.

Includes unit test.

### Sniff::isUseOfGlobalConstant(): allow for PHP 8.1+ enums

... as an indicator that a `T_STRING` is not a global constant.

Includes unit test.

### Sniff::isUseOfGlobalConstant(): minor code simplification

Use a predefined token array instead of creating the same manually.