### PR TITLE
FunctionNameRestrictions/NewMagicMethods: minor tweaks + extra tests

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -14,7 +14,8 @@ use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHPCSUtils\BackCompat\BCTokens;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;
@@ -141,7 +142,7 @@ class NewMagicMethodsSniff extends Sniff
             return;
         }
 
-        $scopePtr = Scopes::validDirectScope($phpcsFile, $stackPtr, BCTokens::ooScopeTokens());
+        $scopePtr = Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
         if ($scopePtr === false) {
             return;
         }
@@ -164,8 +165,8 @@ class NewMagicMethodsSniff extends Sniff
                         return;
                     }
                 }
-            } else {
-                // Class.
+            } elseif (isset(Collections::ooCanImplement()[$tokens[$scopePtr]['code']]) === true) {
+                // Class or enum.
                 $implementedInterfaces = ObjectDeclarations::findImplementedInterfaceNames($phpcsFile, $scopePtr);
 
                 if (\is_array($implementedInterfaces) === true) {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.inc
@@ -126,3 +126,29 @@ interface DoesNotExtendSerializableInterface extends Iterator, ArrayAccess {
     public function __serialize(); // Error.
     public function __unserialize($data); // Error.
 }
+
+/*
+ * Safeguard handling of magic methods in PHP 8.1+ enums.
+ * Only `__call()`, `__callStatic()`, and `__invoke()` are allowed in enums, but that's not the concern of this sniff.
+ */
+enum MyEnum
+{
+    public function __get($name) {}
+    public function __isset($name) {}
+    public function __unset($name) {}
+    public static function __set_state($properties) {}
+    public function __toString() {}
+    public static function __callStatic($name, $arguments) {}
+    public function __invoke($x) {}
+    public function __debugInfo() {}
+    public function __serialize() {}
+    public function __unserialize($data) {}
+    public function __construct() {}
+    public function __destruct() {}
+}
+
+enum MyEnum implements Serializable
+{
+    public function __serialize() {} // OK.
+    public function __unserialize($data) {} // OK.
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.inc
@@ -121,3 +121,8 @@ interface SerializableExtendedInterface extends Iterator, Serializable, ArrayAcc
     public function __serialize();
     public function __unserialize($data);
 }
+
+interface DoesNotExtendSerializableInterface extends Iterator, ArrayAccess {
+    public function __serialize(); // Error.
+    public function __unserialize($data); // Error.
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.inc
@@ -66,7 +66,7 @@ $a = new class
     public static function __callStatic($name, $arguments) {}
     public function __invoke($x) {}
     public function __debugInfo() {}
-}
+};
 
 /*
  * PHP 7.4: new (un)serialize magic methods.

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -86,6 +86,9 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
             ['__unserialize', '7.3', [96], '7.4'],
             ['__construct', '4.4', [97], '5.0'],
             ['__destruct', '4.4', [98], '5.0'],
+
+            ['__serialize', '7.3', [126], '7.4'],
+            ['__unserialize', '7.3', [127], '7.4'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -89,6 +89,19 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
 
             ['__serialize', '7.3', [126], '7.4'],
             ['__unserialize', '7.3', [127], '7.4'],
+
+            // Enums.
+            ['__get', '4.4', [136], '5.0'],
+            ['__isset', '5.0', [137], '5.1'],
+            ['__unset', '5.0', [138], '5.1'],
+            ['__set_state', '5.0', [139], '5.1'],
+            ['__callStatic', '5.2', [141], '5.3'],
+            ['__invoke', '5.2', [142], '5.3'],
+            ['__debugInfo', '5.5', [143], '5.6'],
+            ['__serialize', '7.3', [144], '7.4'],
+            ['__unserialize', '7.3', [145], '7.4'],
+            ['__construct', '4.4', [146], '5.0'],
+            ['__destruct', '4.4', [147], '5.0'],
         ];
     }
 
@@ -125,6 +138,7 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
             [38],
             [65],
             [91],
+            [140],
         ];
     }
 
@@ -200,11 +214,13 @@ class NewMagicMethodsUnitTest extends BaseSniffTest
             [74],
             [75],
 
-            // Magic serialization methods in a class implementing Serializable.
+            // Magic serialization methods in a class/enum implementing Serializable.
             [112],
             [115],
             [121],
             [122],
+            [152],
+            [153],
         ];
     }
 


### PR DESCRIPTION
### FunctionNameRestrictions/NewMagicMethods: fix parse error in test case file

### FunctionNameRestrictions/NewMagicMethods: minor tweaks

1. Using `BCTokens` is currently not needed now support for PHPCS < 3.7.1 has been dropped.
2. Performance tweak - `trait`s cannot implement, so let's not even attempt to find an `implements ...` statement.

### FunctionNameRestrictions/NewMagicMethods: add extra test

.. to safeguard that the magic `__[un]serialize()` methods will be flagged when an interface does **_not_** extend the `Serializable` interface.

### FunctionNameRestrictions/NewMagicMethods: add tests with PHP 8.1+ enums

The sniff already handles this correctly, no changes needed.