### PR TITLE
PHP 8.3 | :sparkles: New `PHPCompatibility.ParameterValues.RemovedMbStrimWidthNegativeWidth` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedMbStrimWidthNegativeWidthStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedMbStrimWidthNegativeWidthStandard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed passing negative $width to mb_strimwidth()"
+    >
+    <standard>
+    <![CDATA[
+    Passing a negative $width to mb_strimwidth() is deprecated since PHP 8.3 and support will be removed in PHP 9.0.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: calling mb_strimwidth() with a positive $width.">
+        <![CDATA[
+mb_strimwidth('Hello World', 0, <em>10</em>);
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.3: calling mb_strimwidth() with a negative $width.">
+        <![CDATA[
+mb_strimwidth('Hello World', 0, <em>-5</em>);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrimWidthNegativeWidthSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrimWidthNegativeWidthSniff.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\TokenGroup;
+use PHPCSUtils\Utils\PassedParameters;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Passing a negative $width to mb_strimwidth() is deprecated since PHP 8.3.
+ * Support will be removed in PHP 9.0.
+ *
+ * Note: this was introduced in PHP 7.1. Also {@see NewNegativeStringOffsetSniff}.
+ *
+ * PHP version 8.3
+ * PHP version 9.0
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_3#passing_negative_widths_to_mb_strimwidth
+ * @link https://www.php.net/manual/en/function.mb-strimwidth.php
+ *
+ * @since 10.0.0
+ */
+final class RemovedMbStrimWidthNegativeWidthSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, bool>
+     */
+    protected $targetFunctions = [
+        'mb_strimwidth' => true,
+    ];
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrAbove('8.3') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 3, 'width');
+        if ($targetParam === false) {
+            return;
+        }
+
+        if (TokenGroup::isNegativeNumber($phpcsFile, $targetParam['start'], $targetParam['end']) === false) {
+            return;
+        }
+
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+
+        $phpcsFile->addWarning(
+            'Passing a negative $width to mb_strimwidth() is deprecated since PHP 8.3. Found: %s',
+            $firstNonEmpty,
+            'Deprecated',
+            [$targetParam['clean']]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrimWidthNegativeWidthUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrimWidthNegativeWidthUnitTest.inc
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Test mb_strimwidth() should no be called with a negative string $width since PHP 8.3.
+ */
+
+/*
+ * OK.
+ */
+// Not our target.
+echo MB_STRIMWIDTH;
+$obj->mb_strimwidth;
+$obj->mb_strimwidth();
+$obj?->mb_strimwidth();
+MyClass::mb_strimwidth();
+My\Vendor\mb_strimwidth();
+#[MB_Strimwidth()]
+function do_something() {}
+
+mb_strimwidth();
+mb_strimwidth( /*comment */ );
+mb_strimwidth($str, 100); // No $width passed, fatal error for missing required args, but not the concern of this sniff.
+mb_strimwidth($str, -100, 10, '' );
+mb_strimwidth($str, -100, -10 * -2, '' );
+Mb_Strimwidth(
+    // Some comment.
+    width: 0
+    // phpcs:ignore Standard.Category.Sniff -- for reasons.
+);
+$a = mb_strimwidth(trim_marker: '', start: -2, string: $str, ); // No $width passed, fatal error for missing required args, but not the concern of this sniff.
+$a = mb_strimwidth(trim_marker: '', width: 5, start: -2, string: $str, );
+
+// Undetermined.
+mb_strimwidth($str, -100, $width, '' );
+mb_strimwidth($str, -100, $width * 2, '' );
+\mb_strimwidth($str, -100, ClassName::WIDTH, '' );
+
+/*
+ * PHP 8.3: calling mb_strimwidth() with a negative string $width.
+ */
+$a = mb_strimwidth($str, -100, -10, '' );
+
+// Safeguard support for PHP 8 named parameters.
+$a = \MB_StrimWidth(start: -2, width: -10, string: $str, trim_marker: '');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrimWidthNegativeWidthUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrimWidthNegativeWidthUnitTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedMbStrimWidthNegativeWidth sniff.
+ *
+ * @group removedMbStrimWidthNegativeWidth
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedMbStrimWidthNegativeWidthSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedMbStrimWidthNegativeWidthUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify passing a negative $width to mb_strimwidth() is correctly detected.
+     *
+     * @dataProvider dataRemovedMbStrimWidthNegativeWidth
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedMbStrimWidthNegativeWidth($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertWarning($file, $line, 'Passing a negative $width to mb_strimwidth() is deprecated since PHP 8.3.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedMbStrimWidthNegativeWidth()
+     *
+     * @return array
+     */
+    public static function dataRemovedMbStrimWidthNegativeWidth()
+    {
+        return [
+            [40],
+            [43],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 36 lines.
+        for ($line = 1; $line <= 36; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> - MBString
>   . Passing a negative $width to mb_strimwidth() is now deprecated.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_3#passing_negative_widths_to_mb_strimwidth
* https://github.com/php/php-src/blob/548fc6a8185625bf50c708a9337db01f14860ba1/UPGRADING#L150-L151
* php/php-src#11615
* https://github.com/php/php-src/commit/af3c220abbff2415ccd79aeac1888edfc106ffa6

This adds a new sniff to detect the above.

Includes tests and documentation.

Related to #1589