### PR TITLE
IniDirectives/NewIniDirectives: refactor to use the AbstractFunctionCallParameterSniff and other improvements

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -947,7 +947,7 @@ class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        $filteredToken = TextStrings::stripQuotes($iniToken['raw']);
+        $filteredToken = TextStrings::stripQuotes($iniToken['clean']);
         if (isset($this->newIniDirectives[$filteredToken]) === false) {
             return;
         }

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -32,7 +32,7 @@ $test = ini_get('exit_on_timeout');
 ini_set('mbstring.http_output_conv_mimetype', 1);
 $test = ini_get('mbstring.http_output_conv_mimetype');
 
-ini_set('request_order', 1);
+ini_set('request_order' /*comment*/, 1);
 $test = ini_get('request_order');
 
 ini_set('cli.pager', 1);
@@ -77,7 +77,7 @@ $test = ini_get('windows_show_crt_warning');
 ini_set('intl.use_exceptions', 1);
 $test = ini_get('intl.use_exceptions');
 
-ini_set('mysqlnd.sha256_server_public_key', 1);
+ini_set( /*comment*/ 'mysqlnd.sha256_server_public_key', 1);
 $test = ini_get('mysqlnd.sha256_server_public_key');
 
 ini_set('auto_globals_jit', 1);

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -544,3 +544,6 @@ $test = ini_get('mysqli.local_infile_directory');
 
 ini_set('pm.max_spawn_rate', 10);
 $test = ini_get('pm.max_spawn_rate');
+
+// Safeguard no false positives on PHP 8.1+ first class callables.
+register_callback(ini_get(...));

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -547,3 +547,7 @@ $test = ini_get('pm.max_spawn_rate');
 
 // Safeguard no false positives on PHP 8.1+ first class callables.
 register_callback(ini_get(...));
+
+// Safeguard against false positives when target param not found.
+ini_set(value: 1); // Missing param.
+$test = ini_get(ini: 'oci8.statement_cache_size'); // Wrong param name.

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -349,6 +349,8 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             [5],
             [6],
             [549],
+            [552],
+            [553],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -348,6 +348,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTest
             [4],
             [5],
             [6],
+            [549],
         ];
     }
 


### PR DESCRIPTION
### IniDirectives/NewIniDirectives: refactor to use the AbstractFunctionCallParameterSniff

As the sniff examines the contents of a function call parameter, it is more appropriate to base the sniff on the `AbstractFunctionCallParameterSniff` so it can benefit from any "is this a function call ?" determination fixes made in that abstract.

This was previously not possible as the sniff extended the `AbstractNewFeatureSniff` sniff, but after the refactor done in #1406, this is now possible.

In the future, once a similar `AbstractFunctionCallParameterSniff` class is expected to be available via PHPCSUtils, this change will also allow us to switch over to that abstract more easily.

### IniDirectives/NewIniDirectives: prevent some false negatives

The `'raw'` key in the parameter arrays returned from the `PassedParameters` class contains - as per the name - the _raw_ contents of the parameter.

Since PHPCSUtils 1.0.0-alpha4, the return array also contain a `'clean'` index, which contains the contents of the parameter cleaned of comments.

By switching to using that key, some false negatives get fixed.

Includes unit tests demonstrating the issue and safeguarding the fix.

### IniDirectives/NewIniDirectives: add test with PHP 8.1+ first class callable syntax

### IniDirectives/NewIniDirectives: add some extra tests

... to cover more code branches.