### PR TITLE
PHP 8.3 | :sparkles: New `PHPCompatibility.ParameterValues.RemovedLdapConnectSignatures` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedLdapConnectSignaturesStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedLdapConnectSignaturesStandard.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed ldap_connect() Signatures"
+    >
+    <standard>
+    <![CDATA[
+    Calling ldap_connect() with its two-parameter signature is deprecated since PHP 8.3 and support will be removed in PHP 9.0.
+
+    Call ldap_connect() with an LDAP-URI as the first (and only) parameter instead.
+    Or in case the underlying library is Oracle and one wants to add wallet-details, pass an LDAP-URI as the $uri parameter and pass `null` as the $port parameter.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: calling ldap_connect() with an LDAP-URI in the $uri parameter.">
+        <![CDATA[
+ldap_connect(<em>"ldap://$host:$port??369"</em>);
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.3: calling ldap_connect() with separate $host and $port parameters.">
+        <![CDATA[
+ldap_connect(<em>$host</em>, <em>$port</em>);
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Cross-version compatible: calling ldap_connect() with wallet-details with an LDAP-URI in the $uri parameter and null for the $port value.">
+        <![CDATA[
+ldap_connect(
+    <em>"ldap://$host:$port??369"</em>,
+    <em>null</em>,
+    $wallet,
+    $password,
+    $auth_mode,
+);
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.3: calling ldap_connect() with wallet-details with separate $host and $port parameters.">
+        <![CDATA[
+ldap_connect(
+    <em>$host</em>,
+    <em>369</em>,
+    $wallet,
+    $password,
+    $auth_mode,
+);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedLdapConnectSignaturesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedLdapConnectSignaturesSniff.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\PassedParameters;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Detect function calls to ldap_connect() using deprecated function signatures.
+ *
+ * `ldap_connect()` historically supports three signatures:
+ * - `ldap_connect(?string $uri = null)`
+ * - `ldap_connect(?string $host = null, int $port = 389)`
+ * - `ldap_connect(?string $uri, int $port, string $wallet, string $password, int $auth_mode)`
+ *
+ * The two parameter - $host, $port - signature is deprecated since PHP 8.3 and support will be removed in PHP 9.0.
+ *
+ * PHP version 8.3
+ * PHP version 9.0
+ *
+ * {@internal Normally this would be handled via the RemovedFunctionParameters sniff, but this
+ * function has *three* distinct signatures and the signatures are being deprecated in reverse order,
+ * i.e. the 2-param signature is being deprecated in PHP 8.3, while the 3+ param signature is being
+ * deprecated in PHP 8.4.
+ * For that reason, the RemovedFunctionParameters sniff is not suitable to handle this.}
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters
+ * @link https://www.php.net/ldap_connect
+ *
+ * @since 10.0.0
+ */
+final class RemovedLdapConnectSignaturesSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, bool>
+     */
+    protected $targetFunctions = [
+        'ldap_connect' => true,
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrAbove('8.3') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $uriParam  = PassedParameters::getParameterFromStack($parameters, 1, ['uri', 'host']);
+        $portParam = PassedParameters::getParameterFromStack($parameters, 2, 'port');
+
+        if ($uriParam === false || $portParam === false) {
+            // Not the deprecated two param signature.
+            return;
+        }
+
+        // Check for the, still supported, 3+ param signature and if found, check the second param is `null`.
+        if (\count($parameters) > 2) {
+            $hasVariableContent = $phpcsFile->findNext([\T_VARIABLE, \T_STRING], $portParam['start'], ($portParam['end'] + 1));
+            if ($hasVariableContent !== false) {
+                // We don't have access to the contents of the parameter. Bow out.
+                return;
+            }
+
+            if ($portParam['clean'] === 'null') {
+                // This is the correct value to still use the 3+ param signature. Bow out.
+                return;
+            }
+
+            // Found a 3+ param signature, which doesn't pass `null` as $port.
+            $phpcsFile->addWarning(
+                'Calling ldap_connect() with a $port which is not `null` is deprecated since PHP 8.3. Call ldap_connect() with an LDAP-URI as the $uri parameter and pass `null` for $port instead.',
+                $stackPtr,
+                'DeprecatedPortNotNull'
+            );
+            return;
+        }
+
+        // Found the deprecated 2-param signature.
+        $phpcsFile->addWarning(
+            'Calling ldap_connect() with two parameters is deprecated since PHP 8.3. Call ldap_connect() with an LDAP-URI as the first (and only) parameter instead.',
+            $stackPtr,
+            'DeprecatedTwoParamSignature'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.inc
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Test ldap_connect() alternative signatures.
+ */
+
+/*
+ * OK.
+ */
+// Not our target.
+echo LDAP_CONNECT;
+$obj->ldap_connect;
+$obj->ldap_connect();
+$obj?->ldap_connect();
+MyClass::ldap_connect();
+My\Vendor\ldap_connect();
+#[Ldap_Connect()]
+function do_something() {}
+
+ldap_connect();
+ldap_connect( /*comment */ );
+LDAP_Connect($uri);
+\ldap_connect( "ldap://$host:$port??369" );
+
+// Signature still supported in PHP 8.3, will be deprecated in PHP 8.4.
+ldap_connect($uri, null, $wallet, $password, $auth_mode); // Port value null is okay.
+ldap_connect(
+    $uri,
+    $port, // Value undetermined, so ignore.
+    $wallet,
+    $password,
+    $auth_mode,
+);
+ldap_connect($uri, MY_PORT, $wallet, $password, $auth_mode); // Port value undetermined, so ignore.
+ldap_connect($uri, get_port(), $wallet, $password, $auth_mode); // Port value undetermined, so ignore.
+ldap_connect($uri, 369 + $offset, $wallet, $password, $auth_mode); // Port value undetermined, so ignore.
+
+// Invalid function calls (missing required param(s)). Ignore as not our target.
+\ldap_connect(port: $port);
+\ldap_connect(port: $port, wallet: $wallet);
+\ldap_connect(uri: $uri, wallet: $wallet);
+\ldap_connect(auth_mode: $auth_mode, wallet: $wallet);
+\ldap_connect(auth_mode: $auth_mode, wallet: $wallet, password: $password);
+
+/*
+ * PHP 8.3: calling ldap_connect() with 2 parameters.
+ */
+ldap_connect($host, $port);
+
+// Safeguard support for PHP 8 named parameters.
+// The function itself does not support this for this signature, but that's not the concern of this sniff.
+\ldap_connect(uri: $host, port: $port);
+Ldap_Connect(port: $port, host: $host);
+
+// Three-plus param signature passing a port is also deprecated.
+ldap_connect($uri, 369, $wallet, $password, $auth_mode);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedLdapConnectSignatures sniff.
+ *
+ * @group removedLdapConnectSignatures
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedLdapConnectSignaturesSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedLdapConnectSignaturesUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify that the two parameter signature of ldap_connect() is correctly detected.
+     *
+     * @dataProvider dataRemovedLdapConnectSignatureTwoParams
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedLdapConnectSignatureTwoParams($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertWarning($file, $line, 'Calling ldap_connect() with two parameters is deprecated since PHP 8.3.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedLdapConnectSignatureTwoParams()
+     *
+     * @return array
+     */
+    public static function dataRemovedLdapConnectSignatureTwoParams()
+    {
+        return [
+            [47],
+            [51],
+            [52],
+        ];
+    }
+
+
+    /**
+     * Verify that the three+ parameter signature of ldap_connect() is correctly detected when the second param is not set to null.
+     *
+     * @dataProvider dataRemovedLdapConnectSignatureMoreParamsSecondNotNull
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedLdapConnectSignatureMoreParamsSecondNotNull($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertWarning($file, $line, 'Calling ldap_connect() with a $port which is not `null` is deprecated since PHP 8.3.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedLdapConnectSignatureMoreParamsSecondNotNull()
+     *
+     * @return array
+     */
+    public static function dataRemovedLdapConnectSignatureMoreParamsSecondNotNull()
+    {
+        return [
+            [55],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for valid code for the two param signature check.
+     *
+     * @dataProvider dataNoFalsePositivesTwoParamSignature
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesTwoParamSignature($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesTwoParamSignature()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositivesTwoParamSignature()
+    {
+        $data = [];
+
+        // No errors expected on the first 43 lines.
+        for ($line = 1; $line <= 43; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> - LDAP
>   . Calling ldap_connect() with separate hostname and port is deprecated.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters
* https://github.com/php/php-src/blob/548fc6a8185625bf50c708a9337db01f14860ba1/UPGRADING#L146-L148
* php/php-src#5177
* https://github.com/php/php-src/commit/69a8b63ecf4fec1b35ef4da1ac9579321c45f97f

This adds a new sniff to detect the above.

**Note**:
Normally this kind of change would be handled via the `RemovedFunctionParameters` sniff, but this function has *three* distinct signatures and the signatures are being deprecated in reverse order, i.e. the 2-param signature is being deprecated in PHP 8.3, while the 3+ param signature is being deprecated in PHP 8.4. For that reason, the `RemovedFunctionParameters` sniff is not suitable to handle this.

Also note that, while the three+ param signature is still supported, passing a separate `$host` and `$port` is also deprecated for that signature. Instead a `$uri` should be passed and `$port` should be set to `null`. The sniff does take this into account and handles this via a separate error code.

Includes tests and documentation.

Related to #1589