### PR TITLE
PHP 8.3 | RemovedFunctionParameters: account for signature change for imagerotate()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -99,6 +99,12 @@ class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
                 '8.1'  => false,
             ],
         ],
+        'imagerotate' => [
+            4 => [
+                'name' => 'ignore_transparent',
+                '8.3'  => true,
+            ],
+        ],
         'imap_headerinfo' => [
             5 => [
                 'name' => 'defaulthost',

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -75,19 +75,13 @@ class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
                 '7.0'  => true,
             ],
         ],
-        'imap_headerinfo' => [
-            5 => [
-                'name' => 'defaulthost',
-                '8.0'  => true,
-            ],
-        ],
         /*
          * For the below three functions, it's actually the 3rd parameter which has been deprecated.
          * However with positional arguments, this can only be detected by checking for the "old last" argument.
          * Note: this function explicitly does NOT support named parameters for the function
          * signature without this parameter, but that's not the concern of this sniff.
          */
-        'imagepolygon' => [
+        'imagefilledpolygon' => [
             4 => [
                 'name' => 'num_points',
                 '8.1'  => false,
@@ -99,10 +93,16 @@ class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
                 '8.1'  => false,
             ],
         ],
-        'imagefilledpolygon' => [
+        'imagepolygon' => [
             4 => [
                 'name' => 'num_points',
                 '8.1'  => false,
+            ],
+        ],
+        'imap_headerinfo' => [
+            5 => [
+                'name' => 'defaulthost',
+                '8.0'  => true,
             ],
         ],
         'ldap_first_attribute' => [

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -58,3 +58,6 @@ ldap_first_attribute(
     $result_entry_identifier,
     $ber_identifier // Error.
 );
+
+imagerotate($image, $angle, $bg_color); // OK.
+imagerotate($image, $angle, $bg_color, $ignore_transparent); // Error.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -73,6 +73,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             ['imap_headerinfo', 'defaulthost', '8.0', [30], '7.4'],
             ['odbc_exec', 'flags', '8.0', [33], '7.4'],
             ['odbc_do', 'flags', '8.0', [34], '7.4'],
+            ['imagerotate', 'ignore_transparent', '8.3', [63], '8.2'],
         ];
     }
 
@@ -215,6 +216,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             [32],
             [50],
             [53],
+            [62],
         ];
     }
 


### PR DESCRIPTION
### RemovedFunctionParameters: fix order of the list

This list should be in alphabetical order to make it easier for find a function if an additional parameter is deprecated at a later date.

Fixed now.

### PHP 8.3 | RemovedFunctionParameters: account for signature change for imagerotate()

> - Gd:
>   . Changed imagerotate signature, removed the `ignore_transparent` argument
>     as it was not used internally anyway from PHP 7.x.

Refs:
* https://github.com/php/php-src/blob/548fc6a8185625bf50c708a9337db01f14860ba1/UPGRADING#L211-L213
* php/php-src#11426
* php/php-src@b0d8c10
* https://www.php.net/manual/en/function.imagerotate.php

Related to #1589