### PR TITLE
ParameterValues/NewIconvMbstringCharsetDefault: fixed various edge cases & improved modern PHP support

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -246,8 +246,8 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
      */
     public function processIconvMimeEncode(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
-        $error = 'The default value of the %s parameter index for iconv_mime_encode() was changed from ISO-8859-1 to UTF-8 in PHP 5.6. For cross-version compatibility, the %s should be explicitly set.';
-        $data  = [
+        $errorMsg = 'The default value of the %s parameter index for iconv_mime_encode() was changed from ISO-8859-1 to UTF-8 in PHP 5.6. For cross-version compatibility, the %s should be explicitly set.';
+        $data     = [
             '$options[\'input/output-charset\']',
             '$options[\'input-charset\'] and $options[\'output-charset\'] indexes',
         ];
@@ -256,7 +256,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
         $paramInfo   = $this->targetFunctions[$functionLC];
         $targetParam = PassedParameters::getParameterFromStack($parameters, $paramInfo['position'], $paramInfo['name']);
         if ($targetParam === false) {
-            $phpcsFile->addError($error, $stackPtr, 'PreferencesNotSet', $data);
+            $phpcsFile->addError($errorMsg, $stackPtr, 'PreferencesNotSet', $data);
             return;
         }
 
@@ -264,7 +264,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
         $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
         if ($firstNonEmpty === false) {
             // Parse error or live coding, but preferences is definitely not set, so throw the error.
-            $phpcsFile->addError($error, $stackPtr, 'PreferencesNotSet', $data);
+            $phpcsFile->addError($errorMsg, $stackPtr, 'PreferencesNotSet', $data);
             return;
         }
 
@@ -281,7 +281,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
 
             if ($hasInputCharset !== 1) {
                 $phpcsFile->addError(
-                    $error,
+                    $errorMsg,
                     $firstNonEmpty,
                     'InputPreferenceNotSet',
                     [
@@ -293,7 +293,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
 
             if ($hasOutputCharset !== 1) {
                 $phpcsFile->addError(
-                    $error,
+                    $errorMsg,
                     $firstNonEmpty,
                     'OutputPreferenceNotSet',
                     [
@@ -308,7 +308,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
 
         // The $options parameter was passed, but it was a variable/constant/output of a function call.
         $phpcsFile->addWarning(
-            $error,
+            $errorMsg,
             $firstNonEmpty,
             'Undetermined',
             [

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -14,6 +14,8 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -269,7 +271,8 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
         }
 
         if ($tokens[$firstNonEmpty]['code'] === \T_ARRAY
-            || $tokens[$firstNonEmpty]['code'] === \T_OPEN_SHORT_ARRAY
+            || (isset(Collections::shortArrayListOpenTokensBC()[$tokens[$firstNonEmpty]['code']]) === true
+                && Arrays::isShortArray($phpcsFile, $firstNonEmpty) === true)
         ) {
             // Note: the item names are treated case-sensitively in PHP, so match on exact case.
             $hasInputCharset  = \preg_match('`([\'"])input-charset\1\s*=>`', $targetParam['clean']);

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -247,28 +247,24 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
     public function processIconvMimeEncode(File $phpcsFile, $stackPtr, $functionName, $parameters)
     {
         $error = 'The default value of the %s parameter index for iconv_mime_encode() was changed from ISO-8859-1 to UTF-8 in PHP 5.6. For cross-version compatibility, the %s should be explicitly set.';
+        $data  = [
+            '$options[\'input/output-charset\']',
+            '$options[\'input-charset\'] and $options[\'output-charset\'] indexes',
+        ];
 
         $functionLC  = \strtolower($functionName);
         $paramInfo   = $this->targetFunctions[$functionLC];
         $targetParam = PassedParameters::getParameterFromStack($parameters, $paramInfo['position'], $paramInfo['name']);
         if ($targetParam === false) {
-            $phpcsFile->addError(
-                $error,
-                $stackPtr,
-                'PreferencesNotSet',
-                [
-                    '$options[\'input/output-charset\']',
-                    '$options[\'input-charset\'] and $options[\'output-charset\'] indexes',
-                ]
-            );
-
+            $phpcsFile->addError($error, $stackPtr, 'PreferencesNotSet', $data);
             return;
         }
 
         $tokens        = $phpcsFile->getTokens();
         $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
         if ($firstNonEmpty === false) {
-            // Parse error or live coding.
+            // Parse error or live coding, but preferences is definitely not set, so throw the error.
+            $phpcsFile->addError($error, $stackPtr, 'PreferencesNotSet', $data);
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -274,15 +274,22 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
             || (isset(Collections::shortArrayListOpenTokensBC()[$tokens[$firstNonEmpty]['code']]) === true
                 && Arrays::isShortArray($phpcsFile, $firstNonEmpty) === true)
         ) {
-            // Note: the item names are treated case-sensitively in PHP, so match on exact case.
-            $hasInputCharset  = \preg_match('`([\'"])input-charset\1\s*=>`', $targetParam['clean']);
-            $hasOutputCharset = \preg_match('`([\'"])output-charset\1\s*=>`', $targetParam['clean']);
-            if ($hasInputCharset === 1 && $hasOutputCharset === 1) {
+            $arrayItems       = PassedParameters::getParameters($phpcsFile, $firstNonEmpty);
+            $hasInputCharset  = 0;
+            $hasOutputCharset = 0;
+
+            foreach ($arrayItems as $item) {
+                // Note: the item names are treated case-sensitively in PHP, so match on exact case.
+                $hasInputCharset  += \preg_match('`^\s*([\'"])input-charset\1\s*=>`', $item['clean']);
+                $hasOutputCharset += \preg_match('`^\s*([\'"])output-charset\1\s*=>`', $item['clean']);
+            }
+
+            if ($hasInputCharset > 0 && $hasOutputCharset > 0) {
                 // Both input as well as output charset are set.
                 return;
             }
 
-            if ($hasInputCharset !== 1) {
+            if ($hasInputCharset === 0) {
                 $phpcsFile->addError(
                     $errorMsg,
                     $firstNonEmpty,
@@ -294,7 +301,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
                 );
             }
 
-            if ($hasOutputCharset !== 1) {
+            if ($hasOutputCharset === 0) {
                 $phpcsFile->addError(
                     $errorMsg,
                     $firstNonEmpty,

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
@@ -167,3 +167,40 @@ $a = iconv_mime_encode(
         'output-charset'   => 'UTF-8',
     )
 ); // Error: 'input-charset' not set.
+
+// Test handling of PHP 7.4+ spread in array.
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    [
+        ...$options
+    ]
+); // Warning: Undetermined.
+
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    [
+        'input-charset'  => 'ISO-8859-1',
+        ...$options,
+        'output-charset' => 'UTF-8',
+    ]
+); // OK.
+
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    [
+        'input-charset'  => 'ISO-8859-1',
+        ... /*comment*/ $options,
+    ]
+); // Warning: 'output-charset' potentially not set.
+
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    [
+        ...$options,
+        'output-charset' => 'UTF-8',
+    ]
+); // Warning: 'input-charset' potentially not set.

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
@@ -133,3 +133,6 @@ $a = iconv_mime_encode(
     $field_value,
     [ 'scheme' => $scheme, 'line-length' => $lineLength, 'input-charset' => $inputChar, 'output-charset' => $outputChar ] = $sourceInfo,
 ); // Bad. Parameter is not an array, user error, but does mean target keys are missing.
+
+// Safeguard handling of function as PHP 8.1+ first class callable.
+$var = array_map( iconv_mime_encode(...), ...$arrays );

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
@@ -121,3 +121,15 @@ $a = iconv_mime_encode(
 
 $a = iconv_mime_encode( $field_name, $field_value, /*comment*/ ); // Error: $options not set.
 $a = iconv_mime_encode( options: , field_name: $field_name, field_value: $field_value, ); // Parse error, but that's not our concern. Error: $options not set.
+
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    [ $scheme, $lineLength, , $lineBreakChars ] = $sourceInfo,
+); // Bad. Parameter is not an array, user error, but does mean target keys are missing.
+
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    [ 'scheme' => $scheme, 'line-length' => $lineLength, 'input-charset' => $inputChar, 'output-charset' => $outputChar ] = $sourceInfo,
+); // Bad. Parameter is not an array, user error, but does mean target keys are missing.

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
@@ -136,3 +136,34 @@ $a = iconv_mime_encode(
 
 // Safeguard handling of function as PHP 8.1+ first class callable.
 $var = array_map( iconv_mime_encode(...), ...$arrays );
+
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    [
+        'sub-options' => [
+            'input-charset'  => 'ISO-8859-1',
+            'output-charset' => 'UTF-8',
+        ],
+        'line-length' => 80,
+    ]
+); // Error: 'input-charset/output-charset' not set (as they are not set as keys on the top-level array.
+
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    array(
+        'input-charset'    => 'ISO-8859-1',
+        'input-charset'    => 'ISO-8859-1',
+        'output-charset'   => 'UTF-8',
+    )
+); // OK. Parameter set and the expected array keys set as well. The fact that there are duplicate array keys is irrelevant.
+
+$a = iconv_mime_encode(
+    $field_name,
+    $field_value,
+    array(
+        'output-charset'   => 'UTF-8',
+        'output-charset'   => 'UTF-8',
+    )
+); // Error: 'input-charset' not set.

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
@@ -118,3 +118,6 @@ $a = iconv_mime_encode(
         'line-length'      => 80,
     ]
 ); // Error: 'input-charset' not set (because case-sensitive).
+
+$a = iconv_mime_encode( $field_name, $field_value, /*comment*/ ); // Error: $options not set.
+$a = iconv_mime_encode( options: , field_name: $field_name, field_value: $field_value, ); // Parse error, but that's not our concern. Error: $options not set.

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -149,6 +149,9 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
             [123, '$options[\'input/output-charset\']'],
             [128, '$options[\'input/output-charset\']', 'warning'],
             [134, '$options[\'input/output-charset\']', 'warning'],
+            [143, '$options[\'input-charset\']'],
+            [143, '$options[\'output-charset\']'],
+            [165, '$options[\'input-charset\']'],
         ];
     }
 
@@ -185,6 +188,10 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
         }
 
         $data[] = [138];
+
+        for ($line = 152; $line <= 161; $line++) {
+            $data[] = [$line];
+        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -145,6 +145,8 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
             [96, '$options[\'output-charset\']'],
             [106, '$options[\'input-charset\']'],
             [115, '$options[\'input-charset\']'],
+            [122, '$options[\'input/output-charset\']'],
+            [123, '$options[\'input/output-charset\']'],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -152,6 +152,10 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
             [143, '$options[\'input-charset\']'],
             [143, '$options[\'output-charset\']'],
             [165, '$options[\'input-charset\']'],
+            [175, '$options[\'input-charset\']', 'warning'],
+            [175, '$options[\'output-charset\']', 'warning'],
+            [193, '$options[\'output-charset\']', 'warning'],
+            [202, '$options[\'input-charset\']', 'warning'],
         ];
     }
 
@@ -190,6 +194,10 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
         $data[] = [138];
 
         for ($line = 152; $line <= 161; $line++) {
+            $data[] = [$line];
+        }
+
+        for ($line = 180; $line <= 188; $line++) {
             $data[] = [$line];
         }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -184,6 +184,8 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
             $data[] = [$line];
         }
 
+        $data[] = [138];
+
         return $data;
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -147,6 +147,8 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
             [115, '$options[\'input-charset\']'],
             [122, '$options[\'input/output-charset\']'],
             [123, '$options[\'input/output-charset\']'],
+            [128, '$options[\'input/output-charset\']', 'warning'],
+            [134, '$options[\'input/output-charset\']', 'warning'],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -156,16 +156,35 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
     /**
      * Test that there are no false positives.
      *
+     * @dataProvider dataNoFalsePositivesIconvMimeEncode
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositivesIconvMimeEncode()
+    public function testNoFalsePositivesIconvMimeEncode($line)
     {
         $file = $this->sniffFile(__FILE__, '5.4-7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesIconvMimeEncode()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositivesIconvMimeEncode()
+    {
+        $data = [];
 
         // No errors expected on line 79 - 89.
         for ($line = 79; $line <= 89; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        return $data;
     }
 
 


### PR DESCRIPTION
Sniff review executed together with @diedexx during a co-working session.

---

### ParameterValues/NewIconvMbstringCharsetDefault: fix false negative

If a (named) parameter is passed without a value, the sniff would not throw an error, while it should.

Even though it is a parse error, the sniff can safely conclude that the target array keys will not be set if there is no value for the parameter.

Includes test.

### ParameterValues/NewIconvMbstringCharsetDefault: rename local parameter

### ParameterValues/NewIconvMbstringCharsetDefault: bug fix - sniff gets confused over list param

The `iconv_mime_encode()` function expects an array as the third `$options` parameter, but the sniff did not verify that a short array token was for a short array, not a short list.

This meant that the sniff would incorrectly treat short lists as if they were arrays, leading to potential false positives + false negatives.
Even though that is silly code and shouldn't exist in real life, the sniff should still handle it correctly.

Fixed now.

Includes test.

### ParameterValues/NewIconvMbstringCharsetDefault: refactor no false positives test to data provider

No changes to the actual test.

### ParameterValues/NewIconvMbstringCharsetDefault: add test with PHP 8.1first class callables

... which is already handled correctly by the PHPCSUtils `PassedParameters` class. The test just safeguards this.

### ParameterValues/NewIconvMbstringCharsetDefault: prevent false negatives on $options

As things were, the sniff would do a regex match on the complete content of all tokens concatenated together, as found within the array, instead of checking the individual array items.

While it would probably be exceedingly rare for this bug to come into play in real life, the sniff should still handle things correctly.

Fixed now by parsing the array to its individual items and check each individual array item for the required keys.

Includes tests.

### ParameterValues/NewIconvMbstringCharsetDefault: handle PHP 7.4+ spread in array

PHP 7.4+ introduced "spread in array" (unpacking of one array into another).

As this sniff looks for specific keys in a hard-coded array passed to the `iconv_mime_encode()` function, this could confuse things and could lead to false positives for keys which are being set via the spread out array.

Along the same lines as the `Undetermined` warning when the value of the `$options` parameter is variable, this commit changes the errors for missing array keys in a found `$options` arrays to warnings when the sniff also detected array unpacking within the same array parameter.

Includes tests.

