### PR TITLE
Interfaces/RemovedSerializable: skip over PHP 8.0+ attributes + detect on PHP 8.1 enums

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
@@ -379,7 +379,8 @@ class RemovedSerializableSniff extends Sniff
 
             $funcName = FunctionDeclarations::getName($phpcsFile, $nextFunc);
             if (empty($funcName) || \is_string($funcName) === false) {
-                $nextFunc = $functionScopeCloser;
+                // Shouldn't be possible, but just in case.
+                $nextFunc = $functionScopeCloser; // @codeCoverageIgnore
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
@@ -354,12 +354,20 @@ class RemovedSerializableSniff extends Sniff
         $foundMagicSerialize   = false;
         $foundMagicUnserialize = false;
 
-        while (($nextFunc = $phpcsFile->findNext([\T_FUNCTION, \T_DOC_COMMENT_OPEN_TAG], ($nextFunc + 1), $scopeCloser)) !== false) {
+        while (($nextFunc = $phpcsFile->findNext([\T_FUNCTION, \T_DOC_COMMENT_OPEN_TAG, \T_ATTRIBUTE], ($nextFunc + 1), $scopeCloser)) !== false) {
             // Skip over docblocks.
             if ($tokens[$nextFunc]['code'] === \T_DOC_COMMENT_OPEN_TAG
                 && isset($tokens[$nextFunc]['comment_closer'])
             ) {
                 $nextFunc = $tokens[$nextFunc]['comment_closer'];
+                continue;
+            }
+
+            // Skip over attributes.
+            if ($tokens[$nextFunc]['code'] === \T_ATTRIBUTE
+                && isset($tokens[$nextFunc]['attribute_closer'])
+            ) {
+                $nextFunc = $tokens[$nextFunc]['attribute_closer'];
                 continue;
             }
 

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
@@ -129,9 +129,9 @@ class SkipOverDocblocks implements Serializable, ArrayAccess{ // Deprecation war
      * docblock
      * should
      * be
-     * skipped
-     * over.
+     * skipped over.
      */
+    #[AttributeWhichCouldBeLong, ShouldBeSkippedOver( 10, self::CONST_VALUE)]
     public function unserialize( $data) {}
 }
 

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
@@ -182,5 +182,22 @@ interface ThisInterfaceIsNOTInTheList extends ArrayAcces, \Serializable, ThisInt
 // Reset property.
 // @codingStandardsChangeSetting PHPCompatibility.Interfaces.RemovedSerializable serializableInterfaces
 
+/*
+ * Safeguard handling of enums implementing Serializable
+ */
+enum DoesNotImplementAnyInterface {}
+enum DoesNotImplementSerializable implements SomeInterface, SomeOtherInterface {}
+
+enum HasSerializable implements Serializable { // Deprecation warning.
+    // These magic methods are not allowed on enums, so ignore them when determining the error.
+    public function __serialize() {
+        return $this->data;
+    }
+    public function __unserialize($data) {
+        $this->data = $data;
+    }
+}
+enum HasSerializableToo: string implements Serializable, ArrayAccess {} // Deprecation warning.
+
 // Must be last test: testing class without scope closer.
 class Something implements Serializable {

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
@@ -176,6 +176,9 @@ $anon = new class() implements \ThisInterfaceIsInTheList {
     public function __unserialize($data) {}
 };
 
+interface DoesNotExtend {}
+interface ThisInterfaceIsNOTInTheList extends ArrayAcces, \Serializable, ThisInterfaceisinTheList {} // Missing interface warning (plural found).
+
 // Reset property.
 // @codingStandardsChangeSetting PHPCompatibility.Interfaces.RemovedSerializable serializableInterfaces
 

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
@@ -94,7 +94,8 @@ class RemovedSerializableUnitTest extends BaseSniffTest
         }
 
         $data[] = [172];
-        $data[] = [183];
+        $data[] = [179];
+        $data[] = [186];
 
         return $data;
     }
@@ -227,6 +228,7 @@ class RemovedSerializableUnitTest extends BaseSniffTest
             [143],
             [145],
             [150],
+            [180],
         ];
     }
 

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
@@ -95,9 +95,75 @@ class RemovedSerializableUnitTest extends BaseSniffTest
 
         $data[] = [172];
         $data[] = [179];
-        $data[] = [186];
+        $data[] = [188];
+        $data[] = [189];
+
+        // Parse error.
+        $data[] = [203];
 
         return $data;
+    }
+
+
+    /**
+     * Test deprecated use of Serializable with enums is flagged.
+     *
+     * @dataProvider dataIsDeprecatedOnEnum
+     *
+     * @param int $line Line number where the warning should occur.
+     *
+     * @return void
+     */
+    public function testIsDeprecatedOnEnum($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1-');
+        $this->assertWarning($file, $line, 'The Serializable interface is deprecated since PHP 8.1.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsDeprecated()
+     *
+     * @return array
+     */
+    public function dataIsDeprecatedOnEnum()
+    {
+        return [
+            [191],
+            [200],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for enums.
+     *
+     * @dataProvider dataNoFalsePositivesDeprecatedOnEnum
+     *
+     * @param int $line Line number where no error should occur.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesDeprecatedOnEnum($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1-');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesDeprecated()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesDeprecatedOnEnum()
+    {
+        return [
+            [188],
+            [189],
+        ];
     }
 
 


### PR DESCRIPTION
### Interfaces/RemovedSerializable: skip over PHP 8.0+ attributes

... for efficiency in the token walking.

Tested by adjusting an existing unit test.

### Interfaces/RemovedSerializable: add a few more tests

... for situations handled, but previously not covered by tests.

### Interfaces/RemovedSerializable: detect PHP 8.1+ enums implementing Serializable

Enums can implement interfaces, but they do not support the magic `__[un]serialize()` methods.

This commit ensures that enums implementing the deprecated `Serializable` interface will be flagged with a dedicated error message which doesn't reference the solution which is available for classes.

Includes tests.

Includes removing a condition which is redundant as this is already checked via the `ObjectDeclarations::findImplementedInterfaceNames()` method.