### PR TITLE
FunctionDeclarations/NewParamTypeDeclarations: add extra tests

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -155,3 +155,16 @@ function intersectionTypesIllegalTypes(A&B&A $var) {}
 
 // PHP 8.2 true type.
 function pseudoTypeTrue(true $var = true) {}
+
+// PHP 8.1 types in enum methods.
+enum Suit implements Colorful
+{
+    case Hearts;
+    case Diamonds;
+
+    public function color(string $scheme, ?int $foo = null): string {}
+    public function shape(
+        A|B $union,
+        A&B $intersection,
+    ): mixed {}
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -77,7 +77,7 @@ class Bar {
 // PHP 7.4 arrow functions.
 $arrow = fn(int $a) => $a * 10;
 $arrow = fn(\FQN\ClassName $b) => $b::method();
-$arrow = fn(callable $a) => $a();
+$arrow = fn(callable $a, string $b, mixed $c) => $a();
 $arrow = fn(integer $a) => $a . 'test';
 $arrow = fn($a) => $a * 10; // OK.
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -133,6 +133,9 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             ['parent', '5.1', 150, '8.1'],
 
             ['true', '8.1', 157, '8.2'],
+
+            ['int', '5.6', 165, '7.0'],
+            ['string', '5.6', 165, '7.0'],
         ];
     }
 
@@ -306,6 +309,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             ['iterable|array|Traversable', 119],
             ['int|string|INT', 122],
             ['float|int', 131],
+            ['A|B', 167],
         ];
     }
 
@@ -448,6 +452,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             ['self&\Fully\Qualified\SomeInterface', 149],
             ['Qualified\SomeInterface&parent', 150],
             ['A&B&A', 154],
+            ['A&B', 168],
         ];
     }
 
@@ -573,6 +578,9 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             [150],
             [154],
             [157],
+            [165],
+            [167],
+            [168],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -85,7 +85,9 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             ['self', '5.1', 72, '5.2', false],
             ['parent', '5.1', 73, '5.2', false],
             ['int', '5.6', 78, '7.0'],
-            ['callable', '5.3', 80, '5.4'],
+            ['callable', '5.3', 80, '8.0'],
+            ['string', '5.6', 80, '8.0'],
+            ['mixed', '7.4', 80, '8.0'],
             ['mixed', '7.4', 85, '8.0'],
             ['mixed', '7.4', 88, '8.0', false],
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -564,6 +564,13 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
             [130],
             [131],
             [132],
+            [139],
+            [141],
+            [145],
+            [149],
+            [150],
+            [154],
+            [157],
         ];
     }
 


### PR DESCRIPTION
### FunctionDeclarations/NewParamTypeDeclarations: make the base test more complete

Make sure all lines which would have an error thrown for PHP 4.4 are listed in the `dataTypeDeclaration()` data provider.

### FunctionDeclarations/NewParamTypeDeclarations: minor improvement to arrow function tests

Safeguard that arrow functions with multiple parameters are handled correctly.

### FunctionDeclarations/NewParamTypeDeclarations: add tests with PHP 8.1+ enums

The sniff already handles this correctly, no changes needed.