### PR TITLE
PHP 8.2 | Add support for and detection of stand-alone true, false, null in param, return and property types 

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -26,6 +26,7 @@ use PHPCSUtils\Utils\Variables;
  * - Since PHP 8.0, union types are supported and the union-only `false` and `null` types are available.
  * - Since PHP 8.1, intersection types are supported for class/interface names.
  * - Since PHP 8.2, `false` and `null` can be used as stand-alone types.
+ * - Since PHP 8.2, the `true` sub-type is available.
  *
  * PHP version 7.4+
  *
@@ -35,6 +36,7 @@ use PHPCSUtils\Utils\Variables;
  * @link https://wiki.php.net/rfc/union_types_v2
  * @link https://wiki.php.net/rfc/pure-intersection-types
  * @link https://wiki.php.net/rfc/null-false-standalone-types
+ * @link https://wiki.php.net/rfc/true-type
  *
  * @since 9.2.0
  */
@@ -75,6 +77,10 @@ class NewTypedPropertiesSniff extends Sniff
         'null' => [
             '7.4' => false,
             '8.0' => true,
+        ],
+        'true' => [
+            '8.1' => false,
+            '8.2' => true,
         ],
     ];
 

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -25,6 +25,7 @@ use PHPCSUtils\Utils\Variables;
  * - Since PHP 8.0, `mixed` is allowed to be used as a property type.
  * - Since PHP 8.0, union types are supported and the union-only `false` and `null` types are available.
  * - Since PHP 8.1, intersection types are supported for class/interface names.
+ * - Since PHP 8.2, `false` and `null` can be used as stand-alone types.
  *
  * PHP version 7.4+
  *
@@ -33,6 +34,7 @@ use PHPCSUtils\Utils\Variables;
  * @link https://wiki.php.net/rfc/mixed_type_v2
  * @link https://wiki.php.net/rfc/union_types_v2
  * @link https://wiki.php.net/rfc/pure-intersection-types
+ * @link https://wiki.php.net/rfc/null-false-standalone-types
  *
  * @since 9.2.0
  */
@@ -64,12 +66,12 @@ class NewTypedPropertiesSniff extends Sniff
             '7.4' => false,
             '8.0' => true,
         ],
-        // Union type only.
+        // Union type only in PHP 8.0 and 8.1.
         'false' => [
             '7.4' => false,
             '8.0' => true,
         ],
-        // Union type only.
+        // Union type only in PHP 8.0 and 8.1.
         'null' => [
             '7.4' => false,
             '8.0' => true,
@@ -94,7 +96,7 @@ class NewTypedPropertiesSniff extends Sniff
     ];
 
     /**
-     * Types which are only allowed to occur in union types.
+     * Types which are only allowed to occur in union types in PHP 8.0 and 8.1.
      *
      * @since 10.0.0
      *
@@ -270,9 +272,12 @@ class NewTypedPropertiesSniff extends Sniff
                         );
                     }
 
-                    if (isset($this->unionOnlyTypes[$type]) === true && $isUnionType === false) {
+                    if (isset($this->unionOnlyTypes[$type]) === true
+                        && $isUnionType === false
+                        && $this->supportsBelow('8.1') === true
+                    ) {
                         $phpcsFile->addError(
-                            "The '%s' type can only be used as part of a union type",
+                            "The '%s' type can only be used as part of a union type in PHP 8.1 or earlier",
                             $typeToken,
                             'NonUnion' . \ucfirst($type),
                             [$type]

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -33,6 +33,7 @@ use PHPCSUtils\Utils\Scopes;
  * - Since PHP 8.0, the `mixed` pseudo-type is available.
  * - Since PHP 8.0, union types are supported and the union-only `false` and `null` types are available.
  * - Since PHP 8.1, intersection types are supported for class/interface names.
+ * - Since PHP 8.2, `false` and `null` can be used as stand-alone types.
  *
  * Additionally, this sniff does a cursory check for typical invalid type declarations,
  * such as:
@@ -50,6 +51,7 @@ use PHPCSUtils\Utils\Scopes;
  * @link https://wiki.php.net/rfc/mixed_type_v2
  * @link https://wiki.php.net/rfc/union_types_v2
  * @link https://wiki.php.net/rfc/pure-intersection-types
+ * @link https://wiki.php.net/rfc/null-false-standalone-types
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
@@ -116,12 +118,12 @@ class NewParamTypeDeclarationsSniff extends Sniff
             '7.4' => false,
             '8.0' => true,
         ],
-        // Union type only.
+        // Union type only in PHP 8.0 and 8.1.
         'false' => [
             '7.4' => false,
             '8.0' => true,
         ],
-        // Union type only.
+        // Union type only in PHP 8.0 and 8.1.
         'null' => [
             '7.4' => false,
             '8.0' => true,
@@ -144,7 +146,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
     ];
 
     /**
-     * Types which are only allowed to occur in union types.
+     * Types which are only allowed to occur in union types in PHP 8.0 and 8.1.
      *
      * @since 10.0.0
      *
@@ -198,6 +200,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
         $supportsPHP4  = $this->supportsBelow('4.4');
         $supportsPHP7  = $this->supportsBelow('7.4');
         $supportsPHP80 = $this->supportsBelow('8.0');
+        $supportsPHP81 = $this->supportsBelow('8.1');
         $tokens        = $phpcsFile->getTokens();
 
         foreach ($paramNames as $param) {
@@ -283,9 +286,12 @@ class NewParamTypeDeclarationsSniff extends Sniff
                         );
                     }
 
-                    if (isset($this->unionOnlyTypes[$type]) === true && $isUnionType === false) {
+                    if (isset($this->unionOnlyTypes[$type]) === true
+                        && $isUnionType === false
+                        && $supportsPHP81 === true
+                    ) {
                         $phpcsFile->addError(
-                            "The '%s' type can only be used as part of a union type",
+                            "The '%s' type can only be used as part of a union type in PHP 8.1 or earlier",
                             $param['token'],
                             'NonUnion' . \ucfirst($type),
                             [$type]

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -34,6 +34,7 @@ use PHPCSUtils\Utils\Scopes;
  * - Since PHP 8.0, union types are supported and the union-only `false` and `null` types are available.
  * - Since PHP 8.1, intersection types are supported for class/interface names.
  * - Since PHP 8.2, `false` and `null` can be used as stand-alone types.
+ * - Since PHP 8.2, the `true` sub-type is available.
  *
  * Additionally, this sniff does a cursory check for typical invalid type declarations,
  * such as:
@@ -52,6 +53,7 @@ use PHPCSUtils\Utils\Scopes;
  * @link https://wiki.php.net/rfc/union_types_v2
  * @link https://wiki.php.net/rfc/pure-intersection-types
  * @link https://wiki.php.net/rfc/null-false-standalone-types
+ * @link https://wiki.php.net/rfc/true-type
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
@@ -127,6 +129,10 @@ class NewParamTypeDeclarationsSniff extends Sniff
         'null' => [
             '7.4' => false,
             '8.0' => true,
+        ],
+        'true' => [
+            '8.1' => false,
+            '8.2' => true,
         ],
     ];
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -27,6 +27,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * - Since PHP 8.0, union types are supported and the union-only `false` and `null` types are available.
  * - Since PHP 8.1, the stand-alone `never` type is available.
  * - Since PHP 8.1, intersection types are supported for class/interface names.
+ * - Since PHP 8.2, `false` and `null` can be used as stand-alone types.
  *
  * PHP version 7.0+
  *
@@ -41,6 +42,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * @link https://wiki.php.net/rfc/union_types_v2
  * @link https://wiki.php.net/rfc/noreturn_type
  * @link https://wiki.php.net/rfc/pure-intersection-types
+ * @link https://wiki.php.net/rfc/null-false-standalone-types
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
@@ -121,12 +123,12 @@ class NewReturnTypeDeclarationsSniff extends Sniff
             '7.4' => false,
             '8.0' => true,
         ],
-        // Union type only.
+        // Union type only in PHP 8.0 and 8.1.
         'false' => [
             '7.4' => false,
             '8.0' => true,
         ],
-        // Union type only.
+        // Union type only in PHP 8.0 and 8.1.
         'null' => [
             '7.4' => false,
             '8.0' => true,
@@ -139,7 +141,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
     ];
 
     /**
-     * Types which are only allowed to occur in union types.
+     * Types which are only allowed to occur in union types in PHP 8.0 and 8.1.
      *
      * @since 10.0.0
      *
@@ -249,9 +251,12 @@ class NewReturnTypeDeclarationsSniff extends Sniff
                     );
                 }
 
-                if (isset($this->unionOnlyTypes[$type]) === true && $isUnionType === false) {
+                if (isset($this->unionOnlyTypes[$type]) === true
+                    && $isUnionType === false
+                    && $this->supportsBelow('8.1') === true
+                ) {
                     $phpcsFile->addError(
-                        "The '%s' type can only be used as part of a union type",
+                        "The '%s' type can only be used as part of a union type in PHP 8.1 or earlier",
                         $returnTypeToken,
                         'NonUnion' . \ucfirst($type),
                         [$type]

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -28,6 +28,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * - Since PHP 8.1, the stand-alone `never` type is available.
  * - Since PHP 8.1, intersection types are supported for class/interface names.
  * - Since PHP 8.2, `false` and `null` can be used as stand-alone types.
+ * - Since PHP 8.2, the `true` sub-type is available.
  *
  * PHP version 7.0+
  *
@@ -43,6 +44,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * @link https://wiki.php.net/rfc/noreturn_type
  * @link https://wiki.php.net/rfc/pure-intersection-types
  * @link https://wiki.php.net/rfc/null-false-standalone-types
+ * @link https://wiki.php.net/rfc/true-type
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
@@ -137,6 +139,10 @@ class NewReturnTypeDeclarationsSniff extends Sniff
         'never' => [
             '8.0' => false,
             '8.1' => true,
+        ],
+        'true' => [
+            '8.1' => false,
+            '8.2' => true,
         ],
     ];
 

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -89,10 +89,10 @@ $anon = class() {
     // Intentional fatal error - nullability is not allowed with union types, but that's not the concern of the sniff.
     public ?int|float $unionTypesNullable;
 
-    // Intentional fatal error - null pseudotype is only allowed in union types.
+    // Intentional fatal error in PHP 8.0/8.1 - null pseudotype is only allowed in union types.
     public null $pseudoTypeNull;
 
-    // Intentional fatal error - false pseudotype is only allowed in union types.
+    // Intentional fatal error in PHP 8.0/8.1 - false pseudotype is only allowed in union types.
     public false $pseudoTypeFalse;
 
     // Intentional fatal error - false pseudotype is not allowed in combination with bool, but that's not the concern of the sniff.

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -141,3 +141,8 @@ class IntersectionTypes() {
     // Intentional fatal error - duplicate types are not allowed, but that's not the concern of the sniff.
     public A&B&A $duplicateIntersection;
 }
+
+// PHP 8.2 true type.
+class TrueType() {
+    public true $true = true;
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -310,7 +310,10 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
     public function testInvalidNonUnionNullFalseType($line, $type)
     {
         $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertError($file, $line, "'$type' type can only be used as part of a union type");
+        $this->assertError($file, $line, "'$type' type can only be used as part of a union type in PHP 8.1 or earlier");
+
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file, $line);
     }
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -98,6 +98,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             [138],
             [139],
             [142],
+            [147],
         ];
     }
 
@@ -221,6 +222,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             ['false', '7.4', 96, '8.0', false],
             ['false', '7.4', 99, '8.0'],
             ['mixed', '7.4', 116, '8.0', false],
+            ['true', '8.1', 147, '8.2'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -103,10 +103,10 @@ class FooBar {
 // Intentional fatal error - nullability is not allowed with union types, but that's not the concern of the sniff.
 $closure = function (?int|float $number) {};
 
-// Intentional fatal error - null pseudotype is only allowed in union types.
+// Intentional fatal error in PHP 8.0/8.1 - null pseudotype is only allowed in union types.
 function pseudoTypeNull(null $var = null) {}
 
-// Intentional fatal error - false pseudotype is only allowed in union types.
+// Intentional fatal error in PHP 8.0/8.1 - false pseudotype is only allowed in union types.
 function pseudoTypeFalse(false $var = false) {}
 
 // Intentional fatal error - false pseudotype is not allowed in combination with bool, but that's not the concern of the sniff.

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -152,3 +152,6 @@ class HierachicalIntersection {
 
 // Intentional fatal error - duplicate types are not allowed, but that's not the concern of the sniff.
 function intersectionTypesIllegalTypes(A&B&A $var) {}
+
+// PHP 8.2 true type.
+function pseudoTypeTrue(true $var = true) {}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -129,6 +129,8 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             ['string', '5.6', 145, '8.1'],
             ['self', '5.1', 149, '8.1'],
             ['parent', '5.1', 150, '8.1'],
+
+            ['true', '8.1', 157, '8.2'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -351,7 +351,10 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
     public function testInvalidNonUnionNullFalseType($line, $type)
     {
         $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertError($file, $line, "'$type' type can only be used as part of a union type");
+        $this->assertError($file, $line, "'$type' type can only be used as part of a union type in PHP 8.1 or earlier");
+
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file, $line);
     }
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -126,3 +126,6 @@ class HierachicalIntersection {
 
 // Intentional fatal error - duplicate types are not allowed, but that's not the concern of the sniff.
 function intersectionTypesIllegalTypes(): A&B&A {}
+
+// PHP 8.2 true type.
+function pseudoTypeTrue(): true {}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -66,10 +66,10 @@ function unionTypesAllPseudoTypes($var) : false|self|parent|static|iterable|Reso
 // Intentional fatal error - nullability is not allowed with union types, but that's not the concern of the sniff.
 $closure = function () use($a) :?int|float {};
 
-// Intentional fatal error - null pseudotype is only allowed in union types.
+// Intentional fatal error in PHP 8.0/8.1 - null pseudotype is only allowed in union types.
 function pseudoTypeNull(): null {}
 
-// Intentional fatal error - false pseudotype is only allowed in union types.
+// Intentional fatal error in PHP 8.0/8.1 - false pseudotype is only allowed in union types.
 function pseudoTypeFalse(): false {}
 
 // Intentional fatal error - false pseudotype is not allowed in combination with bool, but that's not the concern of the sniff.

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -274,7 +274,10 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
     public function testInvalidNonUnionNullFalseType($line, $type)
     {
         $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertError($file, $line, "'$type' type can only be used as part of a union type");
+        $this->assertError($file, $line, "'$type' type can only be used as part of a union type in PHP 8.1 or earlier");
+
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file, $line);
     }
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -130,6 +130,8 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             ['self', '5.6', 122, '8.1'],
             ['parent', '5.6', 123, '8.1'],
             ['static', '7.4', 124, '8.1'],
+
+            ['true', '8.1', 131, '8.2'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.2 | NewParamTypeDeclarations: add support for null and `false` as stand-alone types

### PHP 8.2 | NewReturnTypeDeclarations: add support for null and `false` as stand-alone types

### PHP 8.2 | NewTypedProperties: add support for null and false as stand-alone types

> Type System Improvements
>
> It is now possible to use `null` and `false` as stand-alone types.

The sniff already contained tests for the use of `null` and `false` as stand-alone types and would throw an error when detected.
This detection has now been limited to only throw an error when PHP 8.0/8.1 needs to be supported and the error message has been adjusted.

Ref:
* https://wiki.php.net/rfc/null-false-standalone-types
* https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.type-system
* php/php-src@6039c07

### PHP 8.2 | NewParamTypeDeclarations: add support for the true type

### PHP 8.2 | NewReturnTypeDeclarations: add support for the true type

### PHP 8.2 | NewTypedProperties: add support for the true type

> Type System Improvements
>
> The `true` type has been added

Detect use of `true` as a property type.

Ref:
* https://wiki.php.net/rfc/true-type
* https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.type-system
* php/php-src#8326

Related to #1348