### PR TITLE
TokenGroup::is*Number(): change base TestCase

### DIFF
--- a/PHPCompatibility/Util/Tests/Helpers/TokenGroup/IsNumberUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/TokenGroup/IsNumberUnitTest.php
@@ -11,7 +11,7 @@
 namespace PHPCompatibility\Util\Tests\Helpers\TokenGroup;
 
 use PHPCompatibility\Helpers\TokenGroup;
-use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
  * Tests for the `isNumber()`, `isPositiveNumber()` and `isNegativeNumber()` utility functions.
@@ -21,7 +21,7 @@ use PHPCompatibility\Util\Tests\CoreMethodTestFrame;
  *
  * @since 8.2.0
  */
-final class IsNumberUnitTest extends CoreMethodTestFrame
+final class IsNumberUnitTest extends UtilityMethodTestCase
 {
 
     /**


### PR DESCRIPTION
Follow up on #1493 

The `CoreMethodTestFrame` test case is basically a wrapper around the `PHPCSUtils\TestUtils\UtilityMethodTestCase` class with the addition of a dummy sniff to use.

As the `TokenGroup::is*Number()` methods have become stand-alone, they no longer need the dummy sniff.