### PR TITLE
PHP 8.0 | Prevent false positives/negatives for code using the  nullsafe object operator

### DIFF
--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -53,14 +54,14 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      * List of tokens which when they preceed the $stackPtr indicate that this
      * is not a function call.
      *
+     * {@internal The object operators are added to the array in the register() method.}
+     *
      * @since 8.2.0
      *
      * @var array
      */
     private $ignoreTokens = [
-        \T_DOUBLE_COLON    => true,
-        \T_OBJECT_OPERATOR => true,
-        \T_NEW             => true,
+        \T_NEW => true,
     ];
 
 
@@ -73,6 +74,8 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      */
     public function register()
     {
+        $this->ignoreTokens += Collections::objectOperators();
+
         // Handle case-insensitivity of function names.
         $this->targetFunctions = \array_change_key_case($this->targetFunctions, \CASE_LOWER);
 
@@ -117,9 +120,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($this->isMethod === true) {
-            if ($tokens[$prevNonEmpty]['code'] !== \T_DOUBLE_COLON
-                && $tokens[$prevNonEmpty]['code'] !== \T_OBJECT_OPERATOR
-            ) {
+            if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === false) {
                 // Not a call to a PHP method.
                 return;
             }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Operators;
 use PHPCSUtils\Utils\PassedParameters;
@@ -65,24 +66,6 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
         'T_TRAIT'      => true,
         'T_FUNCTION'   => true,
         'T_CLOSURE'    => true,
-    ];
-
-    /**
-     * List of tokens which when they preceed a T_STRING *within a function* indicate
-     * this is not a call to a PHP native function.
-     *
-     * This list already takes into account that nested scoped structures are being
-     * skipped over, so doesn't check for those again.
-     * Similarly, as constants won't have parentheses, those don't need to be checked
-     * for either.
-     *
-     * @since 9.1.0
-     *
-     * @var array
-     */
-    private $noneFunctionCallIndicators = [
-        \T_DOUBLE_COLON    => true,
-        \T_OBJECT_OPERATOR => true,
     ];
 
     /**
@@ -209,7 +192,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
 
             $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), null, true);
             if ($prev !== false) {
-                if (isset($this->noneFunctionCallIndicators[$tokens[$prev]['code']])) {
+                if (isset(Collections::objectOperators()[$tokens[$prev]['code']])) {
                     continue;
                 }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\FunctionUse;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 
 /**
@@ -87,12 +88,11 @@ class ArgumentFunctionsUsageSniff extends Sniff
             return;
         }
 
-        $ignore = [
-            \T_DOUBLE_COLON    => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_FUNCTION        => true,
-            \T_NEW             => true,
+        $ignore  = [
+            \T_FUNCTION => true,
+            \T_NEW      => true,
         ];
+        $ignore += Collections::objectOperators();
 
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -1075,11 +1076,8 @@ class NewFunctionParametersSniff extends Sniff
             return;
         }
 
-        $ignore = [
-            \T_DOUBLE_COLON    => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_NEW             => true,
-        ];
+        $ignore  = [\T_NEW => true];
+        $ignore += Collections::objectOperators();
 
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Detect calls to new native PHP functions.
@@ -4694,11 +4695,8 @@ class NewFunctionsSniff extends Sniff
             return;
         }
 
-        $ignore = [
-            \T_DOUBLE_COLON    => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_NEW             => true,
-        ];
+        $ignore  = [\T_NEW => true];
+        $ignore += Collections::objectOperators();
 
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -208,11 +209,8 @@ class RemovedFunctionParametersSniff extends Sniff
             return;
         }
 
-        $ignore = [
-            \T_DOUBLE_COLON    => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_NEW             => true,
-        ];
+        $ignore  = [\T_NEW => true];
+        $ignore += Collections::objectOperators();
 
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 
 /**
@@ -4953,11 +4954,8 @@ class RemovedFunctionsSniff extends Sniff
             return;
         }
 
-        $ignore = [
-            \T_DOUBLE_COLON    => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_NEW             => true,
-        ];
+        $ignore  = [\T_NEW => true];
+        $ignore += Collections::objectOperators();
 
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\IniDirectives;
 use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
@@ -938,12 +939,11 @@ class NewIniDirectivesSniff extends Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $ignore = [
-            \T_DOUBLE_COLON    => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_FUNCTION        => true,
-            \T_CONST           => true,
+        $ignore  = [
+            \T_FUNCTION => true,
+            \T_CONST    => true,
         ];
+        $ignore += Collections::objectOperators();
 
         $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\IniDirectives;
 use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
@@ -667,12 +668,11 @@ class RemovedIniDirectivesSniff extends Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $ignore = [
-            \T_DOUBLE_COLON    => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_FUNCTION        => true,
-            \T_CONST           => true,
+        $ignore  = [
+            \T_FUNCTION => true,
+            \T_CONST    => true,
         ];
+        $ignore += Collections::objectOperators();
 
         $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -62,12 +62,11 @@ class NewConstantArraysUsingDefineSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $ignore = [
-            \T_DOUBLE_COLON    => true,
-            \T_OBJECT_OPERATOR => true,
-            \T_FUNCTION        => true,
-            \T_CONST           => true,
+        $ignore  = [
+            \T_FUNCTION => true,
+            \T_CONST    => true,
         ];
+        $ignore += Collections::objectOperators();
 
         $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Detect use of new PHP keywords.
@@ -237,8 +238,7 @@ class NewKeywordsSniff extends Sniff
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($prevToken !== false
-            && ($tokens[$prevToken]['code'] === \T_DOUBLE_COLON
-            || $tokens[$prevToken]['code'] === \T_OBJECT_OPERATOR)
+            && isset(Collections::objectOperators()[$tokens[$prevToken]['code']]) === true
         ) {
             // Class property of the same name as one of the keywords. Ignore.
             return;

--- a/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\MethodUse;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -39,10 +40,7 @@ class ForbiddenToStringParametersSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_DOUBLE_COLON,
-            \T_OBJECT_OPERATOR,
-        ];
+        return Collections::objectOperators();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -41,10 +41,7 @@ class NewDirectCallsToCloneSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_DOUBLE_COLON,
-            \T_OBJECT_OPERATOR,
-        ];
+        return Collections::objectOperators();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 
 /**
@@ -202,9 +203,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
 
                 // Now make sure it's the PHP native function being called.
                 $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), $start, true);
-                if ($tokens[$prevNonEmpty]['code'] === \T_DOUBLE_COLON
-                    || $tokens[$prevNonEmpty]['code'] === \T_OBJECT_OPERATOR
-                ) {
+                if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === true) {
                     // Method call, not a call to the PHP native function.
                     continue;
                 }

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Syntax;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Operators;
 
 /**
  * Detect class member access on object instantiation/cloning.
@@ -161,7 +162,9 @@ class NewClassMemberAccessSniff extends Sniff
                 break;
             }
 
-            if ($tokens[$nextNonEmpty]['code'] === \T_OBJECT_OPERATOR) {
+            if ($tokens[$nextNonEmpty]['code'] === \T_OBJECT_OPERATOR
+                || $tokens[$nextNonEmpty]['code'] === \T_NULLSAFE_OBJECT_OPERATOR
+            ) {
                 // No need to walk any further if this is object access.
                 $braces[$nextNonEmpty] = true;
                 break;

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -75,7 +75,9 @@ class NewDynamicAccessToStaticSniff extends Sniff
         if ($tokens[$prevNonEmpty]['code'] === \T_STRING) {
             $prevPrevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
 
-            if ($tokens[$prevPrevNonEmpty]['code'] !== \T_OBJECT_OPERATOR) {
+            if ($tokens[$prevPrevNonEmpty]['code'] !== \T_OBJECT_OPERATOR
+                && $tokens[$prevPrevNonEmpty]['code'] !== \T_NULLSAFE_OBJECT_OPERATOR
+            ) {
                 return;
             }
         }

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Syntax;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Detect function array dereferencing as introduced in PHP 5.4.
@@ -132,7 +133,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
         // Is this T_STRING really a function or method call ?
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevToken !== false
-            && \in_array($tokens[$prevToken]['code'], [\T_DOUBLE_COLON, \T_OBJECT_OPERATOR], true) === false
+            && isset(Collections::objectOperators()[$tokens[$prevToken]['code']]) === false
         ) {
             if ($tokens[$prevToken]['code'] === \T_BITWISE_AND) {
                 // This may be a function declared by reference.

--- a/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Syntax;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * (Nested) Static property and constant fetches as well as method calls can be applied to
@@ -30,18 +31,6 @@ use PHP_CodeSniffer\Util\Tokens;
  */
 class NewNestedStaticAccessSniff extends Sniff
 {
-
-    /**
-     * Access operators.
-     *
-     * @since 10.0.0
-     *
-     * @var array
-     */
-    private $accessOperators = [
-        \T_OBJECT_OPERATOR => true,
-        \T_DOUBLE_COLON    => true,
-    ];
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -122,7 +111,7 @@ class NewNestedStaticAccessSniff extends Sniff
         } while (true);
 
         if ($prevOperator === false
-            || isset($this->accessOperators[$tokens[$prevOperator]['code']]) === false
+            || isset(Collections::objectOperators()[$tokens[$prevOperator]['code']]) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -16,6 +16,7 @@ use PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff;
 use PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Operators;
 
 /**
  * Using the curly brace syntax to access array or string offsets has been deprecated in PHP 7.4
@@ -260,7 +261,9 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
             }
 
             // Handle property access.
-            if ($tokens[$current]['code'] === \T_OBJECT_OPERATOR) {
+            if ($tokens[$current]['code'] === \T_OBJECT_OPERATOR
+                || $tokens[$current]['code'] === \T_NULLSAFE_OBJECT_OPERATOR
+            ) {
                 $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), null, true);
                 if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_STRING) {
                     // Live coding or parse error.

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Variables;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
 
 /**
@@ -80,7 +81,8 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
                     $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($variable + 1), $varEnd, true);
 
                     if ($next !== false
-                        && \in_array($tokens[$next]['code'], [\T_OPEN_SQUARE_BRACKET, \T_OBJECT_OPERATOR, \T_DOUBLE_COLON], true) === true
+                        && (isset(Collections::objectOperators()[$tokens[$next]['code']]) === true
+                            || $tokens[$next]['code'] === \T_OPEN_SQUARE_BRACKET)
                     ) {
                         $phpcsFile->addError(
                             'Global with variable variables is not allowed since PHP 7.0. Found %s',

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
 
@@ -215,8 +216,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
                 );
 
                 if ($afterThis !== false
-                    && ($tokens[$afterThis]['code'] === \T_OBJECT_OPERATOR
-                        || $tokens[$afterThis]['code'] === \T_DOUBLE_COLON)
+                    && isset(Collections::objectOperators()[$tokens[$afterThis]['code']]) === true
                 ) {
                     return;
                 }
@@ -254,8 +254,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
                     );
 
                     if ($afterThis !== false
-                        && ($tokens[$afterThis]['code'] === \T_OBJECT_OPERATOR
-                            || $tokens[$afterThis]['code'] === \T_DOUBLE_COLON
+                        && (isset(Collections::objectOperators()[$tokens[$afterThis]['code']]) === true
                             || $tokens[$afterThis]['code'] === \T_OPEN_SQUARE_BRACKET)
                     ) {
                         $i = $afterThis;

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Variables;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * The interpretation of variable variables has changed in PHP 7.0.
@@ -68,7 +69,10 @@ class NewUniformVariableSyntaxSniff extends Sniff
 
         // The previous non-empty token has to be a $, -> or ::.
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-        if ($prevToken === false || \in_array($tokens[$prevToken]['code'], [\T_DOLLAR, \T_OBJECT_OPERATOR, \T_DOUBLE_COLON], true) === false) {
+        if ($prevToken === false
+            || (isset(Collections::objectOperators()[$tokens[$prevToken]['code']]) === false
+                && $tokens[$prevToken]['code'] !== \T_DOLLAR)
+        ) {
             return;
         }
 

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -23,12 +23,12 @@ function foo($a) {
     debug_backtrace()[0]['class']; // Explicitly requesting a non-args index from the backtrace array.
 }
 
-
 function foo($a) {
 	$a   = 'changed!';
 	$obj = new ABC();
 	echo $obj->
 		func_get_arg(0); // OK, not the PHP native function call.
+	echo $obj?->debug_backtrace(); // OK, not the PHP native function call.
 	echo ABC::func_get_args(); // OK, not the PHP native function call.
 	echo \myNS\debug_print_backtrace(); // OK, not the PHP native function call.
 	const DEBUG_BACKTRACE = 'abc';

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
@@ -30,12 +30,12 @@ function Foo() {
 	$e = Baz($object->func_get_args());
 	$f = Baz(\Bar\func_get_args());
 	$g = Baz( new Func_Get_Args());
+	$h = Baz($obj?->func_num_args());
 
 	if ( !function_exists('func_get_args')) {
 		function func_get_args() {}
 	}
 }
-
 
 /*
  * Test PHP 5.0+: these functions can only be used within a user-defined function.
@@ -48,3 +48,4 @@ if ( \func_num_args() > 0 &&  baz( func_num_args() ) ) {} // x 2 (+ 1 x use in p
 $d = Baz(Bar::func_get_args());
 $e = Baz($object->func_get_args());
 $f = Baz(\Bar\func_get_args());
+$g = Baz($obj?->func_num_args());

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -74,7 +74,7 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTest
      */
     public function testNoFalsePositivesUseAsParameter($line)
     {
-        $file = $this->sniffFile(__FILE__, '5.6');
+        $file = $this->sniffFile(__FILE__, '5.2');
         $this->assertNoViolation($file, $line);
     }
 
@@ -95,7 +95,8 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTest
             [30],
             [31],
             [32],
-            [35],
+            [33],
+            [36],
         ];
     }
 
@@ -163,6 +164,7 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTest
             [48],
             [49],
             [50],
+            [51],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
@@ -134,3 +134,6 @@ ucwords(string: $foo, separators: '|'); // Error.
 
 mb_strrpos( $haystack, encoding: 'UTF-8', needle: $needle ); // OK
 mb_strrpos( $haystack, encoding: 'UTF-8', needle: $needle, offset: 2 ); // Error.
+
+// Prevent false positives on PHP 8.0+ nullsafe method calls.
+$obj?->getenv($varname, true ); // OK.

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -240,6 +240,7 @@ class NewFunctionParametersUnitTest extends BaseSniffTest
     {
         return [
             [4],
+            [139],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1,8 +1,8 @@
 <?php
-
 // These calls should *not* trigger an error.
 ExampleClass::random_bytes(); // Method, not the native PHP function.
 $myobject->random_bytes(); // Method, not the native PHP function.
+$myobject?->random_bytes(); // Method, not the native PHP function.
 myNamespace\random_bytes(); // Namespaced function, not the native PHP function.
 myNamespace\ExampleClass::random_bytes(); // Namespaced method, not the native PHP function.
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1119,6 +1119,7 @@ class NewFunctionsUnitTest extends BaseSniffTest
     public function dataNoFalsePositives()
     {
         return [
+            [3],
             [4],
             [5],
             [6],

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
@@ -38,3 +38,6 @@ parse_str(string: $str); // Error.
 
 openssl_seal( $data, $sealed_data, cipher_algo: $cipher_algo, iv: $iv, encrypted_keys: $encrypted_keys, public_key: $public_key, ); // Ok.
 openssl_seal( $data, $sealed_data, iv: $iv, encrypted_keys: $encrypted_keys, public_key: $public_key, ); // Error.
+
+// Prevent false positives on PHP 8.0+ nullsafe method calls.
+$obj?->mktime();

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -151,6 +151,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
             [15],
             [21],
             [32],
+            [43],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -45,3 +45,6 @@ define( case_insensitive : true, value : 'foo', constant_name: 'CONSTANT' ); // 
 
 imagepolygon($image, color: $color, points: $points); // OK, well not really as this function sig doesn't support named params, but that's not the concern of this sniff.
 imagepolygon($image, color: $color, points: $points, num_points: $num_points); // Warning.
+
+// Prevent false positives on PHP 8.0+ nullsafe method calls.
+$obj?->define( 'CONSTANT', 'foo', true, ); // OK.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -213,6 +213,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             [26],
             [29],
             [32],
+            [50],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1227,3 +1227,6 @@ mhash_get_hash_name();
 mhash_keygen_s2k();
 mhash();
 odbc_result_all();
+
+// Prevent false positives on PHP 8.0+ nullsafe method calls.
+$obj?->php_check_syntax(); // OK.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -1535,6 +1535,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTest
             [250],
             [251],
             [252],
+            [1232],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -3,10 +3,10 @@ function some_random_function() {} // Verify sniff doesn't flag this line.
 some_random_function(); // Verify sniff doesn't flag this line.
 ini_set('display_errors', 1); // Verify sniff doesn't flag this ini directive.
 ini_set(value: 'filter.default', option: $iniName); // Verify sniff doesn't flag on the value parameter.
+$obj?->ini_set('allow_url_include', 1); // Verify sniff doesn't flag methods with the same name as the PHP native function.
 
 ini_set(option: 'allow_url_include', value: 1);
 $test = ini_get(option: 'allow_url_include');
-
 
 ini_set('pcre.backtrack_limit', 1);
 $test = ini_get('pcre.backtrack_limit');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -115,7 +115,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             ['soap.wsdl_cache', '5.2', [188, 189], '5.1.4', '5.1'],
             ['soap.wsdl_cache_limit', '5.2', [191, 192], '5.1.4', '5.1'],
 
-            ['allow_url_include', '5.2', [7, 8], '5.1'],
+            ['allow_url_include', '5.2', [8, 9], '5.1'],
             ['pcre.backtrack_limit', '5.2', [11, 12], '5.1'],
             ['pcre.recursion_limit', '5.2', [14, 15], '5.1'],
             ['session.cookie_httponly', '5.2', [17, 18], '5.1'],
@@ -347,6 +347,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             [3],
             [4],
             [5],
+            [6],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -450,3 +450,6 @@ $test = ini_get('filter.default_options');
 
 ini_set('oci8.old_oci_close_semantics', 0);
 $test = ini_get('oci8.old_oci_close_semantics');
+
+// Prevent false positives on PHP 8.0+ nullsafe method calls.
+$obj?->ini_set('y2k_compliance', 1);

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -404,6 +404,7 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             [160],
             [163],
             [164],
+            [455],
         ];
     }
 

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
@@ -38,3 +38,6 @@ define('DEREF', 'string'[2]);
 // PHP 8.0: calling define() using named parameters.
 define(value: array('bird'), constant_name: 'ANIMALS' ); // Error.
 define(value: 'not an array', constant_name: 'NOTANARRAY' ); // OK.
+
+// Prevent false positives on PHP 8.0+ nullsafe method calls.
+$obj?->define('ANIMALS', []);

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -94,6 +94,7 @@ class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
             [35],
             [36],
             [40],
+            [43],
         ];
     }
 

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.inc
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.inc
@@ -121,6 +121,9 @@ echo MyClass::yield;
 
 echo __dir__; // Magic constants are also case-insensitive.
 
+// Prevent false positives on PHP 8.0+ nullsafe property access.
+echo $obj?->finally;
+
 __halt_compiler();
 
 bla();

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -234,6 +234,35 @@ class NewKeywordsUnitTest extends BaseSniffTest
     }
 
     /**
+     * testFinallyNoFalsePositives
+     *
+     * @dataProvider dataFinallyNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testFinallyNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testConstNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataFinallyNoFalsePositives()
+    {
+        return [
+            [125],
+        ];
+    }
+
+    /**
      * testConst
      *
      * @dataProvider dataConst
@@ -387,7 +416,7 @@ class NewKeywordsUnitTest extends BaseSniffTest
          * not be reported.
          */
         $file = $this->sniffFile(__FILE__, '5.2');
-        $this->assertNoViolation($file, 127);
+        $this->assertNoViolation($file, 130);
     }
 
 

--- a/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.inc
@@ -48,3 +48,5 @@ class MyClass {
         $another->__toString($param);
     }
 }
+
+$obj?->__toString($param);

--- a/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
@@ -58,6 +58,7 @@ class ForbiddenToStringParametersUnitTest extends BaseSniffTest
             [46],
             [47],
             [48],
+            [52],
         ];
     }
 

--- a/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.inc
+++ b/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.inc
@@ -32,3 +32,4 @@ class DEF {
  */
 $a = (new ABC()) ->  /* comment */ __clone();
 StaticClass::__clone();
+$obj?->__clone();

--- a/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
@@ -52,6 +52,7 @@ class NewDirectCallsToCloneUnitTest extends BaseSniffTest
         return [
             [33],
             [34],
+            [35],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.inc
@@ -66,3 +66,7 @@ implode( ( $type === 'a' ? '-' : '|' ), (array) $pieces );
 // Recognize array casts.
 implode( $glue, (array) $object ); // OK.
 implode( (array) $object, $glue ); // Error.
+
+// Prevent false positives on PHP 8.0+ nullsafe method calls.
+$obj?->implode( $pieces, ', ' );
+implode( $obj?->array_map( 'strtolower', $pieces ), $glue ); // Undetermined, same as other params with unrecognized function calls.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
@@ -108,6 +108,8 @@ class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTest
         $data[] = [57];
         $data[] = [64];
         $data[] = [67];
+        $data[] = [71];
+        $data[] = [72];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.inc
@@ -116,3 +116,5 @@ echo (clone $iterable){20};
 // Mixing access with square brackets and curly braces.
 $a = (new Foo( array(1, array(4, 5), 3) )){1}[0]; // Should give two errors (depending on supported PHP version).
 $a = (clone $iterable)[1]{0}; // Should give two errors (depending on supported PHP version).
+
+var_dump((new Bar)?->y);

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
@@ -80,6 +80,7 @@ class NewClassMemberAccessUnitTest extends BaseSniffTest
             [91],
             [96],
             [117, true],
+            [120],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.inc
@@ -62,3 +62,5 @@ class TestKeyword extends StaticAllThings {
         echo $name::$foo;
     }
 }
+
+echo $c?->name::test();

--- a/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
@@ -64,6 +64,7 @@ class NewDynamicAccessToStaticUnitTest extends BaseSniffTest
             [43],
             [61],
             [62],
+            [66],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.inc
@@ -33,5 +33,8 @@ function &test() {
 	echo '123';
 }
 
+// Also recognize this with PHP 8.0 nullsafe object operator.
+echo $foo?->bar()[1];
+
 // Don't throw errors during live code review.
 echo test(

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
@@ -63,6 +63,7 @@ class NewFunctionArrayDereferencingUnitTest extends BaseSniffTest
             [16],
             [28, true],
             [29, true],
+            [37],
         ];
     }
 
@@ -133,7 +134,7 @@ class NewFunctionArrayDereferencingUnitTest extends BaseSniffTest
             [10],
             [11],
             [32],
-            [37],
+            [40],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.inc
@@ -36,3 +36,6 @@ Foo::MY_CONSTANT::$baz;
 
 // Issue #1016.
 echo Foo::bar()::baz();
+
+// No false negative with PHP 8.0 nullsafe object operator.
+echo $foo?->bar()::baz();

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
@@ -68,6 +68,7 @@ class NewNestedStaticAccessUnitTest extends BaseSniffTest
             [19],
             [23],
             [38],
+            [41],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc
@@ -132,5 +132,8 @@ echo testClass::another_test(){0};
 echo $foo->bar()->baz()[0]{2};
 echo $foo->bar()->baz(){0}[2];
 
+// No false negative with PHP 8.0 nullsafe object operator and curlies.
+echo $obj?->array_num{1}, PHP_EOL;
+
 /* Live coding. Intentional parse error. This has to be the last test in the file. */
 $a = $b[0] + $c['something']{

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
@@ -132,5 +132,8 @@ echo testClass::another_test()[0];
 echo $foo->bar()->baz()[0][2];
 echo $foo->bar()->baz()[0][2];
 
+// No false positive with PHP 8.0 nullsafe object operator and curlies.
+echo $obj?->array_num[1], PHP_EOL;
+
 /* Live coding. Intentional parse error. This has to be the last test in the file. */
 $a = $b[0] + $c['something']{

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
@@ -96,6 +96,7 @@ class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTest
             [129],
             [132],
             [133],
+            [136],
         ];
     }
 
@@ -115,7 +116,7 @@ class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTest
         }
 
         // ...and on the last few lines.
-        for ($line = 135; $line <= 137; $line++) {
+        for ($line = 137; $line <= 140; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.inc
@@ -51,5 +51,8 @@ global $test,
     $$test,
 	$$$test ?> <?php
 
+// Prevent false negatives on PHP 8.0+ nullsafe property access.
+global $$var?->key;
+
 // Live coding. Ignore.
 global $$test

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
@@ -57,6 +57,7 @@ class ForbiddenGlobalVariableVariableUnitTest extends BaseSniffTest
             [25],
             [29],
             [31],
+            [55],
         ];
     }
 
@@ -136,7 +137,7 @@ class ForbiddenGlobalVariableVariableUnitTest extends BaseSniffTest
             [15],
             [16],
             [50],
-            [55],
+            [58],
         ];
     }
 

--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.inc
@@ -65,9 +65,9 @@ foreach ($a as $something) {}
 class ForeachInMethod {
     public function testThis($a) {
         foreach($a as $k => $this->item) {}
+        foreach($a as $k => $this?->item) {}
     }
 }
-
 // This was already an error prior to PHP 7.1, so not our concern.
 foreach ($a as $this => $that) {}
 
@@ -80,7 +80,7 @@ foreach ($a as $that => $this) {}
  */
 class UnsetInMethod {
 	public function foo() {
-		unset($this->property); // OK.
+		unset($this->property, $this?->nullsafe_property); // OK.
 		
 		// This throws an "Attempt to unset static property" error across all versions, so not our concern.
 		unset($this::$property);

--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
@@ -301,6 +301,7 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTest
         return [
             [63],
             [67],
+            [68],
             [72],
         ];
     }

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.inc
@@ -41,5 +41,9 @@ echo $  $var['key1']['key2']; // Bad.
 echo $obj  ->   /* comment */ $var['key']; // Bad.
 echo myClass  :: { /* comment */ $var['key']}(); // OK.
 
+// Make sure PHP 8.0+ nullsafe object operator is handled correctly.
+echo $obj?->$var['key'];
+echo $obj?->$var['key']();
+
 // Live coding.
 echo $$var['key'

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
@@ -60,6 +60,8 @@ class NewUniformVariableSyntaxUnitTest extends BaseSniffTest
             [35],
             [40],
             [41],
+            [45],
+            [46],
         ];
     }
 
@@ -107,7 +109,7 @@ class NewUniformVariableSyntaxUnitTest extends BaseSniffTest
             [27],
             [28],
             [42],
-            [45],
+            [49],
         ];
     }
 


### PR DESCRIPTION
This commit adds handling of the PHP 8.0+ nullsafe object operator to all relevant sniffs.

Includes tests.

## Commits

### AbstractFunctionCallParameter: allow for the PHP 8.0+ nullsafe object operator

Prevent false positives for nullsafe method calls when identifying global function calls.
Prevent false negatives for nullsafe method calls when identifying method calls.

Includes unit test in one of the sniffs using the abstract.

### ArgumentFunctionsReportCurrentValue: allow for PHP 8.0+ nullsafe object operator

Prevents false positives for method calls using the same name as the global functions this sniff searches for.

Includes unit test.

### ArgumentFunctionsUsage: allow for PHP 8.0+ nullsafe object operator

Prevents false positives for method calls using the same name as the global functions this sniff searches for.

Includes unit test.
Includes fix to the "no false positives" test which was checking against the wrong PHP `testVersion`.

### NewFunctions: allow for PHP 8.0+ nullsafe object operator

Prevents false positives for method calls using the same name as the global functions this sniff searches for.

Includes unit test.

### NewFunctionParameters: allow for PHP 8.0+ nullsafe object operator

Prevents false positives for method calls using the same name as the global functions this sniff searches for.

Includes unit test.

### RemovedFunctions: allow for PHP 8.0+ nullsafe object operator

Prevents false positives for method calls using the same name as the global functions this sniff searches for.

Includes unit test.

### RemovedFunctionParameters: allow for PHP 8.0+ nullsafe object operator

Prevents false positives for method calls using the same name as the global functions this sniff searches for.

Includes unit test.

### NewIniDirectives: allow for PHP 8.0+ nullsafe object operator

Prevents false positives for method calls using the same name as the global functions this sniff searches for.

Includes unit test.

### RemovedIniDirectives: allow for PHP 8.0+ nullsafe object operator

Prevents false positives for method calls using the same name as the global functions this sniff searches for.

Includes unit test.

### NewConstantArraysUsingDefine: allow for PHP 8.0+ nullsafe object operator

Prevents false positives for method calls using the same name as the global functions this sniff searches for.

Includes unit test.

### NewKeywords: use Collections::objectOperators()

Prevents false positives for property access on properties using the same name as a reserved keyword.

Note: since PHPCS 3.7.0 false positives on this will be rare anyway as there was a change in the tokenizer to improve context sensitive handling of reserved keywords, but still.

Includes unit test.

### ForbiddenToStringParameters: support the PHP 8.0+ nullsafe object operator

Prevents false negatives for method calls using the nullsafe object operator.

Includes unit test.

### NewDirectCallsToClone: support the PHP 8.0+ nullsafe object operator

Prevents false negatives for method calls using the nullsafe object operator.

Includes unit test.

### RemovedImplodeFlexibleParamOrder: allow for PHP 8.0+ nullsafe object operator

Prevents false positives for method calls using the same name as the global functions this sniff searches for.

Includes unit test.

### NewClassMemberAccess: support the PHP 8.0+ nullsafe object operator

Prevents false negatives for class member access using the nullsafe object operator.

Includes unit test.

### NewDynamicAccessToStatic: support the PHP 8.0+ nullsafe object operator

Prevents false negatives for dynamic access to static using the nullsafe object operator.

Includes unit test.

### NewFunctionArrayDereferencing: use Collections::objectOperators()

Accounting for the PHP 8.0+ nullsafe object operator, yields a small performance benefit, preventing some code from executing when it isn't necessary.

Includes unit test.

### NewNestedStaticAccess: support the PHP 8.0+ nullsafe object operator

Prevents false negatives for nested static access using the nullsafe object operator.

Includes unit test.

### RemovedCurlyBraceArrayAccess: support the PHP 8.0+ nullsafe object operator

Prevents false negatives for curly brace property array access using the nullsafe object operator.

Includes unit test.

### ForbiddenGlobalVariableVariable: support the PHP 8.0+ nullsafe object operator

Prevents false negatives for property access using the nullsafe object operator.

Includes unit test.

### ForbiddenThisUseContexts: allow for the PHP 8.0+ nullsafe object operator

Prevents false positives in combination with the nullsafe object operator.

Includes unit test.

### NewUniformVariableSyntax: support the PHP 8.0+ nullsafe object operator

Prevents false negatives in combination with the nullsafe object operator.

Includes unit test.