### PR TITLE
PHP 8.1 | NewReturnTypeDeclarations: support `never` and verify standalone types

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -25,6 +25,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * - Since PHP 8.0, `static` is allowed to be used as a return type.
  * - Since PHP 8.0, `mixed` is allowed to be used as a return type.
  * - Since PHP 8.0, union types are supported and the union-only `false` and `null` types are available.
+ * - Since PHP 8.1, the stand-alone `never` type is available.
  *
  * PHP version 7.0+
  *
@@ -37,6 +38,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * @link https://wiki.php.net/rfc/static_return_type
  * @link https://wiki.php.net/rfc/mixed_type_v2
  * @link https://wiki.php.net/rfc/union_types_v2
+ * @link https://wiki.php.net/rfc/noreturn_type
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
@@ -126,6 +128,11 @@ class NewReturnTypeDeclarationsSniff extends Sniff
         'null' => [
             '7.4' => false,
             '8.0' => true,
+        ],
+        // Subtype of every other type.
+        'never' => [
+            '8.0' => false,
+            '8.1' => true,
         ],
     ];
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -85,3 +85,13 @@ interface FooBar {
 
 // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the sniff.
 function duplicateTypeInUnion(): int|string|INT {}
+
+// PHP 8.1 noreturn type
+function subTypeForAlwaysExitOrThrow(): never {
+	throw new Exception();
+}
+
+$closure = function() : Never {
+	redirect();
+	exit;
+};

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -60,8 +60,8 @@ function unionTypeSimple($number) : int|float {}
 function unionTypesTwoClasses($var): MyClassA|\Package\MyClassB {}
 function unionTypesAllBaseTypes() : array|bool|callable|int|float|null|Object|string {}
 
-// Intentional fatal error - mixing types which cannot be combined, but that's not the concern of the sniff.
-function unionTypesAllPseudoTypes($var) : false|MIXED|self|parent|static|iterable|Resource|void {}
+// This is fine.
+function unionTypesAllPseudoTypes($var) : false|self|parent|static|iterable|Resource {}
 
 // Intentional fatal error - nullability is not allowed with union types, but that's not the concern of the sniff.
 $closure = function () use($a) :?int|float {};
@@ -95,3 +95,14 @@ $closure = function() : Never {
 	redirect();
 	exit;
 };
+
+// Invalid: nullable or union with void.
+function voidIsStandAloneA($a): ?void {}
+function voidIsStandAloneB($a): int|void {}
+
+// Invalid: nullable or union with mixed.
+function mixedIsStandAloneB($a): int|MIXED {}
+
+// Invalid: nullable or union with never.
+function neverIsStandAloneA($a): ?never {}
+function neverIsStandAloneB($a): int|never {}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -123,6 +123,8 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             ['int', '5.6', 87, '8.0'],
             ['string', '5.6', 87, '8.0'],
             ['int', '5.6', 87, '8.0'],
+            ['never', '8.0', 90, '8.1'],
+            ['never', '8.0', 94, '8.1'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -102,13 +102,11 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             ['object', '7.1', 61, '8.0'],
             ['string', '5.6', 61, '8.0'],
             ['false', '7.4', 64, '8.0'],
-            ['mixed', '7.4', 64, '8.0'],
             ['self', '5.6', 64, '8.0'],
             ['parent', '5.6', 64, '8.0'],
             ['static', '7.4', 64, '8.0'],
             ['iterable', '7.0', 64, '8.0'],
             ['Class name', '5.6', 64, '8.0'],
-            ['void', '7.0', 64, '8.0'],
             ['int', '5.6', 67, '8.0'],
             ['float', '5.6', 67, '8.0'],
             ['null', '7.4', 70, '8.0', false],
@@ -162,14 +160,39 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
 
 
     /**
-     * Verify an error is thrown for nullable mixed types.
+     * Verify an error is thrown for combining stand-alone types with the nullability operator or using them in a union type.
+     *
+     * @dataProvider dataInvalidStandAloneType
+     *
+     * @param string $type        The declared type.
+     * @param array  $line        The line number where the error is expected.
+     * @param bool   $testVersion The PHP version in which the type was first allowed to be used.
      *
      * @return void
      */
-    public function testInvalidNullableMixed()
+    public function testInvalidStandAloneType($type, $line, $testVersion)
     {
-        $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertError($file, 56, 'Mixed types cannot be nullable, null is already part of the mixed type');
+        $file = $this->sniffFile(__FILE__, $testVersion);
+        $this->assertError($file, $line, "The '$type' type can only be used as a standalone type");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidStandAloneType()
+     *
+     * @return array
+     */
+    public function dataInvalidStandAloneType()
+    {
+        return [
+            ['mixed', 56, '8.0'],
+            ['void', 100, '7.1'],
+            ['void', 101, '7.1'],
+            ['mixed', 104, '8.0'],
+            ['never', 107, '8.1'],
+            ['never', 108, '8.1'],
+        ];
     }
 
 
@@ -221,7 +244,7 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             ['int|float', 59],
             ['MyClassA|\Package\MyClassB', 60],
             ['array|bool|callable|int|float|null|Object|string', 61],
-            ['false|MIXED|self|parent|static|iterable|Resource|void', 64],
+            ['false|self|parent|static|iterable|Resource', 64],
             ['?int|float', 67],
             ['bool|false', 76],
             ['object|ClassName', 79],


### PR DESCRIPTION
### PHP 8.1 | NewReturnTypeDeclarations: handle new never return type

> **Never type**
>
> A new return-only type `never` has been added. This indicates that a function either `exit()`, throws an exception, or doesn't terminate.

Includes unit tests.

Refs:
* https://wiki.php.net/rfc/noreturn_type
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.never-type
* https://github.com/php/php-src/pull/6761
* https://github.com/php/php-src/commit/6cd0b48cac42d0433bc27585b1b9f0f4b48cbc2d

### NewReturnTypeDeclarations: new check for non-standalone standalone types

The `void`, `mixed` and the new `never` types are "stand-alone" types, i.e types which are not allowed to be combined with other types, so they cannot be part of a type union, nor can they be nullable.

This is a cross-version compatibility issue as the name _could_ have been used, prior to the introduction of the type, as a class/interface name and could have been nullable or part of a union as the class/interface name.

In the `NewReturnTypeDeclarations` sniff, this was so far only addressed by detecting the use of the nullable operator in combination with the `mixed` type.

That particular check has now been refactored to be based on a list of types in the `$standAloneTypes` property and to check for both the nullability operator, as well as the use of the type in a type union.

This includes a minor BC-break in that the `PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.NullableMixed` error code has now been changed to `PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.NonStandaloneMixed` .

Includes unit tests and minor adjustments to the existing unit tests to accommodate.