### PR TITLE
Constants/NewMagicClassConstant: bug fix for functions called "class" + various other updates

### DIFF
--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -72,18 +72,18 @@ class NewMagicClassConstantSniff extends Sniff
             return;
         }
 
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-        if ($prevToken === false || $tokens[$prevToken]['code'] !== \T_DOUBLE_COLON) {
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($tokens[$prevToken]['code'] !== \T_DOUBLE_COLON) {
             return;
         }
 
-        $subjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true, null, true);
+        $subjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
         if ($subjectPtr === false) {
             // Shouldn't be possible.
             return; // @codeCoverageIgnore
         }
 
-        $preSubjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($subjectPtr - 1), null, true, null, true);
+        $preSubjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($subjectPtr - 1), null, true);
         if (isset(Collections::ooHierarchyKeywords()[$tokens[$subjectPtr]['code']]) === true
             || ($tokens[$subjectPtr]['code'] === \T_STRING
                 && isset(Collections::objectOperators()[$tokens[$preSubjectPtr]['code']]) === false)

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -72,6 +72,12 @@ class NewMagicClassConstantSniff extends Sniff
             return;
         }
 
+        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextToken !== false && $tokens[$nextToken]['code'] === \T_OPEN_PARENTHESIS) {
+            // Function call or declaration for a function called "class".
+            return;
+        }
+
         $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($tokens[$prevToken]['code'] !== \T_DOUBLE_COLON) {
             return;

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.inc
@@ -50,3 +50,12 @@ $name = ($string = 'text')::class; // Using ::class on a string literal.
 $name = (1+1)::class; // Using ::class on a literal.
 const A = [0]::class; // Using ::class on a literal.
 $name = ClassName::CONSTANT_NAME::class; // Objects can not be set as the value for a constant.
+
+// Safeguard against false positives for functions called "class".
+class NotTheMagicConstant {
+    public function &class() {
+        self::class();
+        NotTheMagicConstant::class();
+        My\Class\ClassName::class();
+    }
+}

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.inc
@@ -62,3 +62,7 @@ class NotTheMagicConstant {
 
 // Safeguard handling of class resolution with PHP 8.0 nullsafe object operator.
 class_exists($obj?->otherObjectSavedAsProperty::class));
+
+// Safeguard handling of class resolution found within PHP 8.0+ attribute.
+#[MyAttribute(\Fully\Qualified\Other::class)]
+function hasAttribute() {}

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.inc
@@ -59,3 +59,6 @@ class NotTheMagicConstant {
         My\Class\ClassName::class();
     }
 }
+
+// Safeguard handling of class resolution with PHP 8.0 nullsafe object operator.
+class_exists($obj?->otherObjectSavedAsProperty::class));

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -140,6 +140,7 @@ class NewMagicClassConstantUnitTest extends BaseSniffTest
             [50],
             [51],
             [52],
+            [64],
         ];
     }
 

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -89,12 +89,18 @@ class NewMagicClassConstantUnitTest extends BaseSniffTest
      */
     public function dataNoFalsePositives()
     {
-        return [
+        $data = [
             [4],
             [10],
             [18],
             [19],
         ];
+
+        for ($line = 54; $line <= 61; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -61,6 +61,7 @@ class NewMagicClassConstantUnitTest extends BaseSniffTest
             [30],
             [31],
             [32],
+            [67],
         ];
     }
 


### PR DESCRIPTION
### Constants/NewMagicClassConstant: minor code tweaks

Remove a condition which can never be met and small other tweaks.

### Constants/NewMagicClassConstant: bug fix for functions called "class"

Since PHP 7.0, `class` can be used as a method name. The sniff did not take this into account correctly.

Fixed now.

Includes unit tests.

### Constants/NewMagicClassConstant: add test with PHP 8.0+ nullsafe object operator

The sniff already handles this correctly, no changes needed.

### Constants/NewMagicClassConstant: add test with PHP 8.0+ attribute

The sniff already handles this correctly, no changes needed.