### PR TITLE
Upgrade/LowPHP[CS]Sniff: minor efficiency tweak

### DIFF
--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPCSSniff.php
@@ -143,5 +143,8 @@ class LowPHPCSSniff extends Sniff
         MessageHelper::addMessage($phpcsFile, $message, 0, $isError, $errorCode, $replacements);
 
         $this->examine = false;
+
+        // No need to look at this file again.
+        return ($phpcsFile->numTokens + 1);
     }
 }

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -134,5 +134,8 @@ class LowPHPSniff extends Sniff
         MessageHelper::addMessage($phpcsFile, $message, 0, $isError, $errorCode, $replacements);
 
         $this->examine = false;
+
+        // No need to look at this file again.
+        return ($phpcsFile->numTokens + 1);
     }
 }


### PR DESCRIPTION
The code in the sniffs only runs on the first file containing a PHP open tag, but a file may contain multiple open tags.

While the sniffs will only throw the error/warning once already, it could still trigger the sniffs a second time if multiple open tags are in a file.

This minor tweak will prevent that.