### PR TITLE
PHP 8.3 | :sparkles: New `PHPCompatibility.ParameterValues.RemovedGetClassNoArgs` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedGetClassNoArgsStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedGetClassNoArgsStandard.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed get_[parent_]class() Without Argument"
+    >
+    <standard>
+    <![CDATA[
+    Calling the get_class() or get_parent_class() function without passing any arguments is deprecated since PHP 8.3 and support will be removed in PHP 9.0.
+
+    Pass the $object[_or_class] parameter for PHP cross-version compatible code.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: calling get_class() or get_parent_class() with the $object[_or_class] argument.">
+        <![CDATA[
+class Foo extends Bar {
+    public function example() {
+        <em>get_class($object)</em>;
+        <em>get_parent_class($object)</em>;
+        <em>get_parent_class('Foo')</em>;
+    }
+}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.3: calling get_class() or get_parent_class() without the $object[_or_class] argument.">
+        <![CDATA[
+class Foo extends Bar {
+    public function example() {
+        <em>get_class()</em>;
+        <em>get_parent_class()</em>;
+    }
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedGetClassNoArgsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedGetClassNoArgsSniff.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\PassedParameters;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Detect: Calling get_class() and get_parent_class() without arguments is deprecated as of PHP 8.3.
+ * This will become a fatal error as of PHP 9.0.
+ *
+ * PHP version 8.3
+ * PHP version 9.0
+ *
+ * @link https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#get_class_and_get_parent_class
+ * @link https://www.php.net/manual/en/function.get-class.php
+ * @link https://www.php.net/manual/en/function.get-parent-class.php
+ *
+ * @since 10.0.0
+ */
+final class RemovedGetClassNoArgsSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * The error message.
+     *
+     * @since 10.0.0
+     *
+     * @var string
+     */
+    const ERROR_MSG = 'Calling %s() without the $%s argument is deprecated since PHP 8.3.';
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array
+     */
+    protected $targetFunctions = [
+        'get_class'        => 'object',
+        'get_parent_class' => 'object_or_class',
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrAbove('8.3') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return void
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $functionLc = \strtolower($functionName);
+        $target     = PassedParameters::getParameterFromStack($parameters, 1, $this->targetFunctions[\strtolower($functionLc)]);
+        if ($target !== false) {
+            return;
+        }
+
+        // Uh oh.. function call must be using named params and passing an incorrect name.
+        $phpcsFile->addWarning(
+            self::ERROR_MSG,
+            $stackPtr,
+            'ArgIncorrect',
+            [$functionLc, $this->targetFunctions[$functionLc]]
+        );
+    }
+
+    /**
+     * Process the function if no parameters were found.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     *
+     * @return void
+     */
+    public function processNoParameters(File $phpcsFile, $stackPtr, $functionName)
+    {
+        $functionLc = \strtolower($functionName);
+        $phpcsFile->addWarning(
+            self::ERROR_MSG,
+            $stackPtr,
+            'ArgMissing',
+            [$functionLc, $this->targetFunctions[$functionLc]]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedGetClassNoArgsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedGetClassNoArgsUnitTest.inc
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Test get_[parent_]class() should no longer be called without arguments since PHP 8.3.
+ */
+
+/*
+ * OK.
+ */
+// Not our target.
+echo GET_CLASS;
+$obj->get_called_class;
+$obj->get_class();
+$obj?->get_called_class();
+MyClass::get_class();
+My\Vendor\get_called_class();
+#[Get_Class()]
+function do_something() {}
+
+get_class($object);
+get_parent_class($object_or_class);
+\get_parent_class(ClassName::class);
+Get_Parent_Class('ClassName');
+
+// Not allowed since PHP 7.2, but not the concern of this sniff.
+get_class(null);
+
+/*
+ * PHP 8.3: calling the functions without arguments.
+ */
+get_class();
+\get_parent_class();
+Get_Class( /* comment */ );
+get_parent_class(
+    /* comment */
+);
+
+// Also not OK: wrong parameter name used.
+\get_class(something_else: $object);
+get_parent_class(something_else: $object_or_class);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedGetClassNoArgsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedGetClassNoArgsUnitTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedGetClassNoArgs sniff.
+ *
+ * @group removedGetClassNoArgs
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedGetClassNoArgsSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedGetClassNoArgsUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test receiving an expected warning for calling get_[parent_]class() without arguments.
+     *
+     * @dataProvider dataRemovedGetClassNoArgs
+     *
+     * @param int    $line         Line number where the warning should occur.
+     * @param string $functionName Expected function name.
+     * @param string $argName      Expected function parameter name.
+     *
+     * @return void
+     */
+    public function testRemovedGetClassNoArgs($line, $functionName, $argName)
+    {
+        $file    = $this->sniffFile(__FILE__, '8.3');
+        $warning = \sprintf('Calling %s() without the $%s argument is deprecated since PHP 8.3.', $functionName, $argName);
+        $this->assertWarning($file, $line, $warning);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedGetClassNoArgs()
+     *
+     * @return array
+     */
+    public static function dataRemovedGetClassNoArgs()
+    {
+        return [
+            [30, 'get_class', 'object'],
+            [31, 'get_parent_class', 'object_or_class'],
+            [32, 'get_class', 'object'],
+            [33, 'get_parent_class', 'object_or_class'],
+            [38, 'get_class', 'object'],
+            [39, 'get_parent_class', 'object_or_class'],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 26 lines.
+        for ($line = 1; $line <= 26; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
This PR is part of a series to address the "Deprecate functions with overloaded signatures" RFC.

>   . Calling get_class() and get_parent_class() without arguments is now
>     deprecated.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#get_class_and_get_parent_class
* https://github.com/php/php-src/blob/655f116be57b46efe32221d7adfec6d6b81eeece/UPGRADING#L131-L132
* php/php-src#11703
* https://github.com/php/php-src/commit/11262320538936a0c1a8675b336e1c99c57a31e8

This adds a new sniff to detect the above.

Includes tests and documentation.

Related to #1589