### PR TITLE
Various sniffs: remove redundant try/catch

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -12,7 +12,6 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
@@ -60,14 +59,9 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
             return;
         }
 
-        try {
-            // Get all parameters from the function signature.
-            $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
-            if (empty($parameters)) {
-                return;
-            }
-        } catch (RuntimeException $e) {
-            // Most likely a T_STRING which wasn't an arrow function.
+        // Get all parameters from the function signature.
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        if (empty($parameters)) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -12,7 +12,6 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
@@ -60,13 +59,8 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
         }
 
         // Get all parameters from method signature.
-        try {
-            $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
-            if (empty($parameters)) {
-                return;
-            }
-        } catch (RuntimeException $e) {
-            // Most likely a T_STRING which wasn't an arrow function.
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        if (empty($parameters)) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -13,7 +13,6 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
@@ -66,40 +65,35 @@ class NewNullableTypesSniff extends Sniff
             return;
         }
 
-        try {
-            /*
-             * Check parameter type declarations.
-             */
-            $params = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
-            if (empty($params) === false) {
-                foreach ($params as $param) {
-                    if ($param['nullable_type'] === true) {
-                        $phpcsFile->addError(
-                            'Nullable type declarations are not supported in PHP 7.0 or earlier. Found: %s',
-                            $param['token'],
-                            'typeDeclarationFound',
-                            [$param['type_hint']]
-                        );
-                    }
+        /*
+         * Check parameter type declarations.
+         */
+        $params = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        if (empty($params) === false) {
+            foreach ($params as $param) {
+                if ($param['nullable_type'] === true) {
+                    $phpcsFile->addError(
+                        'Nullable type declarations are not supported in PHP 7.0 or earlier. Found: %s',
+                        $param['token'],
+                        'typeDeclarationFound',
+                        [$param['type_hint']]
+                    );
                 }
             }
+        }
 
-            /*
-             * Check return type declarations.
-             */
-            $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
-            if ($properties['nullable_return_type'] === true) {
-                $nullPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($properties['return_type_token'] - 1), null, true);
-                $phpcsFile->addError(
-                    'Nullable return types are not supported in PHP 7.0 or earlier. Found: %s',
-                    $nullPtr,
-                    'returnTypeFound',
-                    [$properties['return_type']]
-                );
-            }
-        } catch (RuntimeException $e) {
-            // Most likely a T_STRING which wasn't an arrow function.
-            return;
+        /*
+         * Check return type declarations.
+         */
+        $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
+        if ($properties['nullable_return_type'] === true) {
+            $nullPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($properties['return_type_token'] - 1), null, true);
+            $phpcsFile->addError(
+                'Nullable return types are not supported in PHP 7.0 or earlier. Found: %s',
+                $nullPtr,
+                'returnTypeFound',
+                [$properties['return_type']]
+            );
         }
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -10,7 +10,6 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Sniff;
@@ -78,14 +77,9 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
             return;
         }
 
-        try {
-            // Get all parameters from the function signature.
-            $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
-            if (empty($parameters)) {
-                return;
-            }
-        } catch (RuntimeException $e) {
-            // Most likely a T_STRING which wasn't an arrow function.
+        // Get all parameters from the function signature.
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        if (empty($parameters)) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -373,22 +373,15 @@ class NewInterfacesSniff extends Sniff
         /*
          * Check parameter type declarations.
          */
-        try {
-            $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
-
-            if (empty($parameters) === false && \is_array($parameters) === true) {
-                foreach ($parameters as $param) {
-                    if ($param['type_hint'] === '') {
-                        continue;
-                    }
-
-                    $this->checkTypeHint($phpcsFile, $param['type_hint_token'], $param['type_hint']);
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        if (empty($parameters) === false && \is_array($parameters) === true) {
+            foreach ($parameters as $param) {
+                if ($param['type_hint'] === '') {
+                    continue;
                 }
+
+                $this->checkTypeHint($phpcsFile, $param['type_hint_token'], $param['type_hint']);
             }
-        } catch (RuntimeException $e) {
-            // This must have been a T_STRING which wasn't an arrow function.
-            // Checking the return type will be futile, so just bow out.
-            return;
         }
 
         /*


### PR DESCRIPTION
... which is no longer needed now support for PHPCS < 3.7.1 has been dropped and we can rely on PHPCS native support for arrow functions.