### PR TITLE
AbstractInitialValueSniff: prevent potential infinite loop

### DIFF
--- a/PHPCompatibility/AbstractInitialValueSniff.php
+++ b/PHPCompatibility/AbstractInitialValueSniff.php
@@ -189,7 +189,8 @@ abstract class AbstractInitialValueSniff extends Sniff
                 || ($tokens[$stackPtr]['code'] === \T_CONST && $tokens[$start]['code'] !== \T_STRING)
                 || ($tokens[$stackPtr]['code'] !== \T_CONST && $tokens[$start]['code'] !== \T_VARIABLE)
             ) {
-                // Shouldn't be possible.
+                // Shouldn't be possible, skip over the problematic part of the statement.
+                $start = ($end + 1);
                 continue;
             }
 

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
@@ -159,6 +159,33 @@ FOOBAR;
 }
 
 /*
+ * Test detection in multi-declarations where not all parts have an initial value.
+ */
+static $a, $b, $c = <<<"EOT"
+Multi-declaration in static variable.
+EOT
+    $d;
+
+// Class properties.
+class foo
+{
+    private $baz, $foy = <<<FOOBAR
+Multi-declaration Property example
+FOOBAR
+        , $booboo;
+}
+
+/*
+ * Test to safeguard against a potentially infinite loop in the abstract.
+ * This code is a parse error, but we should still guard against infinite loops.
+ */
+class c {
+    public f() {
+        strpos($haystack, 'needle', 0);
+    }
+}
+
+/*
  * Safeguard that PHP 7.3+ flexible heredoc initial values are also detected correctly.
  * IMPORTANT: this must be the last test in the file!
  */

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -74,10 +74,12 @@ class NewHeredocUnitTest extends BaseSniffTest
             [136, 'default parameter values'],
             [146, 'constants'],
             [156, 'constants'],
+            [164, 'static variables'],
+            [172, 'class properties'],
         ];
 
         if (\PHP_VERSION_ID >= 70300) {
-            $data[] = [165, 'static variables'];
+            $data[] = [192, 'static variables'];
         }
 
         return $data;


### PR DESCRIPTION
The defensive coding which is in place for a few "shouldn't be possible" cases, does not move the stackPtr forward, which means that if those conditions are hit, there is the potential for the sniff getting into an infinite loop.

While this shouldn't be possible with valid PHP code, the infinite loop should still be avoided.

Fixed now.

Includes tests via the `NewHeredoc` sniff (which already has a `@covers` tag for the `AbstractInitialValueSniff`).

Props @jrchamp for reporting and working together with me to fix this.