### PR TITLE
PHP 8.3 | NewIniDirectives: various updates

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -1055,6 +1055,11 @@ class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.2' => false,
             '8.3' => true,
         ],
+        'opcache.jit_max_trace_length' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'opcache',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -1046,6 +1046,15 @@ class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.2'       => true,
             'extension' => 'oci8',
         ],
+
+        'zend.max_allowed_stack_size' => [
+            '8.2' => false,
+            '8.3' => true,
+        ],
+        'zend.reserved_stack_size' => [
+            '8.2' => false,
+            '8.3' => true,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -623,3 +623,6 @@ $test = ini_get('zend.max_allowed_stack_size');
 
 ini_set('zend.reserved_stack_size', 10);
 $test = ini_get('zend.reserved_stack_size');
+
+ini_set('opcache.jit_max_trace_length', 10);
+$test = ini_get('opcache.jit_max_trace_length');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -617,3 +617,9 @@ $test = ini_get('error_log_mode');
 
 ini_set('oci8.prefetch_lob_size', 10);
 $test = ini_get('oci8.prefetch_lob_size');
+
+ini_set('zend.max_allowed_stack_size', 10);
+$test = ini_get('zend.max_allowed_stack_size');
+
+ini_set('zend.reserved_stack_size', 10);
+$test = ini_get('zend.reserved_stack_size');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -296,6 +296,7 @@ class NewIniDirectivesUnitTest extends BaseSniffTestCase
 
             ['zend.max_allowed_stack_size', '8.3', [621, 622], '8.2'],
             ['zend.reserved_stack_size', '8.3', [624, 625], '8.2'],
+            ['opcache.jit_max_trace_length', '8.3', [627, 628], '8.2'],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -293,6 +293,9 @@ class NewIniDirectivesUnitTest extends BaseSniffTestCase
 
             ['error_log_mode', '8.2', [615, 616], '8.1'],
             ['oci8.prefetch_lob_size', '8.2', [618, 619], '8.1'],
+
+            ['zend.max_allowed_stack_size', '8.3', [621, 622], '8.2'],
+            ['zend.reserved_stack_size', '8.3', [624, 625], '8.2'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.3 | NewIniDirectives: recognize zend.*_stack_size

> - zend.max_allowed_stack_size
>   . New INI directive to set the maximum allowed stack size. Possible
>     values are `0` (detect the process or thread maximum stack size), `-1`
>     (no limit), or a positive number of bytes. The default is `0`. When it
>     is not possible to detect the the process or thread maximum stack size,
>     a known system default is used. Setting this value too high has the same
>     effect as disabling the stack size limit. Fibers use fiber.stack_size
>     as maximum allowed stack size. An Error is thrown when the process call
>     stack exceeds `zend.max_allowed_stack_size-zend.reserved_stack_size`
>     bytes, to prevent stack-overflow-induced segmentation faults, with
>     the goal of making debugging easier. The stack size increases during
>     uncontrolled recursions involving internal functions or the magic methods
>     __toString, __clone, __sleep, __destruct.  This is not related to stack
>     buffer overflows, and is not a security feature.
>
> - zend.reserved_stack_size
>   . New INI directive to set the reserved stack size, in bytes. This is
>     subtracted from the max allowed stack size, as a buffer, when checking the
>     stack size

Refs:
* https://github.com/php/php-src/blob/548fc6a8185625bf50c708a9337db01f14860ba1/UPGRADING#L531-L549
* php/php-src#9104
* php/php-src@a11c8a3

### PHP 8.3 | NewIniDirectives: recognize opcache.jit_max_trace_length

Not mentioned in the changelog (yet), came across it when I was looking into JIT.

Refs:
* php/php-src#11173
* php/php-src@0e5ac62

Related to #1589