### PR TITLE
CS: various minor cleanup

### DIFF
--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -13,7 +13,6 @@ namespace PHPCompatibility\Helpers;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCompatibility\Sniff;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\GetTokensAsString;

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -16,7 +16,6 @@ use PHP_CodeSniffer\Sniffs\Sniff as PHPCS_Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\TestVersionTrait;
 use PHPCSUtils\Tokens\Collections;
-use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -464,8 +464,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
 
                 if (empty($tokens[$j]['nested_parenthesis']) === false) {
                     $parentheses = $tokens[$j]['nested_parenthesis'];
-                    end($parentheses);
-                    $openParens   = key($parentheses);
+                    \end($parentheses);
+                    $openParens   = \key($parentheses);
                     $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($openParens - 1), null, true);
                     if ($prevNonEmpty !== false
                         && $tokens[$prevNonEmpty]['code'] === \T_UNSET

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -235,7 +235,7 @@ class NewKeywordsSniff extends Sniff
         if ($tokenType === 'T_YIELD') {
             $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
             if ($tokens[$nextToken]['code'] === \T_STRING
-                && strtolower($tokens[$nextToken]['content']) === 'from'
+                && \strtolower($tokens[$nextToken]['content']) === 'from'
             ) {
                 $tokenType = 'T_YIELD_FROM';
                 $end       = $nextToken;

--- a/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
@@ -11,7 +11,6 @@
 namespace PHPCompatibility\Sniffs\Numbers;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\Numbers;
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
@@ -141,7 +141,7 @@ class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCallParame
             $length    = \strlen($embedInfo['remaining']);
             if ($embedInfo['remaining'] !== $content) {
                 // Add 1 character to the count for each variable stripped.
-                $length += count($embedInfo['embeds']);
+                $length += \count($embedInfo['embeds']);
             }
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -13,7 +13,6 @@ namespace PHPCompatibility\Sniffs\Syntax;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Utils\Operators;
 
 /**
  * Detect class member access on object instantiation/cloning.

--- a/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
@@ -12,7 +12,6 @@ namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\GetTokensAsString;
-use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\TextStrings;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -16,7 +16,6 @@ use PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff;
 use PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Utils\Operators;
 
 /**
  * Using the curly brace syntax to access array or string offsets has been deprecated in PHP 7.4

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -76,7 +76,7 @@ class NewHeredocUnitTest extends BaseSniffTest
             [156, 'constants'],
         ];
 
-        if (PHP_VERSION_ID >= 70300) {
+        if (\PHP_VERSION_ID >= 70300) {
             $data[] = [165, 'static variables'];
         }
 

--- a/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.php
@@ -11,7 +11,6 @@
 namespace PHPCompatibility\Tests\Numbers;
 
 use PHPCompatibility\Tests\BaseSniffTest;
-use PHPCSUtils\BackCompat\Helper;
 
 /**
  * Tests for the NewExplicitOctalNotationSniff sniff.

--- a/PHPCompatibility/Util/Tests/Helpers/ComplexVersionDeprecatedRemovedFeatureTraitUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ComplexVersionDeprecatedRemovedFeatureTraitUnitTest.php
@@ -35,7 +35,7 @@ final class ComplexVersionDeprecatedRemovedFeatureTraitUnitTest extends TestCase
     {
         if (\method_exists($this, 'expectException')) {
             // PHPUnit 5+.
-            if (PHP_VERSION_ID >= 70000) {
+            if (\PHP_VERSION_ID >= 70000) {
                 $this->expectException('TypeError');
             } else {
                 $this->expectException('PHPUnit_Framework_Error');
@@ -240,7 +240,7 @@ final class ComplexVersionDeprecatedRemovedFeatureTraitUnitTest extends TestCase
     {
         if (\method_exists($this, 'expectException')) {
             // PHPUnit 5+.
-            if (PHP_VERSION_ID >= 70000) {
+            if (\PHP_VERSION_ID >= 70000) {
                 $this->expectException('TypeError');
             } else {
                 $this->expectException('PHPUnit_Framework_Error');

--- a/PHPCompatibility/Util/Tests/Helpers/ComplexVersionNewFeatureTraitUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ComplexVersionNewFeatureTraitUnitTest.php
@@ -35,7 +35,7 @@ final class ComplexVersionNewFeatureTraitUnitTest extends TestCase
     {
         if (\method_exists($this, 'expectException')) {
             // PHPUnit 5+.
-            if (PHP_VERSION_ID >= 70000) {
+            if (\PHP_VERSION_ID >= 70000) {
                 $this->expectException('TypeError');
             } else {
                 $this->expectException('PHPUnit_Framework_Error');
@@ -150,7 +150,7 @@ final class ComplexVersionNewFeatureTraitUnitTest extends TestCase
     {
         if (\method_exists($this, 'expectException')) {
             // PHPUnit 5+.
-            if (PHP_VERSION_ID >= 70000) {
+            if (\PHP_VERSION_ID >= 70000) {
                 $this->expectException('TypeError');
             } else {
                 $this->expectException('PHPUnit_Framework_Error');

--- a/PHPCompatibility/Util/Tests/Helpers/TestVersionTraitUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/TestVersionTraitUnitTest.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Util\Tests\Helpers;
 
 use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Config;
 use PHPCompatibility\Helpers\TestVersionTrait;
 use PHPCSUtils\BackCompat\Helper;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
@@ -45,9 +46,7 @@ class TestVersionTraitUnitTest extends TestCase
      */
     public static function initializeConfig()
     {
-        if (\class_exists('\PHP_CodeSniffer\Config') === true) {
-            self::$config = new \PHP_CodeSniffer\Config();
-        }
+        self::$config = new Config();
     }
 
     /**


### PR DESCRIPTION
Mostly removing a few unused `use` statements (after previous changes) and fixing up the use of global constants and functions to be fully qualified.