### PR TITLE
Interfaces/InternalInterfaces: detect interfaces extending + enums implementing

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Interfaces;
 
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
@@ -40,8 +41,19 @@ class InternalInterfacesSniff extends Sniff
      */
     protected $internalInterfaces = [
         'Traversable'       => 'shouldn\'t be implemented directly, implement the Iterator or IteratorAggregate interface instead.',
-        'DateTimeInterface' => 'is intended for type hints only and is not implementable.',
+        'DateTimeInterface' => 'is intended for type hints only and is not implementable or extendable.',
         'Throwable'         => 'cannot be implemented directly, extend the Exception class instead.',
+    ];
+
+    /**
+     * A list of PHP internal interfaces, which cannot be extended by userland interfaces.
+     *
+     * @since 10.0.0
+     *
+     * @var array(string => bool)
+     */
+    private $cannotBeExtended = [
+        'DateTimeInterface' => true,
     ];
 
 
@@ -56,10 +68,12 @@ class InternalInterfacesSniff extends Sniff
     {
         // Handle case-insensitivity of interface names.
         $this->internalInterfaces = \array_change_key_case($this->internalInterfaces, \CASE_LOWER);
+        $this->cannotBeExtended   = \array_change_key_case($this->cannotBeExtended, \CASE_LOWER);
 
         return [
             \T_CLASS,
             \T_ANON_CLASS,
+            \T_INTERFACE,
         ];
     }
 
@@ -77,7 +91,14 @@ class InternalInterfacesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $interfaces = ObjectDeclarations::findImplementedInterfaceNames($phpcsFile, $stackPtr);
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['code'] === \T_INTERFACE) {
+            $interfaces = ObjectDeclarations::findExtendedInterfaceNames($phpcsFile, $stackPtr);
+            $targets    = $this->cannotBeExtended;
+        } else {
+            $interfaces = ObjectDeclarations::findImplementedInterfaceNames($phpcsFile, $stackPtr);
+            $targets    = $this->internalInterfaces;
+        }
 
         if (\is_array($interfaces) === false || $interfaces === []) {
             return;
@@ -86,7 +107,7 @@ class InternalInterfacesSniff extends Sniff
         foreach ($interfaces as $interface) {
             $interface   = \ltrim($interface, '\\');
             $interfaceLc = \strtolower($interface);
-            if (isset($this->internalInterfaces[$interfaceLc]) === true) {
+            if (isset($targets[$interfaceLc]) === true) {
                 $error     = 'The interface %s %s';
                 $errorCode = MessageHelper::stringToErrorCode($interfaceLc) . 'Found';
                 $data      = [

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -70,13 +70,8 @@ class InternalInterfacesSniff extends Sniff
         $this->internalInterfaces = \array_change_key_case($this->internalInterfaces, \CASE_LOWER);
         $this->cannotBeExtended   = \array_change_key_case($this->cannotBeExtended, \CASE_LOWER);
 
-        return [
-            \T_CLASS,
-            \T_ANON_CLASS,
-            \T_INTERFACE,
-        ];
+        return Collections::ooCanImplement() + [\T_INTERFACE => \T_INTERFACE];
     }
-
 
     /**
      * Processes this test, when one of its tokens is encountered.

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.inc
@@ -1,7 +1,7 @@
 <?php
 
 class MyTraversable implements Traversable {}
-class MyDateTimeInterface implements DateTimeInterface {}
+class MyDateTimeClass implements DateTimeInterface {}
 class MyThrowable implements Throwable {}
 
 class MyMultiple implements SomeInterface, Throwable, AnotherInterface, \Traversable {} // Test multiple interfaces.
@@ -22,3 +22,8 @@ $d = new class implements SomeInterface, Throwable, AnotherInterface, Traversabl
 // Safeguard handling of classes which don't implement.
 class ImplementsNothing {}
 class ImplementsNothingEither extends Foo {}
+
+// DateTimeInterface cannot be extended by userland interfaces. The others can.
+interface IDontExtend {} // OK.
+interface MyDateTimeInterface extends MyNs\DateTimeInterface, Traversable, Throwable, ArrayAccess {} // OK.
+interface MyDateTimeInterface extends ArrayAccess, DateTimeInterface, SomeInterface {} // Error.

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.inc
@@ -18,3 +18,7 @@ $a = new class implements Traversable {}
 $b = new class implements DateTimeInterface {}
 $c = new class implements \Throwable {}
 $d = new class implements SomeInterface, Throwable, AnotherInterface, Traversable {} // Test multiple interfaces.
+
+// Safeguard handling of classes which don't implement.
+class ImplementsNothing {}
+class ImplementsNothingEither extends Foo {}

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.inc
@@ -27,3 +27,11 @@ class ImplementsNothingEither extends Foo {}
 interface IDontExtend {} // OK.
 interface MyDateTimeInterface extends MyNs\DateTimeInterface, Traversable, Throwable, ArrayAccess {} // OK.
 interface MyDateTimeInterface extends ArrayAccess, DateTimeInterface, SomeInterface {} // Error.
+
+// Safeguard handling of PHP 8.1+ enums implementing internal interfaces.
+enum ImplementsNothing {} // OK.
+enum MyOkayEnum implements SomeInterface, AnotherInterface {} // OK.
+enum MyTraversableEnum implements Traversable {} // Error.
+enum MyDateTimeEnum implements DateTimeInterface {} // Error.
+enum MyThrowableEnum implements \Throwable {} // Error.
+enum MyMultipleEnum implements SomeInterface, Throwable, AnotherInterface, Traversable {} // Test multiple interfaces.

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -39,7 +39,7 @@ class InternalInterfacesUnitTest extends BaseSniffTest
      */
     protected $messages = [
         'Traversable'       => 'The interface Traversable shouldn\'t be implemented directly, implement the Iterator or IteratorAggregate interface instead.',
-        'DateTimeInterface' => 'The interface DateTimeInterface is intended for type hints only and is not implementable.',
+        'DateTimeInterface' => 'The interface DateTimeInterface is intended for type hints only and is not implementable or extendable.',
         'Throwable'         => 'The interface Throwable cannot be implemented directly, extend the Exception class instead.',
     ];
 
@@ -93,6 +93,9 @@ class InternalInterfacesUnitTest extends BaseSniffTest
             ['Throwable', 19],
             ['Traversable', 20],
             ['Throwable', 20],
+
+            // Interface extends ...
+            ['DateTimeInterface', 29],
         ];
     }
 
@@ -103,8 +106,8 @@ class InternalInterfacesUnitTest extends BaseSniffTest
      */
     public function testCaseInsensitive()
     {
-        $this->assertError($this->sniffResult, 9, 'The interface DATETIMEINTERFACE is intended for type hints only and is not implementable.');
-        $this->assertError($this->sniffResult, 10, 'The interface datetimeinterface is intended for type hints only and is not implementable.');
+        $this->assertError($this->sniffResult, 9, 'The interface DATETIMEINTERFACE is intended for type hints only and is not implementable or extendable.');
+        $this->assertError($this->sniffResult, 10, 'The interface datetimeinterface is intended for type hints only and is not implementable or extendable.');
     }
 
     /**
@@ -135,6 +138,8 @@ class InternalInterfacesUnitTest extends BaseSniffTest
             [14],
             [23],
             [24],
+            [27],
+            [28],
         ];
     }
 

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -96,6 +96,13 @@ class InternalInterfacesUnitTest extends BaseSniffTest
 
             // Interface extends ...
             ['DateTimeInterface', 29],
+
+            // Enums.
+            ['Traversable', 34],
+            ['DateTimeInterface', 35],
+            ['Throwable', 36],
+            ['Traversable', 37],
+            ['Throwable', 37],
         ];
     }
 
@@ -140,6 +147,8 @@ class InternalInterfacesUnitTest extends BaseSniffTest
             [24],
             [27],
             [28],
+            [32],
+            [33],
         ];
     }
 

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -57,7 +57,7 @@ class InternalInterfacesUnitTest extends BaseSniffTest
     }
 
     /**
-     * Test InternalInterfaces
+     * Test detection of use of internal interfaces.
      *
      * @dataProvider dataInternalInterfaces
      *
@@ -108,7 +108,7 @@ class InternalInterfacesUnitTest extends BaseSniffTest
     }
 
     /**
-     * testNoFalsePositives
+     * Test the sniff doesn't throw false positives for valid code.
      *
      * @dataProvider dataNoFalsePositives
      *
@@ -133,6 +133,8 @@ class InternalInterfacesUnitTest extends BaseSniffTest
         return [
             [13],
             [14],
+            [23],
+            [24],
         ];
     }
 


### PR DESCRIPTION
### Interfaces/InternalInterfaces: add extra tests

... for situations the sniff already accounts for, but which weren't being tested yet.

Includes minor tweaks to the test documentation.

### Interfaces/InternalInterfaces: detect interfaces extending select internal interfaces

Interfaces can `extend` other interfaces.

I have verified whether this is allowed for the internal interfaces and turns out (unsurprisingly) that this is not allowed for the `DateTimeInterface`.
It is fine for the other internal interfaces though.

This commit updates the sniff to take this into account and trigger an error when the `DateTimeInterface` is being extended by a userland interface declaration.

Includes unit tests.

### Interfaces/InternalInterfaces: detect PHP 8.1+ enums implementing internal interfaces

Enums can also implement interfaces, so should be included in this check.

Includes unit tests.