### PR TITLE
PHP 8.0 | TypeDeclaration sniffs: examine properties declared in the constructor correctly

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -202,6 +202,11 @@ class NewParamTypeDeclarationsSniff extends Sniff
                 continue;
             }
 
+            if (empty($param['property_visibility']) === false) {
+                // Constructor property promotion, these are examined by the NewTypedProperties sniff.
+                continue;
+            }
+
             if ($supportsPHP4 === true) {
                 $phpcsFile->addError(
                     'Type declarations were not present in PHP 4.4 or earlier.',

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -107,3 +107,21 @@ $anon = class() {
     // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the sniff.
     public int|string|INT $duplicateTypeInUnion;
 };
+
+// PHP 8.0 constructor property promotion.
+class ConstructorPropertyPromotionWithTypes {
+    public function __construct(
+        protected float|int $x,
+        public ?string &$y = 'test',
+        private mixed $z,
+        public callable $callMe,
+        callable $normalParamIgnore1,
+        ?mixed $normalParamIgnore2,
+    ) {}
+
+    // Ignore. Not a constructor, so no property promotion.
+    public function notAConstructor(float|int $x, callable $callMe) {}
+}
+
+// Ignore. Not a constructor, so no property promotion.
+function __construct(float|int $x, callable $callMe) {}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -88,6 +88,10 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             [102],
             [105],
             [108],
+            [114],
+            [115, true],
+            [116],
+            [117],
         ];
     }
 
@@ -95,17 +99,41 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
     /**
      * Verify the sniff doesn't throw false positives for non-typed properties.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testNoFalsePositivesNewTypedProperties()
+    public function testNoFalsePositivesNewTypedProperties($line)
     {
         $file = $this->sniffFile(__FILE__, '7.3');
-
-        for ($line = 1; $line < 19; $line++) {
-            $this->assertNoViolation($file, $line);
-        }
+        $this->assertNoViolation($file, $line);
     }
 
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = [];
+        // No errors expected on the first 19 lines.
+        for ($line = 1; $line <= 19; $line++) {
+            $cases[] = [$line];
+        }
+
+        // Don't throw errors for normal constructor/function parameters.
+        $cases[] = [118];
+        $cases[] = [119];
+        $cases[] = [123];
+        $cases[] = [127];
+
+        return $cases;
+    }
 
     /**
      * Verify that invalid type declarations are flagged correctly.
@@ -138,6 +166,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             [64, 'callable'],
             [65, 'boolean'],
             [66, 'integer'],
+            [117, 'callable'],
         ];
     }
 
@@ -185,6 +214,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             ['null', '7.4', 93, '8.0', false],
             ['false', '7.4', 96, '8.0', false],
             ['false', '7.4', 99, '8.0'],
+            ['mixed', '7.4', 116, '8.0', false],
         ];
     }
 
@@ -256,6 +286,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             ['object|ClassName', 102],
             ['iterable|array|Traversable', 105],
             ['int|string|INT', 108],
+            ['float|int', 114],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -120,3 +120,15 @@ function pseudoTypeIterableAndArray(iterable|array|Traversable $var) {}
 
 // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the sniff.
 function duplicateTypeInUnion(int|string|INT $var) {}
+
+// PHP 8.0 constructor property promotion. Only the "normal" parameters should be examined.
+class ConstructorPropertyPromotionWithTypes {
+    public function __construct(
+        protected float|int $propertyIgnore1,
+        private mixed $propertyIgnore2,
+        public callable $propertyIgnore3,
+        callable $normalParam1,
+        float|int $normalParam2,
+        mixed $normalParam3,
+    ) {}
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -118,6 +118,11 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             ['array', '5.0', 119, '8.0'],
             ['int', '5.6', 122, '8.0'], // Expected x2.
             ['string', '5.6', 122, '8.0'],
+
+            ['callable', '5.3', 130, '5.4'],
+            ['float', '5.6', 131, '8.0'],
+            ['int', '5.6', 131, '8.0'],
+            ['mixed', '7.4', 132, '8.0', false],
         ];
     }
 
@@ -290,6 +295,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             ['object|ClassName', 116],
             ['iterable|array|Traversable', 119],
             ['int|string|INT', 122],
+            ['float|int', 131],
         ];
     }
 
@@ -469,6 +475,9 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             [116],
             [119],
             [122],
+            [130],
+            [131],
+            [132],
         ];
     }
 
@@ -502,6 +511,9 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             [49],
             [82],
             [91],
+            [127],
+            [128],
+            [129],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.0 | NewTypedProperties: examine properties declared in the constructor

Typed properties declared via a class constructor should also be examined by the `NewTypedProperties` sniff as the allowed types for properties are different than those for parameters.

Includes:
* Adding `T_FUNCTION` to the tokens to be examined.
* Splitting the "type checking" logic off into its own method to allow for multiple properties declared in a constructor.

Includes unit tests.

Ref: https://wiki.php.net/rfc/constructor_promotion

### PHP 8.0 | NewParamTypeDeclarations: ignore promoted properties

Properties declared via a class constructor follow the property type rules, not the parameter type rules, so ignore them for this sniff. These will be examined in the `NewTypedProperties` sniff instead.

Includes unit tests.

Related to #809