### PR TITLE
PHP 8.0 | RemovedFunctions: update some previously deprecated to removed

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4122,7 +4122,8 @@ class RemovedFunctionsSniff extends Sniff
         ],
         '__autoload' => [
             '7.2'         => false,
-            'alternative' => 'SPL autoload',
+            '8.0'         => true,
+            'alternative' => 'spl_autoload_register()',
         ],
         'create_function' => [
             '7.2'         => false,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -4269,6 +4269,7 @@ class RemovedFunctionsSniff extends Sniff
         ],
         'is_real' => [
             '7.4'         => false,
+            '8.0'         => true,
             'alternative' => 'is_float()',
         ],
         'money_format' => [

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -158,8 +158,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['ociwritelobtofile', '5.4', 'OCI-Lob::export() / OCILob::export() (PHP 8+)', 88, '5.3'],
             ['ociwritetemporarylob', '5.4', 'OCI-Lob::writeTemporary() / OCILob::writeTemporary() (PHP 8+)', 89, '5.3'],
 
-            ['__autoload', '7.2', 'SPL autoload', 589, '7.1'],
-
             ['enchant_broker_free', '8.0', 'unset the object', 1174, '7.4'],
             ['enchant_broker_free_dict', '8.0', 'unset the object', 1175, '7.4'],
             ['enchant_dict_add_to_personal', '8.0', 'enchant_dict_add()', 1176, '7.4'],
@@ -1436,6 +1434,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['mcrypt_module_self_test', '7.1', '7.2', 'OpenSSL', 130, '7.0'],
             ['mdecrypt_generic', '7.1', '7.2', 'OpenSSL', 131, '7.0'],
 
+            ['__autoload', '7.2', '8.0', 'spl_autoload_register()', 589, '7.1'],
             ['create_function', '7.2', '8.0', 'an anonymous function', 146, '7.1'],
             ['each', '7.2', '8.0', 'a foreach loop or ArrayIterator', 147, '7.1'],
             ['read_exif_data', '7.2', '8.0', 'exif_read_data()', 149, '7.1'],

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -159,7 +159,6 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['ociwritetemporarylob', '5.4', 'OCI-Lob::writeTemporary() / OCILob::writeTemporary() (PHP 8+)', 89, '5.3'],
 
             ['__autoload', '7.2', 'SPL autoload', 589, '7.1'],
-            ['is_real', '7.4', 'is_float()', 239, '7.3'],
 
             ['enchant_broker_free', '8.0', 'unset the object', 1174, '7.4'],
             ['enchant_broker_free_dict', '8.0', 'unset the object', 1175, '7.4'],
@@ -1466,6 +1465,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['ociinternaldebug', '5.4', '8.0', 'oci_internal_debug() (PHP < 8.0)', 69, '5.3'],
             ['ldap_control_paged_result_response', '7.4', '8.0', 'ldap_search()', 234, '7.3'],
             ['ldap_control_paged_result', '7.4', '8.0', 'ldap_search()', 235, '7.3'],
+            ['is_real', '7.4', '8.0', 'is_float()', 239, '7.3'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.0 | RemovedFunctions: is_real() has been removed

Refs:
* php/php-src#5506
* php/php-src@31a626c


### PHP 8.0 | RemovedFunctions: recognize __autoload() as removed

>   . Removed ability to specify an autoloader using an __autoload() function.
>     spl_autoload_register() should be used instead.

Refs:
* https://github.com/php/php-src/blob/be71cadc2f899bc39fe27098042139392e2187db/UPGRADING#L41C1-L42C52
* php/php-src#3770
* php/php-src@0dfd918

Related to #809