### PR TITLE
CONTRIBUTING: update info about running PHPCS on this repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -97,7 +97,7 @@ In order to run the tests on the sniffs, the following installation steps are re
 
     If you install using Composer, make sure you run `composer install --prefer-source` to get access to the unit tests and other development related files.
 
-    **Pro-tip**: If you develop regularly for the PHPCompatibility standard, it may be preferable to use a git clone based install of PHP CodeSniffer to allow you to easily test sniffs with different PHP CodeSniffer versions by switching between tags.
+    **Pro-tip**: If you develop regularly for the PHPCompatibility standard, it may be preferable to use a git clone based install of PHP CodeSniffer to allow you to easily test sniffs with different PHP CodeSniffer versions by switching between tags/branches.
 
 2. If you used Composer, PHPUnit should be installed automatically and you are done.
 
@@ -143,29 +143,9 @@ Checking Code Style Locally
 -----------------------
 
 PHPCompatibility uses the [PHPCSDevCS](https://github.com/PHPCSStandards/PHPCSDevCS) standard for code style.
-As PHPCompatibility is one of the dependencies of PHPCSDevCS, we have a recursive dependency which makes it slightly less intuitive to work with.
-On top of that, PHPCSDevCS has a higher minimum PHPCS requirement than PHPCompatibility, so fun times getting this working ;-)
-
-If you have a local test environment setup which is based on git clones, clone the [PHPCSDevCS](https://github.com/PHPCSStandards/PHPCSDevCS) repo and register it with your PHPCS clone using the `--installed_paths` argument.
-You can then run `phpcs` from the command-line from the root directory of this repo to check the code style of your branch/patch.
-
-> :bulb: Pro-tips:
-> * Make sure your PHPCS clone is checked out at a recent PHPCS version (PHPCS 3.5.0 or higher) before running the CS check.
-> * Keep the PHPCSDevCS repo up to date.
->     You may want to start _watching releases_ on GitHub for the repo to know when there are updates available.
-> * The PHPCSDevCS repo is expected to add more external standards in the (near) future.
->     If you run into _"Unknown standard"_ errors, this might be the cause and you'll need to make sure those additional external standards are also available on your system and registered with your local PHPCS clone.
 
 If you have a Composer based local test environment setup, there are helper scripts available to check the code style.
 * `composer checkcs`
 * `composer fixcs`
 
-These helper scripts will temporarily install PHPCSDevCS, run the code style check and then remove PHPCSDevCS again.
-
-If the PHPCS run exits with errors, fix those and run either one of the scripts again to make sure the temporary dependency is removed before committing your changes or run `composer remove-devcs` to make sure the `composer.json` file is cleaned up.
-
-> :bulb: Pro-tips:
-> * If you run into time-outs when running the `checkcs` or `fixcs` scripts, you can run the underlying scripts directly to get round that:
->     - `composer install-devcs`
->     - `vendor/bin/phpcs` or `vendor/bin/phpcbf`
->     - `composer remove-devcs`
+If the PHPCS run exits with errors, fix those and run `composer checkcs` again to verify.


### PR DESCRIPTION
Follow up on PR #1352, which dropped support for PHPCS < 3.7.1.

As the `PHPCSDevCS` repo is now a direct dependency and the work-arounds we had in place for it have been removed in commit 17e7a63d53e94c5cdabf6788ea520bcebe166607, the information about these work-arounds can also be removed from the `CONTRIBUTING.md` guide.