### PR TITLE
Classes/RemovedOrphanedParent: bug fix for parent used as function name + detect in more places

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -13,7 +13,6 @@ namespace PHPCompatibility\Sniffs\Classes;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\MessageHelper;
 
@@ -62,13 +61,13 @@ class RemovedOrphanedParentSniff extends Sniff
             return;
         }
 
-        $classPtr = Conditions::getLastCondition($phpcsFile, $stackPtr, Collections::ooCanExtend());
-        if ($classPtr === false) {
+        $tokens   = $phpcsFile->getTokens();
+        $classPtr = Conditions::getLastCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
+        if ($classPtr === false || $tokens[$classPtr]['code'] === \T_TRAIT) {
             // Use outside of a class scope. Not our concern.
             return;
         }
 
-        $tokens = $phpcsFile->getTokens();
         if (isset($tokens[$classPtr]['scope_opener']) === false) {
             // No scope opener known. Probably a parse error.
             return;

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
@@ -10,7 +10,7 @@ function test() {
 // Valid use of the parent keyword.
 class ExtendedClass extends ParentClass
 {
-    public function test() {
+    public function test(parent $param): parent {
         echo parent::class;
         $this->foo = parent::$foo;
         return parent::test();
@@ -20,7 +20,7 @@ class ExtendedClass extends ParentClass
 class PlainClass {
     public function create_anon_class() {
         $anon = new class() extends ParentClass {
-            public function test() {
+            public function test(parent $param): parent {
                 echo parent::class;
                 $this->foo = parent::$foo;
                 return parent::test();
@@ -32,7 +32,7 @@ class PlainClass {
 // PHP 7.4: Deprecated parent in class without parent.
 class ParentClass
 {
-    public function test() {
+    public function test(parent $param) {
         echo parent::class;
         $this->foo = parent::$foo;
         return parent::test();
@@ -41,7 +41,7 @@ class ParentClass
 
 class ImplementedClass implements SomeInterface
 {
-    public function test() {
+    public function test(): parent {
         echo parent::class;
         $this->foo = parent::$foo;
         return parent::test();
@@ -52,7 +52,7 @@ class ImplementedClass implements SomeInterface
 class NestingStuff extends Nested {
     public function create_anon_class() {
         return new class() {
-            public function test() {
+            public function test(parent|SomeInterface $param) {
                 echo parent::class;
                 $this->foo = parent::$foo;
                 return parent::test();

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
@@ -61,6 +61,19 @@ class NestingStuff extends Nested {
     }
 }
 
+// Test handling of incorrectly tokenized parent keywords. See PHPCS #3797.
+class PHP4DOMTree {
+    function &parent() {
+        $parent =& PHP4DOMTree::from_DOMDocument($this->_element->parent());
+        $global_parent = parent($var);
+    }
+
+    function flagMe() {
+        $obj = new parent;
+        return new parent();
+    }
+}
+
 // Intentional parse error. This has to be the last test in the file.
 class SomeClass extends Something
     public function test() {

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
@@ -111,6 +111,19 @@ class ModernPHP {
     ) {}
 }
 
+// Safeguard detection of parent when used in PHP 8.1+ enums, which cannot have a parent.
+// See: https://3v4l.org/vDIQg
+enum PlainEnum
+{
+    public function test(
+        parent $param
+    ): parent {
+        echo parent::class;
+        $this->foo = parent::$foo;
+        return parent::test();
+    }
+}
+
 // Intentional parse error. This has to be the last test in the file.
 class SomeClass extends Something
     public function test() {

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
@@ -97,6 +97,20 @@ trait MightHaveParent
     }
 }
 
+// Safeguard handling of parent when used with PHP 7.4+ typed properties, PHP 8.0+ constructor property promotion,
+// PHP 8.0+ attributes, PHP 8.0+ union types, PHP 8.1+ intersection types.
+class ModernPHP {
+    public parent $propA;
+    public SomeInterface|parent $propB;
+
+    #[SomeAttribute(parent::CONSTANT_NAME)]
+    public function __construct(
+        protected ?parent $parent,
+        private object&parent $object,
+        parent|string $param,
+    ) {}
+}
+
 // Intentional parse error. This has to be the last test in the file.
 class SomeClass extends Something
     public function test() {

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
@@ -74,6 +74,19 @@ class PHP4DOMTree {
     }
 }
 
+// PHP 7.4 Deprecated parent in class without parent also applies to interfaces, with and without parent.
+// See: https://3v4l.org/7OT7b
+interface NoParent {
+    public function testA(parent $obj);
+    public function testB(): parent;
+    public function parent();
+}
+
+interface HasParent extends NoParent {
+    public function testA(parent $obj);
+    public function testB(): parent;
+}
+
 // Intentional parse error. This has to be the last test in the file.
 class SomeClass extends Something
     public function test() {

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
@@ -87,6 +87,16 @@ interface HasParent extends NoParent {
     public function testB(): parent;
 }
 
+// Using parent in traits is fine.
+trait MightHaveParent
+{
+    public function test(parent $obj): parent {
+        echo parent::class;
+        $this->foo = parent::$foo;
+        return parent::test();
+    }
+}
+
 // Intentional parse error. This has to be the last test in the file.
 class SomeClass extends Something
     public function test() {

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -142,8 +142,12 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
         $cases[] = [68];
         $cases[] = [82];
 
+        for ($line = 89; $line <= 99; $line++) {
+            $cases[] = [$line];
+        }
+
         // Add parse error test case.
-        $cases[] = [93];
+        $cases[] = [103];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -67,6 +67,12 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
             [58],
             [72],
             [73],
+            [103],
+            [104],
+            [106],
+            [108],
+            [109],
+            [110],
         ];
     }
 
@@ -147,7 +153,7 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
         }
 
         // Add parse error test case.
-        $cases[] = [103];
+        $cases[] = [117];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -62,6 +62,8 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
             [56],
             [57],
             [58],
+            [72],
+            [73],
         ];
     }
 
@@ -96,8 +98,12 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
             $cases[] = [$line];
         }
 
-        // Add parse error test case.
+        $cases[] = [66];
         $cases[] = [67];
+        $cases[] = [68];
+
+        // Add parse error test case.
+        $cases[] = [80];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -73,6 +73,11 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
             [108],
             [109],
             [110],
+            [119],
+            [120],
+            [121],
+            [122],
+            [123],
         ];
     }
 
@@ -153,7 +158,7 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
         }
 
         // Add parse error test case.
-        $cases[] = [117];
+        $cases[] = [128];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -53,12 +53,15 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
     public function dataRemovedOrphanedParent()
     {
         return [
+            [35],
             [36],
             [37],
             [38],
+            [44],
             [45],
             [46],
             [47],
+            [55],
             [56],
             [57],
             [58],

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -26,15 +26,15 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
 {
 
     /**
-     * testRemovedOrphanedParent.
+     * Verify that use of the `parent` keyword in classes without a parent gets flagged.
      *
-     * @dataProvider dataRemovedOrphanedParent
+     * @dataProvider dataRemovedOrphanedParentInClass
      *
      * @param int $line The line number where a warning is expected.
      *
      * @return void
      */
-    public function testRemovedOrphanedParent($line)
+    public function testRemovedOrphanedParentInClass($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
         $this->assertWarning($file, $line, 'Using "parent" inside a class without parent is deprecated since PHP 7.4');
@@ -46,11 +46,11 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testRemovedOrphanedParent()
+     * @see testRemovedOrphanedParentInClass()
      *
      * @return array
      */
-    public function dataRemovedOrphanedParent()
+    public function dataRemovedOrphanedParentInClass()
     {
         return [
             [35],
@@ -67,6 +67,42 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
             [58],
             [72],
             [73],
+        ];
+    }
+
+
+    /**
+     * Verify that use of the `parent` keyword in interfaces gets flagged.
+     *
+     * @dataProvider dataRemovedOrphanedParentInInterface
+     *
+     * @param int $line The line number where a warning is expected.
+     *
+     * @return void
+     */
+    public function testRemovedOrphanedParentInInterface($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertWarning($file, $line, 'Using "parent" inside an interface is deprecated since PHP 7.4');
+
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Using "parent" inside an interface is deprecated since PHP 7.4 and removed since PHP 8.0');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedOrphanedParentInInterface()
+     *
+     * @return array
+     */
+    public function dataRemovedOrphanedParentInInterface()
+    {
+        return [
+            [80],
+            [81],
+            [86],
+            [87],
         ];
     }
 
@@ -104,9 +140,10 @@ class RemovedOrphanedParentUnitTest extends BaseSniffTest
         $cases[] = [66];
         $cases[] = [67];
         $cases[] = [68];
+        $cases[] = [82];
 
         // Add parse error test case.
-        $cases[] = [80];
+        $cases[] = [93];
 
         return $cases;
     }


### PR DESCRIPTION
### Classes/RemovedOrphanedParent: bug fix for parent used as function name

Turns out PHPCS does not tokenize the `parent` keyword correctly as `T_STRING` when used as a function name in a function declaration which returns by reference, nor when that function name is subsequently called.
A fix has been pulled for this upstream: squizlabs/PHP_CodeSniffer#3797

In the mean time, this commit fixes the issue for this sniff in a PHPCS cross-version compatible manner.

Includes unit tests.

Fixes #1489

### Classes/RemovedOrphanedParent: add tests with parent used as type declaration

The sniff already handles this correctly, no changes needed.

### Classes/RemovedOrphanedParent: detect use of parent in interfaces

Based on https://3v4l.org/7OT7b, it looks like support for the use of `parent` as a type declaration in interfaces has also been deprecated in PHP 7.4 and removed in PHP 8.0.

For interfaces, it doesn't matter whether the interface extends another interface or not.

This commit adjusts the sniff to detect this.

The sniff will throw a slightly adjusted error message and use a separate error code when the `parent` keyword is detected as used in an interface.

Includes unit tests.

### Classes/RemovedOrphanedParent: add tests with traits

Using the `parent` keyword in traits is still fine. See: https://3v4l.org/NbR8O#veol

The sniff already handles this correctly, no changes needed.

### Classes/RemovedOrphanedParent: add tests with various PHP 7.4-8.1 features

Add tests with:
* PHP 7.4 typed properties.
* PHP 8.0 constructor property promotion.
* PHP 8.0 attributes.
* PHP 8.0 union types.
* PHP 8.1 intersection types.

The sniff already handles this correctly, no changes needed.

### Classes/RemovedOrphanedParent: add support for PHP 8.1 enums

As enums cannot have a parent, the same error applies. See: https://3v4l.org/vDIQg

Includes unit tests.