### PR TITLE
MethodUse/ForbiddenToStringParameters: add test with PHP 8.1 first class callables

### DIFF
--- a/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.inc
@@ -50,3 +50,6 @@ class MyClass {
 }
 
 $obj?->__toString($param);
+
+// Ignore PHP 8.1 first class callable syntax as undetermined as it is unknown whether params will be passed.
+register_callback($obj->__toString(...));

--- a/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
@@ -93,6 +93,8 @@ class ForbiddenToStringParametersUnitTest extends BaseSniffTest
             $cases[] = [$line];
         }
 
+        $cases[] = [55];
+
         return $cases;
     }
 


### PR DESCRIPTION
The sniff already handles this correctly, no changes needed.