### PR TITLE
Change `TestVersionTrait` to `ScannedCode` class

### DIFF
--- a/PHPCompatibility/Helpers/ScannedCode.php
+++ b/PHPCompatibility/Helpers/ScannedCode.php
@@ -15,20 +15,23 @@ use PHPCompatibility\Exceptions\InvalidTestVersionRange;
 use PHPCSUtils\BackCompat\Helper;
 
 /**
- * Helper for working with the PHPCompatibility testVersion configuration variable.
+ * Helper for working with the PHPCompatibility `testVersion` configuration variable.
+ *
+ * The `testVersion` is used to determine whether the code being scanned needs to support
+ * a certain PHP version or not.
  *
  * Used by nearly all sniffs.
  *
  * ---------------------------------------------------------------------------------------------
- * This trait is only intended for internal use by PHPCompatibility and is not part of the public API.
+ * This class is only intended for internal use by PHPCompatibility and is not part of the public API.
  * This also means that it has no promise of backward compatibility. Use at your own risk.
  * ---------------------------------------------------------------------------------------------
  *
  * @since 5.6    Base methods introduced in the generic `Sniff` class.
- * @since 10.0.0 Methods moved from the generic `Sniff` class to a dedicated trait to
+ * @since 10.0.0 Methods moved from the generic `Sniff` class to this dedicated class to
  *               allow for sniffs which don't extends the PHPCompatibility `Sniff` class.
  */
-trait TestVersionTrait
+final class ScannedCode
 {
 
     /**
@@ -53,6 +56,7 @@ trait TestVersionTrait
      * @since 7.1.3  Now allows for partial ranges such as `5.2-`.
      * @since 10.0.0 - Will allow for "testVersion" config in lowercase.
      *               - Will throw a PHP Exception instead of a warning for an invalid testVersion.
+     *               - The method is now static.
      *
      * @return array $arrTestVersions will hold an array containing min/max version
      *               of PHP that we are checking against (see above).  If only a
@@ -62,7 +66,7 @@ trait TestVersionTrait
      * @throws \PHPCompatibility\Exceptions\InvalidTestVersionRange When the range in the testVersion is invalid.
      * @throws \PHPCompatibility\Exceptions\InvalidTestVersion      When the testVersion itself is invalid.
      */
-    private function getTestVersion()
+    private static function getTestVersion()
     {
         static $arrTestVersions = [];
 
@@ -124,6 +128,7 @@ trait TestVersionTrait
      * Should be used when sniffing for *old* PHP features (deprecated/removed).
      *
      * @since 5.6
+     * @since 10.0.0 The method is now static.
      *
      * @param string $phpVersion A PHP version number in 'major.minor' format.
      *
@@ -131,9 +136,9 @@ trait TestVersionTrait
      *              is equal to or higher than the highest supported PHP version
      *              in testVersion. False otherwise.
      */
-    public function supportsAbove($phpVersion)
+    public static function shouldRunOnOrAbove($phpVersion)
     {
-        $testVersion = $this->getTestVersion();
+        $testVersion = self::getTestVersion();
         $testVersion = $testVersion[1];
 
         if (\is_null($testVersion) === true
@@ -153,6 +158,7 @@ trait TestVersionTrait
      * Should be used when sniffing for *new* PHP features.
      *
      * @since 5.6
+     * @since 10.0.0 The method is now static.
      *
      * @param string $phpVersion A PHP version number in 'major.minor' format.
      *
@@ -160,9 +166,9 @@ trait TestVersionTrait
      *              supported PHP version in testVersion.
      *              False otherwise or if no testVersion is provided.
      */
-    public function supportsBelow($phpVersion)
+    public static function shouldRunOnOrBelow($phpVersion)
     {
-        $testVersion = $this->getTestVersion();
+        $testVersion = self::getTestVersion();
         $testVersion = $testVersion[0];
 
         if (\is_null($testVersion) === false

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff as PHPCS_Sniff;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCompatibility\Helpers\TestVersionTrait;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Namespaces;
@@ -27,7 +27,6 @@ use PHPCSUtils\Utils\Scopes;
  */
 abstract class Sniff implements PHPCS_Sniff
 {
-    use TestVersionTrait;
 
     /**
      * Returns the fully qualified class name for a new class instantiation.
@@ -369,7 +368,7 @@ abstract class Sniff implements PHPCS_Sniff
         $subsetStart = $start;
         $subsetEnd   = ($arithmeticOperator - 1);
 
-        while (TokenGroup::isNumber($phpcsFile, $subsetStart, $subsetEnd, $this->supportsBelow('5.6'), true) !== false
+        while (TokenGroup::isNumber($phpcsFile, $subsetStart, $subsetEnd, ScannedCode::shouldRunOnOrBelow('5.6'), true) !== false
             && isset($tokens[($arithmeticOperator + 1)]) === true
         ) {
             $subsetStart  = ($arithmeticOperator + 1);
@@ -381,7 +380,7 @@ abstract class Sniff implements PHPCS_Sniff
 
             if ($arithmeticOperator === false) {
                 // Last calculation operator already reached.
-                if (TokenGroup::isNumber($phpcsFile, $subsetStart, $end, $this->supportsBelow('5.6'), true) !== false) {
+                if (TokenGroup::isNumber($phpcsFile, $subsetStart, $end, ScannedCode::shouldRunOnOrBelow('5.6'), true) !== false) {
                     return true;
                 }
 

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Attributes;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\GetTokensAsString;
@@ -60,7 +61,7 @@ class NewAttributesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -77,7 +78,7 @@ class ForbiddenExtendingFinalPHPClassSniff extends Sniff
             return;
         }
 
-        if ($this->supportsAbove($this->finalClasses[$classNameLc]) === false) {
+        if (ScannedCode::shouldRunOnOrAbove($this->finalClasses[$classNameLc]) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -52,7 +53,7 @@ class NewAnonymousClassesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.6') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.6') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
@@ -1316,7 +1317,7 @@ class NewClassesSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -53,7 +54,7 @@ class NewConstVisibilitySniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
@@ -53,7 +54,7 @@ final class NewConstructorPropertyPromotionSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/NewFinalConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewFinalConstantsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -53,7 +54,7 @@ class NewFinalConstantsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('8.0') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('8.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -102,7 +103,7 @@ class NewLateStaticBindingSniff extends Sniff
 
         $inClass = Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
 
-        if ($inClass === true && $this->supportsBelow('5.2') === true) {
+        if ($inClass === true && ScannedCode::shouldRunOnOrBelow('5.2') === true) {
             $phpcsFile->addError(
                 'Late static binding is not supported in PHP 5.2 or earlier.',
                 $stackPtr,

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\ObjectDeclarations;
@@ -53,7 +54,7 @@ final class NewReadonlyClassesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('8.1') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('8.1') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
@@ -59,7 +60,7 @@ final class NewReadonlyPropertiesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('8.0') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('8.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -232,7 +233,7 @@ class NewTypedPropertiesSniff extends Sniff
             $errorSuffix = ' (promoted property ' . $typeInfo['param_name'] . ')';
         }
 
-        if ($this->supportsBelow('7.3') === true) {
+        if (ScannedCode::shouldRunOnOrBelow('7.3') === true) {
             $phpcsFile->addError(
                 'Typed properties are not supported in PHP 7.3 or earlier. Found: %s' . $errorSuffix,
                 $typeToken,
@@ -244,7 +245,7 @@ class NewTypedPropertiesSniff extends Sniff
             $isUnionType        = (\strpos($type, '|') !== false);
             $isIntersectionType = (\strpos($type, '&') !== false);
 
-            if ($this->supportsBelow('7.4') === true && $isUnionType === true) {
+            if (ScannedCode::shouldRunOnOrBelow('7.4') === true && $isUnionType === true) {
                 $phpcsFile->addError(
                     'Union types are not present in PHP version 7.4 or earlier. Found: %s' . $errorSuffix,
                     $typeToken,
@@ -253,7 +254,7 @@ class NewTypedPropertiesSniff extends Sniff
                 );
             }
 
-            if ($this->supportsBelow('8.0') === true && $isIntersectionType === true) {
+            if (ScannedCode::shouldRunOnOrBelow('8.0') === true && $isIntersectionType === true) {
                 $phpcsFile->addError(
                     'Intersection types are not present in PHP version 8.0 or earlier. Found: %s',
                     $typeToken,
@@ -275,7 +276,7 @@ class NewTypedPropertiesSniff extends Sniff
                      * Only throw an error if PHP 8+ needs to be supported.
                      */
                     if (($type === 'mixed' && $typeInfo['nullable_type'] === true)
-                        && $this->supportsAbove('8.0') === true
+                        && ScannedCode::shouldRunOnOrAbove('8.0') === true
                     ) {
                         $phpcsFile->addError(
                             'Mixed types cannot be nullable, null is already part of the mixed type' . $errorSuffix,
@@ -286,7 +287,7 @@ class NewTypedPropertiesSniff extends Sniff
 
                     if (isset($this->unionOnlyTypes[$type]) === true
                         && $isUnionType === false
-                        && $this->supportsBelow('8.1') === true
+                        && ScannedCode::shouldRunOnOrBelow('8.1') === true
                     ) {
                         $phpcsFile->addError(
                             "The '%s' type can only be used as part of a union type in PHP 8.1 or earlier",
@@ -330,7 +331,7 @@ class NewTypedPropertiesSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
@@ -498,11 +499,11 @@ class RemovedClassesSniff extends Sniff
         $isError     = null;
 
         if (empty($versionInfo['removed']) === false
-            && $this->supportsAbove($versionInfo['removed']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['removed']) === true
         ) {
             $isError = true;
         } elseif (empty($versionInfo['deprecated']) === false
-            && $this->supportsAbove($versionInfo['deprecated']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['deprecated']) === true
         ) {
             $isError = false;
 

--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Classes;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -57,7 +58,7 @@ class RemovedOrphanedParentSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.4') === false) {
             return;
         }
 
@@ -101,7 +102,7 @@ class RemovedOrphanedParentSniff extends Sniff
         $code    = 'Deprecated';
         $isError = false;
 
-        if ($this->supportsAbove('8.0') === true) {
+        if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
             $error  .= ' and removed since PHP 8.0';
             $code    = 'Removed';
             $isError = true;

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsInTraitsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsInTraitsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Constants;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\Scopes;
@@ -53,7 +54,7 @@ final class NewConstantsInTraitsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('8.1') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('8.1') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\Constants;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
 /**
@@ -6693,7 +6694,7 @@ class NewConstantsSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Constants;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -62,7 +63,7 @@ class NewMagicClassConstantSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === false) {
             return;
         }
 
@@ -95,7 +96,7 @@ class NewMagicClassConstantSniff extends Sniff
                 && isset(Collections::objectOperators()[$tokens[$preSubjectPtr]['code']]) === false)
         ) {
             // This is a syntax which is supported on PHP 5.5 and higher.
-            if ($this->supportsBelow('5.4') === true) {
+            if (ScannedCode::shouldRunOnOrBelow('5.4') === true) {
                 $phpcsFile->addError(
                     'The magic class constant ClassName::class was not available in PHP 5.4 or earlier',
                     $stackPtr,

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\Constants;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\MessageHelper;
 
@@ -2656,11 +2657,11 @@ class RemovedConstantsSniff extends Sniff
         $isError     = null;
 
         if (empty($versionInfo['removed']) === false
-            && $this->supportsAbove($versionInfo['removed']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['removed']) === true
         ) {
             $isError = true;
         } elseif (empty($versionInfo['deprecated']) === false
-            && $this->supportsAbove($versionInfo['deprecated']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['deprecated']) === true
         ) {
             $isError = false;
 

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -107,7 +108,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.3') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.3') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\Conditions;
@@ -85,7 +86,7 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
         $errorCode = 'Found';
         $data      = [$tokens[$stackPtr]['content']];
 
-        if ($this->supportsAbove('7.0')) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === true) {
             $error    .= ' and will throw a fatal error since PHP 7.0';
             $isError   = true;
             $errorCode = 'FatalError';

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -87,7 +88,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.4') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -51,7 +52,7 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
@@ -242,11 +243,11 @@ class NewExecutionDirectivesSniff extends Sniff
         $shouldError = false;
 
         if (empty($versionInfo['not_in_version']) === false
-            && $this->supportsBelow($versionInfo['not_in_version']) === true
+            && ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === true
         ) {
             $shouldError = true;
         } elseif (empty($versionInfo['conditional_version']) === false
-            && $this->supportsBelow($versionInfo['conditional_version']) === true
+            && ScannedCode::shouldRunOnOrBelow($versionInfo['conditional_version']) === true
         ) {
             $shouldError = true;
 

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -53,7 +54,7 @@ class NewForeachExpressionReferencingSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -52,7 +53,7 @@ class NewListInForeachSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\ControlStructures;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -52,7 +53,7 @@ class NewMultiCatchSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/NewNonCapturingCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewNonCapturingCatchSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ControlStructures;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 
 /**
@@ -52,7 +53,7 @@ class NewNonCapturingCatchSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\Extensions;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
@@ -342,11 +343,11 @@ class RemovedExtensionsSniff extends Sniff
         $isError     = null;
 
         if (empty($versionInfo['removed']) === false
-            && $this->supportsAbove($versionInfo['removed']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['removed']) === true
         ) {
             $isError = true;
         } elseif (empty($versionInfo['deprecated']) === false
-            && $this->supportsAbove($versionInfo['deprecated']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['deprecated']) === true
         ) {
             $isError = false;
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -65,7 +66,7 @@ class AbstractPrivateMethodsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.1') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.1') === false) {
             return;
         }
 
@@ -83,7 +84,7 @@ class AbstractPrivateMethodsSniff extends Sniff
         }
 
         if ($tokens[$scopePtr]['code'] === \T_TRAIT) {
-            if ($this->supportsBelow('7.4') === true) {
+            if (ScannedCode::shouldRunOnOrBelow('7.4') === true) {
                 $phpcsFile->addError(
                     'Traits cannot declare "abstract private" methods in PHP 7.4 or below',
                     $stackPtr,

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -61,7 +62,7 @@ class ForbiddenFinalPrivateMethodsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('8.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('8.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
@@ -55,7 +56,7 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.4') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
@@ -54,7 +55,7 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -55,7 +56,7 @@ class ForbiddenToStringParametersSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.3') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.3') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -58,7 +59,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.1') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.1') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewArrowFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewArrowFunctionSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHP_CodeSniffer\Files\File;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 
 /**
@@ -51,7 +52,7 @@ class NewArrowFunctionSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.3') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.3') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -74,7 +75,7 @@ class NewClosureSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.2')) {
+        if (ScannedCode::shouldRunOnOrBelow('5.2') === true) {
             $phpcsFile->addError(
                 'Closures / anonymous functions are not available in PHP 5.2 or earlier',
                 $stackPtr,
@@ -86,7 +87,7 @@ class NewClosureSniff extends Sniff
          * Closures can only be declared as static since PHP 5.4.
          */
         $isStatic = $this->isClosureStatic($phpcsFile, $stackPtr);
-        if ($this->supportsBelow('5.3') && $isStatic === true) {
+        if (ScannedCode::shouldRunOnOrBelow('5.3') === true && $isStatic === true) {
             $phpcsFile->addError(
                 'Closures / anonymous functions could not be declared as static in PHP 5.3 or earlier',
                 $stackPtr,
@@ -105,7 +106,7 @@ class NewClosureSniff extends Sniff
         $scopeEnd   = $tokens[$stackPtr]['scope_closer'];
         $usesThis   = $this->findThisUsageInClosure($phpcsFile, $scopeStart, $scopeEnd);
 
-        if ($this->supportsBelow('5.3')) {
+        if (ScannedCode::shouldRunOnOrBelow('5.3') === true) {
             /*
              * Closures declared within classes only have access to $this since PHP 5.4.
              */
@@ -146,7 +147,7 @@ class NewClosureSniff extends Sniff
         /*
          * Check for correct usage.
          */
-        if ($this->supportsAbove('5.4') && $usesThis !== false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.4') === true && $usesThis !== false) {
 
             $thisFound = $usesThis;
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -73,7 +74,7 @@ class NewExceptionsFromToStringSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.3') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.3') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -61,7 +62,7 @@ class NewNullableTypesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Tokens\Collections;
@@ -203,10 +204,10 @@ class NewParamTypeDeclarationsSniff extends Sniff
             return;
         }
 
-        $supportsPHP4  = $this->supportsBelow('4.4');
-        $supportsPHP7  = $this->supportsBelow('7.4');
-        $supportsPHP80 = $this->supportsBelow('8.0');
-        $supportsPHP81 = $this->supportsBelow('8.1');
+        $supportsPHP4  = ScannedCode::shouldRunOnOrBelow('4.4');
+        $supportsPHP7  = ScannedCode::shouldRunOnOrBelow('7.4');
+        $supportsPHP80 = ScannedCode::shouldRunOnOrBelow('8.0');
+        $supportsPHP81 = ScannedCode::shouldRunOnOrBelow('8.1');
         $tokens        = $phpcsFile->getTokens();
 
         foreach ($paramNames as $param) {
@@ -267,7 +268,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
                         && (Conditions::hasCondition($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) === false
                             || ($tokens[$stackPtr]['code'] === \T_FUNCTION
                             && Scopes::isOOMethod($phpcsFile, $stackPtr) === false))
-                        && $this->supportsBelow('5.1') === false
+                        && ScannedCode::shouldRunOnOrBelow('5.1') === false
                     ) {
                         $phpcsFile->addError(
                             "'%s' type cannot be used outside of class scope",
@@ -283,7 +284,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
                      * Only throw an error if PHP 8+ needs to be supported.
                      */
                     if (($type === 'mixed' && $param['nullable_type'] === true)
-                        && $this->supportsAbove('8.0') === true
+                        && ScannedCode::shouldRunOnOrAbove('8.0') === true
                     ) {
                         $phpcsFile->addError(
                             'Mixed types cannot be nullable, null is already part of the mixed type',
@@ -340,7 +341,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -213,7 +214,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
         $isUnionType        = (\strpos($returnType, '|') !== false);
         $isIntersectionType = (\strpos($returnType, '&') !== false);
 
-        if ($this->supportsBelow('7.4') === true && $isUnionType === true) {
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === true && $isUnionType === true) {
             $phpcsFile->addError(
                 'Union types are not present in PHP version 7.4 or earlier. Found: %s',
                 $returnTypeToken,
@@ -222,7 +223,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
             );
         }
 
-        if ($this->supportsBelow('8.0') === true && $isIntersectionType === true) {
+        if (ScannedCode::shouldRunOnOrBelow('8.0') === true && $isIntersectionType === true) {
             $phpcsFile->addError(
                 'Intersection types are not present in PHP version 8.0 or earlier. Found: %s',
                 $returnTypeToken,
@@ -247,7 +248,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
                 if (isset($this->standAloneTypes[$type]) === true
                     && ($isUnionType === true
                     || $properties['nullable_return_type'] === true)
-                    && $this->supportsAbove($this->standAloneTypes[$type]) === true
+                    && ScannedCode::shouldRunOnOrAbove($this->standAloneTypes[$type]) === true
                 ) {
                     $phpcsFile->addError(
                         "The '%s' type can only be used as a standalone type",
@@ -259,7 +260,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
 
                 if (isset($this->unionOnlyTypes[$type]) === true
                     && $isUnionType === false
-                    && $this->supportsBelow('8.1') === true
+                    && ScannedCode::shouldRunOnOrBelow('8.1') === true
                 ) {
                     $phpcsFile->addError(
                         "The '%s' type can only be used as part of a union type in PHP 8.1 or earlier",
@@ -300,7 +301,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -53,7 +54,7 @@ class NewTrailingCommaSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -142,7 +143,7 @@ class NonStaticMagicMethodsSniff extends Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         // Should be removed, the requirement was previously also there, 5.3 just started throwing a warning about it.
-        if ($this->supportsAbove('5.3') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.3') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -59,7 +60,7 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('8.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('8.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -73,7 +74,7 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('8.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('8.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -54,7 +55,7 @@ class RemovedReturnByReferenceFromVoidSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('8.1') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('8.1') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -204,7 +205,7 @@ class NewMagicMethodsSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -76,7 +77,7 @@ class RemovedMagicAutoloadSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.2') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.2') === false) {
             return;
         }
 
@@ -98,7 +99,7 @@ class RemovedMagicAutoloadSniff extends Sniff
         $code    = 'Deprecated';
         $isError = false;
 
-        if ($this->supportsAbove('8.0') === true) {
+        if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
             $error  .= ' and no longer supported since PHP 8.0';
             $code    = 'Removed';
             $isError = true;

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -64,7 +65,7 @@ class RemovedNamespacedAssertSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.3') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.3') === false) {
             return;
         }
 
@@ -86,7 +87,7 @@ class RemovedNamespacedAssertSniff extends Sniff
         $error   = 'Declaring a namespaced function called assert() is deprecated since PHP 7.3';
         $code    = 'Deprecated';
         $isError = false;
-        if ($this->supportsAbove('8.0') === true) {
+        if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
             $error  .= ' and will throw a fatal error since PHP 8.0';
             $code    = 'Removed';
             $isError = true;

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -74,7 +75,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 
@@ -148,7 +149,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
             $code    = 'Deprecated';
             $isError = false;
 
-            if ($this->supportsAbove('8.0') === true) {
+            if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
                 $error  .= ' and removed since PHP 8.0';
                 $code    = 'Removed';
                 $isError = true;

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -137,7 +138,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -115,7 +116,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
             $isError = false;
             $message = 'Use of %s() outside of a user-defined function is only supported if the file is included from within a user-defined function in another file prior to PHP 5.3.';
 
-            if ($this->supportsAbove('5.3') === true) {
+            if (ScannedCode::shouldRunOnOrAbove('5.3') === true) {
                 $isError  = true;
                 $message .= ' As of PHP 5.3, it is no longer supported at all.';
             }
@@ -126,7 +127,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
         /*
          * Check for use of the functions as a parameter in a function call.
          */
-        if ($this->supportsBelow('5.2') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.2') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
@@ -1095,7 +1096,7 @@ class NewFunctionParametersSniff extends AbstractFunctionCallParameterSniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
@@ -4740,7 +4741,7 @@ class NewFunctionsSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -53,7 +54,7 @@ class NewNamedParametersSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\MessageHelper;
@@ -185,7 +186,7 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
                 continue;
             }
 
-            if ($this->supportsAbove($version) === true) {
+            if (ScannedCode::shouldRunOnOrAbove($version) === true) {
                 if ($required === true && $versionInfo['optionalRemoved'] === '') {
                     $versionInfo['optionalRemoved'] = $version;
                     $versionInfo['error']           = true;

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
@@ -235,11 +236,11 @@ class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
         $isError     = null;
 
         if (empty($versionInfo['removed']) === false
-            && $this->supportsAbove($versionInfo['removed']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['removed']) === true
         ) {
             $isError = true;
         } elseif (empty($versionInfo['deprecated']) === false
-            && $this->supportsAbove($versionInfo['deprecated']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['deprecated']) === true
         ) {
             $isError = false;
 

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
@@ -5000,11 +5001,11 @@ class RemovedFunctionsSniff extends Sniff
         $isError     = null;
 
         if (empty($versionInfo['removed']) === false
-            && $this->supportsAbove($versionInfo['removed']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['removed']) === true
         ) {
             $isError = true;
         } elseif (empty($versionInfo['deprecated']) === false
-            && $this->supportsAbove($versionInfo['deprecated']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['deprecated']) === true
         ) {
             $isError = false;
 

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
@@ -423,7 +424,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractFunctionCallPara
                 continue;
             }
 
-            if ($required === true && $this->supportsBelow($version) === true) {
+            if ($required === true && ScannedCode::shouldRunOnOrBelow($version) === true) {
                 $versionInfo['requiredVersion'] = $version;
             }
         }

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Generators;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -70,7 +71,7 @@ class NewGeneratorReturnSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.6') !== true) {
+        if (ScannedCode::shouldRunOnOrBelow('5.6') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\IniDirectives;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
@@ -978,7 +979,7 @@ class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\IniDirectives;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
@@ -708,11 +709,11 @@ class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
         $isError     = null;
 
         if (empty($versionInfo['removed']) === false
-            && $this->supportsAbove($versionInfo['removed']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['removed']) === true
         ) {
             $isError = true;
         } elseif (empty($versionInfo['deprecated']) === false
-            && $this->supportsAbove($versionInfo['deprecated']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['deprecated']) === true
         ) {
             $isError = false;
 

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\InitialValue;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
@@ -55,7 +56,7 @@ class NewConstantArraysUsingConstSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.5') !== true) {
+        if (ScannedCode::shouldRunOnOrBelow('5.5') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\InitialValue;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
@@ -52,7 +53,7 @@ class NewConstantArraysUsingDefineSniff extends AbstractFunctionCallParameterSni
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('5.6') !== true);
+        return (ScannedCode::shouldRunOnOrBelow('5.6') === false);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\InitialValue;
 
 use PHPCompatibility\AbstractInitialValueSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -113,7 +114,7 @@ class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('5.5') !== true);
+        return (ScannedCode::shouldRunOnOrBelow('5.5') === false);
     }
 
     /**
@@ -175,7 +176,7 @@ class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
         switch ($tokens[$nextNonSimple]['code']) {
             case \T_MINUS:
             case \T_PLUS:
-                if (TokenGroup::isNumber($phpcsFile, $start, $end, $this->supportsBelow('5.6'), true) !== false) {
+                if (TokenGroup::isNumber($phpcsFile, $start, $end, ScannedCode::shouldRunOnOrBelow('5.6'), true) !== false) {
                     // Int or float with sign.
                     return true;
                 }

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\InitialValue;
 
 use PHPCompatibility\AbstractInitialValueSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\MessageHelper;
@@ -73,7 +74,7 @@ class NewHeredocSniff extends AbstractInitialValueSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('5.2') !== true);
+        return (ScannedCode::shouldRunOnOrBelow('5.2') === false);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInDefineSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\InitialValue;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\Parentheses;
 use PHPCSUtils\Utils\PassedParameters;
@@ -48,7 +49,7 @@ final class NewNewInDefineSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('8.0') === false);
+        return (ScannedCode::shouldRunOnOrBelow('8.0') === false);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\InitialValue;
 
 use PHPCompatibility\AbstractInitialValueSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
@@ -70,7 +71,7 @@ final class NewNewInInitializersSniff extends AbstractInitialValueSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('8.0') === false);
+        return (ScannedCode::shouldRunOnOrBelow('8.0') === false);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\Interfaces;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Tokens\Collections;
@@ -501,7 +502,7 @@ class NewInterfacesSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Interfaces;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -134,7 +135,7 @@ class RemovedSerializableSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('8.1') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('8.1') === false) {
             return;
         }
 
@@ -160,7 +161,7 @@ class RemovedSerializableSniff extends Sniff
             /*
              * Okay, so we have an interface which extends Serializable in one way or another.
              */
-            if ($this->supportsBelow('7.3') === false) {
+            if (ScannedCode::shouldRunOnOrBelow('7.3') === false) {
                 /*
                  * Check if the interface requires implementation of the magic methods.
                  */
@@ -246,7 +247,7 @@ class RemovedSerializableSniff extends Sniff
              * If PHP < 7.4 does not need to be supported, recommend removing the Serializable implementation,
              * but only for direct implementations of Serializable as other interfaces may provide additional functionality.
              */
-            if ($this->supportsBelow('7.3') === false
+            if (ScannedCode::shouldRunOnOrBelow('7.3') === false
                 && \array_intersect($matchedInterfaces, $this->phpSerializableInterfaces) !== []
             ) {
                 $message = 'When the magic __serialize() and __unserialize() methods are available and the code base does not need to support PHP < 7.4, the implementation of the Serializable interface can be removed.';

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Keywords;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
@@ -54,7 +55,7 @@ class CaseSensitiveKeywordsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Keywords;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -433,7 +434,7 @@ class ForbiddenNamesSniff extends Sniff
          *  The only restriction is that the namespace name cannot start with a `namespace` segment"
          */
         $nextContentLC = \strtolower($tokens[$next]['content']);
-        if ($this->supportsBelow('7.4') === false
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === false
             && $nextContentLC !== 'namespace'
             && \strpos($nextContentLC, 'namespace\\') !== 0 // PHPCS 4.x.
         ) {
@@ -523,7 +524,7 @@ class ForbiddenNamesSniff extends Sniff
          * of classes, interfaces and traits."
          */
         if (Scopes::isOOMethod($phpcsFile, $stackPtr) === true
-            && $this->supportsBelow('5.6') === false
+            && ScannedCode::shouldRunOnOrBelow('5.6') === false
         ) {
             return;
         }
@@ -577,7 +578,7 @@ class ForbiddenNamesSniff extends Sniff
          */
         if ($nameLc !== 'class'
             && Scopes::isOOConstant($phpcsFile, $stackPtr) === true
-            && $this->supportsBelow('5.6') === false
+            && ScannedCode::shouldRunOnOrBelow('5.6') === false
         ) {
             return;
         }
@@ -795,7 +796,7 @@ class ForbiddenNamesSniff extends Sniff
         }
 
         if ($this->invalidNames[$name] === 'all'
-            || $this->supportsAbove($this->invalidNames[$name])
+            || ScannedCode::shouldRunOnOrAbove($this->invalidNames[$name]) === true
         ) {
             $this->addError($phpcsFile, $stackPtr, $name);
         }
@@ -853,7 +854,7 @@ class ForbiddenNamesSniff extends Sniff
             return;
         }
 
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 
@@ -885,7 +886,7 @@ class ForbiddenNamesSniff extends Sniff
         ];
 
         if (isset($this->softReservedNames[$name]) === true
-            && $this->supportsAbove($this->softReservedNames[$name]) === true
+            && ScannedCode::shouldRunOnOrAbove($this->softReservedNames[$name]) === true
         ) {
             $error  .= ' soft reserved keyword as of PHP version %s';
             $isError = false;
@@ -893,7 +894,7 @@ class ForbiddenNamesSniff extends Sniff
         }
 
         if (isset($this->otherForbiddenNames[$name]) === true
-            && $this->supportsAbove($this->otherForbiddenNames[$name]) === true
+            && ScannedCode::shouldRunOnOrAbove($this->otherForbiddenNames[$name]) === true
         ) {
             if (isset($isError) === true) {
                 $error .= ' and a';

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\Keywords;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
@@ -330,7 +331,7 @@ class NewKeywordsSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\LanguageConstructs;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -57,7 +58,7 @@ class NewEmptyNonVariableSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\LanguageConstructs;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
 /**
@@ -115,7 +116,7 @@ class NewLanguageConstructsSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Lists;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
@@ -61,7 +62,7 @@ class AssignmentOrderSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Lists;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
@@ -55,7 +56,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Lists;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
@@ -55,7 +56,7 @@ class NewKeyedListSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Lists;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
@@ -57,7 +58,7 @@ class NewListReferenceAssignmentSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.2') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.2') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Lists;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
@@ -58,7 +59,7 @@ class NewShortListSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\MethodUse;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -56,7 +57,7 @@ class ForbiddenToStringParametersSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.3') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.3') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\MethodUse;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -57,7 +58,7 @@ class NewDirectCallsToCloneSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.6') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.6') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Miscellaneous;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -87,7 +88,7 @@ class NewPHPOpenTagEOFSniff extends Sniff
             return;
         }
 
-        if ($this->supportsBelow('7.3') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.3') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Miscellaneous;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
@@ -73,7 +74,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Namespaces;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\Namespaces;
@@ -56,7 +57,7 @@ class ReservedNamesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.3') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.3') === false) {
             // Namespaces were introduced in PHP 5.3.
             return;
         }

--- a/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\Numbers;
 
 use PHP_CodeSniffer\Files\File;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\Numbers;
 
@@ -53,7 +54,7 @@ class NewExplicitOctalNotationSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('8.0') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('8.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Numbers/NewNumericLiteralSeparatorSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/NewNumericLiteralSeparatorSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Numbers;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\Numbers;
 
@@ -58,7 +59,7 @@ class NewNumericLiteralSeparatorSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.3') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.3') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Numbers;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -166,7 +167,7 @@ class RemovedHexadecimalNumericStringsSniff extends Sniff
             }
         }
 
-        $isError = $this->supportsAbove('7.0');
+        $isError = ScannedCode::shouldRunOnOrAbove('7.0');
 
         MessageHelper::addMessage(
             $phpcsFile,

--- a/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Numbers;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\GetTokensAsString;
@@ -70,7 +71,7 @@ class ValidIntegersSniff extends Sniff
         $numberInfo = Numbers::getCompleteNumber($phpcsFile, $stackPtr);
 
         if (Numbers::isBinaryInt($numberInfo['content']) === true) {
-            if ($this->supportsBelow('5.3')) {
+            if (ScannedCode::shouldRunOnOrBelow('5.3') === true) {
                 $error = 'Binary integer literals were not present in PHP version 5.3 or earlier. Found: %s';
                 $data  = [$numberInfo['orig_content']];
                 $phpcsFile->addError($error, $stackPtr, 'BinaryIntegerFound', $data);
@@ -86,7 +87,7 @@ class ValidIntegersSniff extends Sniff
             return $numberInfo['last_token'];
         }
 
-        $isError = $this->supportsAbove('7.0');
+        $isError = ScannedCode::shouldRunOnOrAbove('7.0');
 
         $isInvalidOctal = $this->isInvalidOctalInteger($tokens, $stackPtr, $numberInfo);
         if ($isInvalidOctal !== false) {

--- a/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Operators;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -85,7 +86,7 @@ class ChangedConcatOperatorPrecedenceSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.4') === false) {
             return;
         }
 
@@ -191,7 +192,7 @@ class ChangedConcatOperatorPrecedenceSniff extends Sniff
 
         $message = 'Using an unparenthesized expression containing a "." before a "+" or "-" has been deprecated in PHP 7.4';
         $isError = false;
-        if ($this->supportsAbove('8.0') === true) {
+        if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
             $message .= ' and removed in PHP 8.0';
             $isError  = true;
         }

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Operators;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
@@ -79,7 +80,7 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 
@@ -97,7 +98,7 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
             --$end;
         }
 
-        if (TokenGroup::isNegativeNumber($phpcsFile, $start, $end, $this->supportsBelow('5.6'), true) !== true) {
+        if (TokenGroup::isNegativeNumber($phpcsFile, $start, $end, ScannedCode::shouldRunOnOrBelow('5.6'), true) !== true) {
             // Not a negative number or undetermined.
             return;
         }

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\Operators;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
 /**
@@ -134,7 +135,7 @@ class NewOperatorsSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Operators;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\Operators;
@@ -57,7 +58,7 @@ class NewShortTernarySniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.2') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.2') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Operators;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\BCFile;
@@ -74,7 +75,7 @@ class RemovedTernaryAssociativitySniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.4') === false) {
             return;
         }
 
@@ -147,7 +148,7 @@ class RemovedTernaryAssociativitySniff extends Sniff
             $message = 'The left-associativity of the ternary operator has been deprecated in PHP 7.4';
             $code    = 'Deprecated';
             $isError = false;
-            if ($this->supportsAbove('8.0') === true) {
+            if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
                 $message .= ' and removed in PHP 8.0';
                 $code     = 'Removed';
                 $isError  = true;

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
@@ -62,7 +63,7 @@ class ChangedIntToBoolParamTypeSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('8.0') === false);
+        return (ScannedCode::shouldRunOnOrAbove('8.0') === false);
     }
 
     /**
@@ -94,7 +95,7 @@ class ChangedIntToBoolParamTypeSniff extends AbstractFunctionCallParameterSniff
         $functionLC   = \strtolower($functionName);
         $functionInfo = $this->targetFunctions[$functionLC];
         foreach ($functionInfo as $offset => $paramInfo) {
-            if ($this->supportsAbove($paramInfo['since']) === false) {
+            if (ScannedCode::shouldRunOnOrAbove($paramInfo['since']) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
@@ -82,7 +83,7 @@ class ChangedObStartEraseFlagsSniff extends AbstractFunctionCallParameterSniff
         $data  = [$targetParam['clean']];
 
         if ($cleanValueLc === 'true' || $cleanValueLc === 'false') {
-            if ($this->supportsAbove('5.4') === true) {
+            if (ScannedCode::shouldRunOnOrAbove('5.4') === true) {
                 $phpcsFile->addError($error, $targetParam['start'], 'BooleanFound', $data);
             }
 
@@ -90,8 +91,8 @@ class ChangedObStartEraseFlagsSniff extends AbstractFunctionCallParameterSniff
         }
 
         if ((\preg_match('`PHP_OUTPUT_HANDLER_(CLEANABLE|FLUSHABLE|REMOVABLE|STDFLAGS)`', $targetParam['clean']) === 1
-            || TokenGroup::isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], $this->supportsBelow('5.6'), true) !== false)
-            && $this->supportsBelow('5.3') === true
+            || TokenGroup::isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], ScannedCode::shouldRunOnOrBelow('5.6'), true) !== false)
+            && ScannedCode::shouldRunOnOrBelow('5.3') === true
         ) {
             $phpcsFile->addError($error, $targetParam['start'], 'IntegerFound', $data);
         }

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -49,7 +50,7 @@ class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('7.2') === false);
+        return (ScannedCode::shouldRunOnOrAbove('7.2') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -80,7 +81,7 @@ class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallParameterS
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('7.2') === false);
+        return (ScannedCode::shouldRunOnOrAbove('7.2') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\PassedParameters;
@@ -48,7 +49,7 @@ class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCallParame
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('5.4') === false);
+        return (ScannedCode::shouldRunOnOrAbove('5.4') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
@@ -47,7 +48,7 @@ final class NewArrayMergeRecursiveWithGlobalsVarSniff extends AbstractFunctionCa
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('8.0') === false);
+        return (ScannedCode::shouldRunOnOrBelow('8.0') === false);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
@@ -66,7 +67,7 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('5.2') === false);
+        return (ScannedCode::shouldRunOnOrBelow('5.2') === false);
     }
 
 
@@ -90,7 +91,7 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        if (TokenGroup::isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], $this->supportsBelow('5.6'), true) !== false) {
+        if (TokenGroup::isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], ScannedCode::shouldRunOnOrBelow('5.6'), true) !== false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewAssertCustomExceptionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewAssertCustomExceptionSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHP_CodeSniffer\Files\File;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 
 /**
  * Assert() supports custom exceptions as $description since PHP 7.0.
@@ -50,7 +51,7 @@ class NewAssertCustomExceptionSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('5.6') === false);
+        return (ScannedCode::shouldRunOnOrBelow('5.6') === false);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -49,7 +50,7 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
     {
         // Version used here should be (above) the highest version from the `newModes` control,
         // structure below, i.e. the last PHP version in which a new mode was introduced.
-        return ($this->supportsBelow('7.1') === false);
+        return (ScannedCode::shouldRunOnOrBelow('7.1') === false);
     }
 
 
@@ -88,13 +89,13 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
                 continue;
             }
 
-            if (\strpos($tokens[$i]['content'], 'c+') !== false && $this->supportsBelow('5.2.5')) {
+            if (\strpos($tokens[$i]['content'], 'c+') !== false && ScannedCode::shouldRunOnOrBelow('5.2.5') === true) {
                 $errors['cplusFound'] = [
                     'c+',
                     '5.2.5',
                     $targetParam['clean'],
                 ];
-            } elseif (\strpos($tokens[$i]['content'], 'c') !== false && $this->supportsBelow('5.2.5')) {
+            } elseif (\strpos($tokens[$i]['content'], 'c') !== false && ScannedCode::shouldRunOnOrBelow('5.2.5') === true) {
                 $errors['cFound'] = [
                     'c',
                     '5.2.5',
@@ -102,7 +103,7 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
                 ];
             }
 
-            if (\strpos($tokens[$i]['content'], 'e') !== false && $this->supportsBelow('7.0.15')) {
+            if (\strpos($tokens[$i]['content'], 'e') !== false && ScannedCode::shouldRunOnOrBelow('7.0.15') === true) {
                 $errors['eFound'] = [
                     'e',
                     '7.0.15',

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -72,7 +73,7 @@ class NewHTMLEntitiesEncodingDefaultSniff extends AbstractFunctionCallParameterS
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('5.3') === false || $this->supportsAbove('5.4') === false);
+        return (ScannedCode::shouldRunOnOrBelow('5.3') === false || ScannedCode::shouldRunOnOrAbove('5.4') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesFlagsDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesFlagsDefaultSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -76,7 +77,7 @@ class NewHTMLEntitiesFlagsDefaultSniff extends AbstractFunctionCallParameterSnif
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('8.0') === false || $this->supportsAbove('8.1') === false);
+        return (ScannedCode::shouldRunOnOrBelow('8.0') === false || ScannedCode::shouldRunOnOrAbove('8.1') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHPCompatibility\Helpers\HashAlgorithmsTrait;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 
 /**
@@ -223,7 +224,7 @@ class NewHashAlgorithmsSniff extends AbstractFunctionCallParameterSniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -63,7 +64,7 @@ class NewIDNVariantDefaultSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('7.3') === false || $this->supportsAbove('7.4') === false);
+        return (ScannedCode::shouldRunOnOrBelow('7.3') === false || ScannedCode::shouldRunOnOrAbove('7.4') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
@@ -190,7 +191,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('5.5') === false || $this->supportsAbove('5.6') === false);
+        return (ScannedCode::shouldRunOnOrBelow('5.5') === false || ScannedCode::shouldRunOnOrAbove('5.6') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
@@ -86,7 +87,7 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('7.0') === false);
+        return (ScannedCode::shouldRunOnOrBelow('7.0') === false);
     }
 
     /**
@@ -111,7 +112,7 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
                 continue;
             }
 
-            if (TokenGroup::isNegativeNumber($phpcsFile, $targetParam['start'], $targetParam['end'], $this->supportsBelow('5.6')) === false) {
+            if (TokenGroup::isNegativeNumber($phpcsFile, $targetParam['start'], $targetParam['end'], ScannedCode::shouldRunOnOrBelow('5.6')) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -80,7 +81,7 @@ class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCallParame
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('5.3') === false);
+        return (ScannedCode::shouldRunOnOrBelow('5.3') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\PCRERegexTrait;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -106,7 +107,7 @@ class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
     {
         // Version used here should be the highest version from the `$newModifiers` array,
         // i.e. the last PHP version in which a new modifier was introduced.
-        return ($this->supportsBelow('7.2') === false);
+        return (ScannedCode::shouldRunOnOrBelow('7.2') === false);
     }
 
     /**
@@ -170,7 +171,7 @@ class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
             $notInVersion = '';
             foreach ($versionArray as $version => $present) {
                 if ($notInVersion === '' && $present === false
-                    && $this->supportsBelow($version) === true
+                    && ScannedCode::shouldRunOnOrBelow($version) === true
                 ) {
                     $notInVersion = $version;
                 }

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
@@ -71,7 +72,7 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsBelow('7.1') === false);
+        return (ScannedCode::shouldRunOnOrBelow('7.1') === false);
     }
 
 
@@ -120,7 +121,7 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
                 }
 
                 foreach ($versionArray as $version => $present) {
-                    if ($present === false && $this->supportsBelow($version) === true) {
+                    if ($present === false && ScannedCode::shouldRunOnOrBelow($version) === true) {
                         $phpcsFile->addError(
                             'Passing the $format(s) "%s" to pack() is not supported in PHP %s or lower. Found: %s',
                             $targetParam['start'],

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
@@ -82,7 +83,7 @@ class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParameterSn
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('7.4') === false);
+        return (ScannedCode::shouldRunOnOrAbove('7.4') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
@@ -91,7 +92,7 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        if ($this->supportsBelow('7.3') === true) {
+        if (ScannedCode::shouldRunOnOrBelow('7.3') === true) {
             $phpcsFile->addError(
                 'The proc_open() function did not accept $command to be passed in array format in PHP 7.3 and earlier.',
                 $nextNonEmpty,
@@ -99,7 +100,7 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
             );
         }
 
-        if ($this->supportsAbove('7.4') === true) {
+        if (ScannedCode::shouldRunOnOrAbove('7.4') === true) {
             if (\strpos($targetParam['clean'], 'escapeshellarg(') === false) {
                 // Efficiency: prevent needlessly walking the array.
                 return;

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
@@ -89,7 +90,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
             return;
         }
 
-        if ($this->supportsBelow('7.3') === true) {
+        if (ScannedCode::shouldRunOnOrBelow('7.3') === true) {
             $phpcsFile->addError(
                 'The strip_tags() function did not accept $allowed_tags to be passed in array format in PHP 7.3 and earlier.',
                 $nextNonEmpty,
@@ -97,7 +98,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
             );
         }
 
-        if ($this->supportsAbove('7.4') === true) {
+        if (ScannedCode::shouldRunOnOrAbove('7.4') === true) {
             if (\strpos($targetParam['clean'], '>') === false) {
                 // Efficiency: prevent needlessly walking the array.
                 return;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCSUtils\Utils\MessageHelper;
 
 /**
@@ -86,7 +87,7 @@ class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSni
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('7.2') === false);
+        return (ScannedCode::shouldRunOnOrAbove('7.2') === false);
     }
 
     /**
@@ -123,7 +124,7 @@ class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSni
             $targetParam['clean'],
         ];
 
-        if ($this->supportsAbove('8.0') === true) {
+        if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
             $data[0] = ' and removed since PHP 8.0';
             $isError = true;
             $code    = 'Removed';

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -49,7 +50,7 @@ class RemovedGetDefinedFunctionsExcludeDisabledFalseSniff extends AbstractFuncti
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('8.0') === false);
+        return (ScannedCode::shouldRunOnOrAbove('8.0') === false);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
 use PHPCompatibility\Helpers\HashAlgorithmsTrait;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\MessageHelper;
 
@@ -127,11 +128,11 @@ class RemovedHashAlgorithmsSniff extends AbstractFunctionCallParameterSniff
         $isError     = null;
 
         if (empty($versionInfo['removed']) === false
-            && $this->supportsAbove($versionInfo['removed']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['removed']) === true
         ) {
             $isError = true;
         } elseif (empty($versionInfo['deprecated']) === false
-            && $this->supportsAbove($versionInfo['deprecated']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['deprecated']) === true
         ) {
             $isError = false;
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -54,7 +55,7 @@ class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('5.6') === false);
+        return (ScannedCode::shouldRunOnOrAbove('5.6') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
@@ -105,7 +106,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('7.4') === false);
+        return (ScannedCode::shouldRunOnOrAbove('7.4') === false);
     }
 
 
@@ -304,7 +305,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
         $errorCode = 'Deprecated';
         $data      = [$functionName];
 
-        if ($this->supportsAbove('8.0') === true) {
+        if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
             $message  .= ' and is removed since PHP 8.0';
             $isError   = true;
             $errorCode = 'Removed';

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbCheckEncodingNoArgsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbCheckEncodingNoArgsSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 
 /**
@@ -49,7 +50,7 @@ class RemovedMbCheckEncodingNoArgsSniff extends AbstractFunctionCallParameterSni
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('8.1') === false);
+        return (ScannedCode::shouldRunOnOrAbove('8.1') === false);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
@@ -77,7 +78,7 @@ class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParame
      */
     protected function bowOutEarly()
     {
-        return $this->supportsAbove('5.2') === false;
+        return ScannedCode::shouldRunOnOrAbove('5.2') === false;
     }
 
 
@@ -128,11 +129,11 @@ class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParame
         $isError = false;
         $code    = 'Deprecated';
 
-        if ($this->supportsAbove('8.0') === true) {
+        if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
             $error  .= ', hard deprecated since PHP 7.4 and removed since PHP 8.0';
             $isError = true;
             $code    = 'Removed';
-        } elseif ($this->supportsAbove('7.4') === true) {
+        } elseif (ScannedCode::shouldRunOnOrAbove('7.4') === true) {
             $error .= ' and hard deprecated since PHP 7.4';
         }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
@@ -65,7 +66,7 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
     {
         // Version used here should be the lowest version, i.e the version in which the
         // first modifier being detected by this sniff was removed.
-        return ($this->supportsAbove('7.1') === false);
+        return (ScannedCode::shouldRunOnOrAbove('7.1') === false);
     }
 
 
@@ -128,7 +129,7 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
             $code    = 'Deprecated';
             $isError = false;
 
-            if ($this->supportsAbove('8.0') === true) {
+            if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
                 $error  .= ' and removed since PHP 8.0';
                 $code    = 'Removed';
                 $isError = true;
@@ -137,7 +138,7 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
             $error .= '.';
 
             // The alternative mb_ereg_replace_callback() function is only available since 5.4.1.
-            if ($this->supportsBelow('5.4.1') === false) {
+            if (ScannedCode::shouldRunOnOrBelow('5.4.1') === false) {
                 $error .= ' Use mb_ereg_replace_callback() instead (PHP 5.4.1+).';
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
@@ -73,7 +74,7 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('7.2') === false);
+        return (ScannedCode::shouldRunOnOrAbove('7.2') === false);
     }
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\PCRERegexTrait;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
@@ -74,7 +75,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('5.5') === false);
+        return (ScannedCode::shouldRunOnOrAbove('5.5') === false);
     }
 
     /**
@@ -138,7 +139,7 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
             $errorCode = 'Deprecated';
             $data      = [$functionName];
 
-            if ($this->supportsAbove('7.0')) {
+            if (ScannedCode::shouldRunOnOrAbove('7.0') === true) {
                 $error    .= ' and removed since PHP 7.0';
                 $isError   = true;
                 $errorCode = 'Removed';

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\MessageHelper;
@@ -54,7 +55,7 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('4.2') === false);
+        return (ScannedCode::shouldRunOnOrAbove('4.2') === false);
     }
 
 
@@ -96,7 +97,7 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
             $errorCode = 'Deprecated';
             $data      = [$targetParam['clean']];
 
-            if ($this->supportsAbove('7.0') === true) {
+            if (ScannedCode::shouldRunOnOrAbove('7.0') === true) {
                 $message  .= ' and is removed since PHP 7.0';
                 $isError   = true;
                 $errorCode = 'Removed';

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -50,7 +51,7 @@ class RemovedSplAutoloadRegisterThrowFalseSniff extends AbstractFunctionCallPara
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('8.0') === false);
+        return (ScannedCode::shouldRunOnOrAbove('8.0') === false);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedVersionCompareOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedVersionCompareOperatorsSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
@@ -70,7 +71,7 @@ class RemovedVersionCompareOperatorsSniff extends AbstractFunctionCallParameterS
      */
     protected function bowOutEarly()
     {
-        return ($this->supportsAbove('8.1') === false);
+        return (ScannedCode::shouldRunOnOrAbove('8.1') === false);
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -76,7 +77,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.3') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.3') === false) {
             return;
         }
 
@@ -129,7 +130,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
                 $isError   = false;
                 $errorCode = 'Deprecated';
 
-                if ($this->supportsAbove('5.4')) {
+                if (ScannedCode::shouldRunOnOrAbove('5.4') === true) {
                     $error    .= ' and prohibited since PHP 5.4';
                     $isError   = true;
                     $errorCode = 'NotAllowed';

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -69,7 +70,7 @@ class NewArrayStringDereferencingSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.6') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.6') === false) {
             return;
         }
 
@@ -79,7 +80,7 @@ class NewArrayStringDereferencingSniff extends Sniff
         }
 
         $tokens     = $phpcsFile->getTokens();
-        $supports54 = $this->supportsBelow('5.4');
+        $supports54 = ScannedCode::shouldRunOnOrBelow('5.4');
 
         foreach ($dereferencing['braces'] as $openBrace => $closeBrace) {
             if ($supports54 === true && $tokens[$openBrace]['code'] === \T_OPEN_SQUARE_BRACKET) {

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -67,7 +68,7 @@ class NewArrayUnpackingSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.3') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.3') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -69,7 +70,7 @@ class NewClassMemberAccessSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.6') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.6') === false) {
             return;
         }
 
@@ -79,7 +80,7 @@ class NewClassMemberAccessSniff extends Sniff
         }
 
         $tokens     = $phpcsFile->getTokens();
-        $supports53 = $this->supportsBelow('5.3');
+        $supports53 = ScannedCode::shouldRunOnOrBelow('5.3');
 
         $error     = 'Class member access on object %s was not supported in PHP %s or earlier';
         $data      = ['instantiation', '5.3'];

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -57,7 +58,7 @@ class NewDynamicAccessToStaticSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.2') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.2') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 
 /**
@@ -52,7 +53,7 @@ final class NewFirstClassCallablesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('8.0') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('8.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -68,12 +69,12 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.2') === true) {
+        if (ScannedCode::shouldRunOnOrBelow('7.2') === true) {
             $this->detectIndentedNonStandAloneClosingMarker($phpcsFile, $stackPtr);
         }
 
         $tokens = $phpcsFile->getTokens();
-        if ($this->supportsAbove('7.3') === true && $tokens[$stackPtr]['code'] !== \T_STRING) {
+        if (ScannedCode::shouldRunOnOrAbove('7.3') === true && $tokens[$stackPtr]['code'] !== \T_STRING) {
             $this->detectClosingMarkerInBody($phpcsFile, $stackPtr);
         }
     }

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -65,7 +66,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.6') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.6') === false) {
             return;
         }
 
@@ -75,7 +76,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
         }
 
         $tokens     = $phpcsFile->getTokens();
-        $supports53 = $this->supportsBelow('5.3');
+        $supports53 = ScannedCode::shouldRunOnOrBelow('5.3');
 
         foreach ($dereferencing as $openBrace => $closeBrace) {
             if ($supports53 === true

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -58,7 +59,7 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.2') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.2') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\TextStrings;
@@ -58,7 +59,7 @@ class NewInterpolatedStringDereferencingSniff extends Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         // PHP 8.0 supports dereferencing interpolated strings
-        if ($this->supportsBelow('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\BackCompat\BCTokens;
 
@@ -52,7 +53,7 @@ class NewMagicConstantDereferencingSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -58,7 +59,7 @@ class NewNestedStaticAccessSniff extends Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         // PHP 8.0 supports both nested static access and class constant dereferencing
-        if ($this->supportsBelow('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.4') === false) {
             return;
         }
 
@@ -120,7 +121,7 @@ class NewNestedStaticAccessSniff extends Sniff
         if ($seenBrackets === false
             && $tokens[$prev]['code'] === \T_STRING
             && $tokens[$prevOperator]['code'] === \T_DOUBLE_COLON
-            && $this->supportsBelow('7.4') === true
+            && ScannedCode::shouldRunOnOrBelow('7.4') === true
         ) {
             $phpcsFile->addError(
                 'Dereferencing class constants was not supported in PHP 7.4 or earlier.',
@@ -131,7 +132,7 @@ class NewNestedStaticAccessSniff extends Sniff
         }
 
         // This is nested static access.
-        if ($this->supportsBelow('5.6') === true) {
+        if (ScannedCode::shouldRunOnOrBelow('5.6') === true) {
             $phpcsFile->addError(
                 'Nested access to static properties, constants and methods was not supported in PHP 5.6 or earlier.',
                 $stackPtr,

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
@@ -55,7 +56,7 @@ class NewShortArraySniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.3') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('5.3') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCompatibility\Sniffs\Syntax\NewArrayStringDereferencingSniff;
 use PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff;
@@ -148,7 +149,7 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.4') === false) {
             return;
         }
 
@@ -183,7 +184,7 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
             return;
         }
 
-        $isError = ($this->supportsAbove('8.0') === true);
+        $isError = (ScannedCode::shouldRunOnOrAbove('8.0') === true);
 
         $errorMsg  = 'Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4';
         $errorCode = 'Deprecated';

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -56,7 +57,7 @@ class RemovedNewReferenceSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.3') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.3') === false) {
             return;
         }
 
@@ -70,7 +71,7 @@ class RemovedNewReferenceSniff extends Sniff
         $isError   = false;
         $errorCode = 'Deprecated';
 
-        if ($this->supportsAbove('7.0') === true) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === true) {
             $error    .= ' and has been removed in PHP 7.0';
             $isError   = true;
             $errorCode = 'Removed';

--- a/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\TextStrings;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\GetTokensAsString;
@@ -100,7 +101,7 @@ class NewUnicodeEscapeSequenceSniff extends Sniff
                     $valid = $this->isValidUnicodeEscapeSequence($match[1]);
                 }
 
-                if ($this->supportsBelow('5.6') === true && $valid === true) {
+                if (ScannedCode::shouldRunOnOrBelow('5.6') === true && $valid === true) {
                     $phpcsFile->addError(
                         'Unicode codepoint escape sequences are not supported in PHP 5.6 or earlier. Found: %s',
                         $i,
@@ -109,7 +110,7 @@ class NewUnicodeEscapeSequenceSniff extends Sniff
                     );
                 }
 
-                if ($this->supportsAbove('7.0') === true && $valid === false) {
+                if (ScannedCode::shouldRunOnOrAbove('7.0') === true && $valid === false) {
                     $phpcsFile->addError(
                         'Strings containing a literal \u{ followed by an invalid unicode codepoint escape sequence will cause a fatal error in PHP 7.0 and above. Escape the leading backslash to prevent this. Found: %s',
                         $i,

--- a/PHPCompatibility/Sniffs/TextStrings/RemovedDollarBraceStringEmbedsSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/RemovedDollarBraceStringEmbedsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\TextStrings;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\GetTokensAsString;
@@ -65,7 +66,7 @@ class RemovedDollarBraceStringEmbedsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('8.2') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('8.2') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\TypeCasts;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 
 /**
@@ -115,7 +116,7 @@ class NewTypeCastsSniff extends Sniff
         $versionInfo = $this->getVersionInfo($itemArray);
 
         if (empty($versionInfo['not_in_version'])
-            || $this->supportsBelow($versionInfo['not_in_version']) === false
+            || ScannedCode::shouldRunOnOrBelow($versionInfo['not_in_version']) === false
         ) {
             return;
         }

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\TypeCasts;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\MessageHelper;
 
@@ -126,11 +127,11 @@ class RemovedTypeCastsSniff extends Sniff
         $isError     = null;
 
         if (empty($versionInfo['removed']) === false
-            && $this->supportsAbove($versionInfo['removed']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['removed']) === true
         ) {
             $isError = true;
         } elseif (empty($versionInfo['deprecated']) === false
-            && $this->supportsAbove($versionInfo['deprecated']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['deprecated']) === true
         ) {
             $isError = false;
 

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\UseDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -65,14 +66,14 @@ class NewGroupUseDeclarationsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('7.1') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('7.1') === false) {
             return;
         }
 
         $tokens = $phpcsFile->getTokens();
 
         if ($tokens[$stackPtr]['code'] === \T_OPEN_USE_GROUP
-            && $this->supportsBelow('5.6') === true
+            && ScannedCode::shouldRunOnOrBelow('5.6') === true
         ) {
             $phpcsFile->addError(
                 'Group use declarations are not allowed in PHP 5.6 or earlier',

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\UseDeclarations;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -71,7 +72,7 @@ class NewUseConstFunctionSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.5') !== true) {
+        if (ScannedCode::shouldRunOnOrBelow('5.5') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Variables;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -53,7 +54,7 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Variables;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -112,7 +113,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.1') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.1') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Variables;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -54,7 +55,7 @@ class NewUniformVariableSyntaxSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Sniffs\Variables;
 
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -84,7 +85,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('8.1') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('8.1') === false) {
             return;
         }
 
@@ -126,7 +127,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
 
             $hasNonNumeric = $phpcsFile->findNext($allowedNumeric, $searchStart, $searchEnd, true);
             if ($hasNonNumeric === false) {
-                if ($this->supportsBelow('8.0') === true) {
+                if (ScannedCode::shouldRunOnOrBelow('8.0') === true) {
                     // This warning will only be thrown when both PHP < 8.1 and PHP 8.1+ need to be supported.
                     $phpcsFile->addWarning(
                         'The way variables with an integer or floating point variable name are stored in the $GLOBALS variable has changed in PHP 8.1. Please review your code to evaluate the impact.',
@@ -221,7 +222,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
 
         if (($tokens[$prevNonEmpty]['code'] === \T_EQUAL
             || $tokens[$prevNonEmpty]['code'] === \T_COALESCE_EQUAL)
-                && $this->supportsBelow('8.0') === true
+                && ScannedCode::shouldRunOnOrBelow('8.0') === true
         ) {
             // This warning will only be thrown when both PHP < 8.1 and PHP 8.1+ need to be supported.
             $phpcsFile->addWarning(

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Sniffs\Variables;
 
-use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\Conditions;
@@ -131,7 +132,7 @@ class RemovedPredefinedGlobalVariablesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.3') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('5.3') === false) {
             return;
         }
 
@@ -318,11 +319,11 @@ class RemovedPredefinedGlobalVariablesSniff extends Sniff
         $isError     = null;
 
         if (empty($versionInfo['removed']) === false
-            && $this->supportsAbove($versionInfo['removed']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['removed']) === true
         ) {
             $isError = true;
         } elseif (empty($versionInfo['deprecated']) === false
-            && $this->supportsAbove($versionInfo['deprecated']) === true
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['deprecated']) === true
         ) {
             $isError = false;
 


### PR DESCRIPTION
Follow up on #1237

As discussed during our meeting last month, this PR makes the following changes:
* Changes the `TestVersionTrait` trait to a `ScannedCode` class.
* Makes the methods `static`.
* Renames the `supportsAbove()` method to `shouldRunOnOrAbove()`.
* Renames the `supportsBelow()` method to `shouldRunOnOrBelow()`.

The aim of the change from `trait` to `class` and to `static` methods is to allow for these methods to be used in the helper methods in the  `TokenGroup` class as those methods otherwise would not have access to the `testVersion` check logic.

The aim of the renames is to allow the method calls to read more naturally and be more self-explanatory.

Includes updating all references to the trait (now class) and the methods.

Includes minor adjustments to the test code for these methods as the `getTestVersion()` method is `private`. The method was previously accessible as the `trait` was imported into the test class, but that's no longer the case and we do want to test the method via direct unit tests.

Related to #142

----

This is marked as a breaking change.

While the `TestVersionTrait` was a new trait in PHPCompatibility 10.0.0, the change which introduced it was non-breaking as the `Sniff` class `use`d the trait, which meant that none of the sniffs needed to be updated as the original method calls used still worked the same as before.

This commit, however, does mean that all method calls need to be adjusted, which makes this the breaking change.