### PR TITLE
ParameterValues/RemovedNonCryptoHash: bug fix + more tests

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -101,14 +101,20 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
+        // For hash_init(), these hashes are only disabled with HASH_HMAC set.
         $functionLC = \strtolower($functionName);
         if ($functionLC === 'hash_init') {
             $secondParam = PassedParameters::getParameterFromStack($parameters, 2, 'flags');
-            if ($secondParam === false
-                || ($secondParam['clean'] !== 'HASH_HMAC'
-                    && $secondParam['clean'] !== (string) \HASH_HMAC)
+            if ($secondParam === false) {
+                // $flags parameter not found.
+                return;
+            }
+
+            $secondParamContent = ltrim($secondParam['clean'], ' \\'); // Trim off potential leading namespace separator for FQN.
+            if ($secondParamContent !== 'HASH_HMAC'
+                && $secondParamContent !== (string) \HASH_HMAC
             ) {
-                // For hash_init(), these hashes are only disabled with HASH_HMAC set.
+                // $flags parameter not set to HASH_HMAC.
                 return;
             }
         }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
@@ -14,7 +14,7 @@ hash_hmac_file("crc32");
 hash_pbkdf2('crc32b');
 hash_init( flags: HASH_HMAC, algo: 'fnv132', key: $key );
 hash_hmac('fnv1a32');
-hash_hmac_file("fnv164");
+hash_hmac_file("fnv164",);
 hash_pbkdf2('fnv1a64');
 hash_init( 'joaat', 1);
 hash_pbkdf2(

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
@@ -5,14 +5,14 @@
 
 // OK.
 hash_init( 'fnv132');
-hash_init( 'sha1', HASH_HMAC);
+hash_init( 'sha1', HASH_HMAC, $key);
 hash_init( algo: 'gost-crypto', 1);
 
 // Not OK.
 hash_hmac('adler32');
 hash_hmac_file("crc32");
 hash_pbkdf2('crc32b');
-hash_init( flags: HASH_HMAC, algo: 'fnv132' );
+hash_init( flags: HASH_HMAC, algo: 'fnv132', key: $key );
 hash_hmac('fnv1a32');
 hash_hmac_file("fnv164");
 hash_pbkdf2('fnv1a64');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
@@ -24,3 +24,11 @@ hash_init( 'crc32b', HASH_HMAC /*comment*/);
 
 // Safeguard against false positives when target param not found.
 hash_init( algorithm: 'gost-crypto', flags: 1); // OK, well not really, but incorrect algo param name used.
+
+// Safeguard against false negatives for hash_init with FQN HASH_HMAC flag.
+hash_init( 'joaat', \HASH_HMAC, $key);
+hash_init( 'joaat', \  HASH_HMAC, $key); // No longer valid since PHP 8.0, but that's not the concern of this sniff.
+
+// Safeguard against false positives when $flag for hash_init is not HASH_HMAC.
+hash_init( 'joaat', 0, $key);
+hash_init( 'joaat', $unknownValue, $key);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
@@ -21,3 +21,6 @@ hash_pbkdf2(
     'adler32' // Comment.
 );
 hash_init( 'crc32b', HASH_HMAC /*comment*/);
+
+// Safeguard against false positives when target param not found.
+hash_init( algorithm: 'gost-crypto', flags: 1); // OK, well not really, but incorrect algo param name used.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
@@ -27,7 +27,7 @@ class RemovedNonCryptoHashUnitTest extends BaseSniffTest
 {
 
     /**
-     * testNonCryptoHash
+     * Verify detection of function calls using non cryptographic hashes.
      *
      * @dataProvider dataNonCryptoHash
      *
@@ -43,7 +43,7 @@ class RemovedNonCryptoHashUnitTest extends BaseSniffTest
     }
 
     /**
-     * dataNonCryptoHash
+     * Data provider.
      *
      * @see testNonCryptoHash()
      *
@@ -67,18 +67,39 @@ class RemovedNonCryptoHashUnitTest extends BaseSniffTest
 
 
     /**
-     * testNoFalsePositives
+     * Test that there are no false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '7.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 10 lines.
         for ($line = 1; $line <= 10; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        $data[] = [26];
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
@@ -62,6 +62,8 @@ class RemovedNonCryptoHashUnitTest extends BaseSniffTest
             [19, 'hash_init'],
             [20, 'hash_pbkdf2'],
             [23, 'hash_init'],
+            [29, 'hash_init'],
+            [30, 'hash_init'],
         ];
     }
 
@@ -98,6 +100,8 @@ class RemovedNonCryptoHashUnitTest extends BaseSniffTest
         }
 
         $data[] = [26];
+        $data[] = [33];
+        $data[] = [34];
 
         return $data;
     }


### PR DESCRIPTION
### ParameterValues/RemovedNonCryptoHash: fix some unrealistic tests

When the `$flags` parameter is passed to `hash_init` and set to `HASH_HMAC`, the `$key` parameter is required.

### ParameterValues/RemovedNonCryptoHash: add extra test

... to cover more code branches.

### ParameterValues/RemovedNonCryptoHash: bug fix - prevent false negative on FQN flag constant

The flag value `HASH_HMAC` was not correctly recognized when passed as a fully qualified constant.

There also was no test safeguarding against false positives when the `$flag` parameter was passed, but not set to `HASH_HMAC`.

Fixed now.

Includes test.

### ParameterValues/RemovedNonCryptoHash: test with PHP 7.3+ trailing comma in function call