### PR TITLE
NewConstantScalarExpressions: improve and expand tests (modern PHP)

### DIFF
--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -63,15 +63,6 @@ class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
         \T_FALSE                    => \T_FALSE,
         \T_NULL                     => \T_NULL,
 
-        \T_LINE                     => \T_LINE,
-        \T_FILE                     => \T_FILE,
-        \T_DIR                      => \T_DIR,
-        \T_FUNC_C                   => \T_FUNC_C,
-        \T_CLASS_C                  => \T_CLASS_C,
-        \T_TRAIT_C                  => \T_TRAIT_C,
-        \T_METHOD_C                 => \T_METHOD_C,
-        \T_NS_C                     => \T_NS_C,
-
         // Special cases:
         \T_NS_SEPARATOR             => \T_NS_SEPARATOR,
         /*
@@ -107,6 +98,7 @@ class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
     public function setProperties()
     {
         $this->safeOperands += Tokens::$heredocTokens;
+        $this->safeOperands += Tokens::$magicConstants;
         $this->safeOperands += Tokens::$emptyTokens;
     }
 

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\InitialValue;
 use PHPCompatibility\AbstractInitialValueSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
@@ -223,17 +224,7 @@ class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
                 if (empty($arrayItems) === false) {
                     foreach ($arrayItems as $item) {
                         // Check for a double arrow, but only if it's for this array item, not for a nested array.
-                        $doubleArrow = false;
-
-                        $maybeDoubleArrow = $phpcsFile->findNext(
-                            [\T_DOUBLE_ARROW, \T_ARRAY, \T_OPEN_SHORT_ARRAY],
-                            $item['start'],
-                            ($item['end'] + 1)
-                        );
-                        if ($maybeDoubleArrow !== false && $tokens[$maybeDoubleArrow]['code'] === \T_DOUBLE_ARROW) {
-                            // Double arrow is for this nesting level.
-                            $doubleArrow = $maybeDoubleArrow;
-                        }
+                        $doubleArrow = Arrays::getDoubleArrowPtr($phpcsFile, $item['start'], $item['end']);
 
                         if ($doubleArrow === false) {
                             if ($this->isStaticValue($phpcsFile, $item['start'], $item['end'], $nestedArrays) === false) {

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.inc
@@ -263,3 +263,42 @@ static $var = $a;
 static $callA = function($a) {};
 static $callB = strpos( $a, 'a' );
 static $interpolated = "value with $variable";
+
+// Some tests to cover edge cases, safeguarding against false positives.
+class NotOurTargets {
+    public static $property; // The static here triggers the sniff, but should be ignored in favour of the $property token.
+
+    protected $parseError = 10,
+        $secondProp, // Invalid trailing comma.
+        ;
+
+    // All uses of `static` here should be ignored as "not our target".
+    public static function staticFunction($noDefault) : static {
+        $closure = static function() {}; // Not the `static` this sniff is looking for.
+        $bool = $obj instanceof static;
+    }
+}
+
+/*
+ * These are all still not allowed and/or nonsense code. These should all throw errors for pre-5.6, as these are not static values.
+ * Just testing some defensive coding which is in place.
+ */
+class InvalidNotConstantScalarExpression {
+    const NAME = self || parent; // Nonsensical, but testing some defensive coding.
+    const VARS_NOT_ALLOWED = ClassName::$prop;
+    const STATIC_NOT_ALLOWED = 'ClassName'::CONSTANT_NAME;
+}
+
+// Test expression starting with negative number.
+static $var = -1 + 10;
+
+// Test keyed array with static key and expression in the value part.
+class ArrayValue {
+    private $arrayProp1 = [
+        'key' => 10 + 20,
+    ];
+
+    private $arrayProp2 = [
+        10 => __DIR__ . self::FILENAME,
+    ];
+}

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.inc
@@ -314,3 +314,10 @@ $arrow = fn(int $a, int $b = 10 + 20) => $a + $b;
 enum EnumWithConstant {
     protected const MY_ENUM_CONST = ONE + self::THREE;
 }
+
+/*
+ * Test detecting heredoc initial values in PHP 8.2+ constants in traits.
+ */
+trait ConstantsInTraits {
+    public const MY_TRAIT_CONST = (BAR)?10:100);
+}

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.inc
@@ -302,3 +302,8 @@ class ArrayValue {
         10 => __DIR__ . self::FILENAME,
     ];
 }
+
+/*
+ * Test detecting constant scalar expressions as the default parameter value in arrow function declarations.
+ */
+$arrow = fn(int $a, int $b = 10 + 20) => $a + $b;

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.inc
@@ -307,3 +307,10 @@ class ArrayValue {
  * Test detecting constant scalar expressions as the default parameter value in arrow function declarations.
  */
 $arrow = fn(int $a, int $b = 10 + 20) => $a + $b;
+
+/*
+ * Test detecting constant scalar expressions in PHP 8.1+ constants in enums.
+ */
+enum EnumWithConstant {
+    protected const MY_ENUM_CONST = ONE + self::THREE;
+}

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -181,6 +181,7 @@ class NewConstantScalarExpressionsUnitTest extends BaseSniffTest
             [309, 'default'],
 
             [315, 'const'],
+            [322, 'const'],
         ];
     }
 

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -179,6 +179,8 @@ class NewConstantScalarExpressionsUnitTest extends BaseSniffTest
             [301, 'property'],
 
             [309, 'default'],
+
+            [315, 'const'],
         ];
     }
 

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -168,23 +168,56 @@ class NewConstantScalarExpressionsUnitTest extends BaseSniffTest
             [263, 'static'],
             [264, 'static'],
             [265, 'static'],
+
+            [287, 'const'],
+            [288, 'const'],
+            [289, 'const'],
+
+            [293, 'static'],
+
+            [297, 'property'],
+            [301, 'property'],
         ];
     }
 
 
     /**
-     * testNoFalsePositives
+     * Test the sniff doesn't throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.5');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 120 lines.
         for ($line = 1; $line <= 120; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        // ... nor on line 267 - 282.
+        for ($line = 267; $line <= 280; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -177,6 +177,8 @@ class NewConstantScalarExpressionsUnitTest extends BaseSniffTest
 
             [297, 'property'],
             [301, 'property'],
+
+            [309, 'default'],
         ];
     }
 


### PR DESCRIPTION
### NewConstantScalarExpressions: minor code simplification

PHPCS contains a token array listing all the magic constants since PHPCS 3.5.6.

### NewConstantScalarExpressions: add some additional tests

... to cover previously uncovered code paths.

### NewConstantScalarExpressions: code simplification using PHPCSUtils

Use the PHPCSUtils `Arrays::getDoubleArrowPtr()` method to retrieve the stack pointer to the applicable double arrow for the current array item.

This should improve efficiency and reliability.

### NewConstantScalarExpressions: add test with PHP 7.4+ arrow function

... to safeguard this is handled correctly.

### NewConstantScalarExpressions: add tests with constant in PHP 8.1+ enum

... to safeguard these are handled correctly.

### NewConstantScalarExpressions: add tests with PHP 8.2+ constants in traits

... to safeguard these are handled correctly.