### PR TITLE
Lists/AssignmentOrder: implement PHPCSUtils and other improvements

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Lists;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\Lists;
 
@@ -42,11 +43,7 @@ class AssignmentOrderSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_LIST,
-            \T_OPEN_SHORT_ARRAY,
-            \T_OPEN_SQUARE_BRACKET,
-        ];
+        return Collections::listOpenTokensBC();
     }
 
 

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
@@ -60,6 +60,10 @@ list("id" => $id, "name" => $name, $name => $value) = $data[0];
 list("id" => $id, "name" => $name, $label => $id) = $data[0];
 ["id" => $id, "name" => $name, $label => $name] = $data[0];
 
+// Safeguard handling of PHP 7.3+ lists with reference assignment.
+list($a, &$b, &$a) = $array;
+[$a, &$b, &$a] = $array;
+
 // Don't trigger on unfinished code during live code review.
 // This has to be the last test in the file!
 list(

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
@@ -51,6 +51,15 @@ if (true) {}
 // Test handling of list vars with differing whitespace.
 list( $a [ 'key' ], $b [ 'key' ], list($a['key'], $b['key'])) = $array;
 
+// Safeguard handling of PHP 7.1+ keyed lists.
+// Okay: duplicate variable is used as a key not as the variable assignment.
+list("id" => $id, "name" => $name, $name => $value) = $data[0];
+["id" => $id, "name" => $name, $id => $value] = $data[0];
+
+// Error: duplicate variable is used for the variable assignment.
+list("id" => $id, "name" => $name, $label => $id) = $data[0];
+["id" => $id, "name" => $name, $label => $name] = $data[0];
+
 // Don't trigger on unfinished code during live code review.
 // This has to be the last test in the file!
 list(

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
@@ -50,3 +50,7 @@ if (true) {}
 
 // Test handling of list vars with differing whitespace.
 list( $a [ 'key' ], $b [ 'key' ], list($a['key'], $b['key'])) = $array;
+
+// Don't trigger on unfinished code during live code review.
+// This has to be the last test in the file!
+list(

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -67,6 +67,8 @@ class AssignmentOrderUnitTest extends BaseSniffTest
             [45],
             [49],
             [52],
+            [60],
+            [61],
         ];
     }
 
@@ -103,6 +105,8 @@ class AssignmentOrderUnitTest extends BaseSniffTest
             [41],
             [42],
             [56],
+            [57],
+            [65],
         ];
     }
 

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -102,6 +102,7 @@ class AssignmentOrderUnitTest extends BaseSniffTest
             [12],
             [41],
             [42],
+            [56],
         ];
     }
 

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -69,6 +69,8 @@ class AssignmentOrderUnitTest extends BaseSniffTest
             [52],
             [60],
             [61],
+            [64],
+            [65],
         ];
     }
 
@@ -106,7 +108,7 @@ class AssignmentOrderUnitTest extends BaseSniffTest
             [42],
             [56],
             [57],
-            [65],
+            [69],
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require" : {
     "php" : ">=5.4",
     "squizlabs/php_codesniffer" : "^3.7.1",
-    "phpcsstandards/phpcsutils" : "^1.0.4"
+    "phpcsstandards/phpcsutils" : "^1.0.5"
   },
   "require-dev" : {
     "php-parallel-lint/php-parallel-lint": "^1.3.2",


### PR DESCRIPTION
### Lists/AssignmentOrder: implement PHPCSUtils

This should give a small performance boost in combination with PHPCS 3.7.2+.

### Lists/AssignmentOrder: minor code reordering

Re-order the code and bow out early to get rid of the need for some `try-catch`-es, which should help improve performance.

Includes updating the minimum supported PHPCSUtils version, as a bug was discovered in the `Lists::getAssignments()` method. The bug was fixed in PHPCSUtils 1.0.5.

Related to #1477

### Lists/AssignmentOrder: add tests with PHP 7.1+ keyed lists

Note the variables being (re-)used as keys.

The sniff already handles this correctly, no changes needed.

### Lists/AssignmentOrder: add tests with PHP 7.3+ list reference assignments

The sniff already handles this correctly, no changes needed.