### PR TITLE
PHP 8.0 | Keywords/NewKeywords: detect the new `match` keyword (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -153,6 +153,11 @@ class NewKeywordsSniff extends Sniff
             '7.4'         => true,
             'description' => 'The "fn" keyword for arrow functions',
         ],
+        'T_MATCH' => [
+            '7.4'         => false,
+            '8.0'         => true,
+            'description' => 'The "match" keyword',
+        ],
     ];
 
     /**
@@ -276,6 +281,7 @@ class NewKeywordsSniff extends Sniff
         // them.
         if (($nextToken === false
                 || $tokenType === 'T_FN' // Open parenthesis is expected after "fn" keyword.
+                || $tokenType === 'T_MATCH' // ... and after the "match" keyword.
                 || $tokens[$nextToken]['type'] !== 'T_OPEN_PARENTHESIS')
             && ($prevToken === false
                 || $tokens[$prevToken]['type'] !== 'T_CLASS'

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.inc
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.inc
@@ -162,6 +162,66 @@ $result = array_map(
     $numbers
 );
 
+/*
+ * PHP 8.0: match expressions.
+ */
+// OK: match, but not an match expression.
+$a = Foo::match($param);
+$a = MyClass::match;
+$a = MyClass::match[$a];
+$a = $obj->match($param);
+$a = $obj->match->chain($param);
+$a = $obj?->match;
+$a = MyNS\Sub\match($param);
+$a = namespace\match($param);
+
+class Match {
+    const match = 'a';
+
+    public static function match($param) {}
+
+    public function bar() {
+        $this->match = 'a';
+    }
+}
+
+// PHP 8.0 match expressions.
+$statement = match ($this->lexer->lookahead['type']) {
+    Lexer::T_SELECT => $this->SelectStatement(),
+    Lexer::T_UPDATE => $this->UpdateStatement(),
+    Lexer::T_DELETE => $this->DeleteStatement(),
+    default => $this->syntaxError('SELECT, UPDATE or DELETE'),
+};
+
+echo match (1) {
+    0 => 'Foo',
+    1 => 'Bar',
+    2 => 'Baz',
+};
+
+MATCH ($pressedKey) {
+    Key::RETURN_ => save(),
+    Key::DELETE => delete(),
+};
+
+echo Match ($x) {
+    1, 2 => 'Same for 1 and 2',
+    3, 4 => 'Same for 3 and 4',
+};
+
+$result = match ($x) {
+    foo() => ...,
+    $this->bar() => ..., // bar() isn't called if foo() matched with $x
+    $this->baz => ...,
+    // etc.
+};
+
+$x = match ($y) {
+    default => {
+        // This should work fine
+        (match ($z) { ... })
+    },
+};
 
 __halt_compiler();
 

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -473,6 +473,77 @@ class NewKeywordsUnitTest extends BaseSniffTestCase
     }
 
     /**
+     * Test match expressions.
+     *
+     * @dataProvider dataMatchExpressions
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testMatchExpressions($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertError($file, $line, 'The "match" keyword is not present in PHP version 7.4 or earlier');
+
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testMatchExpressions()
+     *
+     * @return array
+     */
+    public static function dataMatchExpressions()
+    {
+        return [
+            [189],
+            [196],
+            [202],
+            [207],
+            [212],
+            [219],
+            [222],
+        ];
+    }
+
+    /**
+     * Test against false positives for match expressions.
+     *
+     * @dataProvider dataMatchExpressionsNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testMatchExpressionsNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testMatchExpressionsNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataMatchExpressionsNoFalsePositives()
+    {
+        $data = [];
+
+        for ($i = 168; $i <= 187; $i++) {
+            $data[] = [$i];
+        }
+
+        return $data;
+    }
+
+    /**
      * testHaltCompiler
      *
      * @return void
@@ -486,7 +557,7 @@ class NewKeywordsUnitTest extends BaseSniffTestCase
          * not be reported.
          */
         $file = $this->sniffFile(__FILE__, '5.2');
-        $this->assertNoViolation($file, 170);
+        $this->assertNoViolation($file, 229);
     }
 
 


### PR DESCRIPTION
PHP 8.0 introduced match expressions.

What with originally still supporting a wide range of PHPCS versions, detection of match expressions would need a lot of custom logic, so this would get a separate sniff (which I had as WIP locally).

However, now support for PHPCS < 3.7.1 has been dropped, detection of the keyword can be handled by the `NewKeywords` sniff. Includes the tests I had originally set up for the separate sniff.

Refs:
* https://wiki.php.net/rfc/match_expression_v2
* https://github.com/php/php-src/pull/5371
* https://github.com/php/php-src/commit/9fa1d1330138ac424f990ff03e62721120aaaec3

Related to #809