### PR TITLE
Lists/NewKeyedList: implement PHPCSUtils + performance improvement

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Lists;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
 /**
@@ -38,11 +39,7 @@ class NewKeyedListSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_LIST                => \T_LIST,
-            \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
-            \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
-        ];
+        return Collections::listOpenTokensBC();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -59,10 +59,18 @@ class NewKeyedListSniff extends Sniff
             return;
         }
 
+        $tokens = $phpcsFile->getTokens();
+        if (isset(Collections::shortArrayListOpenTokensBC()[$tokens[$stackPtr]['code']]) === true
+            && Lists::isShortList($phpcsFile, $stackPtr) === false
+        ) {
+            // Real square brackets or short array, not short list.
+            return;
+        }
+
         try {
             $assignments = Lists::getAssignments($phpcsFile, $stackPtr);
         } catch (RuntimeException $e) {
-            // Parse error, live coding or short array, not short list.
+            // Parse error/live coding.
             return;
         }
 

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.inc
@@ -68,6 +68,10 @@ list(,,,, "key" => $keyed) = $array;
 // Safeguard that the sniff doesn't trigger on short arrays.
 $a = ["x" => $x1, "y" => $y1];
 
+// Safeguard handling of PHP 7.3+ lists with reference assignment.
+list("id" => &$id1, "name" => $name1) = $data[0];
+[$id1, & /*comment*/ $name1] = $data[0];
+
 // Don't trigger on unfinished code during live code review.
 // This has to be the last test in the file!
 list(

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.inc
@@ -64,3 +64,10 @@ list($unkeyed, "key" => $keyed) = $array;
 // Empty elements are not allowed where keys are specified.
 // Parse error, but not our concern, throw an error anyway for the key found.
 list(,,,, "key" => $keyed) = $array;
+
+// Safeguard that the sniff doesn't trigger on short arrays.
+$a = ["x" => $x1, "y" => $y1];
+
+// Don't trigger on unfinished code during live code review.
+// This has to be the last test in the file!
+list(

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
@@ -109,6 +109,8 @@ class NewKeyedListUnitTest extends BaseSniffTest
             [45],
             [47],
             [49],
+            [69],
+            [73],
         ];
     }
 

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
@@ -71,6 +71,7 @@ class NewKeyedListUnitTest extends BaseSniffTest
             [54],
             [62],
             [66],
+            [72],
         ];
     }
 
@@ -111,6 +112,7 @@ class NewKeyedListUnitTest extends BaseSniffTest
             [49],
             [69],
             [73],
+            [77],
         ];
     }
 


### PR DESCRIPTION
### Lists/NewKeyedList: implement PHPCSUtils

This should give a small performance boost in combination with PHPCS 3.7.2+.

### Lists/NewKeyedList: tweak to improve performance

The `Lists::getAssignments()` function does a check on the short list related tokens to ensure the received token is a short list and it will throw an exception when this is not the case.

As the sniffs needs to listen for the `T_OPEN_SHORT_ARRAY` token (and sometimes the `T_OPEN_SQUARE_BRACKET` token as well), this means that in most examined files, an exception will be thrown in the majority of cases.

The creating of the exception + the `try-catch` have a (negative) performance impact.

This commit adds an early check on the received token to verify if it is a short list and bows out early (without the need for exception handling) when it's not.

While this does mean that there will be a duplicate call in the underlying code to `Lists::isShortList()`, the performance impact of this should be negligible as the result of function calls to `Lists::isShortList()` are cached.

Note: The `try-catch` around the call to `Lists::getAssignments()` is still needed, but will now only receive an exception when the `list` keyword is seen without closing parenthesis during live coding, which should be pretty rare.

Includes some additional unit tests to cover the unhappy path.

Related to #1477

### Lists/NewKeyedList: add tests with PHP 7.3+ list reference assignments

The sniff already handles this correctly, no changes needed.