### PR TITLE
:sparkles: New `PHPCompatibility.Classes.ForbiddenExtendingFinalPHPClass` sniff

### DIFF
--- a/PHPCompatibility/Docs/Classes/ForbiddenExtendingFinalPHPClassStandard.xml
+++ b/PHPCompatibility/Docs/Classes/ForbiddenExtendingFinalPHPClassStandard.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Forbidden Extending Final PHP Class"
+    >
+    <standard>
+    <![CDATA[
+    A limited number of PHP native classes have been declared as `final` and are not allowed to be extended by userland code.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: not extending a final class.">
+        <![CDATA[
+class Incomplete {}
+class MyClass <em>extends NonFinalClass</em> {}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.0: extending the PHP native __PHP_Incomplete_Class which became final in PHP 8.0.">
+        <![CDATA[
+class Foo <em>extends __PHP_Incomplete_Class</em> {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Detect extending of PHP native classes which became final at some point.
+ *
+ * PHP version 8.0+
+ *
+ * @since 10.0.0
+ */
+class ForbiddenExtendingFinalPHPClassSniff extends Sniff
+{
+
+    /**
+     * A list of PHP native classes which became final at some point.
+     *
+     * @since 10.0.0
+     *
+     * @var array(string => int) Key is the fully qualified classname.
+     *                           Value the PHP version in which the class became final.
+     */
+    protected $finalClasses = [
+        '\__PHP_Incomplete_Class' => '8.0',
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        // Handle case-insensitivity of class names.
+        $this->finalClasses = \array_change_key_case($this->finalClasses, \CASE_LOWER);
+
+        return [
+            \T_CLASS,
+            \T_ANON_CLASS,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $FQClassName = $this->getFQExtendedClassName($phpcsFile, $stackPtr);
+        if ($FQClassName === '') {
+            return;
+        }
+
+        $classNameLc = \strtolower($FQClassName);
+
+        if (isset($this->finalClasses[$classNameLc]) === false) {
+            return;
+        }
+
+        if ($this->supportsAbove($this->finalClasses[$classNameLc]) === false) {
+            return;
+        }
+
+        $data = [
+            \substr($FQClassName, 1), // Remove global namespace indicator.
+            $this->finalClasses[$classNameLc],
+        ];
+
+        $phpcsFile->addError(
+            'The built-in class %s is final since PHP %s and cannot be extended',
+            $stackPtr,
+            'Found',
+            $data
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace {
+    // OK.
+    class NotExtended {}
+    class ImplementsNotExtended implements Foo {}
+    class MyClass extends PHP_Incomplete_Class {}
+    $anonClass = new class extends SomethingElse {};
+    class NotThePHPNativeClass extends My\NS\__PHP_Incomplete_Class {}
+
+    // Extending a final class.
+    class Incomplete extends __PHP_Incomplete_Class {}
+    $anonClass = new class extends \__PHP_Incomplete_Class {};
+}
+
+namespace MyNamespace {
+    // OK.
+    class NotExtended {}
+    class ImplementsNotExtended implements Foo {}
+    class MyClass extends PHP_Incomplete_Class {}
+    class NotThePHPNativeClass extends \My\__PHP_Incomplete_Class {}
+
+    // Extending a final class.
+    $anonClass = new class extends \__PHP_Incomplete_Class {};
+}

--- a/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the ForbiddenExtendingFinalPHPClass sniff.
+ *
+ * @group forbiddenExtendingFinalPHPClass
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\ForbiddenExtendingFinalPHPClassSniff
+ *
+ * @since 10.0.0
+ */
+class ForbiddenExtendingFinalPHPClassUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Verify an error is thrown when a PHP native class which became final is being extended.
+     *
+     * @dataProvider dataForbiddenExtendingFinalPHPClass
+     *
+     * @param string $className Class name.
+     * @param string $finalIn   The PHP version in which the class was made final.
+     * @param array  $line      The line number in the test file which apply to this class.
+     * @param string $okVersion A PHP version in which the class was ok to be extended.
+     *
+     * @return void
+     */
+    public function testForbiddenExtendingFinalPHPClass($className, $finalIn, $line, $okVersion)
+    {
+        $file = $this->sniffFile(__FILE__, $finalIn);
+        $this->assertError($file, $line, "The built-in class {$className} is final since PHP {$finalIn} and cannot be extended");
+
+        $file = $this->sniffFile(__FILE__, $okVersion);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenExtendingFinalPHPClass()
+     *
+     * @return array
+     */
+    public function dataForbiddenExtendingFinalPHPClass()
+    {
+        return [
+            ['__PHP_Incomplete_Class', '8.0', 12, '7.4'],
+            ['__PHP_Incomplete_Class', '8.0', 13, '7.4'],
+            ['__PHP_Incomplete_Class', '8.0', 24, '7.4'],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return [
+            [5],
+            [6],
+            [7],
+            [8],
+            [9],
+            [18],
+            [19],
+            [20],
+            [21],
+        ];
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4'); // Low version before the first change to final.
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
From the PHP 8.0 changelogs:

> Implemented FR #78638 (__PHP_Incomplete_Class should be final)

Refs:
* https://github.com/php/php-src/blob/0e45ed772df304c58f151d75d75f4ab5d9192c5b/NEWS#L1526
* https://github.com/php/php-src/commit/b418f335d4a764c5d1d4ae59d6c1d0a0bd2550f4

To address this change, I'm introducing a new array based sniff which allows for more classes to be added if/when more native PHP classes would become `final`.

Includes unit tests.