### PR TITLE
ControlStructures/NewMultiCatch: add tests for PHP 8.0+ non-capturing catch

### DIFF
--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.inc
@@ -24,6 +24,15 @@ try {
    // ...
 }
 
+// Safeguard correct handling of PHP 8.0 non-capturing catch.
+try {
+   // Some code...
+} catch (ExceptionType1 | ExceptionType2) {
+   // Code to handle the exception.
+} catch (\Exception) {
+   // ...
+}
+
 // Don't throw errors during live code review.
 try {
    // Some code...

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
@@ -52,6 +52,7 @@ class NewMultiCatchUnitTest extends BaseSniffTest
     {
         return [
             [21],
+            [30],
         ];
     }
 
@@ -85,7 +86,8 @@ class NewMultiCatchUnitTest extends BaseSniffTest
             [10],
             [12],
             [23],
-            [30], // Live coding.
+            [32],
+            [39], // Live coding.
         ];
     }
 


### PR DESCRIPTION
The sniff already handles this correctly, no changes needed.