### PR TITLE
PHP 7.4 | Various sniffs: correctly handle arrow functions

### DIFF
--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -59,6 +59,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
     private $varArgTokens = [
         \T_VARIABLE => \T_VARIABLE,
         \T_CLOSURE  => \T_CLOSURE,
+        \T_FN       => \T_FN,
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -162,6 +162,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
             \T_ARRAY,
             \T_OPEN_SHORT_ARRAY,
             \T_CLOSURE,
+            \T_FN,
         ];
 
         $searchStartToken = $parameter['start'] - 1;
@@ -191,11 +192,12 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
                 continue;
             }
 
-            // Skip past closures passed as function parameters.
-            if ($tokens[$nextVariable]['type'] === 'T_CLOSURE'
+            // Skip past closures and arrow functions passed as function parameters.
+            if (($tokens[$nextVariable]['type'] === 'T_CLOSURE'
+                || $tokens[$nextVariable]['type'] === 'T_FN')
                 && isset($tokens[$nextVariable]['scope_closer'])
             ) {
-                // Skip forward to the end of the closure declaration.
+                // Skip forward to the end of the closure/arrow function declaration.
                 $nextVariable = $tokens[$nextVariable]['scope_closer'];
                 continue;
             }

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.inc
@@ -164,3 +164,15 @@ for ($y = 0; $y < 8; $y++) {
        continue 0_1;
    }
 }
+
+// Test recognizing PHP 7.4 arrow functions as forbidden.
+for ($z = 0; $z < 8; $z++) {
+    // Bad: Break/continue with a closure.
+    if ($z == 10) {
+        break (fn () => 1)(); // Bad.
+    }
+
+    if ($z < 11) {
+        continue (fn () => 1)(); // Bad.
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -85,6 +85,8 @@ class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
             [141, self::ERROR_TYPE_ZERO],
             [149, self::ERROR_TYPE_ZERO],
             [160, self::ERROR_TYPE_ZERO],
+            [172, self::ERROR_TYPE_VARIABLE],
+            [176, self::ERROR_TYPE_VARIABLE],
         ];
 
         return $data;

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.inc
@@ -97,3 +97,8 @@ Hooks::run( 'SecondaryDataUpdates', array( $title, $old, $recursive, $parserOutp
 Hooks::run( 'SecondaryDataUpdates', [ $title, $old, $recursive, $parserOutput, &$updates ] );
 // Similar, but live coding, parse error.
 Hooks::run( 'SecondaryDataUpdates', [ $title, $old,
+
+// Treat PHP 7.4 arrow functions same as closures.
+$d = fn ( &$a ) => $a;
+abc(fn ($a, &$b, $c) => array($a,$b,$c));
+abc(fn ($a, $b, $c) => array($a,$b,&$c));

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
@@ -141,6 +141,11 @@ class ForbiddenCallTimePassByReferenceUnitTest extends BaseSniffTest
             [96],
             [97],
             [99],
+
+            // References in combination with arrow functions.
+            [102],
+            [103],
+            [104],
         ];
     }
 


### PR DESCRIPTION
### PHP 7.4 | ForbiddenBreakContinueVariableArguments: detect arrow functions as variable argument

Includes tests.

### PHP 7.4 | ForbiddenCallTimePassByReference: skip over arrow functions

Includes tests.

Related to #808