### PR TITLE
Classes/NewConstructorPropertyPromotion: support PHP 8.1 readonly properties / intersection type

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
@@ -82,7 +82,7 @@ final class NewConstructorPropertyPromotionSniff extends Sniff
 
             $phpcsFile->addError(
                 'Constructor property promotion is not available in PHP version 7.4 or earlier. Found: %s',
-                $param['visibility_token'],
+                $param['token'],
                 'Found',
                 [$param['content']]
             );

--- a/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.inc
@@ -53,3 +53,16 @@ abstract class ConstructorPropertyPromotionAbstractMethod {
     // 3. The callable type is not supported for properties, but that's not the concern of this sniff.
     abstract public function __construct(public callable $y, private ...$x);
 }
+
+// Safeguard handling of constructor prop promotion with PHP 8.1 intersection types,
+// PHP 8.1 readonly properties and PHP 8.2 stand-alone true/false/null types.
+class ConstructorPropertyPromotionWithReadonlyProperties {
+    public function __construct(
+        public readonly string $x,
+        readonly ?int $noVisibility,
+        readonly private Foo $modifierOrder,
+        readonly Foo&Bar $intersectionType,
+        public true $thisIsSilly,
+        private null $thisIsAlsoSilly,
+    ) {}
+}

--- a/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.php
@@ -56,6 +56,12 @@ final class NewConstructorPropertyPromotionUnitTest extends BaseSniffTest
             [39], // x3.
             [44],
             [54], // x2.
+            [61],
+            [62],
+            [63],
+            [64],
+            [65],
+            [66],
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require" : {
     "php" : ">=5.4",
     "squizlabs/php_codesniffer" : "^3.7.1",
-    "phpcsstandards/phpcsutils" : "^1.0"
+    "phpcsstandards/phpcsutils" : "^1.0.4"
   },
   "require-dev" : {
     "php-parallel-lint/php-parallel-lint": "^1.3.2",


### PR DESCRIPTION
This commit adds tests to the sniff for PHP 8.1 `readonly` properties, as well as tests with PHP 8.1 intersection types and PHP 8.2 stand-alone true/false/null types.

While adding these tests, I discovered an oversight in how support was added for constructor property promotion to the PHPCS native `File::getMethodParameters()` and the PHPCSUtils `FunctionDeclarations::getParameters()` methods, as support for `readonly` properties without explicit visibility was not correctly handled.

A PR has been opened to fix this in PHPCS. In PHPCSUtils, this has been fixed in the `1.0.4` release, which is why the minimum supported PHPCSUtils version has been updated in the `composer.json` file.

As  the above means that the `'visibility_token'` index may not be available, the error will now be thrown on the `'token'` stack pointer, which points to the parameter name.