### PR TITLE
IniDirectives/RemovedIniDirectives: refactor to use the AbstractFunctionCallParameterSniff and other improvements

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -10,10 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\IniDirectives;
 
-use PHPCompatibility\Sniff;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
 use PHP_CodeSniffer\Files\File;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
@@ -32,9 +31,10 @@ use PHPCSUtils\Utils\TextStrings;
  * @since 7.0.1  The sniff will now only throw warnings for `ini_get()`.
  * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
  * @since 9.0.0  Renamed from `DeprecatedIniDirectivesSniff` to `RemovedIniDirectivesSniff`.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
+ *               and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
  */
-class RemovedIniDirectivesSniff extends Sniff
+class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 
@@ -45,11 +45,12 @@ class RemovedIniDirectivesSniff extends Sniff
      * and the official name of the parameter.
      *
      * @since 7.1.0
-     * @since 10.0.0 Moved from the base `Sniff` class to this sniff.
+     * @since 10.0.0 Moved from the base `Sniff` class to this sniff and renamed from
+     *               `$iniFunctions` to `$targetFunctions`.
      *
      * @var array
      */
-    protected $iniFunctions = [
+    protected $targetFunctions = [
         'ini_get' => [
             'position' => 1,
             'name'     => 'option',
@@ -642,51 +643,35 @@ class RemovedIniDirectivesSniff extends Sniff
     ];
 
     /**
-     * Returns an array of tokens this test wants to listen for.
+     * Should the sniff bow out early for specific PHP versions ?
      *
-     * @since 5.5
+     * @since 10.0.0
      *
-     * @return array
+     * @return bool
      */
-    public function register()
+    protected function bowOutEarly()
     {
-        return [\T_STRING];
+        return false;
     }
 
     /**
-     * Processes this test, when one of its tokens is encountered.
+     * Process the parameters of a matched function.
      *
-     * @since 5.5
+     * @since 10.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
      *
      * @return void
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $tokens = $phpcsFile->getTokens();
+        $functionLc = \strtolower($functionName);
+        $paramInfo  = $this->targetFunctions[$functionLc];
 
-        $ignore  = [
-            \T_FUNCTION => true,
-            \T_CONST    => true,
-        ];
-        $ignore += Collections::objectOperators();
-
-        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
-            // Not a call to a PHP function.
-            return;
-        }
-
-        $functionLc = \strtolower($tokens[$stackPtr]['content']);
-        if (isset($this->iniFunctions[$functionLc]) === false) {
-            return;
-        }
-
-        $paramInfo = $this->iniFunctions[$functionLc];
-        $iniToken  = PassedParameters::getParameter($phpcsFile, $stackPtr, $paramInfo['position'], $paramInfo['name']);
+        $iniToken = PassedParameters::getParameterFromStack($parameters, $paramInfo['position'], $paramInfo['name']);
         if ($iniToken === false) {
             return;
         }
@@ -702,7 +687,6 @@ class RemovedIniDirectivesSniff extends Sniff
         ];
         $this->handleFeature($phpcsFile, $iniToken['end'], $itemInfo);
     }
-
 
     /**
      * Handle the retrieval of relevant information and - if necessary - throwing of an

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -676,7 +676,7 @@ class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        $filteredToken = TextStrings::stripQuotes($iniToken['raw']);
+        $filteredToken = TextStrings::stripQuotes($iniToken['clean']);
         if (isset($this->deprecatedIniDirectives[$filteredToken]) === false) {
             return;
         }

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -51,7 +51,7 @@ $a = ini_get('safe_mode_exec_dir');
 ini_set('safe_mode_allowed_env_vars', 1);
 $a = ini_get('safe_mode_allowed_env_vars');
 
-ini_set('safe_mode_protected_env_vars', 1);
+ini_set( /*comment*/ 'safe_mode_protected_env_vars', 1);
 $a = ini_get('safe_mode_protected_env_vars');
 
 ini_set('session.save_handler', 1); // Ok.
@@ -62,7 +62,7 @@ ini_set('always_populate_raw_post_data', 1);
 ini_set('iconv.input_encoding', 'a');
 $a = ini_get('iconv.input_encoding');
 
-ini_set('iconv.output_encoding', 'a');
+ini_set('iconv.output_encoding' /*comment*/, 'a');
 $a = ini_get('iconv.output_encoding');
 
 ini_set('iconv.internal_encoding', 'a');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -453,3 +453,6 @@ $test = ini_get('oci8.old_oci_close_semantics');
 
 // Prevent false positives on PHP 8.0+ nullsafe method calls.
 $obj?->ini_set('y2k_compliance', 1);
+
+// Safeguard no false positives on PHP 8.1+ first class callables.
+register_callback(ini_set(...));

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -456,3 +456,7 @@ $obj?->ini_set('y2k_compliance', 1);
 
 // Safeguard no false positives on PHP 8.1+ first class callables.
 register_callback(ini_set(...));
+
+// Safeguard against false positives when target param not found.
+ini_set(value: 1); // Missing param.
+$test = ini_get(ini: 'filter.default_options'); // Wrong param name.

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -145,8 +145,6 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
     public function dataDeprecatedDirectives()
     {
         return [
-            ['safe_mode_protected_env_vars', '5.3', [54, 55], '5.2'],
-
             ['iconv.input_encoding', '5.6', [62, 63], '5.5'],
             ['iconv.output_encoding', '5.6', [65, 66], '5.5'],
             ['iconv.internal_encoding', '5.6', [68, 69], '5.5'],

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -403,6 +403,7 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             [163],
             [164],
             [455],
+            [458],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -404,6 +404,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTest
             [164],
             [455],
             [458],
+            [461],
+            [462],
         ];
     }
 


### PR DESCRIPTION
### IniDirectives/RemovedIniDirectives: refactor to use the AbstractFunctionCallParameterSniff

As the sniff examines the contents of a function call parameter, it is more appropriate to base the sniff on the `AbstractFunctionCallParameterSniff` so it can benefit from any "is this a function call ?" determination fixes made in that abstract.

This was previously not possible as the sniff extended the `AbstractNewFeatureSniff` sniff, but after the refactor done in #1406, this is now possible.

In the future, once a similar `AbstractFunctionCallParameterSniff` class is expected to be available via PHPCSUtils, this change will also allow us to switch over to that abstract more easily.

### IniDirectives/RemovedIniDirectives: remove duplicate test

This test case is already tested via the `testDeprecatedRemovedDirectives()` test method.

### IniDirectives/RemovedIniDirectives: prevent some false negatives

The `'raw'` key in the parameter arrays returned from the `PassedParameters` class contains - as per the name - the _raw_ contents of the parameter.

Since PHPCSUtils 1.0.0-alpha4, the return array also contain a `'clean'` index, which contains the contents of the parameter cleaned of comments.

By switching to using that key, some false negatives get fixed.

Includes unit tests demonstrating the issue and safeguarding the fix.

### IniDirectives/RemovedIniDirectives: add test with PHP 8.1+ first class callable syntax

### IniDirectives/RemovedIniDirectives: add some extra tests

... to cover more code branches.