### PR TITLE
Upgrade/LowPHP: update the minimum recommended PHP version to 7.2

### DIFF
--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -54,7 +54,7 @@ class LowPHPSniff extends Sniff
      *
      * @var string
      */
-    const MIN_RECOMMENDED_VERSION = '5.4';
+    const MIN_RECOMMENDED_VERSION = '7.2';
 
     /**
      * Keep track of whether this sniff needs to actually run.


### PR DESCRIPTION
PHPCS 4.x will have a minimum PHP version of PHP 7.2, so we may as well start recommending the use of PHP 7.2 or higher for PHPCS scans.

The actual sniffs will still check for all sniffable PHPCompatibility issues.