### PR TITLE
NewKeywords: minor improvement

### DIFF
--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.inc
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.inc
@@ -75,7 +75,7 @@ function testYieldFrom() {
     yield from [3, 4];
     yield
 		from [3, 4]; // This is yield from, but tokenized as two T_YIELD_FROM tokens.
-    yield /*something*/ from [3, 4]; // Test against false positive.
+    yield /*something*/ From [3, 4]; // Test against false positive. Tokenized as T_YIELD + T_STRING prior to PHP 8.3.
 }
 
 // Normal Heredoc is ok.

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -169,7 +169,6 @@ class NewKeywordsUnitTest extends BaseSniffTest
     {
         return [
             [33],
-            [78],
         ];
     }
 
@@ -214,6 +213,7 @@ class NewKeywordsUnitTest extends BaseSniffTest
         return [
             [75],
             [76],
+            [78],
         ];
     }
 


### PR DESCRIPTION
Prior to PHP 8.3, a `yield /*comment*/ from` sequence would be tokenized by PHP (and PHPCS) as `T_YIELD` + `T_COMMENT` + `T_STRING`.

Based on the current test failure on PHP 8.3, this will change in PHP 8.3 and the sequence will now tokenize as `T_YIELD_FROM`.

As the actual test is about `yield from` anyway, I've elected to make this work the same across all PHP versions and to always report this for the use of `yield from` instead of `yield`.

Includes updated test.