### PR TITLE
FunctionUse/NewFunctionParameters: refactor to use the AbstractFunctionCallParameterSniff + message precision fix

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -10,11 +10,10 @@
 
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
-use PHPCompatibility\Sniff;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -26,9 +25,10 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
+ *               and uses the `ComplexVersionNewFeatureTrait`.
  */
-class NewFunctionParametersSniff extends Sniff
+class NewFunctionParametersSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionNewFeatureTrait;
 
@@ -41,11 +41,12 @@ class NewFunctionParametersSniff extends Sniff
      *
      * @since 7.0.0
      * @since 7.0.2 Visibility changed from `public` to `protected`.
-     * @since 10.0.0 The parameter offsets were changed from 0-based to 1-based.
+     * @since 10.0.0 - The parameter offsets were changed from 0-based to 1-based.
+     *               - The property was renamed from `$newFunctionParameters` to `$targetFunctions`.
      *
      * @var array
      */
-    protected $newFunctionParameters = [
+    protected $targetFunctions = [
         'array_filter' => [
             3 => [
                 'name' => 'mode',
@@ -1030,84 +1031,43 @@ class NewFunctionParametersSniff extends Sniff
         ],
     ];
 
-
     /**
-     * Returns an array of tokens this test wants to listen for.
+     * Should the sniff bow out early for specific PHP versions ?
      *
-     * @since 7.0.0
+     * @since 10.0.0
      *
-     * @return array
+     * @return bool
      */
-    public function register()
+    protected function bowOutEarly()
     {
-        // Handle case-insensitivity of function names.
-        $this->newFunctionParameters = \array_change_key_case($this->newFunctionParameters, \CASE_LOWER);
-
-        return [\T_STRING];
+        return false;
     }
 
     /**
-     * Processes this test, when one of its tokens is encountered.
+     * Process the parameters of a matched function.
      *
-     * @since 7.0.0
+     * @since 10.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in
-     *                                               the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
      *
      * @return void
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $tokens = $phpcsFile->getTokens();
+        $functionLc = \strtolower($functionName);
 
-        $function   = $tokens[$stackPtr]['content'];
-        $functionLc = \strtolower($function);
+        // If the parameter count is > 0, we know there will be valid open parenthesis.
+        $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
 
-        if (isset($this->newFunctionParameters[$functionLc]) === false) {
-            return;
-        }
-
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($nextToken === false
-            || $tokens[$nextToken]['code'] !== \T_OPEN_PARENTHESIS
-            || isset($tokens[$nextToken]['parenthesis_owner']) === true
-        ) {
-            return;
-        }
-
-        $ignore  = [\T_NEW => true];
-        $ignore += Collections::objectOperators();
-
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
-            // Not a call to a PHP function.
-            return;
-
-        } elseif ($tokens[$prevToken]['code'] === \T_NS_SEPARATOR) {
-            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
-            if ($tokens[$prevPrevToken]['code'] === \T_STRING
-                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
-            ) {
-                // Namespaced function.
-                return;
-            }
-        }
-
-        $parameters = PassedParameters::getParameters($phpcsFile, $stackPtr);
-        if (empty($parameters)) {
-            return;
-        }
-
-        // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
-
-        foreach ($this->newFunctionParameters[$functionLc] as $offset => $parameterDetails) {
+        foreach ($this->targetFunctions[$functionLc] as $offset => $parameterDetails) {
             $targetParam = PassedParameters::getParameterFromStack($parameters, $offset, $parameterDetails['name']);
 
             if ($targetParam !== false) {
                 $itemInfo = [
-                    'name'   => $function,
+                    'name'   => $functionName,
                     'nameLc' => $functionLc,
                     'offset' => $offset,
                 ];
@@ -1132,7 +1092,7 @@ class NewFunctionParametersSniff extends Sniff
      */
     protected function handleFeature(File $phpcsFile, $stackPtr, array $itemInfo)
     {
-        $itemArray   = $this->newFunctionParameters[$itemInfo['nameLc']][$itemInfo['offset']];
+        $itemArray   = $this->targetFunctions[$itemInfo['nameLc']][$itemInfo['offset']];
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -1059,19 +1059,18 @@ class NewFunctionParametersSniff extends AbstractFunctionCallParameterSniff
     {
         $functionLc = \strtolower($functionName);
 
-        // If the parameter count is > 0, we know there will be valid open parenthesis.
-        $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
-
         foreach ($this->targetFunctions[$functionLc] as $offset => $parameterDetails) {
             $targetParam = PassedParameters::getParameterFromStack($parameters, $offset, $parameterDetails['name']);
 
-            if ($targetParam !== false) {
+            if ($targetParam !== false && $targetParam['clean'] !== '') {
+                $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+
                 $itemInfo = [
                     'name'   => $functionName,
                     'nameLc' => $functionLc,
                     'offset' => $offset,
                 ];
-                $this->handleFeature($phpcsFile, $openParenthesis, $itemInfo);
+                $this->handleFeature($phpcsFile, $firstNonEmpty, $itemInfo);
             }
         }
     }

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
@@ -137,3 +137,12 @@ mb_strrpos( $haystack, encoding: 'UTF-8', needle: $needle, offset: 2 ); // Error
 
 // Prevent false positives on PHP 8.0+ nullsafe method calls.
 $obj?->getenv($varname, true ); // OK.
+
+// Prevent false positive on param which isn't actually a param.
+bcmod( '100', '10', /* to do: add scale */, ); // OK, well, not really, parse error due to trailing comma, but that's not the concern of this sniff.
+
+// Safeguard error is thrown on the line containing the parameter.
+parse_url(
+    $url,
+    PHP_URL_PATH // Error.
+);

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -165,7 +165,7 @@ class NewFunctionParametersUnitTest extends BaseSniffTest
             ['openssl_seal', 'iv', '5.6', [62], '7.0'],
             ['openssl_verify', 'algorithm', '5.1', [63], '5.2'],
             ['parse_ini_file', 'scanner_mode', '5.2', [64], '5.3'],
-            ['parse_url', 'component', '5.1.1', [65], '5.2', '5.1'],
+            ['parse_url', 'component', '5.1.1', [65, 147], '5.2', '5.1'],
             ['pg_escape_bytea', 'connection', '5.1', [123], '5.2'],
             ['pg_escape_string', 'connection', '5.1', [124], '5.2'],
             ['pg_fetch_all', 'mode', '7.0', [99], '7.1'],
@@ -241,6 +241,7 @@ class NewFunctionParametersUnitTest extends BaseSniffTest
         return [
             [4],
             [139],
+            [142],
         ];
     }
 


### PR DESCRIPTION
### FunctionUse/NewFunctionParameters: refactor to use the AbstractFunctionCallParameterSniff

As the sniff examines the existence of specific function call parameters, it is more appropriate to base the sniff on the `AbstractFunctionCallParameterSniff` so it can benefit from any "is this a function call ?" determination fixes made in that abstract.

This was previously not possible as the sniff extended the `AbstractNewFeatureSniff` sniff, but after the refactor done in #1406, this is now possible.

In the future, once a similar `AbstractFunctionCallParameterSniff` class is expected to be available via PHPCSUtils, this change will also allow us to switch over to that abstract more easily.

### FunctionUse/NewFunctionParameters: improve message precision

Throw the error on the first non-empty token of the parameter which is being flagged, instead of on the function open parenthesis.
This will more clearly indicate the issue when people use the PHPCS `code` view.

Includes tests safeguarding the fix.