### PR TITLE
__destruct visibility must not be declared as public

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -52,7 +52,6 @@ class NonStaticMagicMethodsSniff extends Sniff
             'static' => false,
         ],
         '__destruct' => [
-            'visibility' => 'public',
             'static'     => false,
         ],
         '__clone' => [

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
@@ -198,7 +198,7 @@ class MoreNormal
 
 class MoreWrongVisibility
 {
-    private function __destruct() {}
+    private function __destruct() {} // Not actually wrong, private is allowed for destructors.
     protected function __debugInfo() {}
     private function __invoke() {}
     protected static function __set_state() {}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -339,6 +339,7 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             [194],
             [195],
             [196],
+            [201],
 
             // Plain trait.
             [219],

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -94,7 +94,6 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             ['__unserialize', 'public', 'private', 180],
 
             // More magic methods.
-            ['__destruct', 'public', 'private', 201],
             ['__debugInfo', 'public', 'protected', 202],
             ['__invoke', 'public', 'private', 203],
             ['__set_state', 'public', 'protected', 204],


### PR DESCRIPTION
Fix #1542

Ref: https://www.php.net/manual/en/language.oop5.magic.php

Warning
All magic methods, with the exception of __construct(), __destruct(), and __clone(), must be declared as public, otherwise an E_WARNING is emitted. Prior to PHP 8.0.0, no diagnostic was emitted for the magic methods __sleep(), __wakeup(), __serialize(), __unserialize(), and __set_state().