### PR TITLE
Operators/NewOperators: minor code simplification

### DIFF
--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -106,11 +106,10 @@ class NewOperatorsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens    = $phpcsFile->getTokens();
-        $tokenType = $tokens[$stackPtr]['type'];
+        $tokens = $phpcsFile->getTokens();
 
         $itemInfo = [
-            'name' => $tokenType,
+            'name' => $tokens[$stackPtr]['type'],
         ];
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }


### PR DESCRIPTION
Follow up on #1355.

Remove an assignment which is redundant after the code simplification from #1355.