### PR TITLE
FunctionNameRestrictions/RemovedMagicAutoload: various minor tweaks

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -12,7 +12,7 @@ namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHPCSUtils\BackCompat\BCTokens;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Namespaces;
@@ -58,7 +58,7 @@ class RemovedMagicAutoloadSniff extends Sniff
      */
     public function register()
     {
-        $this->checkForScopes += BCTokens::ooScopeTokens();
+        $this->checkForScopes += Tokens::$ooScopeTokens;
 
         return [\T_FUNCTION];
     }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.1.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.1.inc
@@ -34,3 +34,9 @@ class Nested {
         }
     }
 }
+
+enum fooenum {
+    public function __autoload($someclass) {
+        echo 'I am NOT an autoloader as I\'m not in the global namespace';
+    }
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.1.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.1.inc
@@ -6,7 +6,7 @@ function __autoload($someclass) {
 
 class fooclass {
     function __autoload($someclass) {
-        echo 'I am the autoloader in a class (which makes no sense) - I am deprecated from PHP 7.2 onwards';
+        echo 'I am NOT an autoloader as I\'m not in the global namespace';
     }
 }
 
@@ -16,13 +16,13 @@ interface foointerface {
 
 trait footrait {
     function __autoload($someclass) {
-        echo 'I am the autoloader in a trait (which makes no sense) - I am deprecated from PHP 7.2 onwards';
+        echo 'I am NOT an autoloader as I\'m not in the global namespace';
     }
 }
 
 fooanonclass(new class {
     function __autoload($someclass) {
-        echo 'I am the autoloader in an anonymous class (which makes no sense) - I am deprecated from PHP 7.2 onwards';
+        echo 'I am NOT an autoloader as I\'m not in the global namespace';
     }
 });
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.2.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.2.inc
@@ -27,3 +27,9 @@ fooanonclass(new class {
         echo 'I am the autoloader in an anonymous class (which makes no sense) - I am deprecated from PHP 7.2 onwards';
     }
 });
+
+enum fooenum {
+    public function __autoload($someclass) {
+        echo 'I am NOT an autoloader as I\'m not in the global namespace';
+    }
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.2.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.2.inc
@@ -3,12 +3,12 @@
 namespace magicAutoloadDeprecations;
 
 function __autoload($someclass) {
-    echo 'I am the autoloader - I am deprecated from PHP 7.2 onwards';
+    echo 'I am NOT an autoloader as I\'m not in the global namespace';
 }
 
 class fooclass {
     function __autoload($someclass) {
-        echo 'I am the autoloader in a class (which makes no sense) - I am deprecated from PHP 7.2 onwards';
+        echo 'I am NOT an autoloader as I\'m not in the global namespace';
     }
 }
 
@@ -18,13 +18,13 @@ interface foointerface {
 
 trait footrait {
     function __autoload($someclass) {
-        echo 'I am the autoloader in a trait (which makes no sense) - I am deprecated from PHP 7.2 onwards';
+        echo 'I am NOT an autoloader as I\'m not in the global namespace';
     }
 }
 
 fooanonclass(new class {
     function __autoload($someclass) {
-        echo 'I am the autoloader in an anonymous class (which makes no sense) - I am deprecated from PHP 7.2 onwards';
+        echo 'I am NOT an autoloader as I\'m not in the global namespace';
     }
 });
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -114,11 +114,13 @@ class RemovedMagicAutoloadUnitTest extends BaseSniffTest
             [self::TEST_FILE, 14],
             [self::TEST_FILE, 18],
             [self::TEST_FILE, 24],
+            [self::TEST_FILE, 39],
             [self::TEST_FILE_NAMESPACED, 5],
             [self::TEST_FILE_NAMESPACED, 10],
             [self::TEST_FILE_NAMESPACED, 16],
             [self::TEST_FILE_NAMESPACED, 20],
             [self::TEST_FILE_NAMESPACED, 26],
+            [self::TEST_FILE_NAMESPACED, 32],
         ];
     }
 }


### PR DESCRIPTION
### FunctionNameRestrictions/RemovedMagicAutoload: add tests with PHP 8.1+ enums

The sniff already handles this correctly, no changes needed.

### FunctionNameRestrictions/RemovedMagicAutoload: minor simplification

The use of the PHPCSUtils `BCTokens` class is no longer needed (for now) since support for PHPCS < 3.7.1 has been dropped.

### FunctionNameRestrictions/RemovedMagicAutoload: improve test documentation

The text strings used in the test case file were confusing and misleading. Fixed now to lower cognitive load.