### PR TITLE
PHP 8.2.1 | NewFunctions: detect use of `imap_is_open()`

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4907,6 +4907,12 @@ class NewFunctionsSniff extends Sniff
             '8.2'       => true,
             'extension' => 'libxml',
         ],
+
+        'imap_is_open' => [
+            '8.2.0'     => false,
+            '8.2.1'     => true,
+            'extension' => 'imap',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1036,3 +1036,5 @@ oci_set_prefetch_lob();
 odbc_connection_string_is_quoted();
 odbc_connection_string_should_quote();
 odbc_connection_string_quote();
+
+imap_is_open();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1097,6 +1097,8 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['openssl_cipher_key_length', '8.1', 1030, '8.2'],
             ['sodium_crypto_stream_xchacha20_xor_ic', '8.1', 1031, '8.2'],
             ['libxml_get_external_entity_loader', '8.1', 1034, '8.2'],
+
+            ['imap_is_open', '8.2.0', 1040, '8.3', '8.2'],
         ];
     }
 


### PR DESCRIPTION
>  . imap_is_open() (Only as of PHP 8.2.1)

Refs:
* https://github.com/php/php-src/blob/5d90c5057dbf88cea49ac53daf5f4622c1588a84/UPGRADING#L259
* php/php-src#10094
* https://github.com/php/php-src/commit/52a891aeaa1333b3cb02f0dfd796c0fae8ab175c

Related to #1348