### PR TITLE
Sniffs checking properties: improve performance

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -19,6 +19,7 @@ use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ControlStructures;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\Variables;
 
 /**
@@ -1198,13 +1199,12 @@ class NewClassesSniff extends Sniff
      */
     private function processVariableToken(File $phpcsFile, $stackPtr)
     {
-        try {
-            $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
+        if (Scopes::isOOProperty($phpcsFile, $stackPtr) === false) {
             // Not a class property.
             return;
         }
 
+        $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
         if ($properties['type'] === '') {
             return;
         }

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
@@ -68,13 +68,12 @@ final class NewReadonlyPropertiesSniff extends Sniff
         $error  = 'Readonly properties are not supported in PHP 8.0 or earlier. Property %s was declared as readonly.';
 
         if ($tokens[$stackPtr]['code'] === \T_VARIABLE) {
-            try {
-                $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
-            } catch (RuntimeException $e) {
+            if (Scopes::isOOProperty($phpcsFile, $stackPtr) === false) {
                 // Not a class property.
                 return;
             }
 
+            $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
             if ($properties['is_readonly'] === false) {
                 // Not a readonly property.
                 return;

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -149,13 +149,12 @@ class NewTypedPropertiesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         if ($tokens[$stackPtr]['code'] === \T_VARIABLE) {
-            try {
-                $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
-            } catch (RuntimeException $e) {
+            if (Scopes::isOOProperty($phpcsFile, $stackPtr) === false) {
                 // Not a class property.
                 return;
             }
 
+            $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
             if ($properties['type'] === '') {
                 // Not a typed property.
                 return;

--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -20,6 +20,7 @@ use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ControlStructures;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
+use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\Variables;
 
 /**
@@ -379,13 +380,12 @@ class RemovedClassesSniff extends Sniff
      */
     private function processVariableToken(File $phpcsFile, $stackPtr)
     {
-        try {
-            $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
+        if (Scopes::isOOProperty($phpcsFile, $stackPtr) === false) {
             // Not a class property.
             return;
         }
 
+        $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
         if ($properties['type'] === '') {
             return;
         }


### PR DESCRIPTION
These sniffs would try to get the "properties" of **all** variables, while only OO property declarations have "properties".

This meant that in the majority of cases, the function call to `Variables::getMemberProperties()` would result in an exception which would need to be created, then caught and discarded.

By doing a preliminary check on whether a `T_VARIABLE` is a property or not and bowing out early in those cases, we prevent the need for and the overhead of all those exceptions, which should make a significant difference in performance.

Note: this does mean the `Scopes::isOOProperty()` method will be called twice, once here and once within the `Variables::getMemberProperties()` method, but the overhead of that duplicate function call is not comparable with the overhead of the exception creation.

This fix has now been applied to the following sniffs:
* `Classes/NewClasses`
* `Classes/NewReadonlyProperties`
* `Classes/NewTypedProperties`
* `Classes/RemovedClasses`

The same fix has already been applied to the `Interfaces/NewInterfaces` sniff in PR #1569

Related to #1477