### PR TITLE
Variables/NewUniformVariableSyntax: various minor code tweaks + XML docs

### DIFF
--- a/PHPCompatibility/Docs/Variables/NewUniformVariableSyntaxStandard.xml
+++ b/PHPCompatibility/Docs/Variables/NewUniformVariableSyntaxStandard.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Uniform Variable Syntax"
+    >
+    <standard>
+    <![CDATA[
+    As of PHP 7.0, indirect access to variables, properties and methods will now be evaluated strictly in left-to-right order.
+
+    Prior to PHP 7.0, certain expressions would be interpreted using a right-to-left evaluation order, which means that the result of these expressions will be different in PHP 5.x versus PHP 7.x.
+
+    The evaluation order can be made explicit and enforced to be the same PHP cross-version by using curly braces to clarify how the expression should be evaluated.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: Using curly braces to explicitly enforce a specific evaluation order.">
+        <![CDATA[
+echo $<em>{</em>$var['key1']['key2']<em>}</em>;
+echo $obj-><em>{</em>$var['key']<em>}</em>;
+echo $obj-><em>{</em>$var['key']<em>}</em>();
+echo MyClass::<em>{</em>$var['key']<em>}</em>();
+        ]]>
+        </code>
+        <code title="Cross-version INcompatible: Without curly braces the interpretation of these indirect accesses to variables, properties and methods will behave different in PHP &lt;= 5.6 versus PHP 7.0+.">
+        <![CDATA[
+echo <em>$$var['key1']['key2']</em>;
+echo <em>$obj->$var['key']</em>;
+echo <em>$obj->$var['key']()</em>;
+echo <em>MyClass::$var['key']()</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -61,17 +61,18 @@ class NewUniformVariableSyntaxSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Verify that the next token is a square open bracket. If not, bow out.
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
-
-        if ($nextToken === false || $tokens[$nextToken]['code'] !== \T_OPEN_SQUARE_BRACKET || isset($tokens[$nextToken]['bracket_closer']) === false) {
+        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextToken === false
+            || $tokens[$nextToken]['code'] !== \T_OPEN_SQUARE_BRACKET
+            || isset($tokens[$nextToken]['bracket_closer']) === false
+        ) {
             return;
         }
 
         // The previous non-empty token has to be a $, -> or ::.
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-        if ($prevToken === false
-            || (isset(Collections::objectOperators()[$tokens[$prevToken]['code']]) === false
-                && $tokens[$prevToken]['code'] !== \T_DOLLAR)
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if (isset(Collections::objectOperators()[$tokens[$prevToken]['code']]) === false
+            && $tokens[$prevToken]['code'] !== \T_DOLLAR
         ) {
             return;
         }
@@ -79,7 +80,7 @@ class NewUniformVariableSyntaxSniff extends Sniff
         // For static object calls, it only applies when this is a function call.
         if ($tokens[$prevToken]['code'] === \T_DOUBLE_COLON) {
             $hasBrackets = $tokens[$nextToken]['bracket_closer'];
-            while (($hasBrackets = $phpcsFile->findNext(Tokens::$emptyTokens, ($hasBrackets + 1), null, true, null, true)) !== false) {
+            while (($hasBrackets = $phpcsFile->findNext(Tokens::$emptyTokens, ($hasBrackets + 1), null, true)) !== false) {
                 if ($tokens[$hasBrackets]['code'] === \T_OPEN_SQUARE_BRACKET) {
                     if (isset($tokens[$hasBrackets]['bracket_closer'])) {
                         $hasBrackets = $tokens[$hasBrackets]['bracket_closer'];

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.inc
@@ -44,6 +44,8 @@ echo myClass  :: { /* comment */ $var['key']}(); // OK.
 // Make sure PHP 8.0+ nullsafe object operator is handled correctly.
 echo $obj?->$var['key'];
 echo $obj?->$var['key']();
+echo $obj?->{$var['key']};
+echo $obj?->{$var['key']}();
 
 // Live coding.
 echo $$var['key'

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
@@ -109,7 +109,9 @@ class NewUniformVariableSyntaxUnitTest extends BaseSniffTest
             [27],
             [28],
             [42],
-            [49],
+            [47],
+            [48],
+            [51],
         ];
     }
 


### PR DESCRIPTION
### Variables/NewUniformVariableSyntax: add some extra tests

... related to PHP 8.0 nullsafe object operators. This is already handled correctly, just safeguarding it better now.

### Variables/NewUniformVariableSyntax: various minor code tweaks

Minor code simplifications and code readability improvements.

### Variables/NewUniformVariableSyntax: add XML docs 