### PR TITLE
Lists/ForbiddenEmptyListAssignment: implement PHPCSUtils + performance improvement

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -59,10 +59,18 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
             return;
         }
 
+        $tokens = $phpcsFile->getTokens();
+        if (isset(Collections::shortArrayListOpenTokensBC()[$tokens[$stackPtr]['code']]) === true
+            && Lists::isShortList($phpcsFile, $stackPtr) === false
+        ) {
+            // Real square brackets or short array, not short list.
+            return;
+        }
+
         try {
             $assignments = Lists::getAssignments($phpcsFile, $stackPtr);
         } catch (RuntimeException $e) {
-            // Parse error, live coding or short array, not short list.
+            // Parse error/live coding.
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Lists;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
 /**
@@ -38,11 +39,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_LIST,
-            \T_OPEN_SHORT_ARRAY,
-            \T_OPEN_SQUARE_BRACKET,
-        ];
+        return Collections::listOpenTokensBC();
     }
 
     /**


### PR DESCRIPTION
### Lists/ForbiddenEmptyListAssignment: implement PHPCSUtils

This should give a small performance boost in combination with PHPCS 3.7.2+.

### Lists/ForbiddenEmptyListAssignment: tweak to improve performance

The `Lists::getAssignments()` function does a check on the short list related tokens to ensure the received token is a short list and it will throw an exception when this is not the case.

As the sniffs needs to listen for the `T_OPEN_SHORT_ARRAY` token (and sometimes the `T_OPEN_SQUARE_BRACKET` token as well), this means that in most examined files, an exception will be thrown in the majority of cases.

The creating of the exception + the `try-catch` have a (negative) performance impact.

This commit adds an early check on the received token to verify if it is a short list and bows out early (without the need for exception handling) when it's not.

While this does mean that there will be a duplicate call in the underlying code to `Lists::isShortList()`, the performance impact of this should be negligible as the result of function calls to `Lists::isShortList()` are cached.

Note: The `try-catch` around the call to `Lists::getAssignments()` is still needed, but will now only receive an exception when the `list` keyword is seen without closing parenthesis during live coding, which should be pretty rare.

Related to #1477