### PR TITLE
PHP 8.1 | RemovedIniDirectives: recognize `mysqlnd.fetch_data_copy`

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -650,6 +650,10 @@ class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.1'       => false,
             'extension' => 'filter',
         ],
+        'mysqlnd.fetch_data_copy' => [
+            '8.1'       => true,
+            'extension' => 'mysqlnd',
+        ],
         'oci8.old_oci_close_semantics' => [
             '8.1'       => false,
             'extension' => 'oci8',

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -460,3 +460,6 @@ register_callback(ini_set(...));
 // Safeguard against false positives when target param not found.
 ini_set(value: 1); // Missing param.
 $test = ini_get(ini: 'filter.default_options'); // Wrong param name.
+
+ini_set('mysqlnd.fetch_data_copy', 0);
+$test = ini_get('mysqlnd.fetch_data_copy');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -364,6 +364,7 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
             ['assert.quiet_eval', '8.0', [427, 428], '7.4'],
 
             ['log_errors_max_len', '8.1', [433, 434], '8.0'],
+            ['mysqlnd.fetch_data_copy', '8.1', [464, 465], '8.0'],
         ];
     }
 


### PR DESCRIPTION
>  . The mysqlnd.fetch_data_copy ini setting has been removed. However, this
>    should not result in user-visible behavior changes.

Refs:
* https://github.com/php/php-src/blob/6b6a5cd28ed7ecb3eb4ef7eb5af3514e343dfab3/UPGRADING#L112-L113

**Note:** I cannot find a commit which actually removed the setting in the PHP Core repo...
Then again, aside from some tests, I cannot find any code references to the directive in the PHP Core repo either...
https://github.com/search?q=repo%3Aphp%2Fphp-src+mysqlnd.fetch_data_copy&type=code

Related to #1299 