### PR TITLE
FunctionDeclarations/AbstractPrivateMethods: minor simplification + extra tests

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
@@ -12,7 +12,7 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHPCSUtils\BackCompat\BCTokens;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
 
@@ -34,7 +34,7 @@ use PHPCSUtils\Utils\Scopes;
  * @since 9.2.0
  * @since 10.0.0 The sniff has been renamed from `PHPCompatibility.Classes.ForbiddenAbstractPrivateMethods`
  *               to `PHPCompatibility.FunctionDeclarations.AbstractPrivateMethods` and now
- *               includes detection of the PHP 8 change.
+ *               includes detection of the PHP 8.0 change.
  */
 class AbstractPrivateMethodsSniff extends Sniff
 {
@@ -70,7 +70,7 @@ class AbstractPrivateMethodsSniff extends Sniff
         }
 
         $tokens   = $phpcsFile->getTokens();
-        $scopePtr = Scopes::validDirectScope($phpcsFile, $stackPtr, BCTokens::ooScopeTokens());
+        $scopePtr = Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
         if ($scopePtr === false) {
             // Function, not method.
             return;

--- a/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.inc
@@ -42,3 +42,11 @@ trait CrossVersionInValidTrait
     abstract private function privateOverload();
     static private abstract function privateStaticOverload();
 }
+
+// Global function cannot have abstract nor private keyword.
+static function globalFunction() {}
+
+// Interface cannot have private methods, nor abstract methods, but that's not the concern of this sniff.
+interface IllegalPrivate {
+    abstract private function privateToImplement();
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.php
@@ -55,6 +55,7 @@ class AbstractPrivateMethodsUnitTest extends BaseSniffTest
             [29],
             [33],
             [34],
+            [51],
         ];
     }
 
@@ -126,6 +127,8 @@ class AbstractPrivateMethodsUnitTest extends BaseSniffTest
         for ($line = 1; $line <= 24; $line++) {
             $cases[] = [$line];
         }
+
+        $cases[] = [47];
 
         return $cases;
     }


### PR DESCRIPTION
### FunctionDeclarations/AbstractPrivateMethods: minor simplification

The use of the PHPCSUtils `BCTokens` class is no longer needed (for now) since support for PHPCS < 3.7.1 has been dropped.

### FunctionDeclarations/AbstractPrivateMethods: add a few extra tests 