### PR TITLE
PHP 8.2 | New `PHPCompatibility.Constants.NewConstantsInTraits` sniff

### DIFF
--- a/PHPCompatibility/Docs/Constants/NewConstantsInTraitsStandard.xml
+++ b/PHPCompatibility/Docs/Constants/NewConstantsInTraitsStandard.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Constants In Traits"
+    >
+    <standard>
+    <![CDATA[
+    Declaring constants in traits is allowed since PHP 8.2.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: trait without constants.">
+        <![CDATA[
+trait Foo {
+    public $prop = 10;
+    protected method() {}
+}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.2: trait declaring constants.">
+        <![CDATA[
+trait Foo {
+    <em>protected const FLAG_ON = true;</em>
+    <em>final public const FLAG_OFF = false;</em>
+
+    public $prop = 10;
+    protected method() {}
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsInTraitsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsInTraitsSniff.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Constants;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Declaring constants in traits is allowed since PHP 8.2.
+ *
+ * PHP version 8.2
+ *
+ * @link https://wiki.php.net/rfc/constants_in_traits
+ * @link https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.constant-in-traits
+ * @link https://www.php.net/manual/en/language.oop5.traits.php#language.oop5.traits.constants
+ *
+ * @since 10.0.0
+ */
+final class NewConstantsInTraitsSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_CONST];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('8.1') === false) {
+            return;
+        }
+
+        $ooPtr = Scopes::validDirectScope($phpcsFile, $stackPtr, \T_TRAIT);
+        if ($ooPtr === false) {
+            // Not a constant in trait.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Declaring constants in traits is not supported in PHP 8.1 or earlier.',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Constants/NewConstantsInTraitsUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/NewConstantsInTraitsUnitTest.inc
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Valid cross-version/not our targets.
+ */
+const OUTSIDE_OO_SCOPE = 'foo';
+
+class ConstDemo
+{
+    const CLASS_CONST = 1;
+}
+
+interface InterfaceDemo
+{
+    public const INTERFACE_CONST = 1;
+}
+
+$a = new class
+{
+    final const ANONYMOUS_CONST = 1;
+};
+
+enum EnumDemo
+{
+    protected final const ENUM_CONST = 1;
+}
+
+trait traitDemo
+{
+    public function method() {
+        const NOT_TRAIT_CONST_C = 1;
+    }
+}
+
+
+/**
+ * PHP 8.2+: constants in traits.
+ */
+trait traitDemo
+{
+    const TRAIT_CONST_A = 1;
+    public const TRAIT_CONST_B = 1, TRAIT_CONST_C = 2;
+    final const TRAIT_CONST_D = false;
+}

--- a/PHPCompatibility/Tests/Constants/NewConstantsInTraitsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewConstantsInTraitsUnitTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Constants;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewConstantsInTraits sniff.
+ *
+ * @group newConstantsInTraits
+ * @group constants
+ *
+ * @covers \PHPCompatibility\Sniffs\Constants\NewConstantsInTraitsSniff
+ *
+ * @since 10.0.0
+ */
+final class NewConstantsInTraitsUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test that an error is thrown for class constants declared with visibility.
+     *
+     * @dataProvider dataConstantInTrait
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testConstantInTrait($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertError($file, $line, 'Declaring constants in traits is not supported in PHP 8.1 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testConstantInTrait()
+     *
+     * @return array
+     */
+    public function dataConstantInTrait()
+    {
+        return [
+            [41],
+            [42],
+            [43],
+        ];
+    }
+
+
+    /**
+     * Verify that there are no false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+        for ($line = 1; $line <= 35; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Constants in Traits
>
> It is now possible to define constants in traits.

This adds a new sniff to detect this.

Includes unit tests.
Includes docs.

Refs:
* https://wiki.php.net/rfc/constants_in_traits
* https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.constant-in-traits
* https://www.php.net/manual/en/language.oop5.traits.php#language.oop5.traits.constants
* https://github.com/php/php-src/pull/8888

Related #1348