### PR TITLE
PHP 8.3 | RemovedIniDirectives: recognize `opcache.consistency_checks`

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -684,6 +684,10 @@ class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.3'         => false,
             'alternative' => 'zend.assertions',
         ],
+        'opcache.consistency_checks' => [
+            '8.3'       => true,
+            'extension' => 'opcache',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -481,3 +481,6 @@ $test = ini_get('assert.exception');
 
 ini_set('assert.warning', 0);
 $test = ini_get('assert.warning');
+
+ini_set('opcache.consistency_checks', 0);
+$test = ini_get('opcache.consistency_checks');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -416,6 +416,7 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
             ['mysqlnd.fetch_data_copy', '8.1', [464, 465], '8.0'],
 
             ['mysqli.reconnect', '8.2', [467, 468], '8.1'],
+            ['opcache.consistency_checks', '8.3', [485, 486], '8.2'],
         ];
     }
 


### PR DESCRIPTION
> - Opcache:
>   . The opcache.consistency_checks INI directive was removed. This feature was
>     broken with the tracing JIT, as well as with inheritance cache, and has been
>     disabled without a way to enable it since PHP 8.1.18 and PHP 8.2.5. Both the
>     tracing JIT and inheritance cache may modify shm after the script has been
>     persisted, invalidating its checksum. The attempted fix skipped over the
>     modifiable pointers but was rejected due to complexity. For this reason, it
>     was decided to remove the feature instead.

Refs:
* https://github.com/php/php-src/blob/3ff7d18070b4544491327689529d20a277a49eb1/UPGRADING#L53-L60
* php/php-src#11832
* https://github.com/php/php-src/commit/b2dbf0a2c68425d374a3eb7fd14fff2a1ad26061

Related to #1589