### PR TITLE
ParameterValues/HashAlgorithms*: refactor to use the AbstractFunctionCallParameterSniff + bug fix

### DIFF
--- a/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
+++ b/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
@@ -89,6 +89,6 @@ trait HashAlgorithmsTrait
         }
 
         // Algorithm is a text string, so we need to remove the quotes.
-        return TextStrings::stripQuotes(\strtolower($algoParam['raw']));
+        return TextStrings::stripQuotes(\strtolower($algoParam['clean']));
     }
 }

--- a/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
+++ b/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
@@ -10,7 +10,6 @@
 
 namespace PHPCompatibility\Helpers;
 
-use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -70,34 +69,21 @@ trait HashAlgorithmsTrait
      * Get the hash algorithm name from the parameter in a hash function call.
      *
      * @since 7.0.7  Logic moved from the `RemovedHashAlgorithms` sniff to the generic `Sniff` class.
-     * @since 10.0.0 Moved from the base `Sniff` class to the `HashAlgorithmsTrait`.
+     * @since 10.0.0 Moved from the base `Sniff` class to the `HashAlgorithmsTrait`
+     *               and changed significantly.
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of T_STRING function token.
+     * @param string $functionName The token content (function name) which was matched.
+     * @param array  $parameters   Array with information about the parameters.
      *
      * @return string|false The algorithm name without quotes if this was a relevant hash
      *                      function call or false if it was not.
      */
-    public function getHashAlgorithmParameter(File $phpcsFile, $stackPtr)
+    public function getHashAlgorithmParameter($functionName, array $parameters)
     {
-        $tokens = $phpcsFile->getTokens();
-
-        // Check for the existence of the token and that it is the right token.
-        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_STRING) {
-            return false;
-        }
-
-        $functionName   = $tokens[$stackPtr]['content'];
+        // Get the parameter which should contain the algorithm name from the parameter stack.
         $functionNameLc = \strtolower($functionName);
-
-        // Bow out if not one of the functions we're targetting.
-        if (isset($this->hashAlgoFunctions[$functionNameLc]) === false) {
-            return false;
-        }
-
-        // Get the parameter from the function call which should contain the algorithm name.
-        $paramInfo = $this->hashAlgoFunctions[$functionNameLc];
-        $algoParam = PassedParameters::getParameter($phpcsFile, $stackPtr, $paramInfo['position'], $paramInfo['name']);
+        $paramInfo      = $this->hashAlgoFunctions[$functionNameLc];
+        $algoParam      = PassedParameters::getParameterFromStack($parameters, $paramInfo['position'], $paramInfo['name']);
         if ($algoParam === false) {
             return false;
         }

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
-use PHPCompatibility\Sniff;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHPCompatibility\Helpers\HashAlgorithmsTrait;
 use PHP_CodeSniffer\Files\File;
@@ -24,10 +24,10 @@ use PHP_CodeSniffer\Files\File;
  *
  * @since 7.0.7
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
- * @since 10.0.0 Now uses the new `HashAlgorithmsTrait`.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
+ *               and uses the `ComplexVersionNewFeatureTrait` and the `HashAlgorithmsTrait`.
  */
-class NewHashAlgorithmsSniff extends Sniff
+class NewHashAlgorithmsSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionNewFeatureTrait;
     use HashAlgorithmsTrait;
@@ -149,32 +149,44 @@ class NewHashAlgorithmsSniff extends Sniff
 
 
     /**
-     * Returns an array of tokens this test wants to listen for.
+     * Constructor.
      *
-     * @since 7.0.7
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return [\T_STRING];
-    }
-
-
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @since 7.0.7
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
+     * @since 10.0.0
      *
      * @return void
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function __construct()
     {
-        $algo = $this->getHashAlgorithmParameter($phpcsFile, $stackPtr);
+        $this->targetFunctions = $this->hashAlgoFunctions;
+    }
+
+    /**
+     * Should the sniff bow out early for specific PHP versions ?
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return false;
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return void
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $algo = $this->getHashAlgorithmParameter($functionName, $parameters);
         if (empty($algo) || \is_string($algo) === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
-use PHPCompatibility\Sniff;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
 use PHPCompatibility\Helpers\HashAlgorithmsTrait;
 use PHP_CodeSniffer\Files\File;
@@ -25,10 +25,10 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * @since 5.5
  * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
- * @since 10.0.0 Now uses the new `HashAlgorithmsTrait`.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
+ *               and uses the `ComplexVersionNewFeatureTrait` and the `HashAlgorithmsTrait`.
  */
-class RemovedHashAlgorithmsSniff extends Sniff
+class RemovedHashAlgorithmsSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
     use HashAlgorithmsTrait;
@@ -53,32 +53,44 @@ class RemovedHashAlgorithmsSniff extends Sniff
     ];
 
     /**
-     * Returns an array of tokens this test wants to listen for.
+     * Constructor.
      *
-     * @since 5.5
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return [\T_STRING];
-    }
-
-
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @since 5.5
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
+     * @since 10.0.0
      *
      * @return void
      */
-    public function process(File $phpcsFile, $stackPtr)
+    public function __construct()
     {
-        $algo = $this->getHashAlgorithmParameter($phpcsFile, $stackPtr);
+        $this->targetFunctions = $this->hashAlgoFunctions;
+    }
+
+    /**
+     * Should the sniff bow out early for specific PHP versions ?
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return false;
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return void
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $algo = $this->getHashAlgorithmParameter($functionName, $parameters);
         if (empty($algo) || \is_string($algo) === false) {
             return;
         }

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.inc
@@ -40,3 +40,8 @@ hash('xxh32');
 hash_init('xxh64');
 hash_file('xxh3');
 hash('xxh128');
+
+// Safeguard handling of function call missing required param / live coding.
+hash_init();
+hash_hmac( data: 'salsa20', key: $key ); // Missing $algo param.
+hash_pbkdf2(algorithm: 'salsa20'); // Incorrect param name.

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.inc
@@ -16,10 +16,10 @@ hash_file("ripemd320");
 hash_file( "salsa10" );
 
 hash_hmac(     "salsa20"      );
-hash_hmac_file("snefru256");
+hash_hmac_file("snefru256" /*comment*/);
 hash_init(   'sha224'  );
 
-hash("joaat");
+hash(/*comment*/ "joaat");
 hash("fnv132", "2nd param", 3, false);
 hash("fnv164");
 

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -116,6 +116,10 @@ class NewHashAlgorithmsUnitTest extends BaseSniffTest
             [6],
             [7],
             [8],
+
+            [45],
+            [46],
+            [47],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.inc
@@ -16,10 +16,10 @@ hash_file('salsa10');
 hash_file('salsa20');
 
 hash_hmac_file(algo: "salsa10");
-hash_hmac( "salsa20" );
+hash_hmac( "salsa20" /*comment*/ );
 hash_init(   'salsa10'  );
 
-hash("salsa10");
+hash(/*comment*/ "salsa10");
 hash("salsa10", "2nd param", 3, false);
 
 hash_pbkdf2('salsa20');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.inc
@@ -23,3 +23,8 @@ hash(/*comment*/ "salsa10");
 hash("salsa10", "2nd param", 3, false);
 
 hash_pbkdf2('salsa20');
+
+// Safeguard handling of function call missing required param / live coding.
+hash_init();
+hash_hmac( data: 'salsa20', key: $key ); // Missing $algo param.
+hash_pbkdf2(algorithm: 'salsa20'); // Incorrect param name.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
@@ -100,6 +100,9 @@ class RemovedHashAlgorithmsUnitTest extends BaseSniffTest
             [6],
             [7],
             [8],
+            [28],
+            [29],
+            [30],
         ];
     }
 


### PR DESCRIPTION
### ParameterValues/HashAlgorithms*: refactor to use the AbstractFunctionCallParameterSniff

As the `NewHashAlgorithms` and the `RemovedHashAlgorithms` sniffs examine the contents of a function call parameter, it is more appropriate to base the sniffs on the `AbstractFunctionCallParameterSniff` so it can benefit from any "is this a function call ?" determination fixes made in that abstract.

This was previously not possible as the sniffs extended the `AbstractNewFeatureSniff` sniff, but after the refactor done in #1406, this is now possible.

Includes adjusting the `HashAlgorithmsTrait` which contained the pertinent "is this a function call ?" logic.

In the future, once a similar `AbstractFunctionCallParameterSniff` class is expected to be available via PHPCSUtils, this change will also allow us to switch over to that abstract more easily.

Note: The `HashAlgorithmsTrait::$hashAlgoFunctions` cannot be renamed to `$targetFunctions` as it would yield a fatal error:
`Fatal error: PHPCompatibility\AbstractFunctionCallParameterSniff and PHPCompatibility\Helpers\HashAlgorithmsTrait define the same property ($targetFunctions) in the composition of PHPCompatibility\Sniffs\ParameterValues\NewHashAlgorithmsSniff. However, the definition differs and is considered incompatible.`

For that reason, a `__construct()` method has been introduced to assign the value of the `HashAlgorithmsTrait::$hashAlgoFunctions` property to the `$targetFunctions` property, which is expected by the abstract sniff.

### ParameterValues/HashAlgorithms*: prevent some false negatives

The `'raw'` key in the parameter arrays returned from the `PassedParameters` class contains - as per the name - the _raw_ contents of the parameter.

Since PHPCSUtils 1.0.0-alpha4, the return array also contain a `'clean'` index, which contains the contents of the parameter cleaned of comments.

By switching to using that key, some false negatives get fixed.

Includes unit tests demonstrating the issue and safeguarding the fix.

### ParameterValues/HashAlgorithms*: add some extra tests

... to cover all code branches.