### PR TITLE
FunctionDeclarations/RemovedCallingDestructAfterConstructorExit: various minor tweaks

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -63,6 +63,7 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
             return;
         }
 
+        // Note: interface constructors cannot contain code, enums cannot contain constructors or destructors.
         $classPtr = Scopes::validDirectScope($phpcsFile, $stackPtr, [\T_CLASS, \T_ANON_CLASS, \T_TRAIT]);
         if ($classPtr === false) {
             // Function, not method.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -100,7 +100,7 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
                 continue;
             }
 
-            // Skip over nested closed scopes as possible for efficiency.
+            // Skip over nested closed scopes as much as possible for efficiency.
             // Ignore arrow functions as they aren't closed scopes.
             if (isset(Collections::closedScopes()[$tokens[$current]['code']]) === true
                 && isset($tokens[$current]['scope_closer']) === true

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -70,6 +70,14 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
             return;
         }
 
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false
+            || isset($tokens[$classPtr]['scope_opener'], $tokens[$classPtr]['scope_closer']) === false
+        ) {
+            // Parse error, tokenizer error or live coding.
+            return;
+        }
+
         $name = FunctionDeclarations::getName($phpcsFile, $stackPtr);
         if (empty($name) === true) {
             // Parse error or live coding.
@@ -78,12 +86,6 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
 
         if (\strtolower($name) !== '__construct') {
             // The rule only applies to constructors. Bow out.
-            return;
-        }
-
-        $tokens = $phpcsFile->getTokens();
-        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
-            // Parse error or live coding.
             return;
         }
 
@@ -128,11 +130,6 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
 
         if (empty($exits) === true) {
             // No calls to exit or die found.
-            return;
-        }
-
-        if (isset($tokens[$classPtr]['scope_opener'], $tokens[$classPtr]['scope_closer']) === false) {
-            // Parse error, tokenizer error or live coding.
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -140,10 +140,18 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
         $classClose  = $tokens[$classPtr]['scope_closer'];
         $nextFunc    = $classOpen;
 
-        while (($nextFunc = $phpcsFile->findNext([\T_FUNCTION, \T_DOC_COMMENT_OPEN_TAG, \T_USE], ($nextFunc + 1), $classClose)) !== false) {
+        while (($nextFunc = $phpcsFile->findNext([\T_FUNCTION, \T_DOC_COMMENT_OPEN_TAG, \T_ATTRIBUTE, \T_USE], ($nextFunc + 1), $classClose)) !== false) {
             // Skip over docblocks.
             if ($tokens[$nextFunc]['code'] === \T_DOC_COMMENT_OPEN_TAG) {
                 $nextFunc = $tokens[$nextFunc]['comment_closer'];
+                continue;
+            }
+
+            // Skip over attributes.
+            if ($tokens[$nextFunc]['code'] === \T_ATTRIBUTE
+                && isset($tokens[$nextFunc]['attribute_closer'])
+            ) {
+                $nextFunc = $tokens[$nextFunc]['attribute_closer'];
                 continue;
             }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
@@ -73,7 +73,7 @@ abstract class HasDestructAndExtends extends ClassWhichMayOrMayNotContainADestru
      * This should be easily skipped over.
      */
     abstract function something();
-
+    #[AttributeWhichCouldBeLong, ShouldBeSkippedOver( 10, self::CONST_VALUE)]
     public function __DeStruct() {
         // Destructor will not be called on exit() in constructor.
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
@@ -122,3 +122,9 @@ class ExitNotInFunctionScope {
 
     public function __destruct() {}
 }
+
+function __construct() {}
+
+interface DoesntHaveCodeInFunctions {
+    public function __construct();
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
@@ -101,9 +101,10 @@ class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTest
         $cases[] = [56];
         $cases[] = [61];
         $cases[] = [66];
-        $cases[] = [106];
-        $cases[] = [112];
-        $cases[] = [119];
+
+        for ($line = 101; $line <= 130; $line++) {
+            $cases[] = [$line];
+        }
 
         return $cases;
     }


### PR DESCRIPTION
### FunctionDeclarations/RemovedCallingDestructAfterConstructorExit: add note about PHP 8.1 enums

### FunctionDeclarations/RemovedCallingDestructAfterConstructorExit: minor doc grammar fix

### FunctionDeclarations/RemovedCallingDestructAfterConstructorExit: minor efficiency tweak

Bow out earlier when the sniff could never get a valid result anyway.

### FunctionDeclarations/RemovedCallingDestructAfterConstructorExit: skip over PHP 8.0+ attributes

... for efficiency in the token walking.

### FunctionDeclarations/RemovedCallingDestructAfterConstructorExit: add some extra tests

... to cover more code branches.