### PR TITLE
Refactor initial value sniffs

### DIFF
--- a/PHPCompatibility/AbstractInitialValueSniff.php
+++ b/PHPCompatibility/AbstractInitialValueSniff.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Abstract base sniff to examine all typical places which take an initial value.
+ *
+ * Initial (default) values have some restrictions in PHP and, over time,
+ * some of those restrictions have been lifted.
+ * This base sniff allows for examining these initial values.
+ *
+ * The restrictions apply to the following places:
+ * - Declarations of constants using the `const` keyword.
+ * - Declarations of default values for OO properties.
+ * - Declarations of default values for function parameters.
+ * - Declarations of initial values for static variables.
+ *
+ * @since 10.0.0
+ */
+abstract class AbstractInitialValueSniff extends Sniff
+{
+
+    /**
+     * Partial error phrases to be used in combination with the error message constant.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, string> Type indicator => suggested partial error phrase
+     */
+    protected $initialValueTypes = [
+        'const'     => 'when defining constants using the const keyword',
+        'property'  => 'in property declarations',
+        'staticvar' => 'in static variable declarations',
+        'default'   => 'in default function arguments',
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $targets = [
+            // Constant declarations.
+            \T_CONST    => \T_CONST,
+
+            // Property declarations.
+            \T_VARIABLE => \T_VARIABLE,
+
+            // Static variable declarations.
+            \T_STATIC   => \T_STATIC,
+        ];
+
+        // Function parameters.
+        $targets += Collections::functionDeclarationTokens();
+
+        return $targets;
+    }
+
+    /**
+     * Allow for a sniff to short-circuit running the logic by bowing out early.
+     *
+     * This method must be implemented in child classes.
+     * Return `false` to never bow out early.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    abstract protected function bowOutEarly();
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void|int Null or integer stack pointer to skip forward.
+     */
+    final public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->bowOutEarly() === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        /*
+         * Handle default values for function parameters.
+         */
+        if (isset(Collections::functionDeclarationTokens()[$tokens[$stackPtr]['code']])) {
+            $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+            if (empty($parameters) || isset($tokens[$stackPtr]['parenthesis_closer']) === false) {
+                // No parameters or parse error/live coding, nothing to do.
+                return;
+            }
+
+            $parenthesisCloser = $tokens[$stackPtr]['parenthesis_closer'];
+            $type              = 'default';
+
+            foreach ($parameters as $param) {
+                if (isset($param['default_token']) === false) {
+                    continue;
+                }
+
+                // Ok, so this parameter has a default value. Let's examine it.
+                $defaultEnd = $parenthesisCloser;
+                if (\is_int($param['comma_token'])) {
+                    $defaultEnd = $param['comma_token'];
+                }
+
+                $this->processInitialValue($phpcsFile, $param['token'], $param['default_token'], $defaultEnd, $type);
+            }
+
+            /*
+             * No need for the sniff to be triggered by the T_VARIABLEs in the function
+             * definition as we've already examined them above, so let's skip over them.
+             */
+            return $parenthesisCloser;
+        }
+
+        /*
+         * Handle default values for constants/properties/static variables.
+         */
+        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
+        if ($endOfStatement === false) {
+            // No semi-colon - live coding.
+            return;
+        }
+
+        $type = 'const';
+
+        // Filter out non-property declarations.
+        if ($tokens[$stackPtr]['code'] === \T_VARIABLE) {
+            if (Scopes::isOOProperty($phpcsFile, $stackPtr) === false) {
+                return;
+            }
+
+            $type = 'property';
+
+            // Move back one token to have the same starting point as the others.
+            $stackPtr = ($stackPtr - 1);
+        }
+
+        // Filter out late static binding, class properties, static closures and arrow function and static return types.
+        if ($tokens[$stackPtr]['code'] === \T_STATIC) {
+            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($next === false || $tokens[$next]['code'] !== \T_VARIABLE) {
+                // Not a static variable declaration. Bow out.
+                return;
+            }
+
+            if (Scopes::isOOProperty($phpcsFile, $next) === true) {
+                // Class properties are examined based on the T_VARIABLE token.
+                return;
+            }
+            unset($next);
+
+            $type = 'staticvar';
+        }
+
+        // Examine each variable/constant in multi-declarations.
+        $start = ($stackPtr + 1);
+        do {
+            $end   = $this->findEndOfCurrentDeclaration($phpcsFile, $start, $endOfStatement);
+            $start = $phpcsFile->findNext(Tokens::$emptyTokens, $start, $end, true);
+            if ($start === false
+                || ($tokens[$stackPtr]['code'] === \T_CONST && $tokens[$start]['code'] !== \T_STRING)
+                || ($tokens[$stackPtr]['code'] !== \T_CONST && $tokens[$start]['code'] !== \T_VARIABLE)
+            ) {
+                // Shouldn't be possible.
+                continue;
+            }
+
+            $this->processSubStatement($phpcsFile, $start, $end, $type);
+
+            $start = ($end + 1);
+
+        } while ($end < $endOfStatement);
+
+        // Skip to the end of the statement to prevent duplicate messages for multi-declarations.
+        return $endOfStatement;
+    }
+
+    /**
+     * Find the end of the current constant/variable declaration in a potential
+     * multi-declaration statement.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile      The file being scanned.
+     * @param int                         $stackPtr       The position of the current token in the
+     *                                                    stack passed in $tokens.
+     * @param int                         $endOfStatement The ultimate end of the statement.
+     *
+     * @return int
+     */
+    private function findEndOfCurrentDeclaration(File $phpcsFile, $stackPtr, $endOfStatement)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $endTokens = [
+            \T_COMMA     => \T_COMMA,
+            \T_SEMICOLON => \T_SEMICOLON,
+            \T_CLOSE_TAG => \T_CLOSE_TAG,
+        ];
+
+        for ($i = $stackPtr; $i <= $endOfStatement; $i++) {
+            if (isset($endTokens[$tokens[$i]['code']]) === true) {
+                // Found the end of the statement.
+                break;
+            }
+
+            // Skip nested statements.
+            if (isset($tokens[$i]['scope_closer']) === true
+                && $i === $tokens[$i]['scope_opener']
+            ) {
+                $i = $tokens[$i]['scope_closer'];
+            } elseif (isset($tokens[$i]['bracket_closer']) === true
+                && $i === $tokens[$i]['bracket_opener']
+            ) {
+                $i = $tokens[$i]['bracket_closer'];
+            } elseif (isset($tokens[$i]['parenthesis_closer']) === true
+                && $i === $tokens[$i]['parenthesis_opener']
+            ) {
+                $i = $tokens[$i]['parenthesis_closer'];
+            }
+        }
+
+        return $i;
+    }
+
+    /**
+     * Process a statement which _may_ or _may not_ have an initial value.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the variable/constant name token
+     *                                               in the stack passed in $tokens.
+     * @param int                         $end       The end of the (sub-)statement.
+     *                                               This will normally be a comma or semi-colon.
+     * @param string                      $type      The "type" of initial value declaration being examined.
+     *                                               The type will match one of the keys in the
+     *                                               `AbstractInitialValueSniff::$initialValueTypes` property.
+     *
+     * @return void
+     */
+    protected function processSubStatement(File $phpcsFile, $stackPtr, $end, $type)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $next   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), $end, true);
+        if ($next === false || $tokens[$next]['code'] !== \T_EQUAL) {
+            // No value assigned.
+            return;
+        }
+
+        $this->processInitialValue($phpcsFile, $stackPtr, ($next + 1), $end, $type);
+    }
+
+    /**
+     * Process a token which has an initial value.
+     *
+     * This method must be implemented in child classes.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the variable/constant name token
+     *                                               in the stack passed in $tokens.
+     * @param int                         $start     The stackPtr to the start of the initial value.
+     * @param int                         $end       The stackPtr to the end of the initial value.
+     *                                               This will normally be a comma or semi-colon.
+     * @param string                      $type      The "type" of initial value declaration being examined.
+     *                                               The type will match one of the keys in the
+     *                                               `AbstractInitialValueSniff::$initialValueTypes` property.
+     *
+     * @return void
+     */
+    abstract protected function processInitialValue(File $phpcsFile, $stackPtr, $start, $end, $type);
+}

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -10,13 +10,12 @@
 
 namespace PHPCompatibility\Sniffs\InitialValue;
 
-use PHPCompatibility\Sniff;
+use PHPCompatibility\AbstractInitialValueSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
-use PHPCSUtils\Utils\Scopes;
 
 /**
  * Detect constant scalar expressions being used to set an initial value.
@@ -32,8 +31,10 @@ use PHPCSUtils\Utils\Scopes;
  * @link https://wiki.php.net/rfc/const_scalar_exprs
  *
  * @since 8.2.0
+ * @since 10.0.0 This sniff now extends the `AbstractInitialValueSniff` class instead of the
+ *               base `Sniff` class.
  */
-class NewConstantScalarExpressionsSniff extends Sniff
+class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
 {
 
     /**
@@ -44,20 +45,6 @@ class NewConstantScalarExpressionsSniff extends Sniff
      * @var string
      */
     const ERROR_PHRASE = 'Constant scalar expressions are not allowed %s in PHP 5.5 or earlier.';
-
-    /**
-     * Partial error phrases to be used in combination with the error message constant.
-     *
-     * @since 8.2.0
-     *
-     * @var array
-     */
-    protected $errorPhrases = [
-        'const'     => 'when defining constants using the const keyword',
-        'property'  => 'in property declarations',
-        'staticvar' => 'in static variable declarations',
-        'default'   => 'in default function arguments',
-    ];
 
     /**
      * Tokens which were allowed to be used in these declarations prior to PHP 5.6.
@@ -107,15 +94,8 @@ class NewConstantScalarExpressionsSniff extends Sniff
         // Set the properties up only once.
         $this->setProperties();
 
-        return [
-            \T_CONST,
-            \T_VARIABLE,
-            \T_FUNCTION,
-            \T_CLOSURE,
-            \T_STATIC,
-        ];
+        return parent::register();
     }
-
 
     /**
      * Make some adjustments to the $safeOperands property.
@@ -130,7 +110,6 @@ class NewConstantScalarExpressionsSniff extends Sniff
         $this->safeOperands += Tokens::$emptyTokens;
     }
 
-
     /**
      * Do a version check to determine if this sniff needs to run at all.
      *
@@ -143,207 +122,42 @@ class NewConstantScalarExpressionsSniff extends Sniff
         return ($this->supportsBelow('5.5') !== true);
     }
 
-
     /**
-     * Processes this test, when one of its tokens is encountered.
+     * Process a token which has an initial value.
      *
-     * @since 8.2.0
+     * @since 10.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
+     * @param int                         $stackPtr  The position of the variable/constant name token
+     *                                               in the stack passed in $tokens.
+     * @param int                         $start     The stackPtr to the start of the initial value.
+     * @param int                         $end       The stackPtr to the end of the initial value.
+     *                                               This will normally be a comma or semi-colon.
+     * @param string                      $type      The "type" of initial value declaration being examined.
+     *                                               The type will match one of the keys in the
+     *                                               `AbstractInitialValueSniff::$initialValueTypes` property.
      *
-     * @return void|int Null or integer stack pointer to skip forward.
+     * @return void
      */
-    public function process(File $phpcsFile, $stackPtr)
+    protected function processInitialValue(File $phpcsFile, $stackPtr, $start, $end, $type)
     {
-        if ($this->bowOutEarly() === true) {
+        $isStaticValue = $this->isStaticValue($phpcsFile, $start, ($end - 1));
+        if ($isStaticValue === true) {
+            // Not a constant scalar expression, nothing to do.
             return;
         }
 
-        $tokens = $phpcsFile->getTokens();
-
-        switch ($tokens[$stackPtr]['type']) {
-            case 'T_FUNCTION':
-            case 'T_CLOSURE':
-                $params = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
-                if (empty($params)) {
-                    // No parameters.
-                    return;
-                }
-
-                $funcToken = $tokens[$stackPtr];
-
-                if (isset($funcToken['parenthesis_owner'], $funcToken['parenthesis_opener'], $funcToken['parenthesis_closer']) === false
-                    || $funcToken['parenthesis_owner'] !== $stackPtr
-                    || isset($tokens[$funcToken['parenthesis_opener']], $tokens[$funcToken['parenthesis_closer']]) === false
-                ) {
-                    // Hmm.. something is going wrong as these should all be available & valid.
-                    return;
-                }
-
-                $opener = $funcToken['parenthesis_opener'];
-                $closer = $funcToken['parenthesis_closer'];
-
-                // Which nesting level is the one we are interested in ?
-                $nestedParenthesisCount = 1;
-                if (isset($tokens[$opener]['nested_parenthesis'])) {
-                    $nestedParenthesisCount += \count($tokens[$opener]['nested_parenthesis']);
-                }
-
-                foreach ($params as $param) {
-                    if (isset($param['default']) === false) {
-                        continue;
-                    }
-
-                    $end = $param['token'];
-                    while (($end = $phpcsFile->findNext([\T_COMMA, \T_CLOSE_PARENTHESIS], ($end + 1), ($closer + 1))) !== false) {
-                        $maybeSkipTo = $this->isRealEndOfDeclaration($tokens, $end, $nestedParenthesisCount);
-                        if ($maybeSkipTo !== true) {
-                            $end = $maybeSkipTo;
-                            continue;
-                        }
-
-                        // Ignore closing parenthesis/bracket if not 'ours'.
-                        if ($tokens[$end]['code'] === \T_CLOSE_PARENTHESIS && $end !== $closer) {
-                            continue;
-                        }
-
-                        // Ok, we've found the end of the param default value declaration.
-                        break;
-                    }
-
-                    if ($this->isValidAssignment($phpcsFile, $param['token'], $end) === false) {
-                        $this->throwError($phpcsFile, $param['token'], 'default', $param['content']);
-                    }
-                }
-
-                /*
-                 * No need for the sniff to be triggered by the T_VARIABLEs in the function
-                 * definition as we've already examined them above, so let's skip over them.
-                 */
-                return $closer;
-
-            case 'T_VARIABLE':
-            case 'T_STATIC':
-            case 'T_CONST':
-                $type = 'const';
-
-                // Filter out non-property declarations.
-                if ($tokens[$stackPtr]['code'] === \T_VARIABLE) {
-                    if (Scopes::isOOProperty($phpcsFile, $stackPtr) === false) {
-                        return;
-                    }
-
-                    $type = 'property';
-
-                    // Move back one token to have the same starting point as the others.
-                    $stackPtr = ($stackPtr - 1);
-                }
-
-                // Filter out late static binding and class properties.
-                if ($tokens[$stackPtr]['code'] === \T_STATIC) {
-                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
-                    if ($next === false || $tokens[$next]['code'] !== \T_VARIABLE) {
-                        // Late static binding.
-                        return;
-                    }
-
-                    if (Scopes::isOOProperty($phpcsFile, $next) === true) {
-                        // Class properties are examined based on the T_VARIABLE token.
-                        return;
-                    }
-                    unset($next);
-
-                    $type = 'staticvar';
-                }
-
-                $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
-                if ($endOfStatement === false) {
-                    // No semi-colon - live coding.
-                    return;
-                }
-
-                $targetNestingLevel = 0;
-                if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
-                    $targetNestingLevel = \count($tokens[$stackPtr]['nested_parenthesis']);
-                }
-
-                // Examine each variable/constant in multi-declarations.
-                $start = $stackPtr;
-                $end   = $stackPtr;
-                while (($end = $phpcsFile->findNext([\T_COMMA, \T_SEMICOLON, \T_OPEN_SHORT_ARRAY, \T_CLOSE_TAG], ($end + 1), ($endOfStatement + 1))) !== false) {
-
-                    $maybeSkipTo = $this->isRealEndOfDeclaration($tokens, $end, $targetNestingLevel);
-                    if ($maybeSkipTo !== true) {
-                        $end = $maybeSkipTo;
-                        continue;
-                    }
-
-                    $start = $phpcsFile->findNext(Tokens::$emptyTokens, ($start + 1), $end, true);
-                    if ($start === false
-                        || ($tokens[$stackPtr]['code'] === \T_CONST && $tokens[$start]['code'] !== \T_STRING)
-                        || ($tokens[$stackPtr]['code'] !== \T_CONST && $tokens[$start]['code'] !== \T_VARIABLE)
-                    ) {
-                        // Shouldn't be possible.
-                        continue;
-                    }
-
-                    if ($this->isValidAssignment($phpcsFile, $start, $end) === false) {
-                        // Create the "found" snippet.
-                        $content    = '';
-                        $tokenCount = ($end - $start);
-                        if ($tokenCount < 20) {
-                            // Prevent large arrays from being added to the error message.
-                            $content = $phpcsFile->getTokensAsString($start, ($tokenCount + 1));
-                        }
-
-                        $this->throwError($phpcsFile, $start, $type, $content);
-                    }
-
-                    $start = $end;
-                }
-
-                // Skip to the end of the statement to prevent duplicate messages for multi-declarations.
-                return $endOfStatement;
-        }
+        $this->throwError($phpcsFile, $stackPtr, $end, $type);
     }
-
-
-    /**
-     * Is a value declared and is the value declared valid pre-PHP 5.6 ?
-     *
-     * @since 8.2.0
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
-     * @param int                         $end       The end of the value definition.
-     *                                               This will normally be a comma or
-     *                                               semi-colon.
-     *
-     * @return bool
-     */
-    protected function isValidAssignment(File $phpcsFile, $stackPtr, $end)
-    {
-        $tokens = $phpcsFile->getTokens();
-        $next   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), $end, true);
-        if ($next === false || $tokens[$next]['code'] !== \T_EQUAL) {
-            // No value assigned.
-            return true;
-        }
-
-        return $this->isStaticValue($phpcsFile, $tokens, ($next + 1), ($end - 1));
-    }
-
 
     /**
      * Is a value declared and is the value declared constant as accepted in PHP 5.5 and lower ?
      *
      * @since 8.2.0
+     * @since 10.0.0 The `$tokens` parameter which was previously at the second position,
+     *               has been removed.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
-     * @param array                       $tokens       The token stack of the current file.
      * @param int                         $start        The stackPtr from which to start examining.
      * @param int                         $end          The end of the value definition (inclusive),
      *                                                  i.e. this token will be examined as part of
@@ -353,8 +167,9 @@ class NewConstantScalarExpressionsSniff extends Sniff
      *
      * @return bool
      */
-    protected function isStaticValue(File $phpcsFile, $tokens, $start, $end, $nestedArrays = 0)
+    protected function isStaticValue(File $phpcsFile, $start, $end, $nestedArrays = 0)
     {
+        $tokens        = $phpcsFile->getTokens();
         $nextNonSimple = $phpcsFile->findNext($this->safeOperands, $start, ($end + 1), true);
         if ($nextNonSimple === false) {
             return true;
@@ -406,7 +221,7 @@ class NewConstantScalarExpressionsSniff extends Sniff
                 }
 
                 // Examine what comes after the namespace/parent/self/double colon, if anything.
-                return $this->isStaticValue($phpcsFile, $tokens, ($nextNonEmpty + 1), $end, $nestedArrays);
+                return $this->isStaticValue($phpcsFile, ($nextNonEmpty + 1), $end, $nestedArrays);
 
             case \T_ARRAY:
             case \T_OPEN_SHORT_ARRAY:
@@ -429,17 +244,17 @@ class NewConstantScalarExpressionsSniff extends Sniff
                         }
 
                         if ($doubleArrow === false) {
-                            if ($this->isStaticValue($phpcsFile, $tokens, $item['start'], $item['end'], $nestedArrays) === false) {
+                            if ($this->isStaticValue($phpcsFile, $item['start'], $item['end'], $nestedArrays) === false) {
                                 return false;
                             }
                         } else {
                             // Examine array key.
-                            if ($this->isStaticValue($phpcsFile, $tokens, $item['start'], ($doubleArrow - 1), $nestedArrays) === false) {
+                            if ($this->isStaticValue($phpcsFile, $item['start'], ($doubleArrow - 1), $nestedArrays) === false) {
                                 return false;
                             }
 
                             // Examine array value.
-                            if ($this->isStaticValue($phpcsFile, $tokens, ($doubleArrow + 1), $item['end'], $nestedArrays) === false) {
+                            if ($this->isStaticValue($phpcsFile, ($doubleArrow + 1), $item['end'], $nestedArrays) === false) {
                                 return false;
                             }
                         }
@@ -473,38 +288,48 @@ class NewConstantScalarExpressionsSniff extends Sniff
                 }
 
                 // Examine what comes after the array, if anything.
-                return $this->isStaticValue($phpcsFile, $tokens, ($closer + 1), $end, $nestedArrays);
+                return $this->isStaticValue($phpcsFile, ($closer + 1), $end, $nestedArrays);
         }
 
         // Ok, so this unsafe token was not one of the exceptions, i.e. this is a PHP 5.6+ syntax.
         return false;
     }
 
-
     /**
      * Throw an error if a scalar expression is found.
      *
      * @since 8.2.0
+     * @since 10.0.0 The `$end` parameter has been added, moving the `$type` parameter
+     *               from the third to the fourth position.
+     *               The previously optional fourth `$content` parameter has been removed.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token to link the error to.
+     * @param int                         $end       The end of the value definition (inclusive).
      * @param string                      $type      Type of usage found.
-     * @param string                      $content   Optional. The value for the declaration as found.
      *
      * @return void
      */
-    protected function throwError(File $phpcsFile, $stackPtr, $type, $content = '')
+    protected function throwError(File $phpcsFile, $stackPtr, $end, $type)
     {
         $error     = static::ERROR_PHRASE;
-        $phrase    = '';
         $errorCode = 'Found';
+        $phrase    = '';
 
-        if (isset($this->errorPhrases[$type]) === true) {
+        if (isset($this->initialValueTypes[$type]) === true) {
             $errorCode = MessageHelper::stringToErrorCode($type) . 'Found';
-            $phrase    = $this->errorPhrases[$type];
+            $phrase    = $this->initialValueTypes[$type];
         }
 
         $data = [$phrase];
+
+        // Create the "found" snippet.
+        $content    = '';
+        $tokenCount = ($end - $stackPtr);
+        if ($tokenCount < 20) {
+            // Prevent large arrays from being added to the error message.
+            $content = \trim(GetTokensAsString::noComments($phpcsFile, $stackPtr, $end));
+        }
 
         if (empty($content) === false) {
             $error .= ' Found: %s';
@@ -512,47 +337,5 @@ class NewConstantScalarExpressionsSniff extends Sniff
         }
 
         $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-    }
-
-
-    /**
-     * Helper function to find the end of multi variable/constant declarations.
-     *
-     * Checks whether a certain part of a declaration needs to be skipped over or
-     * if it is the real end of the declaration.
-     *
-     * @since 8.2.0
-     *
-     * @param array $tokens      Token stack of the current file.
-     * @param int   $endPtr      The token to examine as a candidate end pointer.
-     * @param int   $targetLevel Target nesting level.
-     *
-     * @return bool|int True if this is the real end. Int stackPtr to skip to if not.
-     */
-    private function isRealEndOfDeclaration($tokens, $endPtr, $targetLevel)
-    {
-        // Ignore anything within short array definition brackets for now.
-        if ($tokens[$endPtr]['code'] === \T_OPEN_SHORT_ARRAY
-            && (isset($tokens[$endPtr]['bracket_opener'])
-                && $tokens[$endPtr]['bracket_opener'] === $endPtr)
-            && isset($tokens[$endPtr]['bracket_closer'])
-        ) {
-            // Skip forward to the end of the short array definition.
-            return $tokens[$endPtr]['bracket_closer'];
-        }
-
-        // Skip past commas at a lower nesting level.
-        if ($tokens[$endPtr]['code'] === \T_COMMA) {
-            // Check if a comma is at the nesting level we're targetting.
-            $nestingLevel = 0;
-            if (isset($tokens[$endPtr]['nested_parenthesis']) === true) {
-                $nestingLevel = \count($tokens[$endPtr]['nested_parenthesis']);
-            }
-            if ($nestingLevel > $targetLevel) {
-                return $endPtr;
-            }
-        }
-
-        return true;
     }
 }

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -18,6 +18,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group newConstantScalarExpressions
  * @group initialValue
  *
+ * @covers \PHPCompatibility\AbstractInitialValueSniff
  * @covers \PHPCompatibility\Sniffs\InitialValue\NewConstantScalarExpressionsSniff
  *
  * @since 8.2.0

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -18,6 +18,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @group newHeredoc
  * @group initialValue
  *
+ * @covers \PHPCompatibility\AbstractInitialValueSniff
  * @covers \PHPCompatibility\Sniffs\InitialValue\NewHeredocSniff
  *
  * @since 7.1.4

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
             <file>./PHPCompatibility/Sniff.php</file>
+            <file>./PHPCompatibility/AbstractInitialValueSniff.php</file>
             <directory>./PHPCompatibility/Sniffs/</directory>
             <directory>./PHPCompatibility/Helpers/</directory>
         </whitelist>


### PR DESCRIPTION
### ✨ New AbstractInitialValueSniff class

Adding this abstract class will solve two problems:
1. The `NewHeredocSniff` currently extends the `NewConstantScalarExpressionsSniff` and, as per #608, #793, #1042, one active sniff class extending another active sniff class can lead to fatal errors with how the autoloader in PHPCS itself works, which is something we want to prevent/solve in the 10.0.0 release.
2. Both PHP 8.1 ([New in initializers](https://wiki.php.net/rfc/new_in_initializers)) as well as 8.2 ([Fetch properties of enums in const expressions](https://wiki.php.net/rfc/fetch_property_in_const_expressions)] introduce changes to what syntaxes are allowed within initial values, so additional "initial value" sniffs will need to be written and having this abstract available will make that easier.

The abstract sniff will be tested by implementing the use of the abstract in both the `NewConstantScalarExpressionsSniff` class as well as the `NewHeredocSniff`.

Implementation notes:
* Includes adding support for detecting initial values for parameters of arrow functions via the use of `Collections::functionDeclarationTokens()`.
* PHP 8.0+ attributes have similar restrictions to the values passed in attribute class instantiations.
    Support for detecting this has not been added (yet).

Loosely related to #1261, #1273

### NewHeredoc: decouple from the NewConstantScalarExpressions sniff

Note: The error message will now always display a code snippet, but this snippet will be limited to show the variable/constant name up to the heredoc start marker.
The code snippet will now also be cleaned of potential comments by switching to using the PHPCSUtils `GetTokensAsString` class.

Aside from that, there are no functional changes.

### NewConstantScalarExpressions: implement the AbstractInitialValueSniff

This commit:
* Removes all the code/logic which has been moved to the `AbstractInitialValueSniff`.
    This includes the `$errorPhrases` property and the `process()` and `isRealEndOfDeclaration()` methods.
* Makes a minor change to the `protected` `isStaticValue()` method signature by removing the `$tokens` parameter.
    As the method _calling_ the `isStaticValue()` method does not need the `$tokens` array, it makes more sense to just retrieve it within the `isStaticValue()` method.
* Moves the logic for creating a code snippet to use in the error message from the (now removed) `process()` method to the `throwError()` method, necessitating passing the `$end` parameter and making the `$content` parameter redundant.
* Note: The code snippet will now also be cleaned of potential comments by switching to using the PHPCSUtils `GetTokensAsString` class.

None of the above constitutes a functional change. This is a plain refactor.