### PR TITLE
Introduce two `InvalidTestVersion` exceptions

### DIFF
--- a/PHPCompatibility/Exceptions/InvalidTestVersion.php
+++ b/PHPCompatibility/Exceptions/InvalidTestVersion.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Exceptions;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+
+/**
+ * Exception thrown when an invalid `testVersion` value is passed.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is only intended for internal use by PHPCompatibility and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @since 10.0.0
+ */
+final class InvalidTestVersion extends RuntimeException
+{
+
+    /**
+     * Create a new invalid `testVersion` exception with a standardized text.
+     *
+     * @since 10.0.0
+     *
+     * @param string $testVersion The `testVersion` received.
+     *
+     * @return \PHPCompatibility\Exceptions\InvalidTestVersion
+     */
+    public static function create($testVersion)
+    {
+        return new self(
+            \sprintf(
+                'Invalid PHPCompatibility testVersion provided: \'%s\'',
+                $testVersion
+            )
+        );
+    }
+}

--- a/PHPCompatibility/Exceptions/InvalidTestVersionRange.php
+++ b/PHPCompatibility/Exceptions/InvalidTestVersionRange.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Exceptions;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+
+/**
+ * Exception thrown when an invalid `testVersion` range is passed.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is only intended for internal use by PHPCompatibility and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @since 10.0.0
+ */
+final class InvalidTestVersionRange extends RuntimeException
+{
+
+    /**
+     * Create a new invalid `testVersion` range exception with a standardized text.
+     *
+     * @since 10.0.0
+     *
+     * @param string $testVersion The `testVersion` received.
+     *
+     * @return \PHPCompatibility\Exceptions\InvalidTestVersionRange
+     */
+    public static function create($testVersion)
+    {
+        return new self(
+            \sprintf(
+                'Invalid range in provided PHPCompatibility testVersion: \'%s\'',
+                $testVersion
+            )
+        );
+    }
+}

--- a/PHPCompatibility/Util/Tests/Exceptions/InvalidTestVersionRangeUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Exceptions/InvalidTestVersionRangeUnitTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Util\Tests\Exceptions;
+
+use PHPCompatibility\Exceptions\InvalidTestVersionRange;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCompatibility\Exceptions\InvalidTestVersionRange
+ *
+ * @since 1.0.0
+ */
+final class InvalidTestVersionRangeUnitTest extends TestCase
+{
+
+    /**
+     * Test that the text of the exception is as expected.
+     *
+     * @return void
+     */
+    public function testCreate()
+    {
+        $this->expectException('PHPCompatibility\Exceptions\InvalidTestVersionRange');
+        $this->expectExceptionMessage('Invalid range in provided PHPCompatibility testVersion: \'7.0-5.6\'');
+
+        throw InvalidTestVersionRange::create('7.0-5.6');
+    }
+}

--- a/PHPCompatibility/Util/Tests/Exceptions/InvalidTestVersionUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Exceptions/InvalidTestVersionUnitTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Util\Tests\Exceptions;
+
+use PHPCompatibility\Exceptions\InvalidTestVersion;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCompatibility\Exceptions\InvalidTestVersion
+ *
+ * @since 1.0.0
+ */
+final class InvalidTestVersionUnitTest extends TestCase
+{
+
+    /**
+     * Test that the text of the exception is as expected.
+     *
+     * @return void
+     */
+    public function testCreate()
+    {
+        $this->expectException('PHPCompatibility\Exceptions\InvalidTestVersion');
+        $this->expectExceptionMessage('Invalid PHPCompatibility testVersion provided: \'invalid\'');
+
+        throw InvalidTestVersion::create('invalid');
+    }
+}

--- a/PHPCompatibility/Util/Tests/Helpers/TestVersionTraitUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/TestVersionTraitUnitTest.php
@@ -10,12 +10,10 @@
 
 namespace PHPCompatibility\Util\Tests\Helpers;
 
-use PHPUnit\Framework\TestCase;
 use PHP_CodeSniffer\Config;
 use PHPCompatibility\Helpers\TestVersionTrait;
 use PHPCSUtils\BackCompat\Helper;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Tests for the TestVersionTrait sniff helper.
@@ -26,8 +24,6 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
  */
 class TestVersionTraitUnitTest extends TestCase
 {
-    use ExpectException;
-    use ExpectPHPException;
     use TestVersionTrait;
 
     /**

--- a/PHPCompatibility/Util/Tests/Helpers/TestVersionTraitUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/TestVersionTraitUnitTest.php
@@ -152,10 +152,10 @@ class TestVersionTraitUnitTest extends TestCase
      */
     public function testGetTestVersionInvalidRange($testVersion)
     {
-        $message = \sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion);
+        $message = \sprintf('Invalid range in provided PHPCompatibility testVersion: \'%s\'', $testVersion);
 
-        $this->expectWarning();
-        $this->expectWarningMessage($message);
+        $this->expectException('PHPCompatibility\Exceptions\InvalidTestVersionRange');
+        $this->expectExceptionMessage($message);
 
         $this->testGetTestVersion($testVersion, [null, null]);
     }
@@ -190,10 +190,10 @@ class TestVersionTraitUnitTest extends TestCase
      */
     public function testGetTestVersionInvalidVersion($testVersion)
     {
-        $message = \sprintf('Invalid testVersion setting: \'%s\'', \trim($testVersion));
+        $message = \sprintf('Invalid PHPCompatibility testVersion provided: \'%s\'', \trim($testVersion));
 
-        $this->expectWarning();
-        $this->expectWarningMessage($message);
+        $this->expectException('PHPCompatibility\Exceptions\InvalidTestVersion');
+        $this->expectExceptionMessage($message);
 
         $this->testGetTestVersion($testVersion, [null, null]);
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,7 @@
             <file>./PHPCompatibility/Sniff.php</file>
             <file>./PHPCompatibility/AbstractInitialValueSniff.php</file>
             <directory>./PHPCompatibility/Sniffs/</directory>
+            <directory>./PHPCompatibility/Exceptions/</directory>
             <directory>./PHPCompatibility/Helpers/</directory>
         </whitelist>
     </filter>


### PR DESCRIPTION
### TestVersionTraitUnitTest: use the polyfilled TestCase

As this test does not need to use one of the base `TestCase` classes which handle the integration with PHPCS, we may as well use the `Yoast\PHPUnitPolyfills\TestCases\TestCase`, which includes all possibly needed polyfills.

### Introduce two `InvalidTestVersion` exceptions

... and start using these in the `TestVersionTrait` instead of triggering a PHP warning.

For **end-users**, the net effect of this change is minimal.
* Previously, the warning would display as a PHPCS `Internal.Exception` on line 1 of the first file scanned.
    - The warning would not show if `error_reporting` did not include "warnings".
    - The warning would prevent the PHPCS run from finishing analyzing the file.
* Now, the (caught) exception will still display as a PHPCS `Internal.Exception` on line 1 of the first file scanned.
    - The exception can not be silenced anymore.
    - The exception will prevent the PHPCS run from finishing analyzing the file (same as before).

For **integrators**, the net effect of this change is an improvement.
* Previously, tools integrating PHPCompatibility could not "catch" the warning, only silence it.
* Now, the exception **_can_** be caught by tools which integrate PHPCompatibility.

On "our" side, it will make it easier to support PHPUnit 10.x at some point in the future.

Includes minor tweak to the language used in the error messages.
Includes perfunctory unit tests.
Includes adding the new directory to the test coverage configuration.