### PR TITLE
ParameterValues/NewPasswordAlgoConstantValues: prevent some false positives + more tests

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -114,6 +114,18 @@ class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParameterSn
                 continue;
             }
 
+            // Ignore anything within square brackets.
+            if (isset($tokens[$i]['bracket_closer'])) {
+                $i = $tokens[$i]['bracket_closer'];
+                continue;
+            }
+
+            // Skip past nested arrays, function calls and arbitrary groupings.
+            if (isset($tokens[$i]['parenthesis_closer'])) {
+                $i = $tokens[$i]['parenthesis_closer'];
+                continue;
+            }
+
             if (isset($this->invalidTokenTypes[$tokens[$i]['code']]) === true) {
                 $phpcsFile->addWarning(
                     'The value of the password hash algorithm constants has changed in PHP 7.4. Pass a PHP native constant to the %s() function instead of using the value of the constant. Found: %s',

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
@@ -26,3 +26,10 @@ $hash = password_hash( algo: 3, password: $password, options: $options );
 $hash = \password_hash( $password, '2y', $options );
 $hash = password_HASH( $password, "argon{$type}" /*comment*/, $options );
 $hash = password_needs_rehash( $password, 'argon2id', $options );
+
+// Prevent false positives on parameters passed to a function call used to retrieve the algo name
+// or for array access.
+$hash = password_hash( $password, get_algo( 'argon' ), $options );
+$hash = password_hash( $password, $obj?->get_algo( 10 ), $options );
+$hash = password_hash( $password, $algos['argon'], $options );
+$hash = password_hash( $password, $algos{'argon'}, $options );

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
@@ -2,8 +2,8 @@
 
 // OK.
 $hash = password_hash( $password, PASSWORD_DEFAULT, $options );
-$hash = password_hash( $password, PASSWORD_BCRYPT, $options );
-$hash = password_needs_rehash( $password, PASSWORD_ARGON2I, $options );
+$hash = password_hash( $password, \PASSWORD_BCRYPT, $options );
+$hash = \password_needs_rehash( $password, PASSWORD_ARGON2I, $options );
 $hash = password_hash(
 	password: $password,
 	options: $options
@@ -15,12 +15,14 @@ $hash = password_hash(
 $hash = password_hash( $password, $algo, $options );
 $hash = password_hash( $password, $this->get_algo(), $options );
 $hash = password_hash( $password, static::ALGO, $options );
+$hash = password_hash( $password, MyClass::PASSWORD_BCRYPT, $options );
+$hash = password_hash( $password, \MyNamespace\PASSWORD_BCRYPT, $options );
 
 // Not OK - error.
 $hash = PassWord_hash( $password, null, $options );
 $hash = password_hash( $password, +1, $options );
 $hash = password_needs_rehash( $password, 2, $options );
 $hash = password_hash( algo: 3, password: $password, options: $options );
-$hash = password_hash( $password, '2y', $options );
+$hash = \password_hash( $password, '2y', $options );
 $hash = password_HASH( $password, "argon{$type}" /*comment*/, $options );
 $hash = password_needs_rehash( $password, 'argon2id', $options );

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
@@ -66,16 +66,39 @@ class NewPasswordAlgoConstantValuesUnitTest extends BaseSniffTest
     /**
      * Test that there are no false positives.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 20 lines.
         for ($line = 1; $line <= 20; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 30; $line <= 36; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
@@ -52,13 +52,13 @@ class NewPasswordAlgoConstantValuesUnitTest extends BaseSniffTest
     public function dataNewPasswordAlgoConstantValues()
     {
         return [
-            [20],
-            [21],
             [22],
             [23],
             [24],
             [25],
             [26],
+            [27],
+            [28],
         ];
     }
 
@@ -72,8 +72,8 @@ class NewPasswordAlgoConstantValuesUnitTest extends BaseSniffTest
     {
         $file = $this->sniffFile(__FILE__, '7.4');
 
-        // No errors expected on the first 18 lines.
-        for ($line = 1; $line <= 18; $line++) {
+        // No errors expected on the first 20 lines.
+        for ($line = 1; $line <= 20; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }


### PR DESCRIPTION
### ParameterValues/NewPasswordAlgoConstantValues: add some more tests

... with fully qualified constants, functions and other variations along those lines.

The sniff already seems to handle this correctly, no changes needed.

### ParameterValues/NewPasswordAlgoConstantValues: prevent some false positives

... for the use of integers/floats/text strings etc _within_ a function call or as key for array access.

Includes unit tests.