### PR TITLE
PHP 8.1 | Add support for and detection of intersection types in param, return and property types

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -24,6 +24,7 @@ use PHPCSUtils\Utils\Variables;
  * Typed class property declarations are available since PHP 7.4.
  * - Since PHP 8.0, `mixed` is allowed to be used as a property type.
  * - Since PHP 8.0, union types are supported and the union-only `false` and `null` types are available.
+ * - Since PHP 8.1, intersection types are supported for class/interface names.
  *
  * PHP version 7.4+
  *
@@ -31,6 +32,7 @@ use PHPCSUtils\Utils\Variables;
  * @link https://wiki.php.net/rfc/typed_properties_v2
  * @link https://wiki.php.net/rfc/mixed_type_v2
  * @link https://wiki.php.net/rfc/union_types_v2
+ * @link https://wiki.php.net/rfc/pure-intersection-types
  *
  * @since 9.2.0
  */
@@ -224,14 +226,24 @@ class NewTypedPropertiesSniff extends Sniff
                 [$origType]
             );
         } else {
-            $types       = \explode('|', $type);
-            $isUnionType = (\strpos($type, '|') !== false);
+            $types              = \preg_split('`[|&]`', $type, -1, \PREG_SPLIT_NO_EMPTY);
+            $isUnionType        = (\strpos($type, '|') !== false);
+            $isIntersectionType = (\strpos($type, '&') !== false);
 
             if ($this->supportsBelow('7.4') === true && $isUnionType === true) {
                 $phpcsFile->addError(
                     'Union types are not present in PHP version 7.4 or earlier. Found: %s' . $errorSuffix,
                     $typeToken,
                     'UnionTypeFound',
+                    [$origType]
+                );
+            }
+
+            if ($this->supportsBelow('8.0') === true && $isIntersectionType === true) {
+                $phpcsFile->addError(
+                    'Intersection types are not present in PHP version 8.0 or earlier. Found: %s',
+                    $typeToken,
+                    'IntersectionTypeFound',
                     [$origType]
                 );
             }

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -125,3 +125,19 @@ class ConstructorPropertyPromotionWithTypes {
 
 // Ignore. Not a constructor, so no property promotion.
 function __construct(float|int $x, callable $callMe) {}
+
+// PHP 8.1 intersection types.
+class IntersectionTypes() {
+    public MyClassA&\Package\MyClassB $intersection;
+    public Traversable&\Countable $countableIterator;
+
+    // Intentional fatal error - non-class/interface types are not allowed, but that's not the concern of the sniff.
+    public int&string $illegalIntersection;
+
+    // Intentional fatal error - hierarchical types are not allowed, but that's not the concern of the sniff.
+    public self&\Fully\Qualified\SomeInterface $selfNotAllowed;
+    public Qualified\SomeInterface&parent $parentNotAllowed;
+
+    // Intentional fatal error - duplicate types are not allowed, but that's not the concern of the sniff.
+    public A&B&A $duplicateIntersection;
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -92,6 +92,12 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             [115, true],
             [116],
             [117],
+            [131],
+            [132],
+            [135],
+            [138],
+            [139],
+            [142],
         ];
     }
 
@@ -351,6 +357,47 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             [81],
             [84],
             [99],
+        ];
+    }
+
+
+    /**
+     * Verify that an error is thrown for intersection types.
+     *
+     * @dataProvider dataNewIntersectionTypes
+     *
+     * @param string $type            The declared type.
+     * @param array  $line            The line number where the error is expected.
+     * @param bool   $testNoViolation Whether or not to test noViolation.
+     *                                Defaults to true.
+     *
+     * @return void
+     */
+    public function testNewIntersectionTypes($type, $line, $testNoViolation = true)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, "Intersection types are not present in PHP version 8.0 or earlier. Found: $type");
+
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewIntersectionTypes()
+     *
+     * @return array
+     */
+    public function dataNewIntersectionTypes()
+    {
+        return [
+            ['MyClassA&\Package\MyClassB', 131],
+            ['Traversable&\Countable', 132],
+            ['int&string', 135],
+            ['self&\Fully\Qualified\SomeInterface', 138],
+            ['Qualified\SomeInterface&parent', 139],
+            ['A&B&A', 142],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -132,3 +132,23 @@ class ConstructorPropertyPromotionWithTypes {
         mixed $normalParam3,
     ) {}
 }
+
+// PHP 8.1 intersection types.
+function NOTintersectionTypeBitwiseAndInDefault($var = CONSTANT_A & CONSTANT_B) {}
+
+function intersectionTypes(MyClassA&\Package\MyClassB $var) {}
+class IntersectionTypes {
+    public function setIterator(Traversable&\Countable $countableIterator): void {}
+}
+
+// Intentional fatal error - non-class/interface types are not allowed, but that's not the concern of the sniff.
+function intersectionTypesIllegalTypes(int&string $var) {}
+
+// Intentional fatal error - hierarchical types are not allowed, but that's not the concern of the sniff.
+class HierachicalIntersection {
+    function intersectionTypesIllegalTypes(self&\Fully\Qualified\SomeInterface $var) {}
+    function intersectionTypesIllegalTypes(Qualified\SomeInterface&parent $var) {}
+}
+
+// Intentional fatal error - duplicate types are not allowed, but that's not the concern of the sniff.
+function intersectionTypesIllegalTypes(A&B&A $var) {}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -123,6 +123,12 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             ['float', '5.6', 131, '8.0'],
             ['int', '5.6', 131, '8.0'],
             ['mixed', '7.4', 132, '8.0', false],
+
+            // Intersection types - OK version is 8.1.
+            ['int', '5.6', 145, '8.1'],
+            ['string', '5.6', 145, '8.1'],
+            ['self', '5.1', 149, '8.1'],
+            ['parent', '5.1', 150, '8.1'],
         ];
     }
 
@@ -392,6 +398,81 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             [96],
             [99],
             [113],
+        ];
+    }
+
+
+    /**
+     * Verify that an error is thrown for intersection types.
+     *
+     * @dataProvider dataNewIntersectionTypes
+     *
+     * @param string $type            The declared type.
+     * @param array  $line            The line number where the error is expected.
+     * @param bool   $testNoViolation Whether or not to test noViolation.
+     *                                Defaults to true.
+     *
+     * @return void
+     */
+    public function testNewIntersectionTypes($type, $line, $testNoViolation = true)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, "Intersection types are not present in PHP version 8.0 or earlier. Found: $type");
+
+        if ($testNoViolation === true) {
+            $file = $this->sniffFile(__FILE__, '8.1');
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewIntersectionTypes()
+     *
+     * @return array
+     */
+    public function dataNewIntersectionTypes()
+    {
+        return [
+            ['MyClassA&\Package\MyClassB', 139],
+            ['Traversable&\Countable', 141],
+            ['int&string', 145],
+            ['self&\Fully\Qualified\SomeInterface', 149],
+            ['Qualified\SomeInterface&parent', 150],
+            ['A&B&A', 154],
+        ];
+    }
+
+
+    /**
+     * Verify that no error is thrown when the type is not a union type.
+     *
+     * @dataProvider dataNewIntersectionTypesNoFalsePositives
+     *
+     * @param int $line Line number on which to expect an error.
+     *
+     * @return void
+     */
+    public function testNewIntersectionTypesNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewIntersectionTypesNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNewIntersectionTypesNoFalsePositives()
+    {
+        return [
+            [17],
+            [79],
+            [137],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -29,12 +29,12 @@ function ($a) {}
 function fooObject($a): ObJect {}
 
 function fooInterspersedWithComments($a) :
-	// Comment.
-	?
-	// phpcs:ignore Standard.Category.Sniff -- ignore something about a return type declaration.
-	\myNamespace\
-	// Comment.
-	Baz
+    // Comment.
+    ?
+    // phpcs:ignore Standard.Category.Sniff -- ignore something about a return type declaration.
+    \myNamespace\
+    // Comment.
+    Baz
 {
 }
 
@@ -88,12 +88,12 @@ function duplicateTypeInUnion(): int|string|INT {}
 
 // PHP 8.1 noreturn type
 function subTypeForAlwaysExitOrThrow(): never {
-	throw new Exception();
+    throw new Exception();
 }
 
 $closure = function() : Never {
-	redirect();
-	exit;
+    redirect();
+    exit;
 };
 
 // Invalid: nullable or union with void.
@@ -106,3 +106,23 @@ function mixedIsStandAloneB($a): int|MIXED {}
 // Invalid: nullable or union with never.
 function neverIsStandAloneA($a): ?never {}
 function neverIsStandAloneB($a): int|never {}
+
+
+// PHP 8.1 intersection types.
+function intersectionTypes($var):MyClassA&\Package\MyClassB {}
+class IntersectionTypes {
+    public function setIterator($countableIterator): Traversable&\Countable {}
+}
+
+// Intentional fatal error - non-class/interface types are not allowed, but that's not the concern of the sniff.
+function intersectionTypesIllegalTypes($var):int&string {}
+
+// Intentional fatal error - hierarchical types are not allowed, but that's not the concern of the sniff.
+class HierachicalIntersection {
+    function intersectionTypesIllegalTypes($var) : self&\Fully\Qualified\SomeInterface {}
+    function intersectionTypesIllegalTypes($var): Qualified\SomeInterface&parent {}
+    function intersectionTypesIllegalTypes($var): static&SomeInterface {}
+}
+
+// Intentional fatal error - duplicate types are not allowed, but that's not the concern of the sniff.
+function intersectionTypesIllegalTypes(): A&B&A {}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -123,6 +123,13 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             ['int', '5.6', 87, '8.0'],
             ['never', '8.0', 90, '8.1'],
             ['never', '8.0', 94, '8.1'],
+
+            // Intersection types - OK version is 8.1.
+            ['int', '5.6', 118, '8.1'],
+            ['string', '5.6', 118, '8.1'],
+            ['self', '5.6', 122, '8.1'],
+            ['parent', '5.6', 123, '8.1'],
+            ['static', '7.4', 124, '8.1'],
         ];
     }
 
@@ -314,6 +321,48 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             [61],
             [64],
             [76],
+        ];
+    }
+
+
+    /**
+     * Verify that an error is thrown for intersection types.
+     *
+     * @dataProvider dataNewIntersectionTypes
+     *
+     * @param string $type            The declared type.
+     * @param array  $line            The line number where the error is expected.
+     * @param bool   $testNoViolation Whether or not to test noViolation.
+     *                                Defaults to true.
+     *
+     * @return void
+     */
+    public function testNewIntersectionTypes($type, $line, $testNoViolation = true)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, "Intersection types are not present in PHP version 8.0 or earlier. Found: $type");
+
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewIntersectionTypes()
+     *
+     * @return array
+     */
+    public function dataNewIntersectionTypes()
+    {
+        return [
+            ['MyClassA&\Package\MyClassB', 112],
+            ['Traversable&\Countable', 114],
+            ['int&string', 118],
+            ['self&\Fully\Qualified\SomeInterface', 122],
+            ['Qualified\SomeInterface&parent', 123],
+            ['static&SomeInterface', 124],
+            ['A&B&A', 128],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.1 | NewParamTypeDeclarations: add support for intersection types

### PHP 8.1 | NewReturnTypeDeclarations: add support for intersection types

### PHP 8.1 | NewTypedProperties: add support for intersection types

> Intersection Types
>
> Support for intersection types has been added.

Detect whether a type is an intersection type and throw an error if PHP < 8.1 needs to be supported.

Ref:
* https://wiki.php.net/rfc/pure-intersection-types
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.intersection-types
* https://www.php.net/manual/en/language.types.type-system.php#language.types.type-system.composite.intersection
* php/php-src#6799
* php/php-src@069a9fa


Related to #1299