### PR TITLE
FunctionDeclarations/ForbiddenParameterShadowSuperGlobals: add extra test

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.inc
@@ -23,3 +23,6 @@ function($_GET) {}
 
 // Arrow functions: these should be flagged.
 $arrow = fn( $_ENV ) => $_ENV['key'];
+
+// Safeguard the sniff stays silent when there are no parameters.
+function testingM() {}

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
@@ -97,6 +97,7 @@ class ForbiddenParameterShadowSuperGlobalsUnitTest extends BaseSniffTest
             [15],
             [16],
             [17],
+            [28],
         ];
     }
 


### PR DESCRIPTION
.. to safeguard previously uncovered code paths in the sniff.