### PR TITLE
Mark all Helper traits as "internal"

### DIFF
--- a/PHPCompatibility/Helpers/ComplexVersionDeprecatedRemovedFeatureTrait.php
+++ b/PHPCompatibility/Helpers/ComplexVersionDeprecatedRemovedFeatureTrait.php
@@ -22,6 +22,11 @@ use PHPCSUtils\Utils\MessageHelper;
  * - Other than this, the array can contain arbitrary additional key-value entries for
  *   use by the sniff. These will be disregarded by this trait.
  *
+ * ---------------------------------------------------------------------------------------------
+ * This trait is only intended for internal use by PHPCompatibility and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
  * @since 10.0.0 Refactored out from the previous `AbstractNewFeatureSniff` class.
  */
 trait ComplexVersionDeprecatedRemovedFeatureTrait

--- a/PHPCompatibility/Helpers/ComplexVersionNewFeatureTrait.php
+++ b/PHPCompatibility/Helpers/ComplexVersionNewFeatureTrait.php
@@ -21,6 +21,11 @@ use PHPCSUtils\Utils\MessageHelper;
  * - Other than this, the array can contain arbitrary additional key-value entries for
  *   use by the sniff. These will be disregarded by this trait.
  *
+ * ---------------------------------------------------------------------------------------------
+ * This trait is only intended for internal use by PHPCompatibility and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
  * @since 10.0.0 Refactored out from the previous `AbstractNewFeatureSniff` class.
  */
 trait ComplexVersionNewFeatureTrait

--- a/PHPCompatibility/Helpers/DisableSniffMsgTrait.php
+++ b/PHPCompatibility/Helpers/DisableSniffMsgTrait.php
@@ -18,6 +18,11 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * Used by the Upgrade LowPHP/LowPHPCS sniffs.
  *
+ * ---------------------------------------------------------------------------------------------
+ * This trait is only intended for internal use by PHPCompatibility and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
  * @since 10.0.0 Extracted duplicate code from the above mentioned sniffs into this trait.
  */
 trait DisableSniffMsgTrait

--- a/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
+++ b/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
@@ -19,6 +19,11 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * Used by the new/removed hash algorithm sniffs.
  *
+ * ---------------------------------------------------------------------------------------------
+ * This trait is only intended for internal use by PHPCompatibility and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
  * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
  *
  * @since 5.5

--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -25,6 +25,11 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * Used by the NewPCREModifiersSniff/RemovedPCREModifiersSniff sniffs.
  *
+ * ---------------------------------------------------------------------------------------------
+ * This trait is only intended for internal use by PHPCompatibility and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
  * @since 10.0.0 Logic split off from the `RemovedPCREModifiersSniff` sniff to this trait.
  */
 trait PCRERegexTrait

--- a/PHPCompatibility/Helpers/TestVersionTrait.php
+++ b/PHPCompatibility/Helpers/TestVersionTrait.php
@@ -17,6 +17,11 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * Used by nearly all sniffs.
  *
+ * ---------------------------------------------------------------------------------------------
+ * This trait is only intended for internal use by PHPCompatibility and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
  * @since 5.6    Base methods introduced in the generic `Sniff` class.
  * @since 10.0.0 Methods moved from the generic `Sniff` class to a dedicated trait to
  *               allow for sniffs which don't extends the PHPCompatibility `Sniff` class.


### PR DESCRIPTION
... with no guarantee of BC.

As these traits are all new per version 10.0.0, let's set expectations correctly from the start.