### PR TITLE
Classes/NewConstVisibility: various small updates

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -77,7 +77,7 @@ class NewConstVisibilitySniff extends Sniff
 
         $phpcsFile->addError(
             'Visibility indicators for class constants are not supported in PHP 7.0 or earlier. Found "%s const"',
-            $stackPtr,
+            $prevToken,
             'Found',
             [$tokens[$prevToken]['content']]
         );

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -76,7 +76,7 @@ class NewConstVisibilitySniff extends Sniff
         }
 
         $phpcsFile->addError(
-            'Visibility indicators for class constants are not supported in PHP 7.0 or earlier. Found "%s const"',
+            'Visibility indicators for OO constants are not supported in PHP 7.0 or earlier. Found "%s const"',
             $prevToken,
             'Found',
             [$tokens[$prevToken]['content']]

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.inc
@@ -71,3 +71,17 @@ enum ConstInEnum
     protected const PROTECTED_CONST = 3;
     private const PRIVATE_CONST = 4;
 }
+
+/*
+ * Make sure the sniff handles PHP 8.2 constants in traits correctly.
+ */
+trait ConstInTrait
+{
+    const PUBLIC_CONST_A = 1;
+    final const FINAL_CONST = 2;
+
+    // PHP 7.1+
+    public const PUBLIC_CONST = 3;
+    protected const PROTECTED_CONST = 4;
+    private const PRIVATE_CONST = 5;
+}

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.inc
@@ -58,3 +58,16 @@ class FinalConstDemo
     protected final const FINAL_PROTECTED_CONST_B = 6;
     private final const FINAL_PRIVATE_CONST_B = 8;
 }
+
+/*
+ * Make sure the sniff handles constants in PHP 8.1 enums correctly.
+ */
+enum ConstInEnum
+{
+    const PUBLIC_CONST_A = 1;
+
+    // PHP 7.1+
+    public const PUBLIC_CONST_B = 2;
+    protected const PROTECTED_CONST = 3;
+    private const PRIVATE_CONST = 4;
+}

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
@@ -69,6 +69,10 @@ class NewConstVisibilityUnitTest extends BaseSniffTest
             [70],
             [71],
             [72],
+
+            [84],
+            [85],
+            [86],
         ];
     }
 
@@ -105,6 +109,8 @@ class NewConstVisibilityUnitTest extends BaseSniffTest
             [44],
             [48],
             [67],
+            [80],
+            [81],
         ];
     }
 

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
@@ -26,7 +26,7 @@ class NewConstVisibilityUnitTest extends BaseSniffTest
 {
 
     /**
-     * Test that an error is thrown for class constants declared with visibility.
+     * Test that an error is thrown for OO constants declared with visibility.
      *
      * @dataProvider dataConstVisibility
      *
@@ -37,7 +37,7 @@ class NewConstVisibilityUnitTest extends BaseSniffTest
     public function testConstVisibility($line)
     {
         $file = $this->sniffFile(__FILE__, '7.0');
-        $this->assertError($file, $line, 'Visibility indicators for class constants are not supported in PHP 7.0 or earlier.');
+        $this->assertError($file, $line, 'Visibility indicators for OO constants are not supported in PHP 7.0 or earlier.');
     }
 
     /**
@@ -65,6 +65,10 @@ class NewConstVisibilityUnitTest extends BaseSniffTest
             [57],
             [58],
             [59],
+
+            [70],
+            [71],
+            [72],
         ];
     }
 
@@ -100,6 +104,7 @@ class NewConstVisibilityUnitTest extends BaseSniffTest
             [30],
             [44],
             [48],
+            [67],
         ];
     }
 


### PR DESCRIPTION
### Classes/NewConstVisibility: improve message precision

Throw the error on the visibility token instead of the `const` keyword. This will more clearly indicate the issue when people use the PHPCS `code` view.

### Classes/NewConstVisibility: add tests for constants in PHP 8.1 enums

The sniff already handles this correctly, no functional changes needed, aside from a small tweak to the error message to allow for non-class OO constructs.

### Classes/NewConstVisibility: add tests for PHP 8.2 constants in traits

The sniff already handles this correctly, no changes needed.