### PR TITLE
Generators/NewGeneratorReturn: improved false positive prevention/arrow functions

### DIFF
--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
 
 /**
@@ -98,8 +99,9 @@ class NewGeneratorReturnSniff extends Sniff
             return;
         }
 
-        $targets = [\T_RETURN, \T_CLOSURE, \T_FUNCTION, \T_CLASS, \T_ANON_CLASS];
-        $current = $tokens[$function]['scope_opener'];
+        $targets            = Collections::closedScopes();
+        $targets[\T_RETURN] = \T_RETURN;
+        $current            = $tokens[$function]['scope_opener'];
 
         while (($current = $phpcsFile->findNext($targets, ($current + 1), $tokens[$function]['scope_closer'])) !== false) {
             if ($tokens[$current]['code'] === \T_RETURN) {

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.inc
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.inc
@@ -128,3 +128,24 @@ function skipArrowGeneratorB($a) {
     $arrow = fn($array) => yield $array['key'] ?? yield from $array;
     return $arrow; // OK.
 }
+
+// More guarding against false positives for nested closed scopes.
+function nestedClassMethodReturn() {
+    $a = new class() {
+        public function doSomething() {
+            return 10; // OK.
+        }
+    };
+
+    yield 20;
+}
+
+function nestedEnumReturn() {
+    enum MyNestedEnum {
+        public function doSomething() {
+            return 10; // OK.
+        }
+    }
+
+    yield 20;
+}

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.inc
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.inc
@@ -118,3 +118,13 @@ function notAGeneratorNestedArrowGenerator($a) {
 
     return $arrow1($a); // OK.
 }
+
+// Test for improved code to ignore arrow functions.
+function skipArrowGeneratorA($a) {
+    $arrow = fn($i) => $i && yield $i++;
+    return $arrow; // OK.
+}
+function skipArrowGeneratorB($a) {
+    $arrow = fn($array) => yield $array['key'] ?? yield from $array;
+    return $arrow; // OK.
+}

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -26,7 +26,7 @@ class NewGeneratorReturnUnitTest extends BaseSniffTest
 {
 
     /**
-     * testNewGeneratorReturn
+     * Test detection of final return in generators.
      *
      * @dataProvider dataNewGeneratorReturn
      *
@@ -41,7 +41,7 @@ class NewGeneratorReturnUnitTest extends BaseSniffTest
     }
 
     /**
-     * Data provider dataNewGeneratorReturn.
+     * Data provider.
      *
      * @see testNewGeneratorReturn()
      *
@@ -61,7 +61,7 @@ class NewGeneratorReturnUnitTest extends BaseSniffTest
 
 
     /**
-     * testNoFalsePositives
+     * Test the sniff doesn't throw false positives for valid code.
      *
      * @dataProvider dataNoFalsePositives
      *
@@ -84,14 +84,24 @@ class NewGeneratorReturnUnitTest extends BaseSniffTest
      */
     public function dataNoFalsePositives()
     {
-        return [
-            [6],
-            [15],
-            [21],
-            [53],
-            [107],
-            [119],
-        ];
+        $data = [];
+
+        // No errors expected on the first 24 lines.
+        for ($line = 1; $line <= 24; $line++) {
+            $data[] = [$line];
+        }
+
+        for ($line = 44; $line <= 55; $line++) {
+            $data[] = [$line];
+        }
+
+        $data[] = [67];
+
+        for ($line = 105; $line <= 120; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -97,7 +97,7 @@ class NewGeneratorReturnUnitTest extends BaseSniffTest
 
         $data[] = [67];
 
-        for ($line = 105; $line <= 120; $line++) {
+        for ($line = 105; $line <= 130; $line++) {
             $data[] = [$line];
         }
 

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -97,7 +97,7 @@ class NewGeneratorReturnUnitTest extends BaseSniffTest
 
         $data[] = [67];
 
-        for ($line = 105; $line <= 130; $line++) {
+        for ($line = 105; $line <= 151; $line++) {
             $data[] = [$line];
         }
 


### PR DESCRIPTION
### Generators/NewGeneratorReturn: improve "no false positives" test

... to test with higher precision.

Includes minor tweaks to the test documentation.

### Generators/NewGeneratorReturn: improved false positive prevention for arrow functions

Follow up on #1000, which already indicated that the code added in #1000 to prevent false positives with arrow functions may need improvements.

This commit makes that improvement.

Includes additional unit tests.

### Generators/NewGeneratorReturn: improved false positive prevention for nested closed scopes

As things were, the sniff would skip over functions, closures and (anon) classes nested within a generator function to prevent false positives.

There are, however, more closed scopes: interfaces, traits and enums.

Not skipping over them does not necessarily cause problems as `return` would still have to be within a `function` and functions _are_ being skipped over. Still, being consistent and skipping over **all** closed scopes seems like a better solution.

Includes additional unit tests.