### PR TITLE
ResolveHelper::getFQClassNameFromNewToken(): implement PHPCSUtils and more

### DIFF
--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -12,6 +12,8 @@ namespace PHPCompatibility\Helpers;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
@@ -72,15 +74,11 @@ final class ResolveHelper
             return '';
         }
 
-        $find = [
-            \T_NS_SEPARATOR,
-            \T_STRING,
-            \T_NAMESPACE,
-            \T_WHITESPACE,
-        ];
+        $find                = Collections::namespacedNameTokens();
+        $find[\T_WHITESPACE] = \T_WHITESPACE;
 
         $end       = $phpcsFile->findNext($find, ($start + 1), null, true, null, true);
-        $className = $phpcsFile->getTokensAsString($start, ($end - $start));
+        $className = GetTokensAsString::noEmpties($phpcsFile, $start, ($end - 1));
         $className = \trim($className);
 
         return self::getFQName($phpcsFile, $stackPtr, $className);

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.inc
@@ -44,6 +44,8 @@ $className = 'DateTime';
 /* test 15 */
 new $className;
 
+/* test 17 */
+$anon = new class() {};
 
 // Issue #338 - no infinite loop on unfinished code.
 /* test 16 */

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.php
@@ -69,6 +69,21 @@ final class GetFQClassNameFromNewTokenUnitTest extends UtilityMethodTestCase
             ['/* test 14 */', '\AnotherTesting\DateTime'],
             ['/* test 15 */', ''],
             ['/* test 16 */', ''],
+            ['/* test 17 */', ''],
         ];
+    }
+
+    /**
+     * Test an empty string is returned when an invalid token is passed.
+     *
+     * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQClassNameFromNewToken
+     *
+     * @return void
+     */
+    public function testGetFQClassNameFromNewTokenInvalidToken()
+    {
+        $stackPtr = $this->getTargetToken('/* test 1 */', \T_STRING);
+        $result   = ResolveHelper::GetFQClassNameFromNewToken(self::$phpcsFile, $stackPtr);
+        $this->assertSame('', $result);
     }
 }


### PR DESCRIPTION
### ResolveHelper::getFQClassNameFromNewToken(): implement PHPCSUtils

### ResolveHelper::getFQClassNameFromNewToken(): add extra tests

* ... to safeguard that the method does not accept tokens it shouldn't accept (and returns an empty string in those cases).
* ... to safeguard that the method returns an empty string for the `new` keyword with an anonymous class.

### ResolveHelper::getFQClassNameFromNewToken(): minor simplifications

* Fold a couple of conditions with the same outcome into one.
* Remove check for `T_CLASS` token (old anon class tokenization). This is no longer needed now support for PHPCS < 3.7.1 has been dropped.
* Simplify the `findNext()` calls a little.