### PR TITLE
PHP 8.2 | New `PHPCompatibility.Classes.NewReadonlyClasses` sniff

### DIFF
--- a/PHPCompatibility/Docs/Classes/NewReadonlyClassesStandard.xml
+++ b/PHPCompatibility/Docs/Classes/NewReadonlyClassesStandard.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Readonly Classes"
+    >
+    <standard>
+    <![CDATA[
+    Declaring classes as readonly is supported since PHP 8.2.
+
+    Using the `readonly` keyword on a class declaration will make all properties declared in the class readonly and will forbid declaring dynamic properties on the class.
+    Note: static properties or properties without type declaration are not supported.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: class without the readonly keyword.">
+        <![CDATA[
+class MyClass {}
+final class MyFinalClass {}
+abstract class MyAbstractClass {}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.2: class using the readonly keyword.">
+        <![CDATA[
+readonly class MyClass {}
+final readonly class MyFinalClass {}
+readonly abstract class MyAbstractClass {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Declaring classes as readonly is supported since PHP 8.2.
+ *
+ * PHP version 8.2
+ *
+ * @link https://wiki.php.net/rfc/readonly_classes
+ * @link https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.readonly-classes
+ * @link https://www.php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.readonly
+ *
+ * @since 10.0.0
+ */
+final class NewReadonlyClassesSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_CLASS];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('8.1') === false) {
+            return;
+        }
+
+        $properties = ObjectDeclarations::getClassProperties($phpcsFile, $stackPtr);
+        if ($properties['is_readonly'] === false) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Readonly classes are not supported in PHP 8.1 or earlier.',
+            $properties['readonly_token'],
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewReadonlyClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyClassesUnitTest.inc
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Valid cross-version/not our targets.
+ */
+
+class ClassWithoutKeywords {}
+
+final class FinalClass {}
+
+abstract class AbstractClass {
+    function class() {}
+}
+
+// Anon classes do not take keywords (and are not mentioned in the RFC).
+$anon = new class () {};
+
+/**
+ * PHP 8.2+: readonly classes.
+ */
+readonly class MyReadonlyClass {
+    public string $foo;
+
+    // Untyped properties are not allowed in readonly classes, but that's not the concern of this sniff.
+    public $bar;
+
+    // Static properties are not allowed in readonly classes, but that's not the concern of this sniff.
+    public static int $baz;
+}
+
+abstract readonly class AbstractReadonly {}
+readonly abstract class ReadonlyAbstract {}
+
+final readonly class FinalReadonly {}
+readonly final class ReadonlyFinal {}
+
+// Extending readonly classes is allowed, as long as the child is also marked readonly.
+readonly class ChildClass extends ParentClass {}
+
+// The AllowDynamicProperties attribute is not allowed on readonly classes, but that's not the concern of this sniff.
+#[AllowDynamicProperties]
+readonly class DynamicPropertiesNotAllowed {}
+
+// Verify handling with superfluous whitespace and comments.
+readonly
+// Comment
+abstract
+class
+ClassName {}
+
+// Duplicate readonly modifier is not allowed, but that's not the concern of this sniff.
+readonly readonly class DoubleReadonly {}

--- a/PHPCompatibility/Tests/Classes/NewReadonlyClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyClassesUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewReadonlyClasses sniff.
+ *
+ * @group newReadonlyClasses
+ * @group constants
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewReadonlyClassesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewReadonlyClassesUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test that an error is thrown for class constants declared with visibility.
+     *
+     * @dataProvider dataReadonlyClass
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testReadonlyClass($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertError($file, $line, 'Readonly classes are not supported in PHP 8.1 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testReadonlyClass()
+     *
+     * @return array
+     */
+    public function dataReadonlyClass()
+    {
+        return [
+            [21],
+            [31],
+            [32],
+            [34],
+            [35],
+            [38],
+            [42],
+            [45],
+            [52],
+        ];
+    }
+
+
+    /**
+     * Verify that there are no false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+        for ($line = 1; $line <= 17; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Readonly Classes
>
> Support for readonly on classes has been added.

This adds a new sniff to detect this.

Includes unit tests.
Includes docs.

Refs:
* https://wiki.php.net/rfc/readonly_classes
* https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.readonly-classes
* https://www.php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.readonly
* https://github.com/php/php-src/pull/7305

Related to #1348

**Note: this uses a new feature which is included in PHCPSUtils-1.0.0-rc1.**