### PR TITLE
Tests: rename base class and make abstract

### DIFF
--- a/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
+++ b/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Attributes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewAttributes sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewAttributesUnitTest extends BaseSniffTest
+class NewAttributesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -30,7 +30,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
  * @since 9.0.0  Dropped support for PHP_CodeSniffer 1.x.
  * @since 10.0.0 Updated for preliminary support of PHP_CodeSniffer 4 and dropped support for PHPCS 2.x.
  */
-class BaseSniffTest extends TestCase
+abstract class BaseSniffTestCase extends TestCase
 {
     use AssertStringContains;
 

--- a/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenExtendingFinalPHPClass sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class ForbiddenExtendingFinalPHPClassUnitTest extends BaseSniffTest
+class ForbiddenExtendingFinalPHPClassUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewAnonymousClasses sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class NewAnonymousClassesUnitTest extends BaseSniffTest
+class NewAnonymousClassesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewClasses sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class NewClassesUnitTest extends BaseSniffTest
+class NewClassesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewConstVisibility sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.7
  */
-class NewConstVisibilityUnitTest extends BaseSniffTest
+class NewConstVisibilityUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewConstructorPropertyPromotion sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-final class NewConstructorPropertyPromotionUnitTest extends BaseSniffTest
+final class NewConstructorPropertyPromotionUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewFinalConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewFinalConstantsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewFinalConstants sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewFinalConstantsUnitTest extends BaseSniffTest
+class NewFinalConstantsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewLateStaticBinding sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.3
  */
-class NewLateStaticBindingUnitTest extends BaseSniffTest
+class NewLateStaticBindingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewReadonlyClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyClassesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewReadonlyClasses sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-final class NewReadonlyClassesUnitTest extends BaseSniffTest
+final class NewReadonlyClassesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewReadonlyProperties sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-final class NewReadonlyPropertiesUnitTest extends BaseSniffTest
+final class NewReadonlyPropertiesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewTypedProperties sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.2.0
  */
-class NewTypedPropertiesUnitTest extends BaseSniffTest
+class NewTypedPropertiesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedClasses sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedClassesUnitTest extends BaseSniffTest
+class RemovedClassesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedOrphanedParent sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.2.0
  */
-class RemovedOrphanedParentUnitTest extends BaseSniffTest
+class RemovedOrphanedParentUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Constants/NewConstantsInTraitsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewConstantsInTraitsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Constants;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewConstantsInTraits sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-final class NewConstantsInTraitsUnitTest extends BaseSniffTest
+final class NewConstantsInTraitsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Constants;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewConstants sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.1.0
  */
-class NewConstantsUnitTest extends BaseSniffTest
+class NewConstantsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Constants;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewMagicClassConstant sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.1.4
  */
-class NewMagicClassConstantUnitTest extends BaseSniffTest
+class NewMagicClassConstantUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Constants;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedConstants sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.1.0
  */
-class RemovedConstantsUnitTest extends BaseSniffTest
+class RemovedConstantsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ControlStructures;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the DiscouragedSwitchContinue sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.2.0
  */
-class DiscouragedSwitchContinueUnitTest extends BaseSniffTest
+class DiscouragedSwitchContinueUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ControlStructures;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenBreakContinueOutsideLoop sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.7
  */
-class ForbiddenBreakContinueOutsideLoopUnitTest extends BaseSniffTest
+class ForbiddenBreakContinueOutsideLoopUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ControlStructures;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenBreakContinueVariableArguments sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTest
+class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ControlStructures;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenSwitchWithMultipleDefaultBlocks sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTest
+class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ControlStructures;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewExecutionDirectives sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.3
  */
-class NewExecutionDirectivesUnitTest extends BaseSniffTest
+class NewExecutionDirectivesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/NewForeachExpressionReferencingUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewForeachExpressionReferencingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ControlStructures;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewForeachExpressionReferencing sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class NewForeachExpressionReferencingUnitTest extends BaseSniffTest
+class NewForeachExpressionReferencingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ControlStructures;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewListInForeach sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class NewListInForeachUnitTest extends BaseSniffTest
+class NewListInForeachUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ControlStructures;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewMultiCatch sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.7
  */
-class NewMultiCatchUnitTest extends BaseSniffTest
+class NewMultiCatchUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ControlStructures;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewNonCapturingCatch sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewNonCapturingCatchUnitTest extends BaseSniffTest
+class NewNonCapturingCatchUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Extensions;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedExtensions sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class RemovedExtensionsUnitTest extends BaseSniffTest
+class RemovedExtensionsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the AbstractPrivateMethods sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @since 9.2.0
  * @since 10.0.0 Moved from `Classes` to `FunctionDeclarations`.
  */
-class AbstractPrivateMethodsUnitTest extends BaseSniffTest
+class AbstractPrivateMethodsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenFinalPrivateMethods sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTest
+class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenParameterShadowSuperGlobals sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.3
  */
-class ForbiddenParameterShadowSuperGlobalsUnitTest extends BaseSniffTest
+class ForbiddenParameterShadowSuperGlobalsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenParametersWithSameName sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTest
+class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenToStringParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenToStringParametersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenToStringParameters sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.2.0
  */
-class ForbiddenToStringParametersUnitTest extends BaseSniffTest
+class ForbiddenToStringParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenVariableNamesInClosureUse sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.1.4
  */
-class ForbiddenVariableNamesInClosureUseUnitTest extends BaseSniffTest
+class ForbiddenVariableNamesInClosureUseUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewArrowFunctionUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewArrowFunctionUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * New Arrow Function Sniff tests
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewArrowFunctionUnitTest extends BaseSniffTest
+class NewArrowFunctionUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewClosure sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class NewClosureUnitTest extends BaseSniffTest
+class NewClosureUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewExceptionsFromToString sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.2.0
  */
-class NewExceptionsFromToStringUnitTest extends BaseSniffTest
+class NewExceptionsFromToStringUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewNullableTypes sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.7
  */
-class NewNullableTypesUnitTest extends BaseSniffTest
+class NewNullableTypesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewParamTypeDeclarations sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class NewParamTypeDeclarationsUnitTest extends BaseSniffTest
+class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewReturnTypeDeclarations sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class NewReturnTypeDeclarationsUnitTest extends BaseSniffTest
+class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewTrailingComma sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewTrailingCommaUnitTest extends BaseSniffTest
+class NewTrailingCommaUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NonStaticMagicMethods sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class NonStaticMagicMethodsUnitTest extends BaseSniffTest
+class NonStaticMagicMethodsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedCallingDestructAfterConstructorExit sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTest
+class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedOptionalBeforeRequiredParam sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTest
+class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedReturnByReferenceFromVoid sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedReturnByReferenceFromVoidUnitTest extends BaseSniffTest
+class RemovedReturnByReferenceFromVoidUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionNameRestrictions;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewMagicMethods sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.4
  */
-class NewMagicMethodsUnitTest extends BaseSniffTest
+class NewMagicMethodsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionNameRestrictions;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedMagicAutoload sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.1.0
  */
-class RemovedMagicAutoloadUnitTest extends BaseSniffTest
+class RemovedMagicAutoloadUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionNameRestrictions;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedNamespacedAssert sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class RemovedNamespacedAssertUnitTest extends BaseSniffTest
+class RemovedNamespacedAssertUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionNameRestrictions;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedPHP4StyleConstructors sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTest
+class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionNameRestrictions;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ReservedFunctionNames sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.2.0
  */
-class ReservedFunctionNamesUnitTest extends BaseSniffTest
+class ReservedFunctionNamesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ArgumentFunctionsReportCurrentValue sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.1.0
  */
-class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTest
+class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ArgumentFunctionsUsage sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.2.0
  */
-class ArgumentFunctionsUsageUnitTest extends BaseSniffTest
+class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewFunctionParameters sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class NewFunctionParametersUnitTest extends BaseSniffTest
+class NewFunctionParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewFunctions sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class NewFunctionsUnitTest extends BaseSniffTest
+class NewFunctionsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewNamedParameters sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewNamedParametersUnitTest extends BaseSniffTest
+class NewNamedParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the OptionalToRequiredFunctionParameters sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.1.0
  */
-class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTest
+class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedFunctionParameters sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class RemovedFunctionParametersUnitTest extends BaseSniffTest
+class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedFunctions sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class RemovedFunctionsUnitTest extends BaseSniffTest
+class RemovedFunctionsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\FunctionUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RequiredToOptionalFunctionParameters sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.3
  */
-class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTest
+class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Generators;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewGeneratorReturn sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.2.0
  */
-class NewGeneratorReturnUnitTest extends BaseSniffTest
+class NewGeneratorReturnUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\IniDirectives;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewIniDirectives sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class NewIniDirectivesUnitTest extends BaseSniffTest
+class NewIniDirectivesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\IniDirectives;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedIniDirectives sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class RemovedIniDirectivesUnitTest extends BaseSniffTest
+class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\InitialValue;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewConstantArraysUsingConst sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.1.4
  */
-class NewConstantArraysUsingConstUnitTest extends BaseSniffTest
+class NewConstantArraysUsingConstUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\InitialValue;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewConstantArraysUsingDefine sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class NewConstantArraysUsingDefineUnitTest extends BaseSniffTest
+class NewConstantArraysUsingDefineUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\InitialValue;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewConstantScalarExpressions sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.2.0
  */
-class NewConstantScalarExpressionsUnitTest extends BaseSniffTest
+class NewConstantScalarExpressionsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\InitialValue;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewHeredoc sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.1.4
  */
-class NewHeredocUnitTest extends BaseSniffTest
+class NewHeredocUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/InitialValue/NewNewInDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewNewInDefineUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\InitialValue;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewNewInDefine sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-final class NewNewInDefineUnitTest extends BaseSniffTest
+final class NewNewInDefineUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/InitialValue/NewNewInInitializersUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewNewInInitializersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\InitialValue;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewNewInInitializers sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-final class NewNewInInitializersUnitTest extends BaseSniffTest
+final class NewNewInInitializersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Interfaces;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the InternalInterfaces sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.3
  */
-class InternalInterfacesUnitTest extends BaseSniffTest
+class InternalInterfacesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Interfaces;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewInterfaces sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.3
  */
-class NewInterfacesUnitTest extends BaseSniffTest
+class NewInterfacesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Interfaces;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedSerializable sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedSerializableUnitTest extends BaseSniffTest
+class RemovedSerializableUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Keywords;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the CaseSensitiveKeywords sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.1.4
  */
-class CaseSensitiveKeywordsUnitTest extends BaseSniffTest
+class CaseSensitiveKeywordsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Keywords;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenNames sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class ForbiddenNamesUnitTest extends BaseSniffTest
+class ForbiddenNamesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Keywords;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewKeywords sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class NewKeywordsUnitTest extends BaseSniffTest
+class NewKeywordsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\LanguageConstructs;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewEmptyNonVariable sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.4
  */
-class NewEmptyNonVariableUnitTest extends BaseSniffTest
+class NewEmptyNonVariableUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\LanguageConstructs;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewLanguageConstructs sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.6
  */
-class NewLanguageConstructsUnitTest extends BaseSniffTest
+class NewLanguageConstructsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Lists;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the AssignmentOrder sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class AssignmentOrderUnitTest extends BaseSniffTest
+class AssignmentOrderUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Lists;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenEmptyListAssignment sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTest
+class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Lists;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewKeyedList sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class NewKeyedListUnitTest extends BaseSniffTest
+class NewKeyedListUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Lists;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewListReferenceAssignment sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class NewListReferenceAssignmentUnitTest extends BaseSniffTest
+class NewListReferenceAssignmentUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Lists;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewShortList sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class NewShortListUnitTest extends BaseSniffTest
+class NewShortListUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\MethodUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenToStringParameters sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.2.0
  */
-class ForbiddenToStringParametersUnitTest extends BaseSniffTest
+class ForbiddenToStringParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\MethodUse;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewDirectCallsToClone sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.1.0
  */
-class NewDirectCallsToCloneUnitTest extends BaseSniffTest
+class NewDirectCallsToCloneUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Miscellaneous;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewPHPOpenTagEOF sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class NewPHPOpenTagEOFUnitTest extends BaseSniffTest
+class NewPHPOpenTagEOFUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Miscellaneous;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedAlternativePHPTags sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.4
  */
-class RemovedAlternativePHPTagsUnitTest extends BaseSniffTest
+class RemovedAlternativePHPTagsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Namespaces;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ReservedNames sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class ReservedNamesUnitTest extends BaseSniffTest
+class ReservedNamesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Numbers;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Tests for the NewExplicitOctalNotationSniff sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewExplicitOctalNotationUnitTest extends BaseSniffTest
+class NewExplicitOctalNotationUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Numbers;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 use PHPCSUtils\BackCompat\Helper;
 
 /**
@@ -23,7 +23,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @since 10.0.0
  */
-class NewNumericLiteralSeparatorUnitTest extends BaseSniffTest
+class NewNumericLiteralSeparatorUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Numbers/RemovedHexadecimalNumericStringsUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/RemovedHexadecimalNumericStringsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Numbers;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedHexadecimalNumericStrings sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @since 7.0.3
  * @since 10.0.0 Split off from the ValidIntegers sniff.
  */
-class RemovedHexadecimalNumericStringsUnitTest extends BaseSniffTest
+class RemovedHexadecimalNumericStringsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Numbers/ValidIntegersUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/ValidIntegersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Numbers;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ValidIntegers sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.3
  */
-class ValidIntegersUnitTest extends BaseSniffTest
+class ValidIntegersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Operators;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ChangedConcatOperatorPrecedence sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.2.0
  */
-class ChangedConcatOperatorPrecedenceUnitTest extends BaseSniffTest
+class ChangedConcatOperatorPrecedenceUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Operators;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenNegativeBitshift sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class ForbiddenNegativeBitshiftUnitTest extends BaseSniffTest
+class ForbiddenNegativeBitshiftUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Operators;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewOperators sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @since 9.0.0 Detection of new operators was originally included in the
  *              NewLanguageConstructSniff (since 5.6).
  */
-class NewOperatorsUnitTest extends BaseSniffTest
+class NewOperatorsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Operators;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewShortTernary sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class NewShortTernaryUnitTest extends BaseSniffTest
+class NewShortTernaryUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Operators;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedTernaryAssociativity sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.2.0
  */
-class RemovedTernaryAssociativityUnitTest extends BaseSniffTest
+class RemovedTernaryAssociativityUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ChangedIntToBoolParamType sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class ChangedIntToBoolParamTypeUnitTest extends BaseSniffTest
+class ChangedIntToBoolParamTypeUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ChangedObStartEraseFlags sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class ChangedObStartEraseFlagsUnitTest extends BaseSniffTest
+class ChangedObStartEraseFlagsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenGetClassNull sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class ForbiddenGetClassNullUnitTest extends BaseSniffTest
+class ForbiddenGetClassNullUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenSessionModuleNameUser sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class ForbiddenSessionModuleNameUserUnitTest extends BaseSniffTest
+class ForbiddenSessionModuleNameUserUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenStripTagsSelfClosingXHTML sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTest
+class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewArrayMergeRecursiveWithGlobalsVar sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-final class NewArrayMergeRecursiveWithGlobalsVarUnitTest extends BaseSniffTest
+final class NewArrayMergeRecursiveWithGlobalsVarUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewArrayReduceInitialType sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class NewArrayReduceInitialTypeUnitTest extends BaseSniffTest
+class NewArrayReduceInitialTypeUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewAssertCustomException sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewAssertCustomExceptionUnitTest extends BaseSniffTest
+class NewAssertCustomExceptionUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewFopenModes sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class NewFopenModesUnitTest extends BaseSniffTest
+class NewFopenModesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewHTMLEntitiesEncoding sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class NewHTMLEntitiesEncodingDefaultUnitTest extends BaseSniffTest
+class NewHTMLEntitiesEncodingDefaultUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewHTMLEntitiesFlagsDefault sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewHTMLEntitiesFlagsDefaultUnitTest extends BaseSniffTest
+class NewHTMLEntitiesFlagsDefaultUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewHashAlgorithms sniff.
@@ -24,7 +24,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.7
  */
-class NewHashAlgorithmsUnitTest extends BaseSniffTest
+class NewHashAlgorithmsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewIDNVariantDefault sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class NewIDNVariantDefaultUnitTest extends BaseSniffTest
+class NewIDNVariantDefaultUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewIconvMbstringCharsetDefault sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTest
+class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewNegativeStringOffset sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class NewNegativeStringOffsetUnitTest extends BaseSniffTest
+class NewNegativeStringOffsetUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewNumberFormatMultibyteSeparators sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewNumberFormatMultibyteSeparatorsUnitTest extends BaseSniffTest
+class NewNumberFormatMultibyteSeparatorsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewPCREModifiers sniff.
@@ -24,7 +24,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.2.0
  */
-class NewPCREModifiersUnitTest extends BaseSniffTest
+class NewPCREModifiersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewPackFormat sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class NewPackFormatUnitTest extends BaseSniffTest
+class NewPackFormatUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewPasswordAlgoConstantValues sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class NewPasswordAlgoConstantValuesUnitTest extends BaseSniffTest
+class NewPasswordAlgoConstantValuesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewProcOpenCmdArray sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class NewProcOpenCmdArrayUnitTest extends BaseSniffTest
+class NewProcOpenCmdArrayUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewStripTagsAllowableTagsArray sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTest
+class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedAssertStringAssertion sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedAssertStringAssertionUnitTest extends BaseSniffTest
+class RemovedAssertStringAssertionUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedGetDefinedFunctionsExcludeDisabledFalse sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest extends BaseSniffTest
+class RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedHashAlgorithms sniff.
@@ -24,7 +24,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class RemovedHashAlgorithmsUnitTest extends BaseSniffTest
+class RemovedHashAlgorithmsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedIconvEncoding sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class RemovedIconvEncodingUnitTest extends BaseSniffTest
+class RemovedIconvEncodingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedImplodeFlexibleParamOrder sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTest
+class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedMbCheckEncodingNoArgs sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedMbCheckEncodingNoArgsUnitTest extends BaseSniffTest
+class RemovedMbCheckEncodingNoArgsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedMbStrrposEncodingThirdParam sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTest
+class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedMbstringModifiers sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.5
  */
-class RemovedMbstringModifiersUnitTest extends BaseSniffTest
+class RemovedMbstringModifiersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedNonCryptoHash sniff.
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class RemovedNonCryptoHashUnitTest extends BaseSniffTest
+class RemovedNonCryptoHashUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedPCREModifiers sniff.
@@ -24,7 +24,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.6
  */
-class RemovedPCREModifiersUnitTest extends BaseSniffTest
+class RemovedPCREModifiersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedSetlocaleString sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class RemovedSetlocaleStringUnitTest extends BaseSniffTest
+class RemovedSetlocaleStringUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedSplAutoloadRegisterThrowFalse sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedSplAutoloadRegisterThrowFalseUnitTest extends BaseSniffTest
+class RemovedSplAutoloadRegisterThrowFalseUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\ParameterValues;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedVersionCompareOperators sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedVersionCompareOperatorsUnitTest extends BaseSniffTest
+class RemovedVersionCompareOperatorsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenCallTimePassByReference sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class ForbiddenCallTimePassByReferenceUnitTest extends BaseSniffTest
+class ForbiddenCallTimePassByReferenceUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewArrayStringDereferencing sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.1.4
  */
-class NewArrayStringDereferencingUnitTest extends BaseSniffTest
+class NewArrayStringDereferencingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewArrayUnpacking sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.2.0
  */
-class NewArrayUnpackingUnitTest extends BaseSniffTest
+class NewArrayUnpackingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewClassMemberAccess sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.2.0
  */
-class NewClassMemberAccessUnitTest extends BaseSniffTest
+class NewClassMemberAccessUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewDynamicAccessToStatic sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.1.0
  */
-class NewDynamicAccessToStaticUnitTest extends BaseSniffTest
+class NewDynamicAccessToStaticUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewFirstClassCallablesUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFirstClassCallablesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewFirstClassCallables sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-final class NewFirstClassCallablesUnitTest extends BaseSniffTest
+final class NewFirstClassCallablesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewFlexibleHeredocNowdoc sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.0.0
  */
-class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTest
+class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewFunctionArrayDereferencing sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class NewFunctionArrayDereferencingUnitTest extends BaseSniffTest
+class NewFunctionArrayDereferencingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewFunctionCallTrailingComma sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.2.0
  */
-class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTest
+class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewInterpolatedStringDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewInterpolatedStringDereferencingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewInterpolatedStringDereferencing sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewInterpolatedStringDereferencingUnitTest extends BaseSniffTest
+class NewInterpolatedStringDereferencingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewMagicConstantDereferencing sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewMagicConstantDereferencingUnitTest extends BaseSniffTest
+class NewMagicConstantDereferencingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewNestedStaticAccess sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class NewNestedStaticAccessUnitTest extends BaseSniffTest
+class NewNestedStaticAccessUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewShortArray sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class NewShortArrayUnitTest extends BaseSniffTest
+class NewShortArrayUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedCurlyBraceArrayAccess sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTest
+class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Syntax;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedNewReference sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 5.5
  */
-class RemovedNewReferenceUnitTest extends BaseSniffTest
+class RemovedNewReferenceUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/TextStrings/NewUnicodeEscapeSequenceUnitTest.php
+++ b/PHPCompatibility/Tests/TextStrings/NewUnicodeEscapeSequenceUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\TextStrings;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewUnicodeEscapeSequence sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.3.0
  */
-class NewUnicodeEscapeSequenceUnitTest extends BaseSniffTest
+class NewUnicodeEscapeSequenceUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.php
+++ b/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\TextStrings;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedDollarBraceStringEmbeds sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-class RemovedDollarBraceStringEmbedsUnitTest extends BaseSniffTest
+class RemovedDollarBraceStringEmbedsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\TypeCasts;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewTypeCasts sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.0.1
  */
-class NewTypeCastsUnitTest extends BaseSniffTest
+class NewTypeCastsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\TypeCasts;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedTypeCasts sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 8.0.1
  */
-class RemovedTypeCastsUnitTest extends BaseSniffTest
+class RemovedTypeCastsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
+++ b/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Upgrade;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 use PHPCompatibility\Sniffs\Upgrade\LowPHPSniff;
 
 /**
@@ -23,7 +23,7 @@ use PHPCompatibility\Sniffs\Upgrade\LowPHPSniff;
  *
  * @since 9.3.0
  */
-class LowPHPUnitTest extends BaseSniffTest
+class LowPHPUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\UseDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewGroupUseDeclarations sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class NewGroupUseDeclarationsUnitTest extends BaseSniffTest
+class NewGroupUseDeclarationsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\UseDeclarations;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewUseConstFunction sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.1.4
  */
-class NewUseConstFunctionUnitTest extends BaseSniffTest
+class NewUseConstFunctionUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Variables;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenGlobalVariableVariable sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.0.0
  */
-class ForbiddenGlobalVariableVariableUnitTest extends BaseSniffTest
+class ForbiddenGlobalVariableVariableUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Variables;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the ForbiddenThisUseContexts sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 9.1.0
  */
-class ForbiddenThisUseContextsUnitTest extends BaseSniffTest
+class ForbiddenThisUseContextsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Variables;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the NewUniformVariableSyntax sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 7.1.2
  */
-class NewUniformVariableSyntaxUnitTest extends BaseSniffTest
+class NewUniformVariableSyntaxUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Variables;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedIndirectModificationOfGlobals sniff.
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  *
  * @since 10.0.0
  */
-final class RemovedIndirectModificationOfGlobalsUnitTest extends BaseSniffTest
+final class RemovedIndirectModificationOfGlobalsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCompatibility\Tests\Variables;
 
-use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
  * Test the RemovedPredefinedGlobalVariables sniff.
@@ -24,7 +24,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * @since 7.0   RemovedVariablesSniffTest.
  * @since 7.1.3 Merged to one sniff & test.
  */
-class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTest
+class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -121,5 +121,5 @@ if (class_exists('PHPUnit_Framework_TestCase') === true
     class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
 }
 
-require_once __DIR__ . '/PHPCompatibility/Tests/BaseSniffTest.php';
+require_once __DIR__ . '/PHPCompatibility/Tests/BaseSniffTestCase.php';
 unset($phpcsUtilsDir, $phpcsDir, $vendorDir);


### PR DESCRIPTION
The `BaseSniffTest` class, which is used as a basis for all test classes, should by rights be an `abstract` class as it doesn't contain any tests itself.

However, using the `Test` suffix for abstract test case classes is deprecated since PHPUnit 9.6.

Even though this wasn't causing us any problems so far (as the class wasn't `abstract`), let's tidy this up to future-proof PHPUnit cross-version compatibility.

So, in this commit:
* The `BaseSniffTest` class is renamed to `BaseSniffTestCase`, including updating the file name to match.
* All test classes which `extend` the class have been updated to now extend the `BaseSniffTestCase`.

Ref: https://github.com/sebastianbergmann/phpunit/issues/5132