### PR TITLE
FunctionDeclarations/ForbiddenFinalPrivateMethods: add extra tests

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.inc
@@ -45,3 +45,11 @@ trait CrossVersionInValidTrait
     final private function privateFinal();
     static private final function privateStaticFinal();
 }
+
+// Global function cannot have final nor private keyword.
+static function globalFunction() {}
+
+// Interface cannot have private methods, nor final methods, but that's not the concern of this sniff.
+interface IllegalPrivate {
+    final private function privateToImplement();
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.inc
@@ -53,3 +53,9 @@ static function globalFunction() {}
 interface IllegalPrivate {
     final private function privateToImplement();
 }
+
+// Safeguard handling of PHP 8.1+ enums.
+enum MyEnum {
+    final public static function publicFinal();
+    final private function privateFinal() {}
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
@@ -56,6 +56,7 @@ class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTest
             [40],
             [45],
             [46],
+            [54],
         ];
     }
 
@@ -90,6 +91,7 @@ class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTest
             $cases[] = [$line];
         }
 
+        $cases[] = [50];
         return $cases;
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
@@ -57,6 +57,7 @@ class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTest
             [45],
             [46],
             [54],
+            [60],
         ];
     }
 
@@ -92,6 +93,8 @@ class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTest
         }
 
         $cases[] = [50];
+        $cases[] = [59];
+
         return $cases;
     }
 


### PR DESCRIPTION
### FunctionDeclarations/ForbiddenFinalPrivateMethods: add a few extra tests

### FunctionDeclarations/ForbiddenFinalPrivateMethods: add tests for methods in PHP 8.1 enums

The sniff already handles this correctly, no changes needed.