### PR TITLE
:sparkles: PHP 8.1: New `PHPCompatibility.InitialValue.NewNewInDefine` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInDefineSniff.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\InitialValue;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\Parentheses;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Detect declaration of constants using `define()` with an object (instantiation) as value
+ * as supported since PHP 8.1.
+ *
+ * PHP version 8.1
+ *
+ * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.new-in-initializer
+ *
+ * @since 10.0.0
+ */
+final class NewNewInDefineSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions the sniff is looking for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, bool> Key is the function name, value irrelevant.
+     */
+    protected $targetFunctions = [
+        'define' => true,
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('8.0') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $valueParam = PassedParameters::getParameterFromStack($parameters, 2, 'value');
+        if ($valueParam === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Nesting level will always be set as the parameter is within the parenthesis of the define() function call.
+        $targetNestingLevel = \count($tokens[$valueParam['start']]['nested_parenthesis']);
+
+        $start = $valueParam['start'];
+        while (($hasNew = $phpcsFile->findNext(\T_NEW, $start, ($valueParam['end'] + 1))) !== false) {
+            // Handle nesting within arrays.
+            $currentNestingLevel = 0;
+            foreach ($tokens[$hasNew]['nested_parenthesis'] as $opener => $closer) {
+                // Always count outer parentheses.
+                if ($opener < $valueParam['start']) {
+                    ++$currentNestingLevel;
+                    continue;
+                }
+
+                // Only count inner parentheses when they are not for an array.
+                $owner = Parentheses::getOwner($phpcsFile, $opener);
+                if ($owner === false || $tokens[$owner]['code'] !== \T_ARRAY) {
+                    ++$currentNestingLevel;
+                }
+            }
+
+            if ($currentNestingLevel === $targetNestingLevel) {
+                $phpcsFile->addError(
+                    'Passing an object as the value when declaring constants using define is not allowed in PHP 8.0 or earlier',
+                    $hasNew,
+                    'Found'
+                );
+                return;
+            }
+
+            $start = ($hasNew + 1);
+        }
+    }
+}

--- a/PHPCompatibility/Tests/InitialValue/NewNewInDefineUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewNewInDefineUnitTest.inc
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Valid cross-version.
+ */
+define('NO_NEW', 10);
+define('NESTED_NEW', mine(new Foo)); // Was already allowed as long as the return value was not an object.
+
+
+/*
+ * Not our targets.
+ */
+notDefine('NOT_DEFINE', new \Foo());
+
+define($name); // Missing required param, but not our concern.
+
+Some\Package\define('NOT_GLOBAL_FUNCTION', new Foo);
+$obj?->define('NOT_GLOBAL_FUNCTION', new Foo);
+ClassName::define('NOT_GLOBAL_FUNCTION', new Foo);
+
+class myClass {
+    const define = new Foo;
+    function &define($a, $b = new Foo) {}
+}
+
+
+/*
+ * Undetermined.
+ */
+define('VARIABLE_VALUE', $object);
+define('CONST_VALUE', Foo::CONST_NAME);
+define('PROP_VALUE', Foo::$prop);
+
+
+/*
+ * PHP 8.1 new in define.
+ */
+define('PASSING_NEW_OBJECT', new Foo);
+define('PASSING_NEW_WITH_PARAMS', new Foo($var));
+define('PASSING_NEW_WITH_NESTED_NEW', new Foo(new Bar())); // Will only throw 1 error.
+define(value: new Foo(), constant_name: 'NAMED_PARAMS', );
+
+// Handle nesting in arrays correctly. Prior to PHP 8.1, objects were not allowed in array values, now they are.
+define('OBJECT_IN_LONG_ARRAY', array(new Foo));
+define('OBJECT_IN_NESTED_LONG_ARRAY', array(array(new Foo)));
+define('OBJECT_IN_SHORT_ARRAY', [new Foo]);
+
+// Prevent false negatives when there is an outer array wrapper.
+$array = array(
+    function ($value) {
+        define($value, array(new Foo));
+    },
+);

--- a/PHPCompatibility/Tests/InitialValue/NewNewInDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewNewInDefineUnitTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\InitialValue;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewNewInDefine sniff.
+ *
+ * @group newNewInDefine
+ * @group initialValue
+ *
+ * @covers \PHPCompatibility\Sniffs\InitialValue\NewNewInDefineSniff
+ *
+ * @since 10.0.0
+ */
+final class NewNewInDefineUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify that objects (new class instantiations) being passed to define() are detected correctly.
+     *
+     * @dataProvider dataNewInDefine
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewInDefine($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Passing an object as the value when declaring constants using define is not allowed in PHP 8.0 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewInDefine()
+     *
+     * @return array
+     */
+    public function dataNewInDefine()
+    {
+        return [
+            [38],
+            [39],
+            [40],
+            [41],
+            [44],
+            [45],
+            [46],
+            [51],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff doesn't throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
+        for ($line = 1; $line <= 34; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> `new` in Initializers
>
> [...] Objects can also be passed to `define()` now.

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.new-in-initializer
* https://github.com/php/php-src/pull/7149
* https://github.com/php/php-src/commit/53aed48e5de2493787738f2945653110c30d694f

Includes unit tests.

Related to #1299