### PR TITLE
Lists/NewListReferenceAssignment: implement PHPCSUtils + performance improvement

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Lists;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
 /**
@@ -40,11 +41,7 @@ class NewListReferenceAssignmentSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_LIST                => \T_LIST,
-            \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
-            \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
-        ];
+        return Collections::listOpenTokensBC();
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -61,10 +61,18 @@ class NewListReferenceAssignmentSniff extends Sniff
             return;
         }
 
+        $tokens = $phpcsFile->getTokens();
+        if (isset(Collections::shortArrayListOpenTokensBC()[$tokens[$stackPtr]['code']]) === true
+            && Lists::isShortList($phpcsFile, $stackPtr) === false
+        ) {
+            // Real square brackets or short array, not short list.
+            return;
+        }
+
         try {
             $assignments = Lists::getAssignments($phpcsFile, $stackPtr);
         } catch (RuntimeException $e) {
-            // Parse error, live coding or short array, not short list.
+            // Parse error/live coding.
             return;
         }
 

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.inc
@@ -43,6 +43,10 @@ if (true) {}
 // Safeguard that the sniff doesn't trigger on short arrays.
 $a = [&$x1, $y1];
 
+// Safeguard handling of PHP 7.1+ keyed lists.
+list("id" => &$id1, "name" => $name1) = $data[0];
+["id" => $id1, "name" => & /*comment*/ $name1] = $data[0];
+
 // Don't trigger on unfinished code during live code review.
 // This has to be the last test in the file!
 list(

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.inc
@@ -39,3 +39,10 @@ foreach ($array as [&$a, $b]) {}
 // Test handling of tokenizer issue in older PHPCS versions.
 if (true) {}
 [$id1, &$name1] = $data;
+
+// Safeguard that the sniff doesn't trigger on short arrays.
+$a = [&$x1, $y1];
+
+// Don't trigger on unfinished code during live code review.
+// This has to be the last test in the file!
+list(

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
@@ -59,6 +59,8 @@ class NewListReferenceAssignmentUnitTest extends BaseSniffTest
             [36], // x2.
             [37],
             [41],
+            [47],
+            [48],
         ];
     }
 
@@ -101,7 +103,7 @@ class NewListReferenceAssignmentUnitTest extends BaseSniffTest
             [31],
             [32],
             [44],
-            [48],
+            [52],
         ];
     }
 

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
@@ -100,6 +100,8 @@ class NewListReferenceAssignmentUnitTest extends BaseSniffTest
             [29],
             [31],
             [32],
+            [44],
+            [48],
         ];
     }
 


### PR DESCRIPTION
### Lists/NewListReferenceAssignment: implement PHPCSUtils

This should give a small performance boost in combination with PHPCS 3.7.2+.

### Lists/NewListReferenceAssignment: tweak to improve performance

The `Lists::getAssignments()` function does a check on the short list related tokens to ensure the received token is a short list and it will throw an exception when this is not the case.

As the sniffs needs to listen for the `T_OPEN_SHORT_ARRAY` token (and sometimes the `T_OPEN_SQUARE_BRACKET` token as well), this means that in most examined files, an exception will be thrown in the majority of cases.

The creating of the exception + the `try-catch` have a (negative) performance impact.

This commit adds an early check on the received token to verify if it is a short list and bows out early (without the need for exception handling) when it's not.

While this does mean that there will be a duplicate call in the underlying code to `Lists::isShortList()`, the performance impact of this should be negligible as the result of function calls to `Lists::isShortList()` are cached.

Note: The `try-catch` around the call to `Lists::getAssignments()` is still needed, but will now only receive an exception when the `list` keyword is seen without closing parenthesis during live coding, which should be pretty rare.

Includes some additional unit tests to cover the unhappy path.

Related to #1477

### Lists/NewListReferenceAssignment: add tests with PHP 7.1+ keyed lists

The sniff already handles this correctly, no changes needed.