### PR TITLE
InitialValue/NewConstantArraysUsingDefine: refactor to use the AbstractFunctionCallParameterSniff + some bug fixes

### DIFF
--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\InitialValue;
 
-use PHPCompatibility\Sniff;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
@@ -27,74 +27,68 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 7.0.0
  * @since 9.0.0 Renamed from `ConstantArraysUsingDefineSniff` to `NewConstantArraysUsingDefineSniff`.
+ * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class instead of `Sniff`.
  */
-class NewConstantArraysUsingDefineSniff extends Sniff
+class NewConstantArraysUsingDefineSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**
-     * Returns an array of tokens this test wants to listen for.
+     * Functions the sniff is looking for.
      *
-     * @since 7.0.0
+     * @since 10.0.0
      *
-     * @return array
+     * @var array
      */
-    public function register()
+    protected $targetFunctions = [
+        'define' => true,
+    ];
+
+    /**
+     * Should the sniff bow out early for specific PHP versions ?
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
     {
-        return [\T_STRING];
+        return ($this->supportsBelow('5.6') !== true);
     }
 
     /**
-     * Processes this test, when one of its tokens is encountered.
+     * Process the parameters of a matched function.
      *
-     * @since 7.0.0
+     * @since 10.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
      *
      * @return void
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        if ($this->supportsBelow('5.6') !== true) {
+        $valueParam = PassedParameters::getParameterFromStack($parameters, 2, 'value');
+        if (isset($valueParam['start'], $valueParam['end']) === false) {
             return;
         }
 
         $tokens = $phpcsFile->getTokens();
 
-        $ignore  = [
-            \T_FUNCTION => true,
-            \T_CONST    => true,
-        ];
-        $ignore += Collections::objectOperators();
-
-        $prevToken = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
-        if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
-            // Not a call to a PHP function.
-            return;
-        }
-
-        $functionLc = \strtolower($tokens[$stackPtr]['content']);
-        if ($functionLc !== 'define') {
-            return;
-        }
-
-        $secondParam = PassedParameters::getParameter($phpcsFile, $stackPtr, 2, 'value');
-        if (isset($secondParam['start'], $secondParam['end']) === false) {
-            return;
-        }
-
         $targetNestingLevel = 0;
-        if (isset($tokens[$secondParam['start']]['nested_parenthesis'])) {
-            $targetNestingLevel = \count($tokens[$secondParam['start']]['nested_parenthesis']);
+        if (isset($tokens[$valueParam['start']]['nested_parenthesis'])) {
+            $targetNestingLevel = \count($tokens[$valueParam['start']]['nested_parenthesis']);
         }
 
-        $array = $phpcsFile->findNext(Collections::arrayOpenTokensBC(), $secondParam['start'], ($secondParam['end'] + 1));
+        $array = $phpcsFile->findNext(Collections::arrayOpenTokensBC(), $valueParam['start'], ($valueParam['end'] + 1));
         if ($array !== false
             && ($tokens[$array]['code'] === \T_ARRAY
                 || Arrays::isShortArray($phpcsFile, $array) === true)
         ) {
-            if ((isset($tokens[$array]['nested_parenthesis']) === false && $targetNestingLevel === 0) || \count($tokens[$array]['nested_parenthesis']) === $targetNestingLevel) {
+            if ((isset($tokens[$array]['nested_parenthesis']) === false && $targetNestingLevel === 0)
+                || \count($tokens[$array]['nested_parenthesis']) === $targetNestingLevel
+            ) {
                 $phpcsFile->addError(
                     'Constant arrays using define are not allowed in PHP 5.6 or earlier',
                     $array,

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -81,11 +81,21 @@ class NewConstantArraysUsingDefineSniff extends AbstractFunctionCallParameterSni
             $targetNestingLevel = \count($tokens[$valueParam['start']]['nested_parenthesis']);
         }
 
+        $find             = Collections::arrayOpenTokensBC();
+        $find[\T_CLOSURE] = \T_CLOSURE;
+        $find[\T_FN]      = \T_FN;
+
         $current = ($valueParam['start'] - 1);
         do {
-            $current = $phpcsFile->findNext(Collections::arrayOpenTokensBC(), ($current + 1), ($valueParam['end'] + 1));
+            $current = $phpcsFile->findNext($find, ($current + 1), ($valueParam['end'] + 1));
             if ($current === false) {
                 break;
+            }
+
+            if (isset(Collections::functionDeclarationTokens()[$tokens[$current]['code']], $tokens[$current]['scope_closer'])) {
+                // Skip over closure and arrow function definitions. Not the concern of this sniff.
+                $current = $tokens[$current]['scope_closer'];
+                continue;
             }
 
             if (isset(Collections::shortArrayListOpenTokensBC()[$tokens[$current]['code']])

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
@@ -51,3 +51,7 @@ $obj = new Define('name', array());
 // Prevent false negative with compound value.
 define('NAME', functionReturningArray(array()) + array('sn', 'givenname', 'mail')); // Error.
 define('NAME', functionReturningArray(array()) + functionReturningArray(array())); // OK (undetermined).
+
+// Prevent false positive on closure/PHP 7.4 arrow function with PHP 8.1 "new in initializer".
+define('CLOSURE_OBJECT_FROM_CLOSURE', function() { return array(1, 2, 3); });
+define('CLOSURE_OBJECT_FROM_ARROW', fn() => array(1, 2, 3));

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
@@ -20,7 +20,7 @@ $object->define('ANIMALS', 'dog');
 
 class myClass {
     const define = true;
-    function define($name, $value = array()) {}
+    function &define($name, $value = array()) {}
 }
 
 notDefine('ANIMALS', 'dog');
@@ -41,3 +41,9 @@ define(value: 'not an array', constant_name: 'NOTANARRAY' ); // OK.
 
 // Prevent false positives on PHP 8.0+ nullsafe method calls.
 $obj?->define('ANIMALS', []);
+
+// No false positive on namespace define.
+MyOwn\define('name', array());
+
+// No false positive on class called "define".
+$obj = new Define('name', array());

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
@@ -47,3 +47,7 @@ MyOwn\define('name', array());
 
 // No false positive on class called "define".
 $obj = new Define('name', array());
+
+// Prevent false negative with compound value.
+define('NAME', functionReturningArray(array()) + array('sn', 'givenname', 'mail')); // Error.
+define('NAME', functionReturningArray(array()) + functionReturningArray(array())); // OK (undetermined).

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.inc
@@ -6,7 +6,7 @@ define('ANIMALS', [
     'bird'
 ]);
 
-define('ANIMALS', array(
+DEFINE('ANIMALS', array(
     'dog',
     'cat',
     'bird'
@@ -19,8 +19,8 @@ myClass::define('ANIMALS', 'dog');
 $object->define('ANIMALS', 'dog');
 
 class myClass {
-	const define = true;
-	function define() {}
+    const define = true;
+    function define($name, $value = array()) {}
 }
 
 notDefine('ANIMALS', 'dog');

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -53,6 +53,7 @@ class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
             [3],
             [9],
             [39],
+            [52],
         ];
     }
 
@@ -97,6 +98,7 @@ class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
             [43],
             [46],
             [49],
+            [53],
         ];
     }
 

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -95,6 +95,8 @@ class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
             [36],
             [40],
             [43],
+            [46],
+            [49],
         ];
     }
 

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -99,6 +99,8 @@ class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
             [46],
             [49],
             [53],
+            [56],
+            [57],
         ];
     }
 


### PR DESCRIPTION
### InitialValue/NewConstantArraysUsingDefine: minor improvements to tests

* Ensure that non-lowercased call to `define()` is tested.
* Ensure that function declaration _could_ be a false positive.

### InitialValue/NewConstantArraysUsingDefine: refactor to use the AbstractFunctionCallParameterSniff

As the sniff examines the existence of specific function call parameters, it is more appropriate to base the sniff on the `AbstractFunctionCallParameterSniff` so it can benefit from any "is this a function call ?" determination fixes made in that abstract.

This straight away fixes some false positives. See the extra tests.

In the future, once a similar `AbstractFunctionCallParameterSniff` class is expected to be available via PHPCSUtils, this change will also allow us to switch over to that abstract more easily.

### InitialValue/NewConstantArraysUsingDefine: prevent false negative

The code checking for an array token would only check the _first_ array-like token found and the sniff would end if that token was either not a (short) array or not at the correct nesting level.

However, a parameter can consist of multiple tokens, so _all_ array-like tokens in the parameter should be examined to prevent false negatives.

Fixed now.

Includes tests demonstrating the bug and safeguarding the fix.

### InitialValue/NewConstantArraysUsingDefine: prevent false positives with PHP 8.1 "new in initializers"

Since PHP 8.1, initializers can contain objects.
As a side-effect of this, it is now allowed to initialize a constant with an arrow function or closure (as long as no parameters are declared), which would result in an object of the type `Closure`.

This sniff searches specifically for array tokens, but if such array tokens would be found _within_ a closure or arrow function definition, this would lead to a false positive.

This commit updates the sniff to skip over closure and arrow function declarations completely, thereby fixing the false positive.

Includes tests demonstrating the issue and safeguarding the fix.