### PR TITLE
:sparkles: PHP 8.1: New `PHPCompatibility.ParameterValues.NewArrayMergeRecursiveWithGlobalsVar` sniff

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarStandard.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Array Merge Recursive With $GLOBALS"
+    >
+    <standard>
+    <![CDATA[
+    Prior to PHP 8.1, passing the `$GLOBALS` variable, without accessing a specific key, twice to `array_merge_recursive()` would lead to a fatal recursion error.
+
+    Since PHP 8.1, the `$GLOBALS` array no longer contains the `$GLOBALS['GLOBALS']` array entry, which removes the recursion problem.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: not passing the $GLOBALS variable, without accessing a specific key, twice.">
+        <![CDATA[
+array_merge_recursive($GLOBALS);
+array_merge_recursive($GLOBALS, $other);
+array_merge_recursive(
+    $GLOBALS['_GET'],
+    $GLOBALS['_POST']
+);
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.1: passing the $GLOBALS variable twice.">
+        <![CDATA[
+array_merge_recursive($GLOBALS, $GLOBALS);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarSniff.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Detect code which would throw a fatal recursion error on PHP < 8.1.
+ *
+ * PHP version 8.1
+ *
+ * @link https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.globals-access
+ * @link https://wiki.php.net/rfc/restrict_globals_usage
+ *
+ * @since 10.0.0
+ */
+final class NewArrayMergeRecursiveWithGlobalsVarSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions the sniff is looking for. Should be defined in the child class.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = [
+        'array_merge_recursive' => true,
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('8.0') === false);
+    }
+
+    /**
+     * Check if `$GLOBALS` is used twice in array_merge_recursive().
+     *
+     * {@internal Note that `array_merge_recursive()` does not support named parameters due to
+     * the variable nature of the parameters.}
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return void
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $globalsParamCount = 0;
+        foreach ($parameters as $param) {
+            $hasGlobals     = false;
+            $hasNonVarToken = false;
+
+            for ($i = $param['start']; $i <= $param['end']; $i++) {
+                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
+                    continue;
+                }
+
+                if ($tokens[$i]['code'] !== \T_VARIABLE) {
+                    $hasNonVarToken = true;
+                    continue;
+                }
+
+                if ($tokens[$i]['content'] === '$GLOBALS') {
+                    $hasGlobals = true;
+                }
+            }
+
+            if ($hasGlobals === true && $hasNonVarToken === false) {
+                ++$globalsParamCount;
+            }
+        }
+
+        if ($globalsParamCount > 1) {
+            $phpcsFile->addError(
+                'Recursively merging the $GLOBALS array is not supported prior to PHP 8.1.',
+                $stackPtr,
+                'Found'
+            );
+        }
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarUnitTest.inc
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Not our targets.
+ */
+$obj->array_merge_recursive($GLOBALS, $GLOBALS );
+ClassName::array_merge_recursive($GLOBALS, $GLOBALS);
+$obj?->array_merge_recursive($GLOBALS, $GLOBALS);
+My\array_merge_recursive($GLOBALS, $GLOBALS);
+$obj = new array_merge_recursive($GLOBALS, $GLOBALS);
+register_callback(array_merge_recursive(...));
+
+/*
+ * Valid cross-version: not passing $GLOBALS twice to array_merge_recursive().
+ */
+array_merge_recursive();
+array_merge_recursive($GLOBALS);
+array_merge_recursive(my_get_array(), $GLOBALS, $someOtherArray);
+array_merge_recursive($GLOBALS, $someOtherArray);
+array_merge_recursive($GLOBALS, $GLOBALS['_GET']);
+array_merge_recursive($GLOBALS['_POST'], $GLOBALS);
+
+/*
+ * PHP 8.0: catchable fatal error: Recursion detected.
+ * PHP 7.x: warning: Recursion detected.
+ * PHP < 7.0: would exhaust memory to the limit.
+ */
+array_merge_recursive($GLOBALS, $GLOBALS);
+array_merge_recursive($GLOBALS, $someOtherArray, $GLOBALS, my_get_array(),);

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarUnitTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Test the NewArrayMergeRecursiveWithGlobalsVar sniff.
+ *
+ * @group newArrayMergeRecursiveWithGlobalsVar
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewArrayMergeRecursiveWithGlobalsVarSniff
+ *
+ * @since 10.0.0
+ */
+final class NewArrayMergeRecursiveWithGlobalsVarUnitTest extends BaseSniffTest
+{
+
+    /**
+     * Test detecting use of `array_merge_recursive()` with $GLOBALS passed multiple times.
+     *
+     * @dataProvider dataRecursiveMerge
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testRecursiveMerge($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Recursively merging the $GLOBALS array is not supported prior to PHP 8.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRecursiveMerge()
+     *
+     * @return array
+     */
+    public function dataRecursiveMerge()
+    {
+        return [
+            [28],
+            [29],
+        ];
+    }
+
+
+    /**
+     * Test the sniff does not throw false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = [];
+
+        // No errors expected on the first 22 lines.
+        for ($line = 1; $line <= 22; $line++) {
+            $cases[] = [$line];
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
This change is a side-effect of the "Remove Indirect Modification of $GLOBALS" RFC, which removed the recursive `$GLOBALS['GLOBALS']` key from the `$GLOBALS` array. Also see PR #1487

> Access to the $GLOBALS array is now subject to a number of restrictions.
> Read and write access to individual array elements like $GLOBALS['var']
> continues to work as-is. Read-only access to the entire $GLOBALS array also
> continues to be supported. However, write access to the entire $GLOBALS
> array is no longer supported. For example, array_pop($GLOBALS) will result
> in an error.

Refs:
* https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.globals-access
* https://github.com/php/php-src/blob/28a1a6be0873a109cb02ba32784bf046b87a02e4/UPGRADING#L23-L29
* https://wiki.php.net/rfc/restrict_globals_usage
* https://github.com/php/php-src/pull/6487

Includes unit tests.
Includes XML docs.

Related to #1299