### PR TITLE
PHP 8.0 | :sparkles: New `PHPCompatibility.ParameterValues.ForbiddenGetClassNoArgsOutsideOO` sniff

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/ForbiddenGetClassNoArgsOutsideOOStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/ForbiddenGetClassNoArgsOutsideOOStandard.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Forbidden get_class() Without Arguments outside OO scope"
+    >
+    <standard>
+    <![CDATA[
+    Calling the get_class() function without arguments from outside an OO scope throws an Error since PHP 8.0.
+    Along the same lines, calling the get_called_class() function from outside an OO scope will also throw an Error since PHP 8.0.
+
+    Previously, an `E_WARNING` was raised and the functions returned `false`.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: calling get_class() with an argument; or calling get_class() without argument from within class scope.">
+        <![CDATA[
+echo <em>get_class($object)</em>;
+
+class Example {
+    public function do_something() {
+        return <em>get_class()</em>;
+    }
+}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.0: calling get_class() without an argument from outside an OO scope.">
+        <![CDATA[
+echo <em>get_class()</em>;
+
+function do_something() {
+    return <em>get_class()</em>;
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Cross-version compatible: calling get_called_class() from within class scope.">
+        <![CDATA[
+class Example {
+    public function do_something() {
+        return <em>get_called_class()</em>;
+    }
+}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.0: calling get_called_class() from outside an OO scope.">
+        <![CDATA[
+echo <em>get_called_class()</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNoArgsOutsideOOSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNoArgsOutsideOOSniff.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\Conditions;
+use PHPCSUtils\Utils\Scopes;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Detect: Calling get_[called_]class() without arguments from outside a class will throw an Error since PHP 8.0.
+ *
+ * Previously, an `E_WARNING` was raised and the functions returned `false`.
+ *
+ * PHP version 8.0
+ *
+ * @link https://www.php.net/manual/en/function.get-class.php#refsect1-function.get-class-changelog
+ * @link https://www.php.net/manual/en/function.get-called-class.php#refsect1-function.get-called-class-changelog
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenGetClassNoArgsOutsideOOSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = [
+        'get_class'        => 'without an argument, ',
+        'get_called_class' => '',
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrAbove('8.0') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return void
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        // Nothing to do. Function called with one or more parameters.
+    }
+
+    /**
+     * Process the function if no parameters were found.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     *
+     * @return void
+     */
+    public function processNoParameters(File $phpcsFile, $stackPtr, $functionName)
+    {
+        $lastCondition = Conditions::getLastCondition($phpcsFile, $stackPtr, \T_FUNCTION);
+        if ($lastCondition !== false && Scopes::isOOMethod($phpcsFile, $lastCondition) === true) {
+            // This function call will be executed within an OO context.
+            return;
+        }
+
+        $functionLc = \strtolower($functionName);
+        $phpcsFile->addError(
+            'Calling %s() %sfrom outside of an OO scope, will throw an Error since PHP 8.0.',
+            $stackPtr,
+            'Found',
+            [$functionLc, $this->targetFunctions[$functionLc]]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNoArgsOutsideOOUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNoArgsOutsideOOUnitTest.inc
@@ -1,0 +1,138 @@
+<?php
+/*
+ * Test calling get_class() without arg outside a class will throw a fatal error since PHP 8.0.
+ */
+
+/*
+ * OK.
+ */
+// Not our target.
+echo GET_CLASS;
+$obj->get_called_class;
+$obj->get_class();
+$obj?->get_called_class();
+MyClass::get_class();
+My\Vendor\get_called_class();
+#[Get_Class()]
+function do_something() {}
+
+// Passes parameter.
+get_class( $obj );
+
+function globalFunction() {
+    get_class($obj);
+}
+
+$closure = function() {
+    \Get_Class($obj);
+};
+
+$arrow = fn() => get_class($obj);
+
+// Will be executed within class context.
+class NestedFunctionsWillBeExecutedInGlobalScopeC {
+    public function inMethod() {
+        get_class();
+        get_called_class();
+    }
+}
+
+trait NestedFunctionsWillBeExecutedInGlobalScopeT {
+    public function inMethod() {
+        get_class();
+        \get_called_class();
+    }
+}
+
+$anon = new class {
+    public function inMethod() {
+        get_class();
+        get_called_class();
+    }
+};
+
+enum NestedFunctionsWillBeExecutedInGlobalScopeE {
+    public function inMethod() {
+        \get_class();
+        get_called_class();
+    }
+}
+
+class CallablesWillBeExecutedInsideClassContextWhenCalledFromOutside {
+    public function inClosure() {
+        $callable = function() {
+            echo get_called_class();
+            return get_class();
+        };
+        return $callable;
+    }
+
+    public function inArrow() {
+        $callable = fn() => get_called_class();
+        return fn() => get_class();
+    }
+}
+
+// Not allowed since PHP 7.2, but not the concern of this sniff.
+get_class(null);
+
+/*
+ * PHP 8.0: calling the functions without args from outside OO scope.
+ */
+get_class();
+get_called_class();
+
+function anotherGlobalFunction() {
+    \get_class();
+    \get_called_class();
+
+    $callable = function() {
+         return get_class();
+    };
+
+    return fn() => Get_Called_Class();
+}
+
+$closure = function() {
+    get_class();
+    get_called_class();
+};
+
+$arrow = fn() => get_class();
+$arrow = fn() => get_called_class();
+
+class NestedFunctionsWillBeExecutedInGlobalScopeC {
+    public function method() {
+        function globalFunctionNestedInMethodC() {
+            GET_CLASS();
+            GET_called_CLASS();
+        }
+    }
+}
+
+$anon = new class {
+    public function method() {
+        function globalFunctionNestedInMethodA() {
+            \get_class();
+            \get_called_class();
+        }
+    }
+};
+
+trait NestedFunctionsWillBeExecutedInGlobalScopeT {
+    public function method() {
+        function globalFunctionNestedInMethodT() {
+            \get_class();
+            \get_called_class();
+        }
+    }
+}
+
+enum NestedFunctionsWillBeExecutedInGlobalScopeE {
+    public function method() {
+        function globalFunctionNestedInMethodE() {
+            get_class();
+            get_called_class();
+        }
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNoArgsOutsideOOUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNoArgsOutsideOOUnitTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenGetClassNoArgsOutsideOO sniff.
+ *
+ * @group forbiddenGetClassNoArgsOutsideOO
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\ForbiddenGetClassNoArgsOutsideOOSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenGetClassNoArgsOutsideOOUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test receiving an error for calling get_class() without arguments outside class scope.
+     *
+     * @dataProvider dataForbiddenGetClassNoArgsOutsideOO
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testForbiddenGetClassNoArgsOutsideOO($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, ' from outside of an OO scope, will throw an Error since PHP 8.0.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenGetClassNoArgsOutsideOO()
+     *
+     * @return array
+     */
+    public static function dataForbiddenGetClassNoArgsOutsideOO()
+    {
+        return [
+            [82],
+            [83],
+            [86],
+            [87],
+            [90],
+            [93],
+            [97],
+            [98],
+            [101],
+            [102],
+            [107],
+            [108],
+            [116],
+            [117],
+            [125],
+            [126],
+            [134],
+            [135],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 78 lines.
+        for ($line = 1; $line <= 78; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> 8.0.0 	Calling this function from outside a class, without any arguments, will now throw an `Error`.
>            Previously, an `E_WARNING` was raised and the function returned `false`.

Applies to both `get_class()` as well as `get_called_class()`.

Refs:
* https://www.php.net/manual/en/function.get-class.php#refsect1-function.get-class-changelog
* https://github.com/php/php-src/commit/213b6667817b887e29f7fdf3a046c37c4462f756
* https://3v4l.org/f05rn
* https://3v4l.org/a7h7r

This adds a new sniff to detect the above, which wasn't mentioned in the PHP 8.0 generic changelog nor in the migration guide, though a note about it can be found on the functions manual pages.

Includes tests and documentation.

Related to #809