### PR TITLE
PHP 8.0 | NewInterfaces: add support for DOM living standard APIs related interfaces (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -127,6 +127,16 @@ class NewInterfacesSniff extends Sniff
             '7.4' => false,
             '8.0' => true,
         ],
+        'DOMChildNode' => [
+            '7.4'       => false,
+            '8.0'       => true,
+            'extension' => 'dom',
+        ],
+        'DOMParentNode' => [
+            '7.4'       => false,
+            '8.0'       => true,
+            'extension' => 'dom',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -193,6 +193,8 @@ enum MyBackedEnum: string implements NotATarget, Serializable, ArrayAccess {
     public function __wakeup();
 }
 
+class MyDom implements DOMChildNode, DOMParentNode {}
+
 // Test parse error/live coding.
 // This MUST be the last test in the file!
 try {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -80,6 +80,8 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             ['Throwable', '5.6', [37, 52, 62, 93, 98, 103, 162, 186], '7.0'],
             ['SessionUpdateTimestampHandlerInterface', '5.6', [90, 142, 162], '7.0'],
             ['Stringable', '7.4', [112, 179], '8.0'],
+            ['DOMChildNode', '7.4', [196], '8.0'],
+            ['DOMParentNode', '7.4', [196], '8.0'],
         ];
     }
 
@@ -212,7 +214,7 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             [177],
             [185],
             [189],
-            [199],
+            [201],
         ];
     }
 


### PR DESCRIPTION
> - Dom:
>   . Introduce DOMParentNode and DOMChildNode with new traversal and
>     manipulation APIs.

Refs:
* https://wiki.php.net/rfc/dom_living_standard_api
* php/php-src#4709
* https://github.com/php/php-src/commit/5acd86df8e39fe65f98e4cc2c5fc1c59ab90f68d
* https://www.php.net/manual/en/book.dom.php

Related to #809