### PR TITLE
FunctionNameRestrictions/ReservedFunctionNames: support PHP 8.0 attributes and more

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -13,7 +13,6 @@ namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;
@@ -79,10 +78,10 @@ class ReservedFunctionNamesSniff implements Sniff
             return;
         }
 
-        $ooPtr = Scopes::validDirectScope($phpcsFile, $stackPtr, BCTokens::ooScopeTokens());
+        $ooPtr = Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
 
         /*
-         * Check functions declared in the global namespace.
+         * Check functions declared in the global namespace or in a namespace.
          */
         if ($ooPtr === false) {
             if (FunctionDeclarations::isMagicFunctionName($functionName) === true) {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -138,10 +138,13 @@ class ReservedFunctionNamesSniff implements Sniff
     private function isFunctionDeprecated(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        $find   = Tokens::$methodPrefixes;
-        $find[] = \T_WHITESPACE;
 
-        $commentEnd = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
+        $ignore                = Tokens::$methodPrefixes;
+        $ignore               += Tokens::$phpcsCommentTokens;
+        $ignore[\T_WHITESPACE] = \T_WHITESPACE;
+        $ignore[\T_COMMENT]    = \T_COMMENT;
+
+        $commentEnd = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
         if ($tokens[$commentEnd]['code'] !== \T_DOC_COMMENT_CLOSE_TAG) {
             // Function doesn't have a doc comment or is using the wrong type of comment.
             return false;

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -144,7 +144,21 @@ class ReservedFunctionNamesSniff implements Sniff
         $ignore[\T_WHITESPACE] = \T_WHITESPACE;
         $ignore[\T_COMMENT]    = \T_COMMENT;
 
-        $commentEnd = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
+        for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {
+            if (isset($ignore[$tokens[$commentEnd]['code']]) === true) {
+                continue;
+            }
+
+            if ($tokens[$commentEnd]['code'] === \T_ATTRIBUTE_END
+                && isset($tokens[$commentEnd]['attribute_opener']) === true
+            ) {
+                $commentEnd = $tokens[$commentEnd]['attribute_opener'];
+                continue;
+            }
+
+            break;
+        }
+
         if ($tokens[$commentEnd]['code'] !== \T_DOC_COMMENT_CLOSE_TAG) {
             // Function doesn't have a doc comment or is using the wrong type of comment.
             return false;

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -197,6 +197,17 @@ function __deprecatedFunctionWithMultipleAttributes() {} // Ignore.
 #[SomeAttribute]
 function __functionWithAttributeButNoDocblock() {} // Error.
 
+// Verify handling of methods in PHP 8.1+ enums.
+// Enums only support the __call(), __callStatic() and __invoke() magic methods.
+enum LimitedMagic {
+    function __call() {} // OK.
+    function __callStatic() {} // OK.
+    function __invoke() {} // OK.
+
+    function __autoload() {} // Error.
+    function __myFunction() {} // Error.
+}
+
 // Live coding/parse error.
 // This has to be the last test in the file.
 function

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -159,3 +159,14 @@ class Magic_Test_PHP74 {
 
 function __serialize() {} // Error.
 function __unserialize() {} // Error.
+
+/**
+ * Function with docblock, but no deprecated tag.
+ *
+ * @return bool
+ */
+function __notADeprecatedFunction() {} // Error.
+
+// Live coding/parse error.
+// This has to be the last test in the file.
+function

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -167,6 +167,18 @@ function __unserialize() {} // Error.
  */
 function __notADeprecatedFunction() {} // Error.
 
+// Improve comment tolerance in deprecated function detection.
+class DeprecatedWithComments {
+    /**
+     * Function description.
+     *
+     * @deprecated 2.3.4
+     */
+    public /*comment*/
+    static // phpcs:ignore Stnd.Cat.Sniff -- for reasons.
+    function __deprecatedMethod() {}
+}
+
 // Live coding/parse error.
 // This has to be the last test in the file.
 function

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -179,6 +179,24 @@ class DeprecatedWithComments {
     function __deprecatedMethod() {}
 }
 
+// Handle PHP 8.0+ attributes correctly when trying to find a docblock.
+
+/**
+ * @deprecated 1.2.3
+ */
+#[SomeAttribute]
+function __deprecatedFunctionWithSingleAttribute() {} // Ignore.
+
+/**
+ * @deprecated 1.2.3
+ */
+#[SomeAttribute]
+#[AnotherAttribute]
+function __deprecatedFunctionWithMultipleAttributes() {} // Ignore.
+
+#[SomeAttribute]
+function __functionWithAttributeButNoDocblock() {} // Error.
+
 // Live coding/parse error.
 // This has to be the last test in the file.
 function

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -89,6 +89,8 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
             [161, 'function'],
 
             [168, 'function'],
+
+            [198, 'function'],
         ];
     }
 
@@ -177,8 +179,11 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
 
             [179],
 
+            [188],
+            [195],
+
             // Live coding/parse error test.
-            [184],
+            [202],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -175,8 +175,10 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
             [156],
             [157],
 
+            [179],
+
             // Live coding/parse error test.
-            [172],
+            [184],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -87,6 +87,8 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
 
             [160, 'function'],
             [161, 'function'],
+
+            [168, 'function'],
         ];
     }
 
@@ -172,6 +174,9 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
 
             [156],
             [157],
+
+            // Live coding/parse error test.
+            [172],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -91,6 +91,9 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
             [168, 'function'],
 
             [198, 'function'],
+
+            [207, 'method'],
+            [208, 'method'],
         ];
     }
 
@@ -182,8 +185,12 @@ class ReservedFunctionNamesUnitTest extends BaseSniffTest
             [188],
             [195],
 
+            [203],
+            [204],
+            [205],
+
             // Live coding/parse error test.
-            [202],
+            [214],
         ];
     }
 


### PR DESCRIPTION
### FunctionNameRestrictions/ReservedFunctionNames: add some extra tests

... for code previously not covered by tests.

### FunctionNameRestrictions/ReservedFunctionNames: bug fix - deprecated functions should be ignored

... but weren't always when the function signature would contain comments.

This commit improves the docblock finding for functions, thereby preventing these false positives.

Includes unit test.

### FunctionNameRestrictions/ReservedFunctionNames: support PHP 8.0+ attributes

... which can be between the function signature and the docblock.

This prevents false positives for deprecated function where the docblock would not being found due to the attribute.

Includes unit tests.

### FunctionNameRestrictions/ReservedFunctionNames: add tests with PHP 8.1+ enums

The sniff already handles this correctly, no changes needed.

### FunctionNameRestrictions/ReservedFunctionNames: minor tweaks 