### PR TITLE
ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocks: add extra tests

### DIFF
--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -63,9 +63,13 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
         $defaultToken = $stackPtr;
         $defaultCount = 0;
         $targetLevel  = $tokens[$stackPtr]['level'] + 1;
-        while ($defaultCount < 2 && ($defaultToken = $phpcsFile->findNext([\T_DEFAULT], $defaultToken + 1, $tokens[$stackPtr]['scope_closer'])) !== false) {
+        while ($defaultCount < 2
+            && ($defaultToken = $phpcsFile->findNext([\T_DEFAULT], $defaultToken + 1, $tokens[$stackPtr]['scope_closer'])) !== false
+        ) {
             // Same level or one below (= two default cases after each other).
-            if ($tokens[$defaultToken]['level'] === $targetLevel || $tokens[$defaultToken]['level'] === ($targetLevel + 1)) {
+            if ($tokens[$defaultToken]['level'] === $targetLevel
+                || $tokens[$defaultToken]['level'] === ($targetLevel + 1)
+            ) {
                 ++$defaultCount;
             }
         }

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.inc
@@ -63,5 +63,58 @@ switch ($something) {
         break;
 }
 
+// Safeguard handling of switch statements using alternative syntax.
+switch ($something):
+    case 1:
+        break;
+    case 2:
+        break;
+    default:
+    default:
+        break;
+endswitch;
+
+// Safeguard handling of case/default statements with semi-colon instead of colon.
+switch ($something) {
+    default;
+        break;
+    case 1;
+        break;
+    case 2;
+        break;
+    default;
+        break;
+}
+
+// Safeguard handling of case/default statements with curly braces after colon.
+switch ($something) {
+    case 1: {
+        break;
+    }
+    default: {
+        break;
+    }
+    case 2: {
+        break;
+    }
+    default: {
+        break;
+    }
+}
+
+// Safeguard handling of case/default statements with mixed syntaxes.
+switch ($something) {
+    case 1: {
+        echo 'something';
+    }
+    default:
+        break;
+    case 2;
+        continue;
+    default: {
+        break;
+    }
+}
+
 // Don't throw errors on live code review.
 switch ($something) {

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.inc
@@ -116,5 +116,19 @@ switch ($something) {
     }
 }
 
+// Safeguard handling when there is a nested PHP 8.0 match structure with default.
+switch ($something) {
+    case 1:
+        break;
+    case 2:
+        $foo = match($a) {
+            'a'     => $a * 10,
+            default => $a * 1,
+        };
+        break;
+    default:
+        break;
+}
+
 // Don't throw errors on live code review.
 switch ($something) {

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
@@ -53,6 +53,10 @@ class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTest
             [3],
             [47],
             [56],
+            [67],
+            [78],
+            [90],
+            [106],
         ];
     }
 
@@ -85,7 +89,7 @@ class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTest
             [14],
             [23],
             [43],
-            [67], // Live coding.
+            [120], // Live coding.
         ];
     }
 

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
@@ -89,7 +89,8 @@ class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTest
             [14],
             [23],
             [43],
-            [120], // Live coding.
+            [120],
+            [134], // Live coding.
         ];
     }
 


### PR DESCRIPTION
### ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocks: minor code readability tweaks

### ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocks: add some extra tests

... with alternative syntax for the `switch` and alternative syntaxes for the `case`/`default` statements.

The sniff already appears to handle this correctly, no changes needed.

Note: there is an issue open upstream about issues with the tokenization of some of these, see squizlabs/PHP_CodeSniffer#3794

### ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocks: add tests with PHP 8.0+ match expressions

... to safeguard that the sniff doesn't get confused over the `default` in the `match` expression.

The sniff already handles this correctly, no changes needed.