### PR TITLE
FunctionDeclarations/RemovedReturnByReferenceFromVoid: bug fix - type keywords are case in-sensitive + more tests

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
@@ -69,7 +69,7 @@ class RemovedReturnByReferenceFromVoidSniff extends Sniff
 
         $functionProps = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
 
-        if ($functionProps['return_type'] !== 'void') {
+        if (\strtolower($functionProps['return_type']) !== 'void') {
             // Not a void function.
             return;
         }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.inc
@@ -74,3 +74,11 @@ interface BarInterface {
 trait BarTrait {
     function &test(): void {}
 }
+
+/*
+ * Safeguard handling of PHP 7.4+ arrow functions.
+ */
+$arrow = fn(): void => $a; // OK.
+$arrow = fn &() => $a; // OK.
+$arrow = fn&() : int|bool => $a; // OK.
+$arrow = fn &(): void => $a; // Error.

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.inc
@@ -82,3 +82,13 @@ $arrow = fn(): void => $a; // OK.
 $arrow = fn &() => $a; // OK.
 $arrow = fn&() : int|bool => $a; // OK.
 $arrow = fn &(): void => $a; // Error.
+
+/*
+ * Safeguard handling of PHP 8.1+ methods in enums.
+ */
+enum FooEnum {
+    public function notReturnByRef(): void {} // OK.
+    public function &noReturnType() {} // OK.
+    public function &notVoidReturnType(): Foo&Bar {} // OK.
+    public function &voidReturnType(): void {} // Error.
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.inc
@@ -18,7 +18,7 @@ $anon = new class() {
 };
 
 abstract class AbstractFoo {
-    abstract function test(): void;
+    abstract function test(): Void;
 }
 
 interface FooInterface {
@@ -53,7 +53,7 @@ class FooDifferentReturn {
  */
 function &referenceWithVoidReturnType() : void {}
 
-$closure = function &(): void {};
+$closure = function &(): VOID {};
 
 class Bar {
     function &test(): void {}
@@ -68,7 +68,7 @@ abstract class AbstractBar {
 }
 
 interface BarInterface {
-    function &test(): void;
+    function &test(): Void;
 }
 
 trait BarTrait {

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
@@ -58,6 +58,7 @@ class RemovedReturnByReferenceFromVoidUnitTest extends BaseSniffTest
             [71],
             [75],
             [84],
+            [93],
         ];
     }
 
@@ -96,6 +97,10 @@ class RemovedReturnByReferenceFromVoidUnitTest extends BaseSniffTest
         $data[] = [81];
         $data[] = [82];
         $data[] = [83];
+
+        $data[] = [90];
+        $data[] = [91];
+        $data[] = [92];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
@@ -57,6 +57,7 @@ class RemovedReturnByReferenceFromVoidUnitTest extends BaseSniffTest
             [67],
             [71],
             [75],
+            [84],
         ];
     }
 
@@ -91,6 +92,10 @@ class RemovedReturnByReferenceFromVoidUnitTest extends BaseSniffTest
         for ($line = 1; $line <= 50; $line++) {
             $data[] = [$line];
         }
+
+        $data[] = [81];
+        $data[] = [82];
+        $data[] = [83];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
@@ -64,16 +64,35 @@ class RemovedReturnByReferenceFromVoidUnitTest extends BaseSniffTest
     /**
      * Verify that there are no false positives for valid code.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 50 lines.
         for ($line = 1; $line <= 50; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        return $data;
     }
 
 


### PR DESCRIPTION
### FunctionDeclarations/RemovedReturnByReferenceFromVoid: rework a test to data provider

### FunctionDeclarations/RemovedReturnByReferenceFromVoid: bug fix - type keywords are case in-sensitive

See: https://3v4l.org/DgnOC

Tested by adjusting some of the existing unit tests.

### FunctionDeclarations/RemovedReturnByReferenceFromVoid: add tests with PHP 7.4+ arrow functions

The sniff already handles this correctly, no changes needed.

### FunctionDeclarations/RemovedReturnByReferenceFromVoid: add tests with PHP 8.1+ enums

The sniff already handles this correctly, no changes needed.