### PR TITLE
FunctionNameRestrictions/RemovedPHP4StyleConstructors: bow out when testVersion min >= 8.0 + efficiency tweak

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -75,7 +75,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if (ScannedCode::shouldRunOnOrAbove('7.0') === false) {
+        if (ScannedCode::shouldRunOnOrAbove('7.0') === false || ScannedCode::shouldRunOnOrBelow('7.4') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -108,10 +108,16 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
         $newConstructorFound = false;
         $oldConstructorFound = false;
         $oldConstructorPos   = -1;
-        while (($nextFunc = $phpcsFile->findNext([\T_FUNCTION, \T_DOC_COMMENT_OPEN_TAG], ($nextFunc + 1), $scopeCloser)) !== false) {
+        while (($nextFunc = $phpcsFile->findNext([\T_FUNCTION, \T_DOC_COMMENT_OPEN_TAG, \T_ATTRIBUTE], ($nextFunc + 1), $scopeCloser)) !== false) {
             // Skip over docblocks.
             if ($tokens[$nextFunc]['code'] === \T_DOC_COMMENT_OPEN_TAG) {
                 $nextFunc = $tokens[$nextFunc]['comment_closer'];
+                continue;
+            }
+
+            // Skip over attributes.
+            if (isset($tokens[$nextFunc]['attribute_closer'])) {
+                $nextFunc = $tokens[$nextFunc]['attribute_closer'];
                 continue;
             }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.inc
@@ -71,11 +71,11 @@ class bar {
     /**
      * This
      * docblock
-     * should
-     * be
+     * should be
      * skipped
      * over.
      */
+    #[SomeAttribute('param', CONSTANT), OtherAttribute]
     function __construct() {
         echo 'I am the real constructor';
     }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
@@ -39,7 +39,7 @@ class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
         $file = $this->sniffFile(__FILE__, '7.0');
         $this->assertWarning($file, $line, 'Declaration of a PHP4 style class constructor is deprecated since PHP 7.0');
 
-        $file = $this->sniffFile(__FILE__, '8.0');
+        $file = $this->sniffFile(__FILE__, '7.2-');
         $this->assertError($file, $line, 'Declaration of a PHP4 style class constructor is deprecated since PHP 7.0 and removed since PHP 8.0');
     }
 
@@ -107,9 +107,20 @@ class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
      *
      * @return void
      */
-    public function testNoViolationsInFileOnValidVersion()
+    public function testNoViolationsInFileOnValidVersionPHP5()
     {
         $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersionPHP8()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
         $this->assertNoViolation($file);
     }
 }


### PR DESCRIPTION
### FunctionNameRestrictions/RemovedPHP4StyleConstructors: skip over PHP 8.0+ attributes

Attributes can be expansive, so skipping over them for efficiency.

Tested by adjusting one of the pre-existing tests.

### FunctionNameRestrictions/RemovedPHP4StyleConstructors: bow out when testVersion min >= 8.0

As of PHP 8.0, PHP 4-style constructors are treated as normal methods no matter what.

If the `testVersion` set by the end user has a minimum supported PHP version of PHP 8.0 or higher, the sniff should stay silent and presume that the method with the same name as the class is not a PHP 4 constructor to begin with.

Tested via the existing test cases.