### PR TITLE
UseDeclarations/NewUseConstFunction: bugfix - "as" keyword is case-insensitive

### DIFF
--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -95,8 +95,7 @@ class NewUseConstFunctionSniff extends Sniff
         // `use const` and `use function` have to be followed by the function/constant name.
         $functionOrConstName = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
         if ($functionOrConstName === false
-            // Identifies as T_AS or T_STRING, this covers both.
-            || ($tokens[$functionOrConstName]['content'] === 'as'
+            || ($tokens[$functionOrConstName]['code'] === \T_AS
             || $tokens[$functionOrConstName]['code'] === \T_COMMA)
         ) {
             // Live coding or incorrect use of reserved keyword, but that is

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -81,12 +81,8 @@ class NewUseConstFunctionSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
+        // Note: $nextNonEmpty will never be `false` as otherwise `isImportUse()` would have returned `false`.
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($nextNonEmpty === false) {
-            // Live coding.
-            return;
-        }
-
         if (isset($this->validUseNames[\strtolower($tokens[$nextNonEmpty]['content'])]) === false) {
             // Not a `use const` or `use function` statement.
             return;

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.inc
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.inc
@@ -29,13 +29,13 @@ $closure = function($a) use ($b) {};
 use const Baz;
 use Const FOOBAR as Baz;
 use function Baz;
-use FUNCTION FooBar as Baz;
+use FUNCTION FooBar AS Baz;
 
 /*
  * Incorrect use, but covered by ForbiddenNames sniff, should not be reported here.
  */
 use const as Baz;
-use function as Baz;
+use function AS Baz;
 use const, function, somethingElse;
 
 /*


### PR DESCRIPTION
### UseDeclarations/NewUseConstFunction: bugfix - "as" keyword is case-insensitive

As things were, the `as` keyword was treated case-sensitively by the sniff, while the keyword is treated case-insensitively by PHP.

The sniff previously looked for the token content being `as`, as the tokenization could be different depending on the PHPCS version.

At this moment, that is no longer the case, so by switching to checking for the keyword based on the token _code_, the bug (false positives) gets fixed.

Includes a few adjusted tests to safeguard the issue.

### UseDeclarations/NewUseConstFunction: remove a redundant condition 