### PR TITLE
NewHeredoc: improve and expand tests (modern PHP)

### DIFF
--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
@@ -137,3 +137,13 @@ $arrow = fn( $a = <<<FOO
 Something
 FOO
 ) => $a;
+
+/*
+ * Test detecting heredoc initial values in PHP 8.1+ constants in enums.
+ */
+enum EnumWithConstant
+{
+    protected const MY_ENUM_CONST = <<<FOOBAR
+Constant in enum example
+FOOBAR;
+}

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
@@ -157,3 +157,11 @@ trait ConstantsInTraits
 Constant in trait example
 FOOBAR;
 }
+
+/*
+ * Safeguard that PHP 7.3+ flexible heredoc initial values are also detected correctly.
+ * IMPORTANT: this must be the last test in the file!
+ */
+static $a = <<<EOD
+            Multi-declaration in static variable.
+            EOD;

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
@@ -31,7 +31,7 @@ FOOBAR;
     protected static $baz = <<<FOOBAR
 Property example
 FOOBAR;
-}
+};
 
 // Interface constants - interfaces cannot declare properties.
 interface FooBar

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
@@ -72,14 +72,14 @@ Constant example
 FOOBAR;
 
 // Nowdoc was only introduced in PHP 5.3 and is sniffed for in a separate sniff.
-$var = <<<'FOOBAR'
+static $var = <<<'FOOBAR'
 Constant example
 FOOBAR;
 
-$array = array( 'key' => <<<FOOBAR
+static $array;
+$array = <<<FOOBAR
 Constant example
-FOOBAR
-);
+FOOBAR;
 
 /*
  * Test handling of multi-declarations.

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
@@ -147,3 +147,13 @@ enum EnumWithConstant
 Constant in enum example
 FOOBAR;
 }
+
+/*
+ * Test detecting heredoc initial values in PHP 8.2+ constants in traits.
+ */
+trait ConstantsInTraits
+{
+    public const MY_TRAIT_CONST = <<<"FOOBAR"
+Constant in trait example
+FOOBAR;
+}

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
@@ -125,3 +125,15 @@ EOD
 This is a function default value.
 EOT
 ) {}
+
+/*
+ * Test detecting heredoc initial values in closure/arrow function declarations.
+ */
+$closure = function($a, $b = <<<FOO
+Something
+FOO
+) {};
+$arrow = fn( $a = <<<FOO
+Something
+FOO
+) => $a;

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -51,7 +51,7 @@ class NewHeredocUnitTest extends BaseSniffTest
      */
     public function dataHeredocInitialize()
     {
-        return [
+        $data = [
             [5, 'static variables'],
             [13, 'constants'],
             [19, 'class properties'],
@@ -75,6 +75,12 @@ class NewHeredocUnitTest extends BaseSniffTest
             [146, 'constants'],
             [156, 'constants'],
         ];
+
+        if (PHP_VERSION_ID >= 70300) {
+            $data[] = [165, 'static variables'];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -70,6 +70,8 @@ class NewHeredocUnitTest extends BaseSniffTest
             [115, 'default parameter values'],
             [121, 'default parameter values'],
             [124, 'default parameter values'],
+            [132, 'default parameter values'],
+            [136, 'default parameter values'],
         ];
     }
 

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -73,6 +73,7 @@ class NewHeredocUnitTest extends BaseSniffTest
             [132, 'default parameter values'],
             [136, 'default parameter values'],
             [146, 'constants'],
+            [156, 'constants'],
         ];
     }
 

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -72,6 +72,7 @@ class NewHeredocUnitTest extends BaseSniffTest
             [124, 'default parameter values'],
             [132, 'default parameter values'],
             [136, 'default parameter values'],
+            [146, 'constants'],
         ];
     }
 


### PR DESCRIPTION
### NewHeredoc: fix unintentional parse error in the tests

### NewHeredoc: fix two incorrect tests

These tests weren't testing anything as they wouldn't trigger the sniff in the right way.

### NewHeredoc: add tests with closures and PHP 7.4+ arrow functions

... to safeguard these are handled correctly.

### NewHeredoc: add tests with constant in PHP 8.1+ enum

... to safeguard these are handled correctly.

### NewHeredoc: add tests with PHP 8.2+ constants in traits

... to safeguard these are handled correctly.

### NewHeredoc: add tests with PHP 7.3+ flexible heredoc

... to safeguard these are handled correctly.

Note: these can only be detected in PHP 7.3+ as flexible heredoc don't parse correctly in earlier PHP versions. There is a separate sniff which will detect the use of flexible heredoc/nowdoc in PHP < 7.3.