### PR TITLE
:sparkles: PHP 8.1: New PHPCompatibility.Variables.RemovedIndirectModificationOfGlobals sniff

### DIFF
--- a/PHPCompatibility/Docs/Variables/RemovedIndirectModificationOfGlobalsStandard.xml
+++ b/PHPCompatibility/Docs/Variables/RemovedIndirectModificationOfGlobalsStandard.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed Indirect Modification of $GLOBALS"
+    >
+    <standard>
+    <![CDATA[
+    As of PHP 8.1, the `$GLOBALS` array is effectively a read-only copy of the global symbol table.
+
+    This has the following side-effects:
+    - The recursive `$GLOBALS['GLOBALS']` entry no longer exists.
+    - Appending unnamed entries to the `$GLOBALS` array is no longer supported.
+    - Assignments which overwrite the `$GLOBALS` array are no longer allowed. This includes unsetting the `$GLOBALS` variable and passing the `$GLOBALS` variable to functions which would modify the received parameter by reference.
+    - Creating a reference to the `$GLOBALS` array is no longer allowed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: appending a named entry to $GLOBALS.">
+        <![CDATA[
+$GLOBALS['name'] = 'value';
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.1: appending an unnamed entry to $GLOBALS.">
+        <![CDATA[
+$GLOBALS[] = 'value';
+        ]]>
+        </code>
+    </code_comparison>
+
+    <code_comparison>
+        <code title="Cross-version compatible: overwriting a subkey in the $GLOBALS array.">
+        <![CDATA[
+$GLOBALS['name'] = 'value';
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.1: overwriting the complete $GLOBALS array.">
+        <![CDATA[
+$GLOBALS = [];
+list($GLOBALS) = $array;
+foreach ($array as $GLOBALS) {}
+
+// Modification by reference.
+array_pop($GLOBALS);
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    Prior to PHP 8.1, assignment of the `$GLOBALS` variable to another variable would effectively function like a reference.
+    Since PHP 8.1, it creates a by-value copy.
+
+    This leads to a change in behaviour when values are subsequently overwritten.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Behaviour in PHP &lt; 8.1.">
+        <![CDATA[
+$a = 1;
+
+// Ostensibly by-value copy, but not really.
+$globals = $GLOBALS;
+
+$globals['a'] = 2;
+var_dump($a); // int(2)
+        ]]>
+        </code>
+        <code title="Behaviour in PHP &gt;= 8.1.">
+        <![CDATA[
+$a = 1;
+
+// By-value copy.
+$globals = $GLOBALS;
+
+$globals['a'] = 2;
+var_dump($a); // int(1)
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    The behaviour for how integer and float variable names are treated with respect to the `$GLOBALS` array has changed in PHP 8.1.
+
+    Normal array key semantics only allow for integer and string keys and canonicalize integral string keys to integers.
+    Prior to PHP 8.1, the way variables with integer or float names were stored in the `$GLOBALS` array was inconsistent with these normal array key semantics.
+
+    This has been fixed in PHP 8.1, which results in a change in behaviour for variables with an integer or floating point number as the variable name.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Behaviour in PHP &lt; 8.1.">
+        <![CDATA[
+${1} = 1;
+$GLOBALS[1] = 2;
+var_dump(${1}); // int(1)
+        ]]>
+        </code>
+        <code title="Behaviour in PHP &gt;= 8.1.">
+        <![CDATA[
+${1} = 1;
+$GLOBALS[1] = 2;
+var_dump(${1}); // int(2)
+        ]]>
+        </code>
+    </code_comparison>
+
+</documentation>

--- a/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
@@ -1,0 +1,356 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Variables;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Context;
+use PHPCSUtils\Utils\Operators;
+use PHPCSUtils\Utils\Parentheses;
+use PHPCSUtils\Utils\PassedParameters;
+use PHPCSUtils\Utils\TextStrings;
+use ReflectionFunction;
+
+/**
+ * Detect indirect modification of the `$GLOBALS` variable and related changes in PHP 8.1.
+ *
+ * As of PHP 8.1, the `$GLOBALS` array is effectively a read-only copy of the global symbol table.
+ *
+ * This has the following side-effects:
+ * - The recursive `$GLOBALS['GLOBALS']` entry no longer exists.
+ * - Appending unnamed entries to the `$GLOBALS` array is no longer supported.
+ * - Assignments which overwrite the `$GLOBALS` array are no longer allowed.
+ *   This includes unsetting the `$GLOBALS` variable and passing the `$GLOBALS` variable
+ *   to functions which would modify the received parameter by reference.
+ * - Creating a reference to the `$GLOBALS` array is no longer allowed.
+ *
+ * Additionally, there are a couple of situations in which the behaviour around the use of $GLOBALS
+ * has changed.
+ *
+ * PHP version 8.1
+ *
+ * @link https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.globals-access
+ * @link https://wiki.php.net/rfc/restrict_globals_usage
+ *
+ * @since 10.0.0
+ */
+final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
+{
+
+    const WRITE_ERROR = 'Only individual keys in the $GLOBALS variable can be modified. The top-level $GLOBALS variable is read-only since PHP 8.1. Detected: %s';
+
+    /**
+     * List of PHP native functions.
+     *
+     * Will be set the first time the list is needed.
+     *
+     * @var array<string, int> Key is the function name in lowercase, value irrelevant.
+     */
+    private $phpNativeFunctions;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [\T_VARIABLE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('8.1') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['content'] !== '$GLOBALS') {
+            return;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
+            // Live coding or parse error.
+            return;
+        }
+
+        if ($tokens[$nextNonEmpty]['code'] === \T_OPEN_SQUARE_BRACKET) {
+            if (isset($tokens[$nextNonEmpty]['bracket_closer']) === false) {
+                // Live coding or parse error.
+                return;
+            }
+
+            $searchStart = ($nextNonEmpty + 1);
+            $searchEnd   = $tokens[$nextNonEmpty]['bracket_closer'];
+
+            $hasNonEmptyTokens = $phpcsFile->findNext(Tokens::$emptyTokens, $searchStart, $searchEnd, true);
+            if ($hasNonEmptyTokens === false) {
+                // Assigning to a new array key.
+                $phpcsFile->addError(
+                    'Appending a new non-named array entry to the $GLOBALS variable is not allowed since PHP 8.1.',
+                    $stackPtr,
+                    'Appending'
+                );
+                return;
+            }
+
+            $allowedNumeric             = Tokens::$emptyTokens;
+            $allowedNumeric[\T_LNUMBER] = \T_LNUMBER;
+            $allowedNumeric[\T_DNUMBER] = \T_DNUMBER;
+
+            $hasNonNumeric = $phpcsFile->findNext($allowedNumeric, $searchStart, $searchEnd, true);
+            if ($hasNonNumeric === false) {
+                if ($this->supportsBelow('8.0') === true) {
+                    // This warning will only be thrown when both PHP < 8.1 and PHP 8.1+ need to be supported.
+                    $phpcsFile->addWarning(
+                        'The way variables with an integer or floating point variable name are stored in the $GLOBALS variable has changed in PHP 8.1. Please review your code to evaluate the impact.',
+                        $stackPtr,
+                        'NumericKey'
+                    );
+                }
+                return;
+            }
+
+            /*
+             * Note: doesn't allow for heredoc/nowdoc string keys, but that would be excedingly rare anyway.
+             * Also doesn't allow for T_DOUBLE_QUOTED_STRING as that means there is variable interpolation
+             * and that would never result in a match anyway.
+             */
+            $allowedText = Tokens::$emptyTokens;
+            $allowedText[\T_CONSTANT_ENCAPSED_STRING] = \T_CONSTANT_ENCAPSED_STRING;
+
+            $hasNonText = $phpcsFile->findNext($allowedText, $searchStart, $searchEnd, true);
+            if ($hasNonText === false) {
+                $key = $phpcsFile->findNext([\T_CONSTANT_ENCAPSED_STRING], $searchStart, $searchEnd);
+                if (TextStrings::stripQuotes($tokens[$key]['content']) === 'GLOBALS') {
+                    $phpcsFile->addError(
+                        'The recursive $GLOBALS[\'GLOBALS\'] key no longer exists since PHP 8.1.',
+                        $key,
+                        'RecursiveKeyAccess'
+                    );
+                    return;
+                }
+            }
+
+            // In all other cases, this will be in access/use of $GLOBALS with a key without changed behaviour.
+            return;
+        }
+
+        $lastOwner = Parentheses::getLastOwner($phpcsFile, $stackPtr);
+        if ($tokens[$lastOwner]['code'] === \T_UNSET) {
+            $phpcsFile->addError(
+                'Unsetting the $GLOBALS variable is not allowed since PHP 8.1.',
+                $stackPtr,
+                'Unset'
+            );
+            return;
+        }
+
+        if ($tokens[$lastOwner]['code'] === \T_LIST) {
+            $phpcsFile->addError(
+                \sprintf(self::WRITE_ERROR, 'list assignment'),
+                $stackPtr,
+                'ListWrite'
+            );
+            return;
+        }
+
+        if ($tokens[$lastOwner]['code'] === \T_FOREACH) {
+            $inForeach = Context::inForeachCondition($phpcsFile, $stackPtr);
+            if ($inForeach === 'beforeAs') {
+                // Read access
+                return;
+            }
+
+            if ($inForeach === 'afterAs') {
+                $phpcsFile->addError(
+                    \sprintf(self::WRITE_ERROR, 'foreach assignment'),
+                    $stackPtr,
+                    'ForeachWrite'
+                );
+                return;
+            }
+        }
+
+        if (isset(BCTokens::assignmentTokens()[$tokens[$nextNonEmpty]['code']]) === true) {
+            $phpcsFile->addError(
+                \sprintf(self::WRITE_ERROR, 'assignment to $GLOBALS'),
+                $stackPtr,
+                'Overwrite'
+            );
+            return;
+        }
+
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($tokens[$prevNonEmpty]['code'] === \T_BITWISE_AND
+            && Operators::isReference($phpcsFile, $prevNonEmpty) === true
+        ) {
+            $phpcsFile->addError(
+                'Creating a reference to the $GLOBALS variable is no longer supported since PHP 8.1.',
+                $stackPtr,
+                'Reference'
+            );
+            return;
+        }
+
+        if (($tokens[$prevNonEmpty]['code'] === \T_EQUAL
+            || $tokens[$prevNonEmpty]['code'] === \T_COALESCE_EQUAL)
+                && $this->supportsBelow('8.0') === true
+        ) {
+            // This warning will only be thrown when both PHP < 8.1 and PHP 8.1+ need to be supported.
+            $phpcsFile->addWarning(
+                'Prior to PHP 8.1, assignment of $GLOBALS to another variable would effectively function like a reference. Since PHP 8.1, it creates a by-value copy.',
+                $stackPtr,
+                'AssignmentOfGlobals'
+            );
+            return;
+        }
+
+        if (isset(Collections::incrementDecrementOperators()[$tokens[$prevNonEmpty]['code']]) === true
+            || isset(Collections::incrementDecrementOperators()[$tokens[$nextNonEmpty]['code']]) === true
+        ) {
+            $phpcsFile->addError(
+                \sprintf(self::WRITE_ERROR, 'variable increment/decrement'),
+                $stackPtr,
+                'IncrementDecrement'
+            );
+            return;
+        }
+
+        $functionPtr = $this->isInNamedPHPNativeFunctionCall($phpcsFile, $stackPtr);
+        if ($functionPtr !== false) {
+            $this->checkFunctionCallForPassByReference($phpcsFile, $stackPtr, $functionPtr);
+        }
+    }
+
+    /**
+     * Check if `$GLOBALS` is (part of) a parameter passed to a global function call to a PHP native function.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token.
+     *
+     * @return int|false Integer stack pointer to the function name token
+     *                   or false when not in a function call.
+     */
+    private function isInNamedPHPNativeFunctionCall(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $lastOpenParens = Parentheses::getLastOpener($phpcsFile, $stackPtr);
+        if ($lastOpenParens === false
+            || isset($tokens[$lastOpenParens]['parenthesis_owner']) === true
+        ) {
+            return false;
+        }
+
+        $maybeLabel = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($lastOpenParens - 1), null, true);
+        if ($maybeLabel === false || $tokens[$maybeLabel]['code'] !== \T_STRING) {
+            // Not a named function call.
+            return false;
+        }
+
+        // Set the native function property only once.
+        if (isset($this->phpNativeFunctions) === false) {
+            $functions                = \get_defined_functions();
+            $functions                = \array_flip($functions['internal']);
+            $this->phpNativeFunctions = \array_change_key_case($functions, \CASE_LOWER);
+        }
+
+        if (isset($this->phpNativeFunctions[\strtolower($tokens[$maybeLabel]['content'])]) === false) {
+            // Definitely not a PHP native function call.
+            return false;
+        }
+
+        $beforeLabel = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($maybeLabel - 1), null, true);
+        if ($beforeLabel !== false
+            && (isset(Collections::objectOperators()[$tokens[$beforeLabel]['code']]) === true
+            || $tokens[$beforeLabel]['code'] === \T_NEW)
+        ) {
+            // Method call or class instantiation, not global function call.
+            return false;
+        }
+
+        if ($tokens[$beforeLabel]['code'] === \T_NS_SEPARATOR) {
+            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($beforeLabel - 1), null, true);
+            if ($tokens[$prevPrevToken]['code'] === \T_STRING
+                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
+            ) {
+                // Namespaced function call.
+                return false;
+            }
+        }
+
+        return $maybeLabel;
+    }
+
+    /**
+     * Check if `$GLOBALS` is in a parameter which is passed by reference.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the current token.
+     * @param int                         $functionPtr The position of the function call name token.
+     *
+     * @return void
+     */
+    private function checkFunctionCallForPassByReference(File $phpcsFile, $stackPtr, $functionPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $reflectionFunction = new ReflectionFunction($tokens[$functionPtr]['content']);
+        $declaredParams     = $reflectionFunction->getParameters();
+
+        $referenceParams = [];
+        foreach ($declaredParams as $param) {
+            if ($param->isPassedByReference() === true) {
+                // Note: position is 0-based, while PassedParameters uses 1-based.
+                $referenceParams[$param->getPosition()] = $param->getName();
+            }
+        }
+
+        if (empty($referenceParams)) {
+            // Function doesn't change any parameters by reference.
+            return;
+        }
+
+        $params = PassedParameters::getParameters($phpcsFile, $functionPtr);
+        foreach ($referenceParams as $position => $name) {
+            $param = PassedParameters::getParameterFromStack($params, ($position + 1), $name);
+            if ($param !== false
+                && ($stackPtr >= $param['start'] && $stackPtr <= $param['end'])
+            ) {
+                // $GLOBALS was passed to the function call by reference.
+                $phpcsFile->addError(
+                    \sprintf(self::WRITE_ERROR, 'pass by reference'),
+                    $stackPtr,
+                    'PassByReference'
+                );
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsUnitTest.inc
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * Valid cross-version: access and write to $GLOBALS with array dereferencing.
+ * Valid cross-version: read-only access to $GLOBALS without array dereferencing.
+ */
+$GLOBALS['x'] = 1;
+$GLOBALS['x']++;
+$GLOBALS['x']--;
+++$GLOBALS['x'];
+--$GLOBALS['x'];
+isset($GLOBALS['x']);
+unset($GLOBALS [ 'x' ]);
+$GLOBALS['z'][] = 1;
+$GLOBALS['za'] =& $ref;
+$ref2 =& $GLOBALS[ /*comment*/ 'x'];
+
+foreach ($GLOBALS as $var => $value) {
+    echo "$var => $value\n";
+}
+
+foreach ($GLOBALS as $var => $_)
+    $$var =& $GLOBALS[$var];
+
+foreach (get_defined_vars() as $var => $value) {
+    $GLOBALS[$var] = $value;
+}
+
+function foo() {
+    global $GLOBALS;
+
+    $names = \array_keys($GLOBALS);
+
+    return $GLOBALS;
+}
+
+if (!array_key_exists('key', $GLOBALS)) {
+    $GLOBALS['key'] = '';
+}
+
+if ($GLOBALS) {
+    // Do something.
+}
+
+$obj->assertArrayHasKey('key', $GLOBALS);
+$obj->assertArrayNotHasKey('key', $GLOBALS);
+
+var_dump($GLOBALS['td']['nsno']);
+
+// Not calls to the PHP native functions which change the passed parameter by reference.
+// Ignore as undetermined.
+$var = $function($GLOBALS);
+$var = match($GLOBALS) {};
+$obj->array_splice($GLOBALS, 0, count($GLOBALS) );
+ClassName::array_pop($GLOBALS);
+$obj?->array_shift($GLOBALS);
+My\extract($GLOBALS, EXTR_REFS);
+$obj = new array_splice($GLOBALS);
+
+by_ref($GLOBALS); // Undetermined, not a PHP native function, so we don't know if argument will be changed by reference or not.
+
+// Not valid since PHP 5.4. Not the concern of this sniff.
+class Foo {
+    function array_pop($GLOBALS) {}
+    function &array_shift($GLOBALS) {}
+}
+
+// Join behaviour has not changed. Already behaved as if it used a copy. See: https://3v4l.org/UNgnI
+function changeVarViaJoinOfGlobals() {
+    $a = 1;
+    $arrayJoin  = [];
+    $arrayJoin += $GLOBALS;
+    $arrayJoin['a'] = 2;
+    var_dump($a);
+}
+
+
+/*
+ * PHP 8.1 compile error: Cannot append to $GLOBALS.
+ * https://3v4l.org/HOYvC
+ */
+$GLOBALS[] = 'new';
+$GLOBALS [ /*comment*/  ] = 'new';
+
+/*
+ * PHP 8.1: changed behaviour with variables with an int/float name.
+ * Int: https://3v4l.org/O6j34, float: https://3v4l.org/RIZHo
+ */
+function mismatchedIntegerKeyHandling() {
+    ${1} = 1;
+    $GLOBALS[ 1 ] = 2;
+    var_dump(${1}); // PHP < 8.1: int(1), PHP 8.1: int(2).
+
+    $GLOBALS[ 23_5231 ]['key'][] = 2; // Key uses PHP 7.4 numeric literal with underscore.
+    $GLOBALS[ 0o324 ]['obj']->prop = 2; // PHP 8.1 octal literal key.
+}
+
+function mismatchedFloatKeyHandling() {
+    ${1.2435} = 1;
+    $GLOBALS[ 1.2435 ] = 2;
+    var_dump(${1.2435}); // PHP < 8.1: int(1), PHP 8.1: int(2).
+}
+
+/*
+ * PHP 8.1: changed behaviour - the recursive 'GLOBALS' subkey no longer exists.
+ * https://3v4l.org/ej4fN
+ */
+isset($GLOBALS['GLOBALS' /*comment*/]); // PHP < 8.1: true, PHP 8.1: false.
+var_dump($GLOBALS[ "GLOBALS" ]); // PHP < 8.1 existed, PHP 8.1: not longer exists - Warning: Undefined global variable $GLOBALS.
+
+/*
+ * PHP 8.1 compile error: writes to $GLOBALS without dereferencing.
+ * https://3v4l.org/Y0tvM
+ */
+unset($GLOBALS);
+unset($something, $_GET['key'], $GLOBALS, $obj->prop);
+
+/*
+ * PHP 8.1 compile error: writes to $GLOBALS without dereferencing.
+ * https://3v4l.org/44aBU
+ */
+$GLOBALS = [];
+$GLOBALS = array();
+$GLOBALS += array("foo" => "foo");
+$GLOBALS =& $x;
+$GLOBALS += get_defined_vars();
+list($s, $GLOBALS, $h) = [1, 2, 3];
+[$s, $GLOBALS, $h] = [1, 2, 3]; // False negative due to short list use.
+foreach ([1] as $GLOBALS) {}
+foreach ([1] as &$GLOBALS) {}
+
+// Also problematic on PHP < 8.1 - Fatal error: Cannot assign reference to non referencable value -, but that's outside of the scope of this sniff.
+list(&$GLOBALS) = [1];
+
+// Also problematic on PHP < 8.1 - Uncaught TypeError: Cannot in/decrement array -, but that's outside of the scope of this sniff.
+$GLOBALS++;
+$GLOBALS--;
+++$GLOBALS;
+--$GLOBALS;
+
+/*
+ * PHP 8.1 compile error: Cannot acquire reference to $GLOBALS.
+ * https://3v4l.org/fI97h
+ */
+$x =& $GLOBALS;
+$x = &$GLOBALS;
+
+/*
+ * PHP 8.1: changed behaviour - assigning $GLOBALS to another variable now creates a copy.
+ * https://3v4l.org/B3qju and https://3v4l.org/aS8AV
+ */
+function changeVarViaCopyOfGlobals() {
+    $a = 1;
+    $globals = $GLOBALS; // Pre-8.1: Ostensibly by-value copy, but not really. PHP 8.1: read-only copy.
+    $globals['a'] = 2;
+    var_dump($a); // PHP < 8.1: int(2), PHP 8.1: int(1).
+
+    $globals ??= $GLOBALS; // Pre-8.1: Ostensibly by-value copy, but not really. PHP 8.1: read-only copy.
+}
+
+/*
+ * PHP 8.1 runtime error: passing $GLOBALS by reference.
+ */
+extract($GLOBALS, EXTR_REFS); // Doesn't throw an error in PHP 8.1, but behaviour has changed according to the RFC.
+array_splice($GLOBALS, 0, count($GLOBALS));
+\array_pop($GLOBALS);
+array_shift($GLOBALS);
+
+// Using PHP 8.0 named parameters.
+// Note: these tests will only work on PHP 8.0 due to PHP having renamed the relevant parameters in PHP 8.0...
+array_splice(offset: 0, array: $GLOBALS, length: count($GLOBALS));
+array_walk(callback: functionName, arg: $extra, array: $GLOBALS);
+
+// Live coding.
+// These tests have to be the last tests in the file.
+$GLOBALS[ = 'x';
+
+$GLOBALS

--- a/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsUnitTest.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Variables;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the RemovedIndirectModificationOfGlobals sniff.
+ *
+ * @group removedIndirectModificationOfGlobals
+ * @group variables
+ *
+ * @covers \PHPCompatibility\Sniffs\Variables\RemovedIndirectModificationOfGlobalsSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedIndirectModificationOfGlobalsUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test detecting use of `$GLOBALS[] = ...`.
+     *
+     * @dataProvider dataAppendToGlobals
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testAppendToGlobals($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertError($file, $line, 'Appending a new non-named array entry to the $GLOBALS variable is not allowed since PHP 8.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testAppendToGlobals()
+     *
+     * @return array
+     */
+    public function dataAppendToGlobals()
+    {
+        return [
+            [82],
+            [83],
+        ];
+    }
+
+
+    /**
+     * Test detecting access to `$GLOBALS` with an integer/float key.
+     *
+     * @dataProvider dataIntFloatKeyInGlobals
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testIntFloatKeyInGlobalsCrossVersion($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0-8.1');
+        $this->assertWarning($file, $line, 'The way variables with an integer or floating point variable name are stored in the $GLOBALS variable has changed in PHP 8.1. Please review your code to evaluate the impact.');
+    }
+
+    /**
+     * Verify that detecting access to `$GLOBALS` with an integer/float key does not get flagged
+     * when only PHP 8.1+ needs to be supported.
+     *
+     * @dataProvider dataIntFloatKeyInGlobals
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testIntFloatKeyInGlobalsPHP81($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1-');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIntFloatKeyInGlobals()
+     *
+     * @return array
+     */
+    public function dataIntFloatKeyInGlobals()
+    {
+        return [
+            [91],
+            [94],
+            [95],
+            [100],
+        ];
+    }
+
+
+    /**
+     * Test detecting use of `$GLOBALS['GLOBALS']`.
+     *
+     * @dataProvider dataRemovedGlobalsSubkey
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testRemovedGlobalsSubkey($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertError($file, $line, 'The recursive $GLOBALS[\'GLOBALS\'] key no longer exists since PHP 8.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedGlobalsSubkey()
+     *
+     * @return array
+     */
+    public function dataRemovedGlobalsSubkey()
+    {
+        return [
+            [108],
+            [109],
+        ];
+    }
+
+
+    /**
+     * Test detecting use of `unset($GLOBALS)`.
+     *
+     * @dataProvider dataUnsettingGlobals
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testUnsettingGlobals($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertError($file, $line, 'Unsetting the $GLOBALS variable is not allowed since PHP 8.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testUnsettingGlobals()
+     *
+     * @return array
+     */
+    public function dataUnsettingGlobals()
+    {
+        return [
+            [115],
+            [116],
+        ];
+    }
+
+
+    /**
+     * Test detecting assignments to the $GLOBALS variable without a subkey.
+     *
+     * @dataProvider dataAssignmentToGlobals
+     *
+     * @param int          $line The line number.
+     * @param string       $type The expected type of assignment found.
+     * @param string|false $skip A skip reason or false when the test shouldn't be skipped.
+     *
+     * @return void
+     */
+    public function testAssignmentToGlobals($line, $type, $skip = false)
+    {
+        if ($skip !== false) {
+            $this->markTestSkipped($skip);
+        }
+
+        $file  = $this->sniffFile(__FILE__, '8.1');
+        $error = \sprintf(
+            'Only individual keys in the $GLOBALS variable can be modified. The top-level $GLOBALS variable is read-only since PHP 8.1. Detected: %s',
+            $type
+        );
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testAssignmentToGlobals()
+     *
+     * @return array
+     */
+    public function dataAssignmentToGlobals()
+    {
+        $data = [
+            [122, 'assignment to $GLOBALS'],
+            [123, 'assignment to $GLOBALS'],
+            [124, 'assignment to $GLOBALS'],
+            [125, 'assignment to $GLOBALS'],
+            [126, 'assignment to $GLOBALS'],
+            [127, 'list assignment'],
+            //[128, 'list assignment'], // False negative due to short list use.
+            [129, 'foreach assignment'],
+            [130, 'foreach assignment'],
+
+            [133, 'list assignment'],
+
+            [136, 'variable increment/decrement'],
+            [137, 'variable increment/decrement'],
+            [138, 'variable increment/decrement'],
+            [139, 'variable increment/decrement'],
+
+            [164, 'pass by reference'],
+            [165, 'pass by reference'],
+            [166, 'pass by reference'],
+            [167, 'pass by reference'],
+        ];
+
+        /*
+         * The sniff will only be able to identify named parameters correctly in all
+         * PHP versions if the parameter name hasn't changed across PHP versions or if
+         * an array of old and new names is passed to PassedParameters.
+         *
+         * Unfortunately, the parameter name of the "pass by reference" parameters for the
+         * functions used in these tests, HAVE changed, so the tests will only be able to pass
+         * on PHP 8.0+.
+         * As the sniff uses Reflection to retrieve the parameter names, we cannot pass
+         * an array of old and new names.
+         */
+        $skip = false;
+        if (\PHP_VERSION_ID < 80000) {
+            $skip = 'Parameter name in native PHP function has changed in PHP 8.0, test cannot succeed';
+        }
+
+        $data[] = [171, 'pass by reference', $skip];
+        $data[] = [172, 'pass by reference', $skip];
+
+        return $data;
+    }
+
+
+    /**
+     * Test detecting use of `& $GLOBALS`.
+     *
+     * @dataProvider dataReferenceToGlobals
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testReferenceToGlobals($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertError($file, $line, 'Creating a reference to the $GLOBALS variable is no longer supported since PHP 8.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testReferenceToGlobals()
+     *
+     * @return array
+     */
+    public function dataReferenceToGlobals()
+    {
+        return [
+            [145],
+            [146],
+        ];
+    }
+
+
+    /**
+     * Test detecting use of `$foo = $GLOBALS;`.
+     *
+     * @dataProvider dataAssignmentOfGlobals
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testAssignmentOfGlobalsCrossVersion($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0-8.1');
+        $this->assertWarning($file, $line, 'Prior to PHP 8.1, assignment of $GLOBALS to another variable would effectively function like a reference. Since PHP 8.1, it creates a by-value copy.');
+    }
+
+    /**
+     * Verify that `$foo = $GLOBALS;` does not get flagged when only PHP 8.1+ needs to be supported.
+     *
+     * @dataProvider dataAssignmentOfGlobals
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testAssignmentOfGlobalsPHP81($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1-');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testAssignmentOfGlobals()
+     *
+     * @return array
+     */
+    public function dataAssignmentOfGlobals()
+    {
+        return [
+            [154],
+            [158],
+        ];
+    }
+
+
+    /**
+     * Test the sniff does not throw false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = [];
+
+        // No errors expected on the first 66 lines.
+        for ($line = 1; $line <= 77; $line++) {
+            $cases[] = [$line];
+        }
+
+        // No errors for the parse errors at the end of the file.
+        for ($line = 173; $line <= 179; $line++) {
+            $cases[] = [$line];
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> Access to the $GLOBALS array is now subject to a number of restrictions.
> Read and write access to individual array elements like $GLOBALS['var']
> continues to work as-is. Read-only access to the entire $GLOBALS array also
> continues to be supported. However, write access to the entire $GLOBALS
> array is no longer supported. For example, array_pop($GLOBALS) will result
> in an error.

Refs:
* https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.globals-access
* https://github.com/php/php-src/blob/28a1a6be0873a109cb02ba32784bf046b87a02e4/UPGRADING#L23-L29
* https://wiki.php.net/rfc/restrict_globals_usage
* https://github.com/php/php-src/pull/6487

This commit introduces a new sniff which attempts to find all code patterns affected by this change, as per the code samples highlighted in the RFC.

* There will no longer be a recursive “GLOBALS” key in the `$GLOBALS` variable.
* Writes to `$GLOBALS` taken as a whole will now generate a compile error, this includes list assignments and unsetting of `$GLOBALS`.
* Passing `$GLOBALS` by reference will trigger a runtime `Error` exception.
* Appending unnamed entries to the `$GLOBALS` array is no longer supported.
* etc

Notes:
* There are two specific situations which constitute a behavioural change. I.e. the code will work in both PHP < 8.1 as well as PHP 8.1+, but the result of the code will be different. The sniff will flag those situations with a `warning` instead of an `error` and will only flag these when both PHP < 8.1 as well as PHP 8.1+ need to be supported (based on the provided `testVersion`).
* There is one known false negative - when `$GLOBALS` with array access is used in a short list. Detecting whether a variable is used in a short list _from within the list_ is hard and potentially very token walking intensive. As this is very, very much an edge case, which would be rare to come across in real code, I have deemed it unwise to pursue detection of this.
* The `extract($GLOBALS, EXTR_REFS);` code sample, which is taken literally from the RFC, will not in actual fact throw a fatal error in PHP 8.1. As it is explicitly highlighted in the RFC as code that will break, it will be treated the same as all other code where `$GLOBALS` is passed by reference and will be flagged with an `error`.
* For non-PHP native functions, it is not possible to the detect whether `$GLOBALS` is being passed by reference. As things are, these will not be flagged, though it could be considered to flag them with a lower `severity` to allow for manual inspection.
* For calls to PHP native functions in combination with named parameters, it is only possible to detect pass by reference if the parameter name hasn't changed between PHP versions. Unfortunately, it has for the two function calls used in the tests. To get round that, we'd need a complete list of all PHP functions which receive parameters by reference, the parameter names across PHP versions and the parameter positions. In my estimation, that wouldn't actually add much value as for code written using PHP 8.0+ syntax, we should generally be able to expect that PHPCS will also be run on PHP 8.0+, in which case, it's a non-issue.

Includes unit tests.
Includes XML docs.

Related to #1299