### PR TITLE
PHP 7.4 | NewIniDirectives: recognize a few more new directives

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -889,6 +889,11 @@ class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '7.4'       => true,
             'extension' => 'ffi',
         ],
+        'mbstring.regex_retry_limit' => [
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'mbstring',
+        ],
         'opcache.cache_id' => [
             '7.3'       => false,
             '7.4'       => true,

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -904,6 +904,10 @@ class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '7.4'       => true,
             'extension' => 'opcache',
         ],
+        'unserialize_max_depth' => [
+            '7.3' => false,
+            '7.4' => true,
+        ],
         'zend.exception_ignore_args' => [
             '7.3' => false,
             '7.4' => true,

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -554,3 +554,6 @@ $test = ini_get(ini: 'oci8.statement_cache_size'); // Wrong param name.
 
 ini_set('unserialize_max_depth', 10);
 $test = ini_get('unserialize_max_depth');
+
+ini_set('mbstring.regex_retry_limit', 10);
+$test = ini_get('mbstring.regex_retry_limit');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -551,3 +551,6 @@ register_callback(ini_get(...));
 // Safeguard against false positives when target param not found.
 ini_set(value: 1); // Missing param.
 $test = ini_get(ini: 'oci8.statement_cache_size'); // Wrong param name.
+
+ini_set('unserialize_max_depth', 10);
+$test = ini_get('unserialize_max_depth');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -261,6 +261,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTestCase
             ['opcache.preload', '7.4', [455, 456], '7.3'],
             ['opcache.preload_user', '7.4', [464, 465], '7.3'],
             ['zend.exception_ignore_args', '7.4', [338, 339], '7.3'],
+            ['unserialize_max_depth', '7.4', [555, 556], '7.3'],
 
             ['com.dotnet_version', '8.0', [536, 537], '7.4'],
             ['pm.status_listen', '8.0', [533, 534], '7.4'],

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -262,6 +262,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTestCase
             ['opcache.preload_user', '7.4', [464, 465], '7.3'],
             ['zend.exception_ignore_args', '7.4', [338, 339], '7.3'],
             ['unserialize_max_depth', '7.4', [555, 556], '7.3'],
+            ['mbstring.regex_retry_limit', '7.4', [558, 559], '7.3'],
 
             ['com.dotnet_version', '8.0', [536, 537], '7.4'],
             ['pm.status_listen', '8.0', [533, 534], '7.4'],


### PR DESCRIPTION
### PHP 7.4 | NewIniDirectives: recognize PHP unserialize_max_depth

From the PHP 7.4 changelog:
>   . A new 'max_depth' option for unserialize(), as well as **an
>    unserialize_max_depth ini setting** have been added. These control the
>    maximum depth of structures permitted during unserialization, and are
>    intended to prevent stack overflows. The default depth limit is 4096 and
>    can be disabled by setting unserialize_max_depth=0.

Refs:
* https://github.com/php/php-src/blob/004cb827501d1ddaf98daacb185a53e0816f78a7/UPGRADING#L357-L361
* php/php-src#4742
* php/php-src@1806ce9

### PHP 7.4 | NewIniDirectives: recognize mbstring.regex_retry_limit

From the PHP 7.4 changelog:
>   . Added mbstring.regex_retry_limit ini setting defaulting to 1000000. It
>     limits the amount of backtracking that may be performed during one mbregex
>     match and thus protects against exponential backtracking attacks (ReDOS).
>     This setting only takes effect when linking against oniguruma >= 6.8.0.

Refs:
* https://github.com/php/php-src/blob/004cb827501d1ddaf98daacb185a53e0816f78a7/UPGRADING#L300-L303
* php/php-src#4768
* php/php-src@6623e7a

Related to #808