### PR TITLE
NewInterfaces: add support for interfaces used in union and intersection types

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -419,7 +419,7 @@ class NewInterfacesSniff extends Sniff
     {
         // Strip off potential nullable indication.
         $typeHint = \ltrim($typeHint, '?');
-        $types    = \explode('|', $typeHint);
+        $types    = \preg_split('`[|&]`', $typeHint, -1, \PREG_SPLIT_NO_EMPTY);
 
         if (empty($types) === true) {
             return;

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -419,24 +419,31 @@ class NewInterfacesSniff extends Sniff
     {
         // Strip off potential nullable indication.
         $typeHint = \ltrim($typeHint, '?');
+        $types    = \explode('|', $typeHint);
 
-        // Strip off potential (global) namespace indication.
-        $typeHint = \ltrim($typeHint, '\\');
-
-        if ($typeHint === '') {
+        if (empty($types) === true) {
             return;
         }
 
-        $typeHintLc = \strtolower($typeHint);
-        if (isset($this->newInterfaces[$typeHintLc]) === false) {
-            return;
-        }
+        foreach ($types as $type) {
+            // Strip off potential (global) namespace indication.
+            $type = \ltrim($type, '\\');
 
-        $itemInfo = [
-            'name'   => $typeHint,
-            'nameLc' => $typeHintLc,
-        ];
-        $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
+            if ($type === '') {
+                return;
+            }
+
+            $typeLc = \strtolower($type);
+            if (isset($this->newInterfaces[$typeLc]) === false) {
+                return;
+            }
+
+            $itemInfo = [
+                'name'   => $type,
+                'nameLc' => $typeLc,
+            ];
+            $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
+        }
     }
 
 

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -37,32 +37,32 @@ class MyDateTimeInterface implements DateTimeInterface {}
 class MyThrowable implements Throwable {}
 
 class MyClass {
-	// Interfaces as typehints.
-	function CountableTypeHint( Countable $a ) {}
-	function OuterIteratorTypeHint( OuterIterator $a ) {}
-	function RecursiveIteratorTypeHint( RecursiveIterator $a ) {}
-	function SeekableIteratorTypeHint( SeekableIterator $a ) {}
-	function SerializableTypeHint( Serializable $a ) {}
-	function SplObserverTypeHint( SplObserver $a ) {}
-	function SplSubjectTypeHint( SplSubject $a ) {}
-	function JsonSerializableTypeHint( JsonSerializable $a ) {}
-	function SessionHandlerInterfaceTypeHint( SessionHandlerInterface $a ) {}
-	function TraversableTypeHint( Traversable $a ) {}
-	function DateTimeInterfaceTypeHint( DateTimeInterface $a ) {}
-	function ThrowableTypeHint( Throwable $a ) {}
+    // Interfaces as typehints.
+    function CountableTypeHint( Countable $a ) {}
+    function OuterIteratorTypeHint( OuterIterator $a ) {}
+    function RecursiveIteratorTypeHint( RecursiveIterator $a ) {}
+    function SeekableIteratorTypeHint( SeekableIterator $a ) {}
+    function SerializableTypeHint( Serializable $a ) {}
+    function SplObserverTypeHint( SplObserver $a ) {}
+    function SplSubjectTypeHint( SplSubject $a ) {}
+    function JsonSerializableTypeHint( JsonSerializable $a ) {}
+    function SessionHandlerInterfaceTypeHint( SessionHandlerInterface $a ) {}
+    function TraversableTypeHint( Traversable $a ) {}
+    function DateTimeInterfaceTypeHint( DateTimeInterface $a ) {}
+    function ThrowableTypeHint( Throwable $a ) {}
 
-	// Namespaced interfaces as typehints
-	function SerializableTypeHint( \Serializable $a ) {} // Error: global namespace.
-	function SplObserverTypeHint( myNameSpace\SplObserver $a ) {} // Ok.
-	function SplSubjectTypeHint( \some\other\SplSubject $a ) {} // Ok.
+    // Namespaced interfaces as typehints
+    function SerializableTypeHint( \Serializable $a ) {} // Error: global namespace.
+    function SplObserverTypeHint( myNameSpace\SplObserver $a ) {} // Ok.
+    function SplSubjectTypeHint( \some\other\SplSubject $a ) {} // Ok.
 
-	// Interfaces as nullable typehints (PHP 7.1+).
-	function TraversableTypeHint( ?Traversable $a ) {}
-	function DateTimeInterfaceTypeHint( ?\DateTimeInterface $a ) {}
-	function ThrowableTypeHint( ?Throwable $a ) {}
-	
-	// Function with multiple typehinted parameters.
-	function MultipleTypeHints (OuterIterator $a, ?int $b, SplObserver $c, ?\RecursiveIterator $d) {}
+    // Interfaces as nullable typehints (PHP 7.1+).
+    function TraversableTypeHint( ?Traversable $a ) {}
+    function DateTimeInterfaceTypeHint( ?\DateTimeInterface $a ) {}
+    function ThrowableTypeHint( ?Throwable $a ) {}
+
+    // Function with multiple typehinted parameters.
+    function MultipleTypeHints (OuterIterator $a, ?int $b, SplObserver $c, ?\RecursiveIterator $d) {}
 }
 
 // Interfaces in type hints in anonymous functions.
@@ -151,4 +151,13 @@ class UnionTypes {
     public Countable|SplObserver $property;
     public function paramType(OuterIterator|RecursiveIterator $param) {}
     public function returnType($param) : SessionHandlerInterface|JsonSerializable {}
+}
+
+// Test support for PHP 8.1 intersection types.
+class IntersectionTypes {
+    public function paramType(NotATarget&AlsoNotATarget $okay) {}
+
+    public Throwable&SessionUpdateTimestampHandlerInterface $property;
+    public function paramType(SeekableIterator&SplSubject $param) {}
+    public function returnType($param) : Reflector&Traversable {}
 }

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -143,3 +143,12 @@ $anon = class() {
 // Test support for PHP 7.4 arrow functions.
 $fn = fn(SessionIdInterface $param) => $param;
 $fn = fn($param): SessionHandlerInterface => $param;
+
+// Test support for PHP 8.0 union types.
+class UnionTypes {
+    public NotATarget|AlsoNotATarget $okay;
+
+    public Countable|SplObserver $property;
+    public function paramType(OuterIterator|RecursiveIterator $param) {}
+    public function returnType($param) : SessionHandlerInterface|JsonSerializable {}
+}

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -64,21 +64,21 @@ class NewInterfacesUnitTest extends BaseSniffTest
     public function dataNewInterface()
     {
         return [
-            ['Reflector', '4.4', [75, 115], '5.0'],
-            ['Traversable', '4.4', [35, 50, 60, 71, 79], '5.0'],
+            ['Reflector', '4.4', [75, 115, 162], '5.0'],
+            ['Traversable', '4.4', [35, 50, 60, 71, 79, 162], '5.0'],
             ['Countable', '5.0', [3, 17, 41, 151], '5.1'],
             ['OuterIterator', '5.0', [4, 42, 65, 152], '5.1'],
             ['RecursiveIterator', '5.0', [5, 43, 65, 152], '5.1'],
-            ['SeekableIterator', '5.0', [6, 17, 28, 44], '5.1'],
+            ['SeekableIterator', '5.0', [6, 17, 28, 44, 161], '5.1'],
             ['Serializable', '5.0', [7, 29, 45, 55, 70, 118, 124], '5.1'],
             ['SplObserver', '5.0', [11, 46, 65, 151], '5.1'],
-            ['SplSubject', '5.0', [12, 17, 47, 69], '5.1'],
+            ['SplSubject', '5.0', [12, 17, 47, 69, 161], '5.1'],
             ['JsonSerializable', '5.3', [13, 48, 133, 134, 153], '5.4'],
             ['SessionHandlerInterface', '5.3', [14, 49, 145, 153], '5.4'],
             ['DateTimeInterface', '5.4', [36, 51, 61, 80], '5.5'],
             ['SessionIdInterface', '5.5.0', [89, 116, 144], '5.6', '5.5'],
-            ['Throwable', '5.6', [37, 52, 62, 93, 98, 103], '7.0'],
-            ['SessionUpdateTimestampHandlerInterface', '5.6', [90, 140], '7.0'],
+            ['Throwable', '5.6', [37, 52, 62, 93, 98, 103, 160], '7.0'],
+            ['SessionUpdateTimestampHandlerInterface', '5.6', [90, 140, 160], '7.0'],
             ['Stringable', '7.4', [112], '8.0'],
         ];
     }
@@ -201,6 +201,7 @@ class NewInterfacesUnitTest extends BaseSniffTest
             [108],
             [137],
             [149],
+            [158],
         ];
     }
 

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -66,15 +66,15 @@ class NewInterfacesUnitTest extends BaseSniffTest
         return [
             ['Reflector', '4.4', [75, 115], '5.0'],
             ['Traversable', '4.4', [35, 50, 60, 71, 79], '5.0'],
-            ['Countable', '5.0', [3, 17, 41], '5.1'],
-            ['OuterIterator', '5.0', [4, 42, 65], '5.1'],
-            ['RecursiveIterator', '5.0', [5, 43, 65], '5.1'],
+            ['Countable', '5.0', [3, 17, 41, 151], '5.1'],
+            ['OuterIterator', '5.0', [4, 42, 65, 152], '5.1'],
+            ['RecursiveIterator', '5.0', [5, 43, 65, 152], '5.1'],
             ['SeekableIterator', '5.0', [6, 17, 28, 44], '5.1'],
             ['Serializable', '5.0', [7, 29, 45, 55, 70, 118, 124], '5.1'],
-            ['SplObserver', '5.0', [11, 46, 65], '5.1'],
+            ['SplObserver', '5.0', [11, 46, 65, 151], '5.1'],
             ['SplSubject', '5.0', [12, 17, 47, 69], '5.1'],
-            ['JsonSerializable', '5.3', [13, 48, 133, 134], '5.4'],
-            ['SessionHandlerInterface', '5.3', [14, 49, 145], '5.4'],
+            ['JsonSerializable', '5.3', [13, 48, 133, 134, 153], '5.4'],
+            ['SessionHandlerInterface', '5.3', [14, 49, 145, 153], '5.4'],
             ['DateTimeInterface', '5.4', [36, 51, 61, 80], '5.5'],
             ['SessionIdInterface', '5.5.0', [89, 116, 144], '5.6', '5.5'],
             ['Throwable', '5.6', [37, 52, 62, 93, 98, 103], '7.0'],
@@ -200,6 +200,7 @@ class NewInterfacesUnitTest extends BaseSniffTest
             [86],
             [108],
             [137],
+            [149],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.0 | NewInterfaces: add support for interfaces used in union types

PHP 8.0 introduces union types.

This adjusts the `NewInterfaces` sniff to be able to detect new interfaces being used as part of a union property, parameter or return type.

Includes tests.

### PHP 8.1 | NewInterfaces: add support for interfaces used in intersection types

PHP 8.1 introduces intersection types.

This adjusts the `NewInterfaces` sniff to be able to detect new interfaces being used as part of a intersection property, parameter or return type.

Includes tests.

Related #809, #1299