### PR TITLE
Composer: update for PHPCSUtils 1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,6 @@
   "suggest" : {
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
-  "minimum-stability": "alpha",
-  "prefer-stable": true,
   "extra": {
     "branch-alias": {
       "dev-master": "9.x-dev",


### PR DESCRIPTION
PHPCSUtils 1.0.0 has been tagged & released. :tada:

This means that the `minimum-stability`/`prefer-stable` settings should no longer be needed.

~~Note: this also includes an allowance (via PHPCSUtils) for the newly released 1.0.0 version of the Composer PHPCS plugin.~~

Ref:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/v1.0.0
~~* https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.0.0~~