### PR TITLE
PHP 8.2 | RemovedIniDirectives: recognize `mysqli.reconnect`

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -658,6 +658,11 @@ class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.1'       => false,
             'extension' => 'oci8',
         ],
+
+        'mysqli.reconnect' => [
+            '8.2'       => true,
+            'extension' => 'mysqli',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -463,3 +463,6 @@ $test = ini_get(ini: 'filter.default_options'); // Wrong param name.
 
 ini_set('mysqlnd.fetch_data_copy', 0);
 $test = ini_get('mysqlnd.fetch_data_copy');
+
+ini_set('mysqli.reconnect', 0);
+$test = ini_get('mysqli.reconnect');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -365,6 +365,8 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
 
             ['log_errors_max_len', '8.1', [433, 434], '8.0'],
             ['mysqlnd.fetch_data_copy', '8.1', [464, 465], '8.0'],
+
+            ['mysqli.reconnect', '8.2', [467, 468], '8.1'],
         ];
     }
 


### PR DESCRIPTION
>  . The INI directive mysqli.reconnect has been removed.

Refs:
* https://github.com/php/php-src/blob/5d90c5057dbf88cea49ac53daf5f4622c1588a84/UPGRADING#L320
* php/php-src#7889
* https://github.com/php/php-src/pull/7889/commits/be3d55d3111308a085700f2c409684b11d2ceeb0

Related to #1348