### PR TITLE
Classes/NewTypedProperties: bug fix for constr. prop. prom. and more

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -191,6 +191,11 @@ class NewTypedPropertiesSniff extends Sniff
                 continue;
             }
 
+            if ($param['type_hint'] === '') {
+                // Not a typed property.
+                return;
+            }
+
             // Juggle some of the array entries to what it expected for properties.
             $paramInfo = [
                 'type'          => $param['type_hint'],

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -99,6 +99,7 @@ class NewTypedPropertiesSniff extends Sniff
         'integer'  => 'int',
         'callable' => false,
         'void'     => false,
+        'never'    => false,
     ];
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -154,3 +154,9 @@ class ConstructorPropertyPromotionNoTypes {
         public &$y = 'test',
     ) {}
 }
+
+// PHP 8.1 never type is not supported for typed properties (not does it make sense).
+class NeverType {
+    public never $neverA;
+    public Never $neverB;
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -160,3 +160,8 @@ class NeverType {
     public never $neverA;
     public Never $neverB;
 }
+
+class EdgeCase {
+    public int $property ?>
+    <?php
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -146,3 +146,11 @@ class IntersectionTypes() {
 class TrueType() {
     public true $true = true;
 }
+
+// PHP 8.0 constructor property promotion.
+class ConstructorPropertyPromotionNoTypes {
+    public function __Construct(
+        protected $x,
+        public &$y = 'test',
+    ) {}
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -99,6 +99,8 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             [139],
             [142],
             [147],
+            [160],
+            [161],
         ];
     }
 
@@ -176,6 +178,8 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             [65, 'boolean'],
             [66, 'integer'],
             [117, 'callable'],
+            [160, 'never'],
+            [161, 'never'],
         ];
     }
 

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -133,11 +133,13 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             $cases[] = [$line];
         }
 
-        // Don't throw errors for normal constructor/function parameters.
+        // Don't throw errors for normal constructor/function parameters/untyped properties.
         $cases[] = [118];
         $cases[] = [119];
         $cases[] = [123];
         $cases[] = [127];
+        $cases[] = [153];
+        $cases[] = [154];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -101,6 +101,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTest
             [147],
             [160],
             [161],
+            [165],
         ];
     }
 


### PR DESCRIPTION
### Classes/NewTypedProperties: prevent false positive for untyped constructor property promotion

Includes unit tests.

### Classes/NewTypedProperties: mark PHP 8.1 never type as invalid

... as it cannot be used for properties.

Includes unit tests.

### Classes/NewTypedProperties: add extra test

... for an edge case the sniff already handles correctly.

Includes unit tests.