### PR TITLE
ParameterValues/ForbiddenStripTagsSelfClosingXHTML: add extra tests

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.1.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.1.inc
@@ -13,3 +13,17 @@ $str = strip_tags($str, allowed_tags: MyClass::get_allowable_tags('<br/>'));
 // Not OK - warning.
 $str = strip_tags($input, '<br/>');
 $str = strip_tags(allowed_tags: '<img/><br/>' . '<meta/><input/>', string: $input);
+
+// Safeguard handling heredocs/nowdocs, including PHP 7.3 indented variants.
+// Okay.
+strip_tags($input, <<<"EOD"
+<img><br><meta><input>
+EOD
+);
+
+// Not okay.
+strip_tags($input,
+<<<EOD
+<img/><br/>$extraTags
+EOD
+);

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.1.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.1.inc
@@ -27,3 +27,8 @@ strip_tags($input,
 <img/><br/>$extraTags
 EOD
 );
+
+// Safeguard against false positives on method calls.
+ClassName::strip_tags($input, '<br/>');
+$obj->strip_tags($input, '<br/>');
+$obj?->strip_tags($input, '<br/>'); // PHP 8.0+.

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.2.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.2.inc
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * The tests involving PHP 7.3+ indented heredocs are in a separate test case file
+ * as any code after an indented heredoc will be tokenizer garbage on PHP < 7.3.
+ */
+
+// Safeguard handling of PHP 7.3 indented heredocs/nowdocs.
+// Okay.
+strip_tags($input,
+    <<<'EOD'
+    <script><p><div>
+    EOD
+);
+
+// Not okay.
+strip_tags($input, <<<'EOD'
+    <meta/><input/>
+    EOD
+);

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
@@ -26,7 +26,21 @@ class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTest
 {
 
     /**
-     * testForbiddenStripTagsSelfClosingXHTML
+     * The name of the primary test case file.
+     *
+     * @var string
+     */
+    const TEST_FILE = 'ForbiddenStripTagsSelfClosingXHTMLUnitTest.1.inc';
+
+    /**
+     * The name of a secondary test case file containing PHP 7.3+ indented heredocs.
+     *
+     * @var string
+     */
+    const TEST_FILE_PHP73HEREDOCS = 'ForbiddenStripTagsSelfClosingXHTMLUnitTest.2.inc';
+
+    /**
+     * Verify detection of the issue.
      *
      * @dataProvider dataForbiddenStripTagsSelfClosingXHTML
      *
@@ -37,7 +51,7 @@ class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTest
      */
     public function testForbiddenStripTagsSelfClosingXHTML($line, $paramValue)
     {
-        $file  = $this->sniffFile(__FILE__, '5.4');
+        $file  = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE, '5.4');
         $error = 'Self-closing XHTML tags are ignored. Only non-self-closing tags should be used in the strip_tags() $allowed_tags parameter since PHP 5.3.4. Found: ' . $paramValue;
 
         $this->assertError($file, $line, $error);
@@ -55,6 +69,7 @@ class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTest
         return [
             [14, "'<br/>'"],
             [15, "'<img/><br/>' . '<meta/><input/>'"],
+            [27, "<<<EOD\n<img/><br/>" . '$extraTags' . "\nEOD"],
         ];
     }
 
@@ -62,27 +77,148 @@ class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTest
     /**
      * Test the sniff does not throw false positives.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
-        $file = $this->sniffFile(__FILE__, '5.4');
+        $file = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $cases = [];
 
         // No errors expected on the first 12 lines.
         for ($line = 1; $line <= 12; $line++) {
-            $this->assertNoViolation($file, $line);
+            $cases[] = [$line];
         }
+
+        // No errors expected for the _correct_ heredoc/nowdocs.
+        for ($line = 17; $line <= 23; $line++) {
+            $cases[] = [$line];
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify correct detection in combination with indented heredoc/nowdocs.
+     *
+     * @dataProvider dataForbiddenStripTagsSelfClosingXHTMLInIndentedHeredoc
+     *
+     * @param int  $line       Line number where the error should occur.
+     * @param bool $paramValue The parameter value detected.
+     *
+     * @return void
+     */
+    public function testForbiddenStripTagsSelfClosingXHTMLInIndentedHeredoc($line, $paramValue)
+    {
+        if (\PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('Test code involving PHP 7.3 heredocs will not tokenize correctly on PHP < 7.3');
+        }
+
+        $file  = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE_PHP73HEREDOCS, '5.4');
+        $error = 'Self-closing XHTML tags are ignored. Only non-self-closing tags should be used in the strip_tags() $allowed_tags parameter since PHP 5.3.4. Found: ' . $paramValue;
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenStripTagsSelfClosingXHTMLInIndentedHeredoc()
+     *
+     * @return array
+     */
+    public function dataForbiddenStripTagsSelfClosingXHTMLInIndentedHeredoc()
+    {
+        return [
+            [18, "<<<'EOD'\n    <meta/><input/>\n    EOD"],
+        ];
+    }
+
+
+    /**
+     * Test the sniff does not throw false positives.
+     *
+     * @dataProvider dataNoFalsePositivesInIndentedHeredoc
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesInIndentedHeredoc($line)
+    {
+        if (\PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('Test code involving PHP 7.3 heredocs will not tokenize correctly on PHP < 7.3');
+        }
+
+        $file = $this->sniffFile(__DIR__ . '/' . self::TEST_FILE_PHP73HEREDOCS, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesInIndentedHeredoc()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesInIndentedHeredoc()
+    {
+        $cases = [];
+
+        // No errors expected on the first 15 lines.
+        for ($line = 1; $line <= 15; $line++) {
+            $cases[] = [$line];
+        }
+
+        return $cases;
     }
 
 
     /**
      * Verify no notices are thrown at all.
      *
+     * @dataProvider dataTestFiles
+     *
+     * @param string $testFile File name for the test case file to use.
+     *
      * @return void
      */
-    public function testNoViolationsInFileOnValidVersion()
+    public function testNoViolationsInFileOnValidVersion($testFile)
     {
-        $file = $this->sniffFile(__FILE__, '5.3');
+        if ($testFile === self::TEST_FILE_PHP73HEREDOCS && \PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('Test code involving PHP 7.3 heredocs will not tokenize correctly on PHP < 7.3');
+        }
+
+        $file = $this->sniffFile(__DIR__ . '/' . $testFile, '5.3');
         $this->assertNoViolation($file);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataTestFiles()
+    {
+        return [
+            [self::TEST_FILE],
+            [self::TEST_FILE_PHP73HEREDOCS],
+        ];
     }
 }

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
@@ -110,6 +110,10 @@ class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTest
             $cases[] = [$line];
         }
 
+        $cases[] = [32];
+        $cases[] = [33];
+        $cases[] = [34];
+
         return $cases;
     }
 


### PR DESCRIPTION
### ParameterValues/ForbiddenStripTagsSelfClosingXHTML: add tests with heredocs/nowdocs

Includes safeguarding support for PHP 7.3+ indented heredoc/nowdocs.

Note: tests for PHP 7.3+ indented heredoc/nowdocs are in a separate file as the tokenizer cannot handle them on PHP < 7.3.

### ParameterValues/ForbiddenStripTagsSelfClosingXHTML: add some extra tests

... to safeguard against false positives from method calls, including method calls using the PHP 8.0+ nullsafe object operator.