### PR TITLE
PHP 8.2 | NewIniDirectives: various updates

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -1041,6 +1041,11 @@ class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.1' => false,
             '8.2' => true,
         ],
+        'oci8.prefetch_lob_size' => [
+            '8.1'       => false,
+            '8.2'       => true,
+            'extension' => 'oci8',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -1036,6 +1036,11 @@ class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.1'       => true,
             'extension' => 'fpm',
         ],
+
+        'error_log_mode' => [
+            '8.1' => false,
+            '8.2' => true,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -611,3 +611,6 @@ $test = ini_get('opcache.jit_max_recursive_returns');
 
 ini_set('opcache.jit_max_polymorphic_calls', 10);
 $test = ini_get('opcache.jit_max_polymorphic_calls');
+
+ini_set('error_log_mode', 10);
+$test = ini_get('error_log_mode');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -614,3 +614,6 @@ $test = ini_get('opcache.jit_max_polymorphic_calls');
 
 ini_set('error_log_mode', 10);
 $test = ini_get('error_log_mode');
+
+ini_set('oci8.prefetch_lob_size', 10);
+$test = ini_get('oci8.prefetch_lob_size');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -290,6 +290,8 @@ class NewIniDirectivesUnitTest extends BaseSniffTestCase
             ['fiber.stack_size', '8.1', [539, 540], '8.0'],
             ['mysqli.local_infile_directory', '8.1', [542, 543], '8.0'],
             ['pm.max_spawn_rate', '8.1', [545, 546], '8.0'],
+
+            ['error_log_mode', '8.2', [615, 616], '8.1'],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -292,6 +292,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTestCase
             ['pm.max_spawn_rate', '8.1', [545, 546], '8.0'],
 
             ['error_log_mode', '8.2', [615, 616], '8.1'],
+            ['oci8.prefetch_lob_size', '8.2', [618, 619], '8.1'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.2 | NewIniDirectives: recognize error_log_mode

>   . Added error_log_mode ini setting that allows setting of permissions for
>     error log file.

Refs:
* https://github.com/php/php-src/blob/5d90c5057dbf88cea49ac53daf5f4622c1588a84/UPGRADING#L89-L90
* php/php-src#7901
* php/php-src@ffdf25a

### PHP 8.2 | NewIniDirectives: recognize oci8.prefetch_lob_size

>   . Added an oci8.prefetch_lob_size directive and oci_set_prefetch_lob()
>     function to tune LOB query performance by reducing the number of
>     round-trips between PHP and Oracle Database when fetching LOBS. This is
>     usable with Oracle Database 12.2 or later.

Refs:
* https://github.com/php/php-src/blob/5d90c5057dbf88cea49ac53daf5f4622c1588a84/UPGRADING#L112-L115
* php/php-src@9cd7f41

Related to #1348