### PR TITLE
TokenGroup::is*Number(): remove `$supportsPHP5` parameter/use `ScannedCode` directly

### DIFF
--- a/PHPCompatibility/Helpers/TokenGroup.php
+++ b/PHPCompatibility/Helpers/TokenGroup.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Helpers;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\ScannedCode;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -38,27 +39,22 @@ final class TokenGroup
      *
      * @since 8.2.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
-     * @param int                         $start        Start of the snippet (inclusive), i.e. this
-     *                                                  token will be examined as part of the
-     *                                                  snippet.
-     * @param int                         $end          End of the snippet (inclusive), i.e. this
-     *                                                  token will be examined as part of the
-     *                                                  snippet.
-     * @param bool                        $supportsPHP5 Whether the `testVersion` set indicated that PHP < 7.0
-     *                                                  needs to be supported.
-     *                                                  This is used to determine how to handle hexidecimal
-     *                                                  numeric strings, which were supported in PHP 5.x,
-     *                                                  but no longer supported in PHP 7.0+.
-     * @param bool                        $allowFloats  Whether to only consider integers, or also floats.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $start       Start of the snippet (inclusive), i.e. this
+     *                                                 token will be examined as part of the
+     *                                                 snippet.
+     * @param int                         $end         End of the snippet (inclusive), i.e. this
+     *                                                 token will be examined as part of the
+     *                                                 snippet.
+     * @param bool                        $allowFloats Whether to only consider integers, or also floats.
      *
      * @return bool True if PHP would evaluate the snippet as a positive number.
      *              False if not or if it could not be reliably determined
      *              (variable or calculations and such).
      */
-    public static function isPositiveNumber(File $phpcsFile, $start, $end, $supportsPHP5, $allowFloats = false)
+    public static function isPositiveNumber(File $phpcsFile, $start, $end, $allowFloats = false)
     {
-        $number = self::isNumber($phpcsFile, $start, $end, $supportsPHP5, $allowFloats);
+        $number = self::isNumber($phpcsFile, $start, $end, $allowFloats);
 
         if ($number === false) {
             return false;
@@ -78,27 +74,22 @@ final class TokenGroup
      *
      * @since 8.2.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
-     * @param int                         $start        Start of the snippet (inclusive), i.e. this
-     *                                                  token will be examined as part of the
-     *                                                  snippet.
-     * @param int                         $end          End of the snippet (inclusive), i.e. this
-     *                                                  token will be examined as part of the
-     *                                                  snippet.
-     * @param bool                        $supportsPHP5 Whether the `testVersion` set indicated that PHP < 7.0
-     *                                                  needs to be supported.
-     *                                                  This is used to determine how to handle hexidecimal
-     *                                                  numeric strings, which were supported in PHP 5.x,
-     *                                                  but no longer supported in PHP 7.0+.
-     * @param bool                        $allowFloats  Whether to only consider integers, or also floats.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $start       Start of the snippet (inclusive), i.e. this
+     *                                                 token will be examined as part of the
+     *                                                 snippet.
+     * @param int                         $end         End of the snippet (inclusive), i.e. this
+     *                                                 token will be examined as part of the
+     *                                                 snippet.
+     * @param bool                        $allowFloats Whether to only consider integers, or also floats.
      *
      * @return bool True if PHP would evaluate the snippet as a negative number.
      *              False if not or if it could not be reliably determined
      *              (variable or calculations and such).
      */
-    public static function isNegativeNumber(File $phpcsFile, $start, $end, $supportsPHP5, $allowFloats = false)
+    public static function isNegativeNumber(File $phpcsFile, $start, $end, $allowFloats = false)
     {
-        $number = self::isNumber($phpcsFile, $start, $end, $supportsPHP5, $allowFloats);
+        $number = self::isNumber($phpcsFile, $start, $end, $allowFloats);
 
         if ($number === false) {
             return false;
@@ -121,19 +112,14 @@ final class TokenGroup
      *
      * @since 8.2.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
-     * @param int                         $start        Start of the snippet (inclusive), i.e. this
-     *                                                  token will be examined as part of the
-     *                                                  snippet.
-     * @param int                         $end          End of the snippet (inclusive), i.e. this
-     *                                                  token will be examined as part of the
-     *                                                  snippet.
-     * @param bool                        $supportsPHP5 Whether the `testVersion` set indicated that PHP < 7.0
-     *                                                  needs to be supported.
-     *                                                  This is used to determine how to handle hexidecimal
-     *                                                  numeric strings, which were supported in PHP 5.x,
-     *                                                  but no longer supported in PHP 7.0+.
-     * @param bool                        $allowFloats  Whether to only consider integers, or also floats.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $start       Start of the snippet (inclusive), i.e. this
+     *                                                 token will be examined as part of the
+     *                                                 snippet.
+     * @param int                         $end         End of the snippet (inclusive), i.e. this
+     *                                                 token will be examined as part of the
+     *                                                 snippet.
+     * @param bool                        $allowFloats Whether to only consider integers, or also floats.
      *
      * @return int|float|bool The number found if PHP would evaluate the snippet as a number.
      *                        The return type will be int if $allowFloats is false, if
@@ -142,7 +128,7 @@ final class TokenGroup
      *                        number or if it could not be reliably determined
      *                        (variable or calculations and such).
      */
-    public static function isNumber(File $phpcsFile, $start, $end, $supportsPHP5, $allowFloats = false)
+    public static function isNumber(File $phpcsFile, $start, $end, $allowFloats = false)
     {
         $stringTokens = Tokens::$heredocTokens + Tokens::$stringTokens;
 
@@ -260,7 +246,7 @@ final class TokenGroup
             // Allow for different behaviour for hex numeric strings between PHP 5 vs PHP 7.
             if ($intString === 1 && \trim($intMatch[0]) === '0'
                 && \preg_match('`^\s*(0x[A-Fa-f0-9]+)`', $stringContent, $hexNumberString) === 1
-                && $supportsPHP5 === true
+                && ScannedCode::shouldRunOnOrBelow('5.6') === true
             ) {
                 // The filter extension still allows for hex numeric strings in PHP 7, so
                 // use that to get the numeric value if possible.

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -13,7 +13,6 @@ namespace PHPCompatibility;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff as PHPCS_Sniff;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Namespaces;
@@ -368,7 +367,7 @@ abstract class Sniff implements PHPCS_Sniff
         $subsetStart = $start;
         $subsetEnd   = ($arithmeticOperator - 1);
 
-        while (TokenGroup::isNumber($phpcsFile, $subsetStart, $subsetEnd, ScannedCode::shouldRunOnOrBelow('5.6'), true) !== false
+        while (TokenGroup::isNumber($phpcsFile, $subsetStart, $subsetEnd, true) !== false
             && isset($tokens[($arithmeticOperator + 1)]) === true
         ) {
             $subsetStart  = ($arithmeticOperator + 1);
@@ -380,7 +379,7 @@ abstract class Sniff implements PHPCS_Sniff
 
             if ($arithmeticOperator === false) {
                 // Last calculation operator already reached.
-                if (TokenGroup::isNumber($phpcsFile, $subsetStart, $end, ScannedCode::shouldRunOnOrBelow('5.6'), true) !== false) {
+                if (TokenGroup::isNumber($phpcsFile, $subsetStart, $end, true) !== false) {
                     return true;
                 }
 

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -176,7 +176,7 @@ class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
         switch ($tokens[$nextNonSimple]['code']) {
             case \T_MINUS:
             case \T_PLUS:
-                if (TokenGroup::isNumber($phpcsFile, $start, $end, ScannedCode::shouldRunOnOrBelow('5.6'), true) !== false) {
+                if (TokenGroup::isNumber($phpcsFile, $start, $end, true) !== false) {
                     // Int or float with sign.
                     return true;
                 }

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -98,7 +98,7 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
             --$end;
         }
 
-        if (TokenGroup::isNegativeNumber($phpcsFile, $start, $end, ScannedCode::shouldRunOnOrBelow('5.6'), true) !== true) {
+        if (TokenGroup::isNegativeNumber($phpcsFile, $start, $end, true) !== true) {
             // Not a negative number or undetermined.
             return;
         }

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
@@ -91,7 +91,7 @@ class ChangedObStartEraseFlagsSniff extends AbstractFunctionCallParameterSniff
         }
 
         if ((\preg_match('`PHP_OUTPUT_HANDLER_(CLEANABLE|FLUSHABLE|REMOVABLE|STDFLAGS)`', $targetParam['clean']) === 1
-            || TokenGroup::isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], ScannedCode::shouldRunOnOrBelow('5.6'), true) !== false)
+            || TokenGroup::isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], true) !== false)
             && ScannedCode::shouldRunOnOrBelow('5.3') === true
         ) {
             $phpcsFile->addError($error, $targetParam['start'], 'IntegerFound', $data);

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -91,7 +91,7 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        if (TokenGroup::isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], ScannedCode::shouldRunOnOrBelow('5.6'), true) !== false) {
+        if (TokenGroup::isNumber($phpcsFile, $targetParam['start'], $targetParam['end'], true) !== false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -112,7 +112,7 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
                 continue;
             }
 
-            if (TokenGroup::isNegativeNumber($phpcsFile, $targetParam['start'], $targetParam['end'], ScannedCode::shouldRunOnOrBelow('5.6')) === false) {
+            if (TokenGroup::isNegativeNumber($phpcsFile, $targetParam['start'], $targetParam['end']) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Util/Tests/Helpers/TokenGroup/IsNumberUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/TokenGroup/IsNumberUnitTest.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Util\Tests\Helpers\TokenGroup;
 
 use PHPCompatibility\Helpers\TokenGroup;
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -33,7 +34,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
      */
     public function testIsNumberInvalidTokenStart()
     {
-        $result = TokenGroup::isNumber(self::$phpcsFile, -1, 10, true);
+        $result = TokenGroup::isNumber(self::$phpcsFile, -1, 10);
         $this->assertFalse($result);
     }
 
@@ -46,7 +47,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
      */
     public function testIsNumberInvalidTokenEnd()
     {
-        $result = TokenGroup::isNumber(self::$phpcsFile, 3, 100000, true);
+        $result = TokenGroup::isNumber(self::$phpcsFile, 3, 100000);
         $this->assertFalse($result);
     }
 
@@ -68,7 +69,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
         $start = ($this->getTargetToken($commentString, \T_EQUAL) + 1);
         $end   = ($this->getTargetToken($commentString, \T_SEMICOLON) - 1);
 
-        $result = TokenGroup::isNumber(self::$phpcsFile, $start, $end, true, $allowFloats);
+        $result = TokenGroup::isNumber(self::$phpcsFile, $start, $end, $allowFloats);
         $this->assertSame($isNumber, $result);
     }
 
@@ -91,7 +92,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
         $start = ($this->getTargetToken($commentString, \T_EQUAL) + 1);
         $end   = ($this->getTargetToken($commentString, \T_SEMICOLON) - 1);
 
-        $result = TokenGroup::isPositiveNumber(self::$phpcsFile, $start, $end, true, $allowFloats);
+        $result = TokenGroup::isPositiveNumber(self::$phpcsFile, $start, $end, $allowFloats);
         $this->assertSame($isPositiveNumber, $result);
     }
 
@@ -115,7 +116,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
         $start = ($this->getTargetToken($commentString, \T_EQUAL) + 1);
         $end   = ($this->getTargetToken($commentString, \T_SEMICOLON) - 1);
 
-        $result = TokenGroup::isNegativeNumber(self::$phpcsFile, $start, $end, true, $allowFloats);
+        $result = TokenGroup::isNegativeNumber(self::$phpcsFile, $start, $end, $allowFloats);
         $this->assertSame($isNegativeNumber, $result);
     }
 
@@ -124,7 +125,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
      *
      * @see testIsNumber()
      *
-     * {@internal Case I13 is tested in separately for its different behaviour on PHP 5 vs 7.}
+     * {@internal Case I13 is tested separately for its different behaviour on PHP 5 vs 7.}
      *
      * @return array
      */
@@ -243,10 +244,12 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
      */
     public function testIsNumberWithHexStringPHP5()
     {
+        Helper::setConfigData('testVersion', '5.5-', true, self::$phpcsFile->config);
+
         $start = ($this->getTargetToken('/* test I13 */', \T_EQUAL) + 1);
         $end   = ($this->getTargetToken('/* test I13 */', \T_SEMICOLON) - 1);
 
-        $result = TokenGroup::isNumber(self::$phpcsFile, $start, $end, true);
+        $result = TokenGroup::isNumber(self::$phpcsFile, $start, $end);
         $this->assertSame(-13369593, $result);
     }
 
@@ -260,10 +263,12 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
      */
     public function testIsNumberWithHexStringPHP7()
     {
+        Helper::setConfigData('testVersion', '7.1-', true, self::$phpcsFile->config);
+
         $start = ($this->getTargetToken('/* test I13 */', \T_EQUAL) + 1);
         $end   = ($this->getTargetToken('/* test I13 */', \T_SEMICOLON) - 1);
 
-        $result = TokenGroup::isNumber(self::$phpcsFile, $start, $end, false);
+        $result = TokenGroup::isNumber(self::$phpcsFile, $start, $end);
         $this->assertSame(0, $result);
     }
 
@@ -279,7 +284,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
         $start = ($this->getTargetToken('/* testHeredocNoEnd */', \T_EQUAL) + 1);
         $end   = $this->getTargetToken('/* testHeredocNoEnd */', \T_START_HEREDOC);
 
-        $result = TokenGroup::isNumber(self::$phpcsFile, $start, $end, true);
+        $result = TokenGroup::isNumber(self::$phpcsFile, $start, $end);
         $this->assertFalse($result);
     }
 
@@ -295,7 +300,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
         $start = ($this->getTargetToken('/* testHeredocNoEnd */', \T_EQUAL) + 1);
         $end   = $this->getTargetToken('/* testHeredocNoEnd */', \T_HEREDOC);
 
-        $result = TokenGroup::isNumber(self::$phpcsFile, $start, $end, true);
+        $result = TokenGroup::isNumber(self::$phpcsFile, $start, $end);
         $this->assertFalse($result);
     }
 }


### PR DESCRIPTION
Follow up on PR #1493, which introduced the new `$supportsPHP5` parameter to get round the issues caused by the `TestVersionTrait` being a `trait`. See commit 17bf43b852594556a2a817d90af627643927b9d8 for more details.

Now, the `TestVersionTrait` has been refactored to the `ScannedCode` class in PR #1555, we can remove the `$supportsPHP5` parameter again, while still keeping the `TokenGroup::is*Number()` methods self-contained and still being able to distinguish between number handling on PHP 5 vs PHP 7, as attested to by the unit tests.

Includes updating all function calls to the `TokenGroup::is*Number()` methods, effectively reverting the changes to these method calls as made in commit 17bf43b852594556a2a817d90af627643927b9d8.