### PR TITLE
ForbiddenNames: fix bug in enum special casing

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -290,6 +290,7 @@ class ForbiddenNamesSniff extends Sniff
                     if ($tokens[$prevNonEmpty]['code'] === \T_DOUBLE_COLON
                         || $tokens[$prevNonEmpty]['code'] === \T_EXTENDS
                         || $tokens[$prevNonEmpty]['code'] === \T_IMPLEMENTS
+                        || $tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR
                     ) {
                         // Use of a construct named `enum`, not an enum declaration.
                         return;

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
@@ -377,3 +377,6 @@ class EnumSpecialCasingTest
         self::ENUM xor \false;
     }
 }
+
+// Issue #1474: more protection against `enum` false positives.
+use Elao\Enum\Bridge\Symfony\Validator\Constraint\Enum as AssertEnum;


### PR DESCRIPTION
Follow up on #1434

In a few cases, the `enum` keyword will be tokenized as `T_STRING`, but should still be treated as the keyword. The sniff was not selective enough about this though and would incorrectly treat a `enum` when used in a namespaced name as the `enum` keyword.

Fixed now.

Includes test.

Fixes #1474