### PR TITLE
Syntax/NewFunctionCallTrailingComma: 2 bug fixes + more tests

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -45,7 +45,6 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
         ];
     }
 
-
     /**
      * Processes this test, when one of its tokens is encountered.
      *
@@ -72,18 +71,11 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
             return;
         }
 
-        if ($tokens[$stackPtr]['code'] === \T_STRING) {
-            $ignore = [
-                \T_FUNCTION => true,
-                \T_CONST    => true,
-                \T_USE      => true,
-            ];
-
-            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-            if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
-                // Not a function call.
-                return;
-            }
+        if ($tokens[$stackPtr]['code'] === \T_STRING
+            && isset($tokens[$nextNonEmpty]['parenthesis_owner']) === true
+        ) {
+            // Function declaration, not a function call.
+            return;
         }
 
         $closer            = $tokens[$nextNonEmpty]['parenthesis_closer'];

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Syntax;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Detect trailing commas in function calls, `isset()` and `unset()` as allowed since PHP 7.3.
@@ -37,12 +38,11 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_STRING,
-            \T_VARIABLE,
-            \T_ISSET,
-            \T_UNSET,
-        ];
+        $targets           = Collections::functionCallTokens();
+        $targets[\T_ISSET] = \T_ISSET;
+        $targets[\T_UNSET] = \T_UNSET;
+
+        return $targets;
     }
 
     /**
@@ -71,8 +71,9 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
             return;
         }
 
-        if ($tokens[$stackPtr]['code'] === \T_STRING
-            && isset($tokens[$nextNonEmpty]['parenthesis_owner']) === true
+        if (($tokens[$stackPtr]['code'] === \T_STRING
+            || isset(Collections::ooHierarchyKeywords()[$tokens[$stackPtr]['code']]))
+                && isset($tokens[$nextNonEmpty]['parenthesis_owner']) === true
         ) {
             // Function declaration, not a function call.
             return;

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
@@ -69,3 +69,7 @@ foo(, 'function', 'bar'); // Parse error, but not our concern.
 
 // List with trailing comma.
 list($drink, $color, $power, ) = $info; // Was already allowed.
+
+// Safeguard that closure use statements with trailing commas are ignored.
+// This is allowed since PHP 8.0, but not the concern of this sniff.
+$closure = function () use( $a, $b, ) {};

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
@@ -73,3 +73,6 @@ list($drink, $color, $power, ) = $info; // Was already allowed.
 // Safeguard that closure use statements with trailing commas are ignored.
 // This is allowed since PHP 8.0, but not the concern of this sniff.
 $closure = function () use( $a, $b, ) {};
+
+// Prevent false positives on function declarations with return by reference.
+function &bar($a, $b,) {}

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
@@ -100,3 +100,6 @@ $anon = new class($param,) {};
 
 // Safeguard against false positives on arrow function declarations.
 $arrow = fn ($a, $b,) => $a * $b;
+
+// Safeguard that trailing comma's in method calls using PHP 8.0+ nullsafe object operator are flagged correctly.
+$foo?->bar( 'method', 'bar', );

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
@@ -107,3 +107,6 @@ $foo?->bar( 'method', 'bar', );
 // Safeguard that trailing comma's in class instantiations in PHP 8.0+ attributes are flagged correctly.
 #[Foo( 'constructor', 'bar', )]
 function bar() {}
+
+// Document how trailing comma's in PHP 8.1+ first class callables are handled.
+register_callback(strtolower(...,)); // Parse error, but throw an error anyway as the calllable is by rights a function call.

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
@@ -54,9 +54,9 @@ $bar('arg1', 'arg2',);
 /*
  * Still not allowed.
  */
-// Trailing comma in function declaration.
-function bar($a, $b,) {} // Parse error, but not our concern.
-$closure = function ($a, $b,) {} // Parse error, but not our concern.
+// Trailing comma in function declaration. Update: Allowed since PHP 8.0, but not the concern of this sniff.
+function bar($a, $b,) {}
+$closure = function ($a, $b,) {}
 
 // Free-standing comma.
 foo(,); // Parse error, but throw an error anyway.
@@ -68,4 +68,4 @@ foo('function', 'bar',,); // Parse error, but throw an error anyway.
 foo(, 'function', 'bar'); // Parse error, but not our concern.
 
 // List with trailing comma.
-list($drink, $color, $power, ) = $info; // Parse error, but not our concern.
+list($drink, $color, $power, ) = $info; // Was already allowed.

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
@@ -103,3 +103,7 @@ $arrow = fn ($a, $b,) => $a * $b;
 
 // Safeguard that trailing comma's in method calls using PHP 8.0+ nullsafe object operator are flagged correctly.
 $foo?->bar( 'method', 'bar', );
+
+// Safeguard that trailing comma's in class instantiations in PHP 8.0+ attributes are flagged correctly.
+#[Foo( 'constructor', 'bar', )]
+function bar() {}

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
@@ -76,3 +76,24 @@ $closure = function () use( $a, $b, ) {};
 
 // Prevent false positives on function declarations with return by reference.
 function &bar($a, $b,) {}
+
+// Examine some more constructs.
+$obj = new MyClass($param);
+$obj = new self($param);
+$obj = new parent($param);
+$obj = new static($param);
+$anon = new class($param) {};
+
+// ... but prevent false positives on function declarations with return by reference when the function name is a reserved keyword.
+// The underlying tokenizer issue should be fixed in PHPCS itself.
+class Foo {
+    function &parent($a, $b,) {}
+    function &self($a, $b,) {}
+}
+
+// These should be flagged.
+$obj = new MyClass($param,);
+$obj = new self($param, );
+$obj = new parent($param , );
+$obj = new static($param,);
+$anon = new class($param,) {};

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
@@ -97,3 +97,6 @@ $obj = new self($param, );
 $obj = new parent($param , );
 $obj = new static($param,);
 $anon = new class($param,) {};
+
+// Safeguard against false positives on arrow function declarations.
+$arrow = fn ($a, $b,) => $a * $b;

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -71,6 +71,7 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
             [98],
             [99],
             [105],
+            [108],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -93,17 +93,22 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
      */
     public function dataNoFalsePositives()
     {
-        return [
-            [6],
-            [7],
-            [8],
-            [9],
-            [51],
-            [58],
-            [59],
-            [68],
-            [71],
-        ];
+        $data = [];
+
+        // No errors expected on the first 10 lines.
+        for ($line = 1; $line <= 10; $line++) {
+            $data[] = [$line];
+        }
+
+        $data[] = [51];
+        $data[] = [58];
+        $data[] = [59];
+
+        for ($line = 66; $line <= 76; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -104,7 +104,7 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
         $data[] = [58];
         $data[] = [59];
 
-        for ($line = 66; $line <= 76; $line++) {
+        for ($line = 66; $line <= 79; $line++) {
             $data[] = [$line];
         }
 

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -113,6 +113,10 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
             $data[] = [$line];
         }
 
+        for ($line = 100; $line <= 103; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -72,6 +72,7 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
             [99],
             [105],
             [108],
+            [112],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -65,6 +65,11 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
             [52],
             [62],
             [65],
+            [95],
+            [96],
+            [97],
+            [98],
+            [99],
         ];
     }
 
@@ -104,7 +109,7 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
         $data[] = [58];
         $data[] = [59];
 
-        for ($line = 66; $line <= 79; $line++) {
+        for ($line = 66; $line <= 93; $line++) {
             $data[] = [$line];
         }
 

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -70,6 +70,7 @@ class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
             [97],
             [98],
             [99],
+            [105],
         ];
     }
 


### PR DESCRIPTION
### Syntax/NewFunctionCallTrailingComma: update comments in test case file

### Syntax/NewFunctionCallTrailingComma: add extra test

... to safeguard against false positives.

### Syntax/NewFunctionCallTrailingComma: bug fix - prevent false positives on function declarations

Trailing comma's in function declarations, as allowed per PHP 8.0, are not the concern of this sniff.

As things were, the sniff would throw false positives for trailing comma's in function declaration statements where the function was declared to return by reference.

Fixed now.

Includes simplifying the code a little as `T_CONST` and `T_USE` can never be found before a `T_STRING` token if there is a parenthesis opener after it.

Includes unit test.

### Syntax/NewFunctionCallTrailingComma: bug fix - examine more tokens

Class instantiations with trailing comma's in the param list should also be detected by this sniff.

However, false positives on function declarations using reserved keywords should be prevented.
PHPCS normally (re-)tokenizes those function name in a declaration to `T_STRING`, but there seems to be a bug in this retokenization for the hierarchy keywords in combination with functions declared to return by reference.

Fixed now.

Includes tests.

Loosely related to #1489

### Syntax/NewFunctionCallTrailingComma: add test with PHP 7.4+ arrow function

The sniff already handles this correctly, no changes needed.

### Syntax/NewFunctionCallTrailingComma: add test with PHP 8.0+ nullsafe object operator

The sniff already handles this correctly, no changes needed.

### Syntax/NewFunctionCallTrailingComma: add test with PHP 8.0+ attributes

The sniff already handles this correctly, no changes needed.

### Syntax/NewFunctionCallTrailingComma: add test with PHP 8.1+ first class callables

IMO the sniff already handles this correctly, no changes needed.