### PR TITLE
FunctionDeclarations/NewReturnTypeDeclarations: add tests with PHP 8.1+ enums

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -129,3 +129,11 @@ function intersectionTypesIllegalTypes(): A&B&A {}
 
 // PHP 8.2 true type.
 function pseudoTypeTrue(): true {}
+
+// PHP 8.1 types in enum methods.
+enum Suit implements Colorful
+{
+    public function color(): ?string {}
+    public function shape(): mixed {}
+    public function union(): A|B {}
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -132,6 +132,10 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             ['static', '7.4', 124, '8.1'],
 
             ['true', '8.1', 131, '8.2'],
+
+            ['string', '5.6', 136, '7.0'],
+            ['mixed', '7.4', 137, '8.0'],
+            ['Class name', '5.6', 138, '8.0'],
         ];
     }
 
@@ -259,6 +263,7 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
             ['object|ClassName', 79],
             ['iterable|array|Traversable', 83],
             ['int|string|INT', 87],
+            ['A|B', 138],
         ];
     }
 


### PR DESCRIPTION
The sniff already handles this correctly, no changes needed.