### PR TITLE
FunctionNameRestrictions/RemovedNamespacedAssert: add tests with PHP 8.1+ enums

### DIFF
--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.1.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.1.inc
@@ -3,7 +3,7 @@
 function assert($something) {}
 
 class fooclass {
-    public function assert($something) {}
+    public function Assert($something) {}
 }
 
 interface foointerface {
@@ -19,7 +19,7 @@ fooanonclass(new class {
 });
 
 namespace ScopedNS {
-	function assert($something) {}
+	function AsSeRt($something) {}
 }
 
 class nested {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.1.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.1.inc
@@ -31,3 +31,7 @@ class nested {
 $cl = function() {
     function assert($something) {}
 };
+
+enum fooenum {
+    public function ASSERT($something) {}
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.2.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.2.inc
@@ -27,5 +27,5 @@ class nested {
 }
 
 $cl = function() {
-    function assert($something) {}
+    function Assert($something) {}
 };

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.2.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.2.inc
@@ -29,3 +29,7 @@ class nested {
 $cl = function() {
     function Assert($something) {}
 };
+
+enum fooenum {
+    public function Assert($something) {}
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -110,10 +110,12 @@ class RemovedNamespacedAssertUnitTest extends BaseSniffTest
             [self::TEST_FILE, 18],
             [self::TEST_FILE, 27],
             [self::TEST_FILE, 32],
+            [self::TEST_FILE, 36],
             [self::TEST_FILE_NAMESPACED, 8],
             [self::TEST_FILE_NAMESPACED, 12],
             [self::TEST_FILE_NAMESPACED, 16],
             [self::TEST_FILE_NAMESPACED, 20],
+            [self::TEST_FILE_NAMESPACED, 34],
         ];
     }
 


### PR DESCRIPTION
### FunctionNameRestrictions/RemovedNamespacedAssert: tweak some tests

... to make sure the case-insensitivity of the function name check is handled correctly.

### FunctionNameRestrictions/RemovedNamespacedAssert: add tests with PHP 8.1+ enums

... to make sure that enum methods are not confused with namespaced functions.

The sniff already handles this correctly, no changes needed.