### PR TITLE
FunctionUse/RemovedFunctionParameters: refactor to use the AbstractFunctionCallParameterSniff + bug fix

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -192,25 +192,24 @@ class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
     {
         $functionLc = \strtolower($functionName);
 
-        // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
-
         foreach ($this->targetFunctions[$functionLc] as $offset => $parameterDetails) {
             $targetParam = PassedParameters::getParameterFromStack($parameters, $offset, $parameterDetails['name']);
 
-            if ($targetParam !== false) {
+            if ($targetParam !== false && $targetParam['clean'] !== '') {
                 if (isset($parameterDetails['callback']) && \method_exists($this, $parameterDetails['callback'])) {
                     if ($this->{$parameterDetails['callback']}($phpcsFile, $targetParam) === false) {
                         continue;
                     }
                 }
 
+                $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+
                 $itemInfo = [
                     'name'   => $functionName,
                     'nameLc' => $functionLc,
                     'offset' => $offset,
                 ];
-                $this->handleFeature($phpcsFile, $openParenthesis, $itemInfo);
+                $this->handleFeature($phpcsFile, $firstNonEmpty, $itemInfo);
             }
         }
     }

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -200,7 +200,7 @@ class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
 
             if ($targetParam !== false) {
                 if (isset($parameterDetails['callback']) && \method_exists($this, $parameterDetails['callback'])) {
-                    if ($this->{$parameterDetails['callback']}($phpcsFile, $parameters[($offset + 1)]) === false) {
+                    if ($this->{$parameterDetails['callback']}($phpcsFile, $targetParam) === false) {
                         continue;
                     }
                 }

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -10,11 +10,10 @@
 
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
-use PHPCompatibility\Sniff;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -27,9 +26,10 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
+ *               and uses the `ComplexVersionNewFeatureTrait`.
  */
-class RemovedFunctionParametersSniff extends Sniff
+class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 
@@ -47,11 +47,12 @@ class RemovedFunctionParametersSniff extends Sniff
      * @since 7.0.0
      * @since 7.0.2  Visibility changed from `public` to `protected`.
      * @since 9.3.0  Optional `callback` key.
-     * @since 10.0.0 The parameter offsets were changed from 0-based to 1-based.
+     * @since 10.0.0 - The parameter offsets were changed from 0-based to 1-based.
+     *               - The property was renamed from `$removedFunctionParameters` to `$targetFunctions`.
      *
      * @var array
      */
-    protected $removedFunctionParameters = [
+    protected $targetFunctions = [
         'curl_version' => [
             1 => [
                 'name' => 'age',
@@ -163,79 +164,38 @@ class RemovedFunctionParametersSniff extends Sniff
         ],
     ];
 
-
     /**
-     * Returns an array of tokens this test wants to listen for.
+     * Should the sniff bow out early for specific PHP versions ?
      *
-     * @since 7.0.0
+     * @since 10.0.0
      *
-     * @return array
+     * @return bool
      */
-    public function register()
+    protected function bowOutEarly()
     {
-        // Handle case-insensitivity of function names.
-        $this->removedFunctionParameters = \array_change_key_case($this->removedFunctionParameters, \CASE_LOWER);
-
-        return [\T_STRING];
+        return false;
     }
 
     /**
-     * Processes this test, when one of its tokens is encountered.
+     * Process the parameters of a matched function.
      *
-     * @since 7.0.0
+     * @since 10.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in
-     *                                               the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
      *
      * @return void
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $tokens = $phpcsFile->getTokens();
-
-        $function   = $tokens[$stackPtr]['content'];
-        $functionLc = \strtolower($function);
-
-        if (isset($this->removedFunctionParameters[$functionLc]) === false) {
-            return;
-        }
-
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($nextToken === false
-            || $tokens[$nextToken]['code'] !== \T_OPEN_PARENTHESIS
-            || isset($tokens[$nextToken]['parenthesis_owner']) === true
-        ) {
-            return;
-        }
-
-        $ignore  = [\T_NEW => true];
-        $ignore += Collections::objectOperators();
-
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
-            // Not a call to a PHP function.
-            return;
-
-        } elseif ($tokens[$prevToken]['code'] === \T_NS_SEPARATOR) {
-            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
-            if ($tokens[$prevPrevToken]['code'] === \T_STRING
-                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
-            ) {
-                // Namespaced function.
-                return;
-            }
-        }
-
-        $parameters = PassedParameters::getParameters($phpcsFile, $stackPtr);
-        if (empty($parameters)) {
-            return;
-        }
+        $functionLc = \strtolower($functionName);
 
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
         $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
 
-        foreach ($this->removedFunctionParameters[$functionLc] as $offset => $parameterDetails) {
+        foreach ($this->targetFunctions[$functionLc] as $offset => $parameterDetails) {
             $targetParam = PassedParameters::getParameterFromStack($parameters, $offset, $parameterDetails['name']);
 
             if ($targetParam !== false) {
@@ -246,7 +206,7 @@ class RemovedFunctionParametersSniff extends Sniff
                 }
 
                 $itemInfo = [
-                    'name'   => $function,
+                    'name'   => $functionName,
                     'nameLc' => $functionLc,
                     'offset' => $offset,
                 ];
@@ -271,7 +231,7 @@ class RemovedFunctionParametersSniff extends Sniff
      */
     protected function handleFeature(File $phpcsFile, $stackPtr, array $itemInfo)
     {
-        $itemArray   = $this->removedFunctionParameters[$itemInfo['nameLc']][$itemInfo['offset']];
+        $itemArray   = $this->targetFunctions[$itemInfo['nameLc']][$itemInfo['offset']];
         $versionInfo = $this->getVersionInfo($itemArray);
         $isError     = null;
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -48,3 +48,13 @@ imagepolygon($image, color: $color, points: $points, num_points: $num_points); /
 
 // Prevent false positives on PHP 8.0+ nullsafe method calls.
 $obj?->define( 'CONSTANT', 'foo', true, ); // OK.
+
+// Prevent false positive on param which isn't actually a param.
+define( 'CONSTANT', 'foo', /*not passed for cross-version compat*/, ); // OK, well, not really, parse error due to trailing comma, but that's not the concern of this sniff
+
+// Safeguard error is thrown on the line containing the parameter.
+ldap_first_attribute(
+    $link_identifier,
+    $result_entry_identifier,
+    $ber_identifier // Error.
+);

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -64,7 +64,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
     public function dataRemovedParameter()
     {
         return [
-            ['ldap_first_attribute', 'ber_identifier', '5.2.4', [11], '5.2', '5.3'],
+            ['ldap_first_attribute', 'ber_identifier', '5.2.4', [11, 59], '5.2', '5.3'],
             ['ldap_next_attribute', 'ber_identifier', '5.2.4', [12], '5.2', '5.3'],
             ['mb_decode_numericentity', 'is_hex', '8.0', [24], '7.4'],
             ['pg_connect', 'options', '8.0', [27], '7.4'],
@@ -214,6 +214,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTest
             [29],
             [32],
             [50],
+            [53],
         ];
     }
 


### PR DESCRIPTION
### FunctionUse/RemovedFunctionParameters: refactor to use the AbstractFunctionCallParameterSniff

As the sniff examines the existence of specific function call parameters, it is more appropriate to base the sniff on the `AbstractFunctionCallParameterSniff` so it can benefit from any "is this a function call ?" determination fixes made in that abstract.

This was previously not possible as the sniff extended the `AbstractNewFeatureSniff` sniff, but after the refactor done in #1406, this is now possible.

In the future, once a similar `AbstractFunctionCallParameterSniff` class is expected to be available via PHPCSUtils, this change will also allow us to switch over to that abstract more easily.

### FunctionUse/RemovedFunctionParameters: bug fix

Follow up on #1433 which added support for named parameter to the sniff.

Looks like one particular reference still presumed positional parameters and was not made compatible with named parameters.

Fixed now.

Note: no test included as at this time the `'callback'` array key appears to be unused, so there is nothing to test this with.

### FunctionUse/RemovedFunctionParameters: improve message precision

Throw the error on the first non-empty token of the parameter which is being flagged, instead of on the function open parenthesis.
This will more clearly indicate the issue when people use the PHPCS `code` view.

Includes tests safeguarding the fix.