### PR TITLE
Lists/NewShortList: implement PHPCSUtils + extra test

### DIFF
--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Lists;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
 /**
@@ -40,10 +41,7 @@ class NewShortListSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_OPEN_SHORT_ARRAY,
-            \T_OPEN_SQUARE_BRACKET,
-        ];
+        return Collections::shortArrayListOpenTokensBC();
     }
 
     /**

--- a/PHPCompatibility/Tests/Lists/NewShortListUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewShortListUnitTest.inc
@@ -33,3 +33,6 @@ foreach ($data as [$id, $name]) {}
 // Test specific buggy tokenizer issue.
 if (true) {}
 [$id1, $name1] = $data[0];
+
+// Safeguard handling of short list with reference assignment.
+[$a, &$b] = $array;

--- a/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
@@ -58,6 +58,7 @@ class NewShortListUnitTest extends BaseSniffTest
             [25], // x2.
             [28],
             [35],
+            [38],
         ];
     }
 


### PR DESCRIPTION
### Lists/NewShortList: implement PHPCSUtils

This should give a small performance boost in combination with PHPCS 3.7.2+.

### Lists/NewShortList: add test with PHP 7.3+ list reference assignments

The sniff already handles this correctly, no changes needed.