### PR TITLE
GH Actions: update for php-coveralls 2.6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,19 +279,18 @@ jobs:
         if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         run: vendor/bin/phpunit -c phpunit10.xml.dist --coverage-cache ./build/phpunit-cache
 
-      # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
-      # Also PHP Coveralls itself (still) isn't fully compatible with PHP 8.0+.
-      - name: Switch to PHP 7.4
-        if: ${{ success() && matrix.php != '7.4' }}
+      # PHP Coveralls v2 (which supports GH Actions) has a PHP 5.5 minimum, so switch the PHP version.
+      - name: Switch to PHP latest
+        if: ${{ success() && matrix.php == '5.4' }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 'latest'
           coverage: none
 
-      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
+      # Global install is used to prevent a conflict with the local composer.lock.
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
+        run: composer global require php-coveralls/php-coveralls:"^2.6.0" --no-interaction
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}


### PR DESCRIPTION
PHP-Coveralls 2.6.0 has just been released and includes a fix for the last known PHP 8.x issue.

This means that it should now be safe to install php-coveralls on PHP 8.x and upload from there, which means we now only need the work-around for the PHP version when on PHP < 5.5 (as Coveralls v1 does not work with GH Actions).

Ref:
* https://github.com/php-coveralls/php-coveralls/releases/tag/v2.6.0