### PR TITLE
PHP 8.3 | NewFunctions: detect use of `json_validate()` (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4913,6 +4913,12 @@ class NewFunctionsSniff extends Sniff
             '8.2.1'     => true,
             'extension' => 'imap',
         ],
+
+        'json_validate' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'json',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1038,3 +1038,5 @@ odbc_connection_string_should_quote();
 odbc_connection_string_quote();
 
 imap_is_open();
+
+json_validate();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1099,6 +1099,8 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['libxml_get_external_entity_loader', '8.1', 1034, '8.2'],
 
             ['imap_is_open', '8.2.0', 1040, '8.3', '8.2'],
+
+            ['json_validate', '8.2', 1042, '8.3'],
         ];
     }
 


### PR DESCRIPTION
>   . Added json_validate(), which returns whether the json is valid for
>     the given $depth and $options.

Refs:
* https://wiki.php.net/rfc/json_validate
* https://github.com/php/php-src/blob/655f116be57b46efe32221d7adfec6d6b81eeece/UPGRADING#L339-L341
* php/php-src#9399
* https://github.com/php/php-src/commit/2e8699f6f2759a906e25cd73fafdd0bd22fd0760

Related to #1589