### PR TITLE
Interfaces/NewInterfaces: detect PHP 8.1+ enums implementing new interfaces and other tweaks

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -20,6 +20,7 @@ use PHPCSUtils\Utils\ControlStructures;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\ObjectDeclarations;
+use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\Variables;
 
 /**
@@ -340,13 +341,11 @@ class NewInterfacesSniff extends Sniff
      */
     private function processVariableToken(File $phpcsFile, $stackPtr)
     {
-        try {
-            $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
-            // Not a class property.
+        if (Scopes::isOOProperty($phpcsFile, $stackPtr) === false) {
             return;
         }
 
+        $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
         if ($properties['type'] === '') {
             return;
         }

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -351,7 +351,7 @@ class NewInterfacesSniff extends Sniff
             return;
         }
 
-        $this->checkTypeHint($phpcsFile, $properties['type_token'], $properties['type']);
+        $this->checkTypeDeclaration($phpcsFile, $properties['type_token'], $properties['type']);
     }
 
 
@@ -381,7 +381,7 @@ class NewInterfacesSniff extends Sniff
                     continue;
                 }
 
-                $this->checkTypeHint($phpcsFile, $param['type_hint_token'], $param['type_hint']);
+                $this->checkTypeDeclaration($phpcsFile, $param['type_hint_token'], $param['type_hint']);
             }
         }
 
@@ -393,7 +393,7 @@ class NewInterfacesSniff extends Sniff
             return;
         }
 
-        $this->checkTypeHint($phpcsFile, $properties['return_type_token'], $properties['return_type']);
+        $this->checkTypeDeclaration($phpcsFile, $properties['return_type_token'], $properties['return_type']);
     }
 
 
@@ -409,7 +409,7 @@ class NewInterfacesSniff extends Sniff
      *
      * @return void
      */
-    private function checkTypeHint($phpcsFile, $stackPtr, $typeHint)
+    private function checkTypeDeclaration($phpcsFile, $stackPtr, $typeHint)
     {
         // Strip off potential nullable indication.
         $typeHint = \ltrim($typeHint, '?');

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -171,6 +171,15 @@ function InvalidType($param): ?\&\SomeType {}
 try {
 } catch ($e) {}
 
+// Test support with PHP 8.0 constructor property promotion.
+class ConstructorProp {
+    public function __construct(
+        protected $property,
+        public Reflector | \ | ParseErrorMissingTypeBetweenUnion $reflProp,
+        private Stringable $stringProp,
+    ) {}
+}
+
 // Test parse error/live coding.
 // This MUST be the last test in the file!
 try {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -185,6 +185,14 @@ try {
 } catch (SomeException) {}
 } catch (MyException | Throwable | AnotherException) {}
 
+// Test support for PHP 8.1 enums implementing interfaces.
+enum NoImplements {}
+enum MyPlainEnum implements JsonSerializable {}
+enum MyBackedEnum: string implements NotATarget, Serializable, ArrayAccess {
+    public function __sleep();
+    public function __wakeup();
+}
+
 // Test parse error/live coding.
 // This MUST be the last test in the file!
 try {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -180,6 +180,11 @@ class ConstructorProp {
     ) {}
 }
 
+// Test support with PHP 8.0 non-capturing catch.
+try {
+} catch (SomeException) {}
+} catch (MyException | Throwable | AnotherException) {}
+
 // Test parse error/live coding.
 // This MUST be the last test in the file!
 try {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -112,6 +112,7 @@ try {
 function StringableTypeHint( Stringable $a ) {}
 
 // Test interfaces extending interfaces.
+interface DoesNotExtend {}
 interface MyReflection extends Reflector {}
 interface MySession extends SessionABC, SessionIdInterface {}
 
@@ -137,6 +138,7 @@ function errorLinePrecisionCheck(
 public Throwable $var; // Ignore, not a property, parse error.
 
 $anon = class() {
+    public $untypedProperty;
     public SessionUpdateTimestampHandlerInterface $property;
 };
 
@@ -161,3 +163,15 @@ class IntersectionTypes {
     public function paramType(SeekableIterator&SplSubject $param) {}
     public function returnType($param) : Reflector&Traversable {}
 }
+
+// Test very invalid type.
+function InvalidType($param): ?\&\SomeType {}
+
+// Test invalid catch.
+try {
+} catch ($e) {}
+
+// Test parse error/live coding.
+// This MUST be the last test in the file!
+try {
+} catch (

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -64,7 +64,7 @@ class NewInterfacesUnitTest extends BaseSniffTest
     public function dataNewInterface()
     {
         return [
-            ['Reflector', '4.4', [75, 116, 164], '5.0'],
+            ['Reflector', '4.4', [75, 116, 164, 178], '5.0'],
             ['Traversable', '4.4', [35, 50, 60, 71, 79, 164], '5.0'],
             ['Countable', '5.0', [3, 17, 41, 153], '5.1'],
             ['OuterIterator', '5.0', [4, 42, 65, 154], '5.1'],
@@ -79,7 +79,7 @@ class NewInterfacesUnitTest extends BaseSniffTest
             ['SessionIdInterface', '5.5.0', [89, 117, 146], '5.6', '5.5'],
             ['Throwable', '5.6', [37, 52, 62, 93, 98, 103, 162], '7.0'],
             ['SessionUpdateTimestampHandlerInterface', '5.6', [90, 142, 162], '7.0'],
-            ['Stringable', '7.4', [112], '8.0'],
+            ['Stringable', '7.4', [112, 179], '8.0'],
         ];
     }
 
@@ -206,7 +206,9 @@ class NewInterfacesUnitTest extends BaseSniffTest
             [160],
             [168],
             [172],
+            [175],
             [177],
+            [186],
         ];
     }
 

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -70,10 +70,10 @@ class NewInterfacesUnitTest extends BaseSniffTest
             ['OuterIterator', '5.0', [4, 42, 65, 154], '5.1'],
             ['RecursiveIterator', '5.0', [5, 43, 65, 154], '5.1'],
             ['SeekableIterator', '5.0', [6, 17, 28, 44, 163], '5.1'],
-            ['Serializable', '5.0', [7, 29, 45, 55, 70, 119, 125], '5.1'],
+            ['Serializable', '5.0', [7, 29, 45, 55, 70, 119, 125, 191], '5.1'],
             ['SplObserver', '5.0', [11, 46, 65, 153], '5.1'],
             ['SplSubject', '5.0', [12, 17, 47, 69, 163], '5.1'],
-            ['JsonSerializable', '5.3', [13, 48, 134, 135, 155], '5.4'],
+            ['JsonSerializable', '5.3', [13, 48, 134, 135, 155, 190], '5.4'],
             ['SessionHandlerInterface', '5.3', [14, 49, 147, 155], '5.4'],
             ['DateTimeInterface', '5.4', [36, 51, 61, 80], '5.5'],
             ['SessionIdInterface', '5.5.0', [89, 117, 146], '5.6', '5.5'],
@@ -115,6 +115,8 @@ class NewInterfacesUnitTest extends BaseSniffTest
             [31, '__wakeup'],
             [120, '__sleep'],
             [121, '__wakeup'],
+            [192, '__sleep'],
+            [193, '__wakeup'],
         ];
     }
 
@@ -209,7 +211,8 @@ class NewInterfacesUnitTest extends BaseSniffTest
             [175],
             [177],
             [185],
-            [191],
+            [189],
+            [199],
         ];
     }
 

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -26,7 +26,7 @@ class NewInterfacesUnitTest extends BaseSniffTest
 {
 
     /**
-     * testNewInterface
+     * Test detection of use of new interfaces.
      *
      * @dataProvider dataNewInterface
      *
@@ -64,21 +64,21 @@ class NewInterfacesUnitTest extends BaseSniffTest
     public function dataNewInterface()
     {
         return [
-            ['Reflector', '4.4', [75, 115, 162], '5.0'],
-            ['Traversable', '4.4', [35, 50, 60, 71, 79, 162], '5.0'],
-            ['Countable', '5.0', [3, 17, 41, 151], '5.1'],
-            ['OuterIterator', '5.0', [4, 42, 65, 152], '5.1'],
-            ['RecursiveIterator', '5.0', [5, 43, 65, 152], '5.1'],
-            ['SeekableIterator', '5.0', [6, 17, 28, 44, 161], '5.1'],
-            ['Serializable', '5.0', [7, 29, 45, 55, 70, 118, 124], '5.1'],
-            ['SplObserver', '5.0', [11, 46, 65, 151], '5.1'],
-            ['SplSubject', '5.0', [12, 17, 47, 69, 161], '5.1'],
-            ['JsonSerializable', '5.3', [13, 48, 133, 134, 153], '5.4'],
-            ['SessionHandlerInterface', '5.3', [14, 49, 145, 153], '5.4'],
+            ['Reflector', '4.4', [75, 116, 164], '5.0'],
+            ['Traversable', '4.4', [35, 50, 60, 71, 79, 164], '5.0'],
+            ['Countable', '5.0', [3, 17, 41, 153], '5.1'],
+            ['OuterIterator', '5.0', [4, 42, 65, 154], '5.1'],
+            ['RecursiveIterator', '5.0', [5, 43, 65, 154], '5.1'],
+            ['SeekableIterator', '5.0', [6, 17, 28, 44, 163], '5.1'],
+            ['Serializable', '5.0', [7, 29, 45, 55, 70, 119, 125], '5.1'],
+            ['SplObserver', '5.0', [11, 46, 65, 153], '5.1'],
+            ['SplSubject', '5.0', [12, 17, 47, 69, 163], '5.1'],
+            ['JsonSerializable', '5.3', [13, 48, 134, 135, 155], '5.4'],
+            ['SessionHandlerInterface', '5.3', [14, 49, 147, 155], '5.4'],
             ['DateTimeInterface', '5.4', [36, 51, 61, 80], '5.5'],
-            ['SessionIdInterface', '5.5.0', [89, 116, 144], '5.6', '5.5'],
-            ['Throwable', '5.6', [37, 52, 62, 93, 98, 103, 160], '7.0'],
-            ['SessionUpdateTimestampHandlerInterface', '5.6', [90, 140, 160], '7.0'],
+            ['SessionIdInterface', '5.5.0', [89, 117, 146], '5.6', '5.5'],
+            ['Throwable', '5.6', [37, 52, 62, 93, 98, 103, 162], '7.0'],
+            ['SessionUpdateTimestampHandlerInterface', '5.6', [90, 142, 162], '7.0'],
             ['Stringable', '7.4', [112], '8.0'],
         ];
     }
@@ -113,8 +113,8 @@ class NewInterfacesUnitTest extends BaseSniffTest
             [9, '__wakeup'],
             [30, '__sleep'],
             [31, '__wakeup'],
-            [119, '__sleep'],
-            [120, '__wakeup'],
+            [120, '__sleep'],
+            [121, '__wakeup'],
         ];
     }
 
@@ -144,8 +144,8 @@ class NewInterfacesUnitTest extends BaseSniffTest
     public function dataNoFalsePositivesUnsupportedMethods()
     {
         return [
-            [126],
             [127],
+            [128],
         ];
     }
 
@@ -166,7 +166,7 @@ class NewInterfacesUnitTest extends BaseSniffTest
 
 
     /**
-     * testNoFalsePositives
+     * Test the sniff doesn't throw false positives for valid code.
      *
      * @dataProvider dataNoFalsePositives
      *
@@ -199,9 +199,14 @@ class NewInterfacesUnitTest extends BaseSniffTest
             [85],
             [86],
             [108],
-            [137],
-            [149],
-            [158],
+            [115],
+            [138],
+            [141],
+            [151],
+            [160],
+            [168],
+            [172],
+            [177],
         ];
     }
 

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -77,7 +77,7 @@ class NewInterfacesUnitTest extends BaseSniffTest
             ['SessionHandlerInterface', '5.3', [14, 49, 147, 155], '5.4'],
             ['DateTimeInterface', '5.4', [36, 51, 61, 80], '5.5'],
             ['SessionIdInterface', '5.5.0', [89, 117, 146], '5.6', '5.5'],
-            ['Throwable', '5.6', [37, 52, 62, 93, 98, 103, 162], '7.0'],
+            ['Throwable', '5.6', [37, 52, 62, 93, 98, 103, 162, 186], '7.0'],
             ['SessionUpdateTimestampHandlerInterface', '5.6', [90, 142, 162], '7.0'],
             ['Stringable', '7.4', [112, 179], '8.0'],
         ];
@@ -208,7 +208,8 @@ class NewInterfacesUnitTest extends BaseSniffTest
             [172],
             [175],
             [177],
-            [186],
+            [185],
+            [191],
         ];
     }
 


### PR DESCRIPTION
### Interfaces/NewInterfaces: rename (private) method

... to a more accurate name.

### Interfaces/NewInterfaces: performance tweak

Only call the `Variables::getMemberProperties()` method when we know for sure something is an OO property to prevent a lot of exceptions which slow things down.

Related to #1477

### Interfaces/NewInterfaces: add extra tests

... for situations already handled, but previously untested.

Includes minor test doc tweaks.

### Interfaces/NewInterfaces: add tests with PHP 8.0+ constructor property promotion

The sniff already handles this correctly, no changes needed.

### Interfaces/NewInterfaces: add tests with PHP 8.0+ non-capturing catch

The sniff already handles this correctly, no changes needed.

### Interfaces/NewInterfaces: detect PHP 8.1+ enums implementing new interfaces

PHP 8.1 introduced enums.

Enums can implement interfaces, so enums should also be examined for new interfaces being implemented.

Note: enums cannot contain the magic `__sleep()` and `__wakeup()` methods (unsupported in combination with Serializable), but that's not the concern of this sniff.

Includes tests.