### PR TITLE
AbstractFunctionCallParameter: prevent false positives on PHP 8.0+ attributes

### DIFF
--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -115,6 +116,11 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
             || isset($tokens[$nextToken]['parenthesis_owner']) === true
         ) {
             return;
+        }
+
+        if (Context::inAttribute($phpcsFile, $stackPtr) === true) {
+            // Class instantiation or constant in attribute, not function call.
+            return false;
         }
 
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.1.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.1.inc
@@ -30,3 +30,7 @@ register_callback(session_module_name(...));
 
 // Safeguard against false positives when target param not found.
 session_module_name(name: 'user'); // Wrong param name.
+
+// Safeguard against false positives when this name is used as an attribute class.
+#[Session_Module_Name('user')]
+function do_something() {}

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
@@ -107,6 +107,7 @@ class ForbiddenSessionModuleNameUserUnitTest extends BaseSniffTestCase
         $cases[] = [26];
         $cases[] = [29];
         $cases[] = [32];
+        $cases[] = [35];
 
         return $cases;
     }


### PR DESCRIPTION
`T_STRING` tokens in PHP 8.0+ attributes are either class names or possibly constant names (as a parameter for the class instantiation). They are never function calls (as things are).

This commit ensures that `T_STRING` tokens in attributes are not confused with function calls for all sniffs based on the `AbstractFunctionCallParameterSniff` class.