### PR TITLE
PHP 8.2 | Various sniffs: detect the new random extension(RFC) 

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -828,6 +828,32 @@ class NewClassesSniff extends Sniff
             '8.1'       => true,
             'extension' => 'curl',
         ],
+
+        'Random\Randomizer' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'random',
+        ],
+        'Random\Engine\Secure' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'random',
+        ],
+        'Random\Engine\Mt19937' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'random',
+        ],
+        'Random\Engine\PcgOneseq128XslRr64' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'random',
+        ],
+        'Random\Engine\Xoshiro256StarStar' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'random',
+        ],
     ];
 
     /**
@@ -1050,6 +1076,22 @@ class NewClassesSniff extends Sniff
             '8.0'       => false,
             '8.1'       => true,
             'extension' => 'fibers',
+        ],
+
+        'Random\RandomError' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'random',
+        ],
+        'Random\BrokenRandomEngineError' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'random',
+        ],
+        'Random\RandomException' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'random',
         ],
     ];
 

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -146,6 +146,17 @@ class NewInterfacesSniff extends Sniff
             '8.0' => false,
             '8.1' => true,
         ],
+
+        'Random\Engine' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'random',
+        ],
+        'Random\CryptoSafeEngine' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'random',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -47,8 +47,9 @@ class ReservedNamesSniff extends Sniff
          * The top-level namespace name "PHP" is reserved by PHP since the introduction
          * of namespaces in PHP 5.3, but not yet in use.
          */
-        'PHP' => '5.3',
-        'FFI' => '7.4',
+        'PHP'    => '5.3',
+        'FFI'    => '7.4',
+        'Random' => '8.2',
     ];
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -470,3 +470,16 @@ $type = new ReflectionIntersectionType();
 $type = new ReflectionEnum();
 $type = new ReflectionEnumBackedCase();
 $type = new ReflectionEnumUnitCase();
+
+class MyRandom extends \Random\Randomizer {
+    protected Random\Engine\Mt19937 $propertyA;
+    protected Random\Engine\PcgOneseq128XslRr64 $propertyB;
+    protected Random\Engine\Xoshiro256StarStar $propertyC;
+
+    public function foo(): \Random\Engine\Secure {
+        try {
+        } catch( Random\RandomError | Random\BrokenRandomEngineError ) {
+        } catch( Random\RandomException $e ) {
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -220,6 +220,11 @@ class NewClassesUnitTest extends BaseSniffTestCase
             ['ReflectionFiber', '8.0', [436], '8.1'],
             ['ReflectionIntersectionType', '8.0', [469], '8.1'],
             ['CURLStringFile', '8.0', [438], '8.1'],
+            ['Random\Randomizer', '8.1', [474], '8.2'],
+            ['Random\Engine\Mt19937', '8.1', [475], '8.2'],
+            ['Random\Engine\PcgOneseq128XslRr64', '8.1', [476], '8.2'],
+            ['Random\Engine\Xoshiro256StarStar', '8.1', [477], '8.2'],
+            ['Random\Engine\Secure', '8.1', [479], '8.2'],
 
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],
@@ -267,6 +272,9 @@ class NewClassesUnitTest extends BaseSniffTestCase
             ['UnhandledMatchError', '7.4', [428], '8.0'],
             ['ValueError', '7.4', [418, 419], '8.0'],
             ['FiberError', '8.0', [437], '8.1'],
+            ['Random\RandomError', '8.1', [481], '8.2'],
+            ['Random\BrokenRandomEngineError', '8.1', [481], '8.2'],
+            ['Random\RandomException', '8.1', [482], '8.2'],
         ];
     }
 

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -197,6 +197,8 @@ class MyDom implements DOMChildNode, DOMParentNode {}
 
 function ExpectsEnumParams(UnitEnum $enum1, BackedEnum $enum2) {}
 
+function useRandomExtension( Random\Engine $paramA, Random\CryptoSafeEngine $paramB ) {}
+
 // Test parse error/live coding.
 // This MUST be the last test in the file!
 try {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -84,6 +84,8 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             ['DOMParentNode', '7.4', [196], '8.0'],
             ['UnitEnum', '8.0', [198], '8.1'],
             ['BackedEnum', '8.0', [198], '8.1'],
+            ['Random\Engine', '8.1', [200], '8.2'],
+            ['Random\CryptoSafeEngine', '8.1', [200], '8.2'],
         ];
     }
 
@@ -216,7 +218,7 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             [177],
             [185],
             [189],
-            [203],
+            [205],
         ];
     }
 

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
@@ -18,5 +18,9 @@ namespace PHP\Classes {
 namespace FFI;
 namespace FFI\MyClass;
 
+// Error PHP 8.2+.
+namespace Random;
+namespace Random\Generator;
+
 // Intentional parse error. This has to be the last test in the file.
 namespace PHP\Cli

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -59,6 +59,8 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
         return [
             [18, 'FFI', '7.4', '7.3'],
             [19, 'FFI', '7.4', '7.3'],
+            [22, 'Random', '8.2', '8.1'],
+            [23, 'Random', '8.2', '8.1'],
         ];
     }
 
@@ -122,7 +124,7 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [4],
             [5],
             [6],
-            [22],
+            [26],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.2 | ReservedNames: detect top-level namespace Random (RFC)
### PHP 8.2 | NewClasses: add support for Random extension related classes (RFC)
### PHP 8.2 | NewInterfaces: add support for Random extension related interfaces (RFC)

> - Random:
>   . New extension that organizes and consolidates existing implementations
>     related to random number generators. New, higher quality RNGs are available
>     and scope issues are eliminated.

PHP 8.2 introduced a new extension `Random`, which declares its classes in the `Random` namespace and reserves that top-level namespace for use by PHP.

Includes tests.

Refs:
* https://wiki.php.net/rfc/rng_extension
* https://wiki.php.net/rfc/random_extension_improvement
* php/php-src#8094
* php/php-src@4d8dd8d

Related to #1348
