### PR TITLE
PHP 8.2 | RemovedFunctions: recognized utf8[en|de]code() as deprecated (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5061,6 +5061,15 @@ class RemovedFunctionsSniff extends Sniff
             '8.1'       => false,
             'extension' => 'odbc',
         ],
+
+        'utf8_encode' => [
+            '8.2'         => false,
+            'alternative' => 'mb_convert_encoding(), UConverter::transcode() or iconv',
+        ],
+        'utf8_decode' => [
+            '8.2'         => false,
+            'alternative' => 'mb_convert_encoding(), UConverter::transcode() or iconv',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1230,3 +1230,6 @@ odbc_result_all();
 
 // Prevent false positives on PHP 8.0+ nullsafe method calls.
 $obj?->php_check_syntax(); // OK.
+
+utf8_encode();
+utf8_decode();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -207,6 +207,8 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['mhash_get_hash_name', '8.1', 'the hash_*() functions', 1226, '8.0'],
             ['mhash_keygen_s2k', '8.1', 'the hash_*() functions', 1227, '8.0'],
             ['mhash', '8.1', 'the hash_*() functions', 1228, '8.0'],
+            ['utf8_encode', '8.2', 'mb_convert_encoding(), UConverter::transcode() or iconv', 1234, '8.1'],
+            ['utf8_decode', '8.2', 'mb_convert_encoding(), UConverter::transcode() or iconv', 1235, '8.1'],
         ];
     }
 


### PR DESCRIPTION
>   . utf8_encode() and utf8_decode() have been deprecated.

Refs:
* https://wiki.php.net/rfc/remove_utf8_decode_and_utf8_encode
* https://github.com/php/php-src/blob/5d90c5057dbf88cea49ac53daf5f4622c1588a84/UPGRADING#L201
* php/php-src#8726
* https://github.com/php/php-src/commit/d9f3ca705c07e0d5c67482e5a40b76422e3ef6d4

Related to #1348