### PR TITLE
PHP 8.2 | NewPCREModifiers: recognize the new "n" modifier

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -20,6 +20,7 @@ use PHPCSUtils\Utils\PassedParameters;
  * Check for the use of newly added regex modifiers for PCRE functions.
  *
  * Initially just checks for the PHP 7.2 new `J` modifier.
+ * As of PHPCompatibility 10.0.0 also check for the PHP 8.2 `n` modifier.
  *
  * PHP version 7.2+
  *
@@ -93,6 +94,10 @@ class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
             '7.1' => false,
             '7.2' => true,
         ],
+        'n' => [
+            '8.1' => false,
+            '8.2' => true,
+        ],
     ];
 
 
@@ -107,7 +112,7 @@ class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
     {
         // Version used here should be the highest version from the `$newModifiers` array,
         // i.e. the last PHP version in which a new modifier was introduced.
-        return (ScannedCode::shouldRunOnOrBelow('7.2') === false);
+        return (ScannedCode::shouldRunOnOrBelow('8.2') === false);
     }
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
@@ -48,3 +48,8 @@ EOD
 // Safeguard support for PHP 8 named parameters.
 preg_grep(array: $input, pattern: '#some text#i'); // OK.
 preg_grep(array: $input, pattern: '#some text#Ji', flags: $flags); // Error.
+
+// Recognize use of the PHP 8.2 "n" modifier.
+preg_match('/.(.)./n', 'abc', $m);
+preg_match('`.(?P<test>.).`n', 'abc', $m);
+preg_match('{.(?P<test>.).}n', 'abc', $m);

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -66,6 +66,7 @@ class NewPCREModifiersUnitTest extends BaseSniffTestCase
     {
         return [
             ['J', '7.1', [3, 4, 10, 17, 19, 25, 43, 50], '7.2'],
+            ['n', '8.1', [53, 54, 55], '8.2'],
         ];
     }
 


### PR DESCRIPTION
>   . Added support for the "n" (NO_AUTO_CAPTURE) modifier, which makes simple
>     `(xyz)` groups non-capturing. Only named groups like `(?<name>xyz)` are
>     capturing. This only affects which groups are capturing, it is still
>     possible to use numbered subpattern references, and the matches array will
>     still contain numbered results.

Refs:
* https://github.com/php/php-src/blob/5d90c5057dbf88cea49ac53daf5f4622c1588a84/UPGRADING#L128-L132
* php/php-src#7583
* https://github.com/php/php-src/commit/e089a50f53c8fd1eb9a932f1856a524d4ac83406

Related to #1348