### PR TITLE
Update terminology

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -690,20 +690,20 @@ abstract class Sniff implements PHPCS_Sniff
      */
     public function isVariable(File $phpcsFile, $start, $end, $targetNestingLevel)
     {
-        static $tokenBlackList, $bracketTokens;
+        static $tokenBlockList, $bracketTokens;
 
         // Create the token arrays only once.
-        if (isset($tokenBlackList, $bracketTokens) === false) {
-            $tokenBlackList  = [
+        if (isset($tokenBlockList, $bracketTokens) === false) {
+            $tokenBlockList  = [
                 \T_OPEN_PARENTHESIS => \T_OPEN_PARENTHESIS,
                 \T_STRING_CONCAT    => \T_STRING_CONCAT,
             ];
-            $tokenBlackList += Tokens::$assignmentTokens;
-            $tokenBlackList += Tokens::$equalityTokens;
-            $tokenBlackList += Tokens::$comparisonTokens;
-            $tokenBlackList += Tokens::$operators;
-            $tokenBlackList += Tokens::$booleanOperators;
-            $tokenBlackList += Tokens::$castTokens;
+            $tokenBlockList += Tokens::$assignmentTokens;
+            $tokenBlockList += Tokens::$equalityTokens;
+            $tokenBlockList += Tokens::$comparisonTokens;
+            $tokenBlockList += Tokens::$operators;
+            $tokenBlockList += Tokens::$booleanOperators;
+            $tokenBlockList += Tokens::$castTokens;
 
             /*
              * List of brackets which can be part of a variable variable.
@@ -732,20 +732,20 @@ abstract class Sniff implements PHPCS_Sniff
         }
 
         // Ok, so the first variable is at the right level, now are there any
-        // blacklisted tokens within the empty() ?
-        $hasBadToken = $phpcsFile->findNext($tokenBlackList, $start, $end);
+        // blocklisted tokens within the empty() ?
+        $hasBadToken = $phpcsFile->findNext($tokenBlockList, $start, $end);
         if ($hasBadToken === false) {
             return true;
         }
 
-        // If there are also bracket tokens, the blacklisted token might be part of a variable
+        // If there are also bracket tokens, the blocklisted token might be part of a variable
         // variable, but if there are no bracket tokens, we know we have an error.
         $hasBrackets = $phpcsFile->findNext($bracketTokens, $start, $end);
         if ($hasBrackets === false) {
             return false;
         }
 
-        // Ok, we have both a blacklisted token as well as brackets, so we need to walk
+        // Ok, we have both a blocklisted token as well as brackets, so we need to walk
         // the tokens of the variable variable.
         for ($i = $start; $i < $end; $i++) {
             // If this is a bracket token, skip to the end of the bracketed expression.
@@ -754,8 +754,8 @@ abstract class Sniff implements PHPCS_Sniff
                 continue;
             }
 
-            // If it's a blacklisted token, not within brackets, we have an error.
-            if (isset($tokenBlackList[$tokens[$i]['code']])) {
+            // If it's a blocklisted token, not within brackets, we have an error.
+            if (isset($tokenBlockList[$tokens[$i]['code']])) {
                 return false;
             }
         }

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\MessageHelper;
  * Suggests alternative extensions if available.
  *
  * As userland functions may be prefixed with a prefix also used by a native
- * PHP extension, the sniff offers the ability to whitelist specific functions
+ * PHP extension, the sniff offers the ability to allowlist specific functions
  * from being flagged by this sniff via a property in a custom ruleset
  * (since PHPCompatibility 7.0.2).
  *
@@ -43,7 +43,7 @@ class RemovedExtensionsSniff extends Sniff
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 
     /**
-     * A list of functions to whitelist, if any.
+     * A list of functions to allow, if any.
      *
      * This is intended for projects using functions which start with the same
      * prefix as one of the removed extensions.
@@ -51,7 +51,7 @@ class RemovedExtensionsSniff extends Sniff
      * This property can be set from the ruleset, like so:
      * <rule ref="PHPCompatibility.Extensions.RemovedExtensions">
      *   <properties>
-     *     <property name="functionWhitelist" type="array" value="mysql_to_rfc3339,mysql_another_function" />
+     *     <property name="functionAllowlist" type="array" value="mysql_to_rfc3339,mysql_another_function" />
      *   </properties>
      * </rule>
      *
@@ -59,7 +59,7 @@ class RemovedExtensionsSniff extends Sniff
      *
      * @var array
      */
-    public $functionWhitelist;
+    public $functionAllowlist;
 
     /**
      * A list of removed extensions with their alternative, if any.
@@ -271,8 +271,8 @@ class RemovedExtensionsSniff extends Sniff
         $function   = $tokens[$stackPtr]['content'];
         $functionLc = \strtolower($function);
 
-        if ($this->isWhiteListed($functionLc) === true) {
-            // Function is whitelisted.
+        if ($this->isAllowListed($functionLc) === true) {
+            // Function is allowlisted.
             return;
         }
 
@@ -289,7 +289,7 @@ class RemovedExtensionsSniff extends Sniff
 
 
     /**
-     * Is the current function being checked whitelisted ?
+     * Is the current function being checked allowlisted?
      *
      * Parsing the list late as it may be provided as a property, but also inline.
      *
@@ -299,23 +299,23 @@ class RemovedExtensionsSniff extends Sniff
      *
      * @return bool
      */
-    protected function isWhiteListed($content)
+    protected function isAllowListed($content)
     {
-        if (isset($this->functionWhitelist) === false) {
+        if (isset($this->functionAllowlist) === false) {
             return false;
         }
 
-        if (\is_string($this->functionWhitelist) === true) {
-            if (\strpos($this->functionWhitelist, ',') !== false) {
-                $this->functionWhitelist = \explode(',', $this->functionWhitelist);
+        if (\is_string($this->functionAllowlist) === true) {
+            if (\strpos($this->functionAllowlist, ',') !== false) {
+                $this->functionAllowlist = \explode(',', $this->functionAllowlist);
             } else {
-                $this->functionWhitelist = (array) $this->functionWhitelist;
+                $this->functionAllowlist = (array) $this->functionAllowlist;
             }
         }
 
-        if (\is_array($this->functionWhitelist) === true) {
-            $this->functionWhitelist = \array_map('strtolower', $this->functionWhitelist);
-            return \in_array($content, $this->functionWhitelist, true);
+        if (\is_array($this->functionAllowlist) === true) {
+            $this->functionAllowlist = \array_map('strtolower', $this->functionAllowlist);
+            return \in_array($content, $this->functionAllowlist, true);
         }
 
         return false;

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.inc
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.inc
@@ -64,16 +64,16 @@ mssql_bind();
 
 ereg();
 
-// @codingStandardsChangeSetting PHPCompatibility.Extensions.RemovedExtensions functionWhitelist mysql_to_rfc3339
+// @codingStandardsChangeSetting PHPCompatibility.Extensions.RemovedExtensions functionAllowlist mysql_to_rfc3339
 mysql_to_rfc3339();
 
 // PHP 7.1 removed extensions:
 mcrypt_encrypt();
 
-// @codingStandardsChangeSetting PHPCompatibility.Extensions.RemovedExtensions functionWhitelist ereg_convert,ereg_translate_to_preg
+// @codingStandardsChangeSetting PHPCompatibility.Extensions.RemovedExtensions functionAllowlist ereg_convert,ereg_translate_to_preg
 ereg_convert();
 ereg_translate_to_preg();
-ereg_replace(); // Non-whitelisted.
+ereg_replace(); // Non-allowlisted.
 
 ibase_trans();
 wddx_deserialize();

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -226,9 +226,9 @@ class RemovedExtensionsUnitTest extends BaseSniffTest
             [58], // Function declaration.
             [59], // Class instantiation.
             [60], // Method call.
-            [68], // Whitelisted function.
-            [74], // Whitelisted function array.
-            [75], // Whitelisted function array.
+            [68], // Allowlisted function.
+            [74], // Allowlisted function array.
+            [75], // Allowlisted function array.
             [82], // Live coding.
         ];
     }

--- a/README.md
+++ b/README.md
@@ -208,12 +208,12 @@ At this moment, there are two sniffs which have a property which can be set via 
 The `PHPCompatibility.Extensions.RemovedExtensions` sniff checks for removed extensions based on the function prefix used for these extensions.
 This might clash with userland functions using the same function prefix.
 
-To whitelist userland functions, you can pass a comma-delimited list of function names to the sniff.
+To allowlist userland functions, you can pass a comma-delimited list of function names to the sniff.
 ```xml
-    <!-- Whitelist the mysql_to_rfc3339() and mysql_another_function() functions. -->
+    <!-- Allowlist the mysql_to_rfc3339() and mysql_another_function() functions. -->
     <rule ref="PHPCompatibility.Extensions.RemovedExtensions">
         <properties>
-            <property name="functionWhitelist" type="array" value="mysql_to_rfc3339,mysql_another_function"/>
+            <property name="functionAllowlist" type="array" value="mysql_to_rfc3339,mysql_another_function"/>
         </properties>
     </rule>
 ```


### PR DESCRIPTION
Fixes https://github.com/PHPCompatibility/PHPCompatibility/issues/1404.

## Rename "blacklist" to "blocklist"

Except for `opcache.blacklist_filename` which is a PHP config: https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.blacklist-filename

There was a PR (https://github.com/php/php-src/pull/5685) to rename it to `opcache.exclude_list_filename` but they couldn't reach consensus.

## Rename "whitelist" to "allowlist"

Except for `phpunit.xml.dist` which is PHPUnit config.

However, when only needing PHPUnit 9.3 the following change can be made (re: https://github.com/sebastianbergmann/phpunit/issues/4288):

```diff
diff --git a/phpunit.xml.dist b/phpunit.xml.dist
index 5439d0d..ee11909 100644
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,12 +22,12 @@
     </testsuites>
 
     <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
+        <coverage includeUncoveredFiles="true" processUncoveredFiles="false">
             <file>./PHPCompatibility/Sniff.php</file>
             <file>./PHPCompatibility/AbstractInitialValueSniff.php</file>
             <directory>./PHPCompatibility/Sniffs/</directory>
             <directory>./PHPCompatibility/Helpers/</directory>
-        </whitelist>
+        </coverage>
     </filter>
 
     <logging>
```


