### PR TITLE
Classes/NewLateStaticBinding: various small updates

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -13,7 +13,6 @@ namespace PHPCompatibility\Sniffs\Classes;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\Conditions;
 
 /**
@@ -101,7 +100,7 @@ class NewLateStaticBindingSniff extends Sniff
                 break;
         }
 
-        $inClass = Conditions::hasCondition($phpcsFile, $stackPtr, BCTokens::ooScopeTokens());
+        $inClass = Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
 
         if ($inClass === true && $this->supportsBelow('5.2') === true) {
             $phpcsFile->addError(

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.inc
@@ -8,7 +8,7 @@ class LateStatic {
         static::foo(); // Late static binding.
         echo static::$bar; // Late static binding.
         $name = static::class; // Late static binding.
-        
+
         $obj = new static; // Late static binding.
         $obj = new static(); // Late static binding.
 
@@ -25,3 +25,20 @@ static function testing() { // Ok.
 }
 
 static::testing(); // Bad. Outside class scope.
+
+$closure = static function() {};
+$arrow = static fn() => 'foo';
+
+class Foo {
+    public function hasStaticDefaultValue( $param = static::SOME_CONST) {} // Late static binding.
+
+    public function hasStaticParamType(static $param) {}
+    public function hasStaticParamUnionType(static|string $param) {}
+    public function hasStaticReturnType(): static {}
+    public function hasStaticReturnIntersectionType(): static&MyInterface {}
+    public function static() {}
+}
+
+// Live coding/parse error.
+// This has to be the last test in the file.
+static

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
@@ -60,6 +60,7 @@ class NewLateStaticBindingUnitTest extends BaseSniffTest
             [13],
             [15],
             [17],
+            [33],
         ];
     }
 
@@ -125,6 +126,14 @@ class NewLateStaticBindingUnitTest extends BaseSniffTest
             [20],
             [23],
             [24],
+            [29],
+            [30],
+            [35],
+            [36],
+            [37],
+            [38],
+            [39],
+            [44],
         ];
     }
 


### PR DESCRIPTION
### Classes/NewLateStaticBinding: minor simplification

The use of the PHPCSUtils `BCTokens` class is no longer needed (for now) since support for PHPCS < 3.7.1 has been dropped.

### Classes/NewLateStaticBinding: add some extra tests

Add extra tests safeguarding against false positives for:
* `static` closure declarations
* `static` arrow function declarations
* Use of `static` in parameter type declarations.
* Use of `static` as a return type.
* `static` tokenized as `T_STRING`, but not the `static` keyword.
* Live coding/parse error.