### PR TITLE
FunctionDeclarations/NonStaticMagicMethods: test tweaks

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
@@ -277,3 +277,78 @@ class Nested {
         function __get() {} // This is a global function, not a method.
     }
 }
+
+/*
+ * Safeguard handling of magic methods in PHP 8.1+ enums.
+ * Only `__call()`, `__callStatic()`, and `__invoke()` are allowed in enums, but that's not the concern of this sniff.
+ */
+enum PlainEnum
+{
+    function __get($name) {}
+    function __set($name, $value) {}
+    function __isset($name) {}
+    function __unset($name) {}
+    function __call($name, $arguments) {}
+    static function __callStatic($name, $arguments) {}
+    function __sleep() {}
+    function __toString() {}
+    static function __set_state($properties) {}
+    function __serialize() {}
+    function __unserialize($data) {}
+}
+
+enum NormalEnum
+{
+    public function __construct() {}
+    public function __destruct() {}
+    public function __clone() {}
+    public function __debugInfo() {}
+    public function __invoke() {}
+    public function getId() {}
+    public function __get($name) {}
+    public function __set($name, $value) {}
+    public function __isset($name) {}
+    public function __unset($name) {}
+    public function __call($name, $arguments) {}
+    public static function __callStatic($name, $arguments) {}
+    public function __sleep() {}
+    public function __toString() {}
+    public static function __set_state($properties) {}
+    public function __serialize() {}
+    public function __unserialize($data) {}
+}
+
+enum WrongVisibilityEnum
+{
+    protected function __debugInfo() {}
+    private function __invoke() {}
+    protected static function __set_state() {}
+    private function __get($name) {}
+    protected function __set($name, $value) {}
+    private function __isset($name) {}
+    protected function __unset($name) {}
+    private function __call($name, $arguments) {}
+    protected static function __callStatic($name, $arguments) {}
+    private function __sleep() {}
+    protected function __toString() {}
+    private function __serialize() {}
+    protected function __unserialize($data) {}
+}
+
+enum WrongStaticEnum
+{
+    static function __construct() {}
+    static function __destruct() {}
+    static function __clone() {}
+    static function __debugInfo() {}
+    static function __invoke() {}
+    static function __get($name) {}
+    static function __set($name, $value) {}
+    static function __isset($name) {}
+    static function __unset($name) {}
+    static function __call($name, $arguments) {}
+    function __callStatic($name, $arguments) {}
+    function __set_state($properties) {}
+    public static function __serialize() {}
+    static public function __unserialize($data) {}
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
@@ -128,7 +128,7 @@ $plain = new class
     function __sleep() {}
     function __toString() {}
     static function __set_state($properties) {}
-}
+};
 
 $normal = new class
 {
@@ -142,7 +142,7 @@ $normal = new class
     public function __sleep() {}
     public function __toString() {}
     public static function __set_state($properties) {}
-}
+};
 
 $wrongVisibility = new class
 {
@@ -154,7 +154,7 @@ $wrongVisibility = new class
     protected static function __callStatic($name, $arguments) {}
     private function __sleep() {}
     protected function __toString() {}
-}
+};
 
 $wrongStatic = new class
 {
@@ -165,14 +165,14 @@ $wrongStatic = new class
     static function __call($name, $arguments) {}
     function __callStatic($name, $arguments) {}
     function __set_state($properties) {}
-}
+};
 
 // PHP 7.4: new __serialize(), unserialize().
 $normal = new class
 {
     public function __serialize() {}
     public function __unserialize($data) {}
-}
+};
 
 class PHP74WrongVisibility
 {

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -109,6 +109,21 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             ['__toString', 'public', 'protected', 257],
             ['__serialize', 'public', 'private', 258],
             ['__unserialize', 'public', 'protected', 259],
+
+            // Enum.
+            ['__debugInfo', 'public', 'protected', 323],
+            ['__invoke', 'public', 'private', 324],
+            ['__set_state', 'public', 'protected', 325],
+            ['__get', 'public', 'private', 326],
+            ['__set', 'public', 'protected', 327],
+            ['__isset', 'public', 'private', 328],
+            ['__unset', 'public', 'protected', 329],
+            ['__call', 'public', 'private', 330],
+            ['__callStatic', 'public', 'protected', 331],
+            ['__sleep', 'public', 'private', 332],
+            ['__toString', 'public', 'protected', 333],
+            ['__serialize', 'public', 'private', 334],
+            ['__unserialize', 'public', 'protected', 335],
         ];
     }
 
@@ -185,6 +200,20 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             ['__call', 268],
             ['__serialize', 271],
             ['__unserialize', 272],
+
+            // Enum.
+            ['__construct', 340],
+            ['__destruct', 341],
+            ['__clone', 342],
+            ['__debugInfo', 343],
+            ['__invoke', 344],
+            ['__get', 345],
+            ['__set', 346],
+            ['__isset', 347],
+            ['__unset', 348],
+            ['__call', 349],
+            ['__serialize', 352],
+            ['__unserialize', 353],
         ];
     }
 
@@ -231,6 +260,9 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
             ['__callStatic', 269],
             ['__set_state', 270],
 
+            // Enum.
+            ['__callStatic', 350],
+            ['__set_state', 351],
         ];
     }
 
@@ -296,6 +328,11 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
 
         // Nested function.
         $data[] = [277];
+
+        // Plain/normal enum.
+        for ($line = 285; $line <= 319; $line++) {
+            $data[] = [$line];
+        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -259,118 +259,45 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTest
      */
     public function dataNoFalsePositives()
     {
-        return [
-            // Plain class.
-            [5],
-            [6],
-            [7],
-            [8],
-            [9],
-            [10],
-            [11],
-            [12],
-            [13],
-            // Normal class.
-            [18],
-            [19],
-            [20],
-            [21],
-            [22],
-            [23],
-            [24],
-            [25],
-            [26],
-            [27],
+        $data = [];
 
-            // Alternative property order & stacked.
-            [58],
+        // Plain/normal class.
+        for ($line = 3; $line <= 28; $line++) {
+            $data[] = [$line];
+        }
 
-            // Plain interface.
-            [71],
-            [72],
-            [73],
-            [74],
-            [75],
-            [76],
-            [77],
-            [78],
-            [79],
-            // Normal interface.
-            [84],
-            [85],
-            [86],
-            [87],
-            [88],
-            [89],
-            [90],
-            [91],
-            [92],
-            [93],
+        // Alternative property order & stacked.
+        $data[] = [58];
 
-            // Plain anonymous class.
-            [122],
-            [123],
-            [124],
-            [125],
-            [126],
-            [127],
-            [128],
-            [129],
-            [130],
-            // Normal anonymous class.
-            [135],
-            [136],
-            [137],
-            [138],
-            [139],
-            [140],
-            [141],
-            [142],
-            [143],
-            [144],
+        // Plain/normal interface.
+        for ($line = 69; $line <= 94; $line++) {
+            $data[] = [$line];
+        }
 
-            // PHP 7.4: __(un)serialize()
-            [173],
-            [174],
+        // Plain/normal anonymous class.
+        for ($line = 120; $line <= 145; $line++) {
+            $data[] = [$line];
+        }
 
-            // More magic methods.
-            [192],
-            [193],
-            [194],
-            [195],
-            [196],
-            [201],
+        // PHP 7.4: __(un)serialize()
+        $data[] = [173];
+        $data[] = [174];
 
-            // Plain trait.
-            [219],
-            [220],
-            [221],
-            [222],
-            [223],
-            [224],
-            [225],
-            [226],
-            [227],
-            [228],
-            [229],
+        // More magic methods.
+        for ($line = 190; $line <= 197; $line++) {
+            $data[] = [$line];
+        }
+        $data[] = [201];
 
-            // Normal trait.
-            [234],
-            [235],
-            [236],
-            [237],
-            [238],
-            [239],
-            [240],
-            [241],
-            [242],
-            [243],
-            [244],
-            [245],
+        // Plain/normal trait.
+        for ($line = 217; $line <= 246; $line++) {
+            $data[] = [$line];
+        }
 
-            // Nested function.
-            [277],
-        ];
+        // Nested function.
+        $data[] = [277];
+
+        return $data;
     }
 
 


### PR DESCRIPTION
### FunctionDeclarations/NonStaticMagicMethods: fix parse errors in test case file

### FunctionDeclarations/NonStaticMagicMethods: improve test maintainability

... of the "no false positive" test data provider.

### FunctionDeclarations/NonStaticMagicMethods: add tests with PHP 8.1+ enums

The sniff already handles this correctly, no changes needed.