### PR TITLE
ResolveHelper::getFQExtendedClassName(): stop accepting interface tokens and other tweaks

### DIFF
--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -93,7 +93,8 @@ final class ResolveHelper
      * the class name could not be reliably inferred.
      *
      * @since 7.0.3
-     * @since 10.0.0 This method is now static.
+     * @since 10.0.0 - This method is now static.
+     *               - The method no longer accepts interface tokens.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of a T_CLASS token.
@@ -111,7 +112,6 @@ final class ResolveHelper
 
         if ($tokens[$stackPtr]['code'] !== \T_CLASS
             && $tokens[$stackPtr]['code'] !== \T_ANON_CLASS
-            && $tokens[$stackPtr]['code'] !== \T_INTERFACE
         ) {
             return '';
         }

--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -105,19 +105,16 @@ final class ResolveHelper
     {
         $tokens = $phpcsFile->getTokens();
 
-        // Check for the existence of the token.
-        if (isset($tokens[$stackPtr]) === false) {
-            return '';
-        }
-
-        if ($tokens[$stackPtr]['code'] !== \T_CLASS
-            && $tokens[$stackPtr]['code'] !== \T_ANON_CLASS
+        // Check for the existence of the token and that it's one of the accepted tokens.
+        if (isset($tokens[$stackPtr]) === false
+            || ($tokens[$stackPtr]['code'] !== \T_CLASS
+            && $tokens[$stackPtr]['code'] !== \T_ANON_CLASS)
         ) {
             return '';
         }
 
         $extends = ObjectDeclarations::findExtendedClassName($phpcsFile, $stackPtr);
-        if (empty($extends) || \is_string($extends) === false) {
+        if (empty($extends)) {
             return '';
         }
 

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQExtendedClassNameUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQExtendedClassNameUnitTest.inc
@@ -46,6 +46,6 @@ class MyTestO extends anotherNS\DateTime {}
 class MyTestP extends \FQNS\DateTime {}
 
 /* test 16 */
-interface MyInterface extends \SomeInterface {}
+$anon = new class extends \SomeClass {};
 /* test 17 */
-interface MyInterface extends SomeInterface {}
+$anon = new class extends SomeClass {};

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQExtendedClassNameUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQExtendedClassNameUnitTest.inc
@@ -49,3 +49,6 @@ class MyTestP extends \FQNS\DateTime {}
 $anon = new class extends \SomeClass {};
 /* test 17 */
 $anon = new class extends SomeClass {};
+
+/* test 18 */
+interface Foo extends ArrayAccess, Iterable {}

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQExtendedClassNameUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQExtendedClassNameUnitTest.php
@@ -38,7 +38,7 @@ final class GetFQExtendedClassNameUnitTest extends UtilityMethodTestCase
      */
     public function testGetFQExtendedClassName($commentString, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, [\T_CLASS, \T_INTERFACE]);
+        $stackPtr = $this->getTargetToken($commentString, [\T_CLASS, \T_ANON_CLASS]);
         $result   = ResolveHelper::getFQExtendedClassName(self::$phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
@@ -68,8 +68,8 @@ final class GetFQExtendedClassNameUnitTest extends UtilityMethodTestCase
             ['/* test 13 */', '\Yet\More\Testing\DateTime'],
             ['/* test 14 */', '\Yet\More\Testing\anotherNS\DateTime'],
             ['/* test 15 */', '\FQNS\DateTime'],
-            ['/* test 16 */', '\SomeInterface'],
-            ['/* test 17 */', '\Yet\More\Testing\SomeInterface'],
+            ['/* test 16 */', '\SomeClass'],
+            ['/* test 17 */', '\Yet\More\Testing\SomeClass'],
         ];
     }
 }

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQExtendedClassNameUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQExtendedClassNameUnitTest.php
@@ -72,4 +72,38 @@ final class GetFQExtendedClassNameUnitTest extends UtilityMethodTestCase
             ['/* test 17 */', '\Yet\More\Testing\SomeClass'],
         ];
     }
+
+    /**
+     * Test an empty string is returned when an invalid token is passed.
+     *
+     * @dataProvider dataGetFQExtendedClassNameInvalidToken
+     *
+     * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQExtendedClassName
+     *
+     * @param string     $commentString The comment which prefaces the T_CLASS token in the test file.
+     * @param int|string $targetType    The token to pass to the method.
+     *
+     * @return void
+     */
+    public function testGetFQExtendedClassNameInvalidToken($commentString, $targetType)
+    {
+        $stackPtr = $this->getTargetToken($commentString, $targetType);
+        $result   = ResolveHelper::getFQExtendedClassName(self::$phpcsFile, $stackPtr);
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetFQExtendedClassNameInvalidToken()
+     *
+     * @return array
+     */
+    public function dataGetFQExtendedClassNameInvalidToken()
+    {
+        return [
+            ['/* test 2 */', \T_EXTENDS],
+            ['/* test 18 */', \T_INTERFACE],
+        ];
+    }
 }


### PR DESCRIPTION
### ResolveHelper::getFQExtendedClassName(): stop accepting interface tokens

Classes can only extend one other class, while interfaces can extend multiple other interfaces.

Treating interfaces as if they are classes will lead to incorrect results.

This method is currently only used by three sniffs which explicitly only check classes, so removing the allowance for `T_INTERFACE` tokens will not cause problems with existing sniffs and will make the method match its name and allow it to be reliable.

Includes transforming the tests which previously tested for getting an extended interface name to now test getting an extended class name for anonymous classes, which were previously untested.

### ResolveHelper::getFQExtendedClassName(): add extra tests

... to safeguard that the method does not accept tokens it shouldn't accept (and returns an empty string in those cases).

### ResolveHelper::getFQExtendedClassName(): minor simplification

* Fold two conditions with the same outcome into one.
* Remove redundant condition.