### PR TITLE
ParameterValues/RemovedSetlocaleString: add extra test

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.inc
@@ -16,3 +16,6 @@ setlocale($array['LC_ALL'], 'nl_NL');
 // Safeguard support for PHP 8 named parameters.
 setlocale(locales: 'nl_NL', category: $category); // Can't be determined.
 setlocale(category: 'LC_ALL', locales: 'nl_NL'); // Error.
+
+// Safeguard against false positives when target param not found.
+setlocale(locales: 'nl_NL', cat: LC_ALL,); // OK, well not really, but using incorrect parameter name.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
@@ -94,6 +94,7 @@ class RemovedSetlocaleStringUnitTest extends BaseSniffTest
         $data[] = [13];
         $data[] = [14];
         $data[] = [17];
+        $data[] = [21];
 
         return $data;
     }


### PR DESCRIPTION
... to cover more code branches.

Includes a PHP 7.3+ trailing comma in function call.