### PR TITLE
:sparkles: PHP 8.1: New `PHPCompatibility.InitialValue.NewNewInInitializers` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\InitialValue;
+
+use PHPCompatibility\AbstractInitialValueSniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\MessageHelper;
+use PHPCSUtils\Utils\Parentheses;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Detect object instantiation in initial values as allowed per PHP 8.1.
+ *
+ * As of PHP 8.1, `new` expressions are allowed in parameter default values,
+ * attribute arguments, static variable initializers and global class constant initializers.
+ * Parameter default values also include defaults for promoted properties.
+ *
+ * The use of a dynamic or non-string class name or an anonymous class is not allowed.
+ * The use of argument unpacking is not allowed. The use of unsupported expressions as arguments is not allowed.
+ *
+ * PHP version 8.1
+ *
+ * @link https://wiki.php.net/rfc/new_in_initializers
+ * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.new-in-initializer
+ *
+ * @since 10.0.0
+ */
+final class NewNewInInitializersSniff extends AbstractInitialValueSniff
+{
+
+    /**
+     * Error message.
+     *
+     * @since 10.0.0
+     *
+     * @var string
+     */
+    const ERROR_PHRASE = 'New in initializers is not supported in PHP 8.0 or earlier for %s.';
+
+    /**
+     * Partial error phrases to be used in combination with the error message constant.
+     *
+     * @since 10.0.0.
+     *
+     * @var array
+     */
+    protected $initialValueTypes = [
+        'const'     => 'global/namespaced constants declared using the const keyword',
+        'property'  => '', // Not supported.
+        'staticvar' => 'static variables',
+        'default'   => 'default parameter values',
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('8.0') === false);
+    }
+
+    /**
+     * Process a token which has an initial value.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the variable/constant name token
+     *                                               in the stack passed in $tokens.
+     * @param int                         $start     The stackPtr to the start of the initial value.
+     * @param int                         $end       The stackPtr to the end of the initial value.
+     *                                               This will normally be a comma or semi-colon.
+     * @param string                      $type      The "type" of initial value declaration being examined.
+     *                                               The type will match one of the keys in the
+     *                                               `AbstractInitialValueSniff::$initialValueTypes` property.
+     *
+     * @return void
+     */
+    protected function processInitialValue(File $phpcsFile, $stackPtr, $start, $end, $type)
+    {
+        if ($type === 'property'
+            || ($type === 'const'
+            && Scopes::validDirectScope($phpcsFile, $stackPtr, Collections::ooConstantScopes()) !== false)
+        ) {
+            // New is (still) not allowed in OO constants or properties.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $targetNestingLevel = 0;
+        if (isset($tokens[$start]['nested_parenthesis'])) {
+            $targetNestingLevel = \count($tokens[$start]['nested_parenthesis']);
+        }
+
+        $error     = self::ERROR_PHRASE;
+        $errorCode = 'Found';
+        $phrase    = '';
+
+        if (isset($this->initialValueTypes[$type]) === true) {
+            $errorCode = MessageHelper::stringToErrorCode($type) . 'Found';
+            $phrase    = $this->initialValueTypes[$type];
+        }
+
+        $data = [$phrase];
+
+        $allowedNameTokens            = Collections::namespacedNameTokens();
+        $allowedNameTokens[\T_SELF]   = \T_SELF;
+        $allowedNameTokens[\T_PARENT] = \T_PARENT;
+
+        $current = $start;
+        while (($hasNew = $phpcsFile->findNext(\T_NEW, $current, $end)) !== false) {
+            // Handle nesting within arrays.
+            $currentNestingLevel = 0;
+            if (isset($tokens[$hasNew]['nested_parenthesis'])) {
+                foreach ($tokens[$hasNew]['nested_parenthesis'] as $opener => $closer) {
+                    // Always count outer parentheses.
+                    if ($opener < $start) {
+                        ++$currentNestingLevel;
+                        continue;
+                    }
+
+                    // Only count inner parentheses when they are not for an array.
+                    $owner = Parentheses::getOwner($phpcsFile, $opener);
+                    if ($owner === false || $tokens[$owner]['code'] !== \T_ARRAY) {
+                        ++$currentNestingLevel;
+                    }
+                }
+            }
+
+            $current = ($hasNew + 1);
+
+            if ($currentNestingLevel !== $targetNestingLevel) {
+                continue;
+            }
+
+            // Only throw an error if this is a non-dynamic object instantiation. Dynamic is still not supported.
+            $isNameInvalid     = $phpcsFile->findNext($allowedNameTokens + Tokens::$emptyTokens, ($hasNew + 1), $end, true);
+            $hasValidNameToken = $phpcsFile->findNext($allowedNameTokens, ($hasNew + 1), $end);
+
+            if ($hasValidNameToken !== false
+                && ($isNameInvalid === false
+                || ($tokens[$isNameInvalid]['code'] === \T_OPEN_PARENTHESIS && $hasValidNameToken < $isNameInvalid))
+            ) {
+                $phpcsFile->addError($error, $hasNew, $errorCode, $data);
+                return;
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/InitialValue/NewNewInInitializersUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewNewInInitializersUnitTest.inc
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * Valid cross-version.
+ */
+const NON_OO_CONST = Foo::CONST_NAME;
+
+function containsStaticVars() {
+	static $var = Foo::class, $bar = 'static value';
+	static $boo = [];
+}
+
+function bar($a, $b = (10 + 5)) {}
+$cl = function ($a = true) {};
+$ar = fn (Foo $a = null) => $a;
+
+
+/*
+ * Not our targets.
+ */
+$closure = static function() { return new Foo; };
+$fn = static fn() => new Foo;
+
+class Something {
+	public function foo() {
+		$bool = new Foo() instanceof static;
+	}
+}
+
+$var = new Foo();
+
+
+/*
+ * PHP 8.1 new in initializers.
+ */
+
+// Non-OO constants declared using the `const` keyword.
+const NON_OO_CONST = new Foo();
+const NON_OO_CONST_LONG_ARRAY = [new Foo()];
+const NON_OO_CONST_SHORT_ARRAY = array(new Foo());
+
+// Static variable declarations.
+function containsStaticVars() {
+	static $var = new Foo(1), $bar = new \Fully\Qualified('static value'); // x2.
+	static $boo = [new Partially\Qualified()];
+}
+
+// Default values for function declarations in all forms.
+function bar($a, $b = new Foo()) {}
+$array = array(
+	'k1' => function ($a, $b = new Foo()) {},
+	'k2' => function ($a, $b = array(new Foo())) {},
+	'k3' => function ($a, $b = [new Foo()]) {},
+	'k4' => function ($a, $b = array(array(new Foo()))) {},
+);
+$ar = fn (Foo $a = new Foo()) => $a;
+
+class ClassMethodsCanUseNew extends Something {
+    public function __construct(
+		public Foo $constructorProp = new Foo(),
+		$normalVar = new self(x: 2),
+	) {}
+
+    private function bar($a = new parent()) {}
+}
+
+$anon = new class {
+    public function __construct(
+		public Foo $constructorProp = new Foo(),
+		$normalVar = new Bar(),
+	) {}
+
+    private function bar($a = new Foo()) {}
+};
+
+interface InterfaceMethodsCanUseNew {
+    public function __construct(
+		$normalVar = new Bar,
+	);
+
+    public function bar($a = new Foo());
+}
+
+trait TraitMethodsCanUseNew {
+    public function __construct(
+		public Foo $constructorProp = new Foo,
+		$normalVar = new Bar(),
+	) {}
+
+    private function bar($a = new Foo()) {}
+}
+
+enum EnumMethodsCanUseNew: string {
+	case Example = 'test';
+    private function bar($a = new Foo) {}
+}
+
+
+/*
+ * Still not supported. Flag anyway.
+ */
+function bar($a, $b = new Foo($bar)) {}
+$cl = function ($a = new namespace\Foo(function_call())) {};
+
+function NewUsingUnsupportedArguments(
+    $c = new A(...[]), // argument unpacking
+    $d = new B($abc), // unsupported constant expression
+) {}
+
+
+/*
+ * Still not supported. Ignore.
+ */
+// `new` is not supported in OO constants or properties.
+class StillNotSupported {
+    const MINE = new Foo();
+    public $prop = new Foo();
+}
+
+$anon = new class {
+    const MINE = new Foo();
+    public $prop = new Foo();
+};
+
+interface InterfaceStillNotSupported {
+    const MINE = new Foo();
+}
+
+trait TraitStillNotSupported {
+    const MINE = new Foo;
+    public $prop = new Foo();
+}
+
+enum EnumStillNotSupported: string {
+    const MINE = new Foo;
+}
+
+// `new` using a dynamic of non-string class name or anonymous class is not allowed.
+function DynamicClassNameNotAllowed(
+    $a = new (CLASS_NAME_CONSTANT)(), // dynamic class name
+    $b = new $className(), // dynamic class name
+    $c = new class {}, // anonymous class
+    $d = new static() {}, // dynamic class name
+) {}
+
+// New at wrong nesting level, but function calls are not supported, so ignore.
+$cl = function ($a = function_call(new namespace\Foo)) {};

--- a/PHPCompatibility/Tests/InitialValue/NewNewInInitializersUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewNewInInitializersUnitTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\InitialValue;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewNewInInitializers sniff.
+ *
+ * @group newNewInInitializers
+ * @group initialValue
+ *
+ * @covers \PHPCompatibility\Sniffs\InitialValue\NewNewInInitializersSniff
+ *
+ * @since 10.0.0
+ */
+final class NewNewInInitializersUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Partial error phrases to be used in combination with the error message constant.
+     *
+     * @since 10.0.0.
+     *
+     * @var array
+     */
+    protected $initialValueTypes = [
+        'const'     => 'global/namespaced constants declared using the const keyword',
+        'property'  => '', // Not supported.
+        'staticvar' => 'static variables',
+        'default'   => 'default parameter values',
+    ];
+
+    /**
+     * Verify that new in initial values is correctly detected.
+     *
+     * @dataProvider dataNewInInitializer
+     *
+     * @param int    $line The line number.
+     * @param string $type Error type.
+     *
+     * @return void
+     */
+    public function testNewInInitializer($line, $type)
+    {
+        $file        = $this->sniffFile(__FILE__, '8.0');
+        $replacement = $this->initialValueTypes[$type];
+        $this->assertError($file, $line, "New in initializers is not supported in PHP 8.0 or earlier for {$replacement}.");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewInInitializer()
+     *
+     * @return array
+     */
+    public function dataNewInInitializer()
+    {
+        return [
+            [38, 'const'],
+            [39, 'const'],
+            [40, 'const'],
+            [44, 'staticvar'], // x2.
+            [45, 'staticvar'],
+            [49, 'default'],
+            [51, 'default'],
+            [52, 'default'],
+            [53, 'default'],
+            [54, 'default'],
+            [56, 'default'],
+            [60, 'default'],
+            [61, 'default'],
+            [64, 'default'],
+            [69, 'default'],
+            [70, 'default'],
+            [73, 'default'],
+            [78, 'default'],
+            [81, 'default'],
+            [86, 'default'],
+            [87, 'default'],
+            [90, 'default'],
+            [95, 'default'],
+
+            // Still not supported, but due to non-static parameters being passed to the constructor. Flag these anyway.
+            [102, 'default'],
+            [103, 'default'],
+            [106, 'default'],
+            [107, 'default'],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff doesn't throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+        for ($line = 1; $line <= 32; $line++) {
+            $data[] = [$line];
+        }
+
+        for ($line = 110; $line <= 148; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> `new` in Initializers
>
> It is now possible to use `new ClassName()` expressions as the default value of a parameter, static variable, global constant initializers, and as attribute arguments.

Refs:
* https://wiki.php.net/rfc/new_in_initializers
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.new-in-initializer
* https://github.com/php/php-src/pull/7153
* https://github.com/php/php-src/commit/52d3d0d8d7d75a2092687e77c78189a6567e515c

Includes unit tests.

Related to #1299