### PR TITLE
PHP 8.3 | NewFunctions: detect use of `mb_str_pad()` (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4919,6 +4919,11 @@ class NewFunctionsSniff extends Sniff
             '8.3'       => true,
             'extension' => 'json',
         ],
+        'mb_str_pad' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'mbstring',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1040,3 +1040,4 @@ odbc_connection_string_quote();
 imap_is_open();
 
 json_validate();
+mb_str_pad();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1101,6 +1101,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['imap_is_open', '8.2.0', 1040, '8.3', '8.2'],
 
             ['json_validate', '8.2', 1042, '8.3'],
+            ['mb_str_pad', '8.2', 1043, '8.3'],
         ];
     }
 


### PR DESCRIPTION
>   . Added mb_str_pad(), which is the mbstring equivalent of str_pad().
>     RFC: https://wiki.php.net/rfc/mb_str_pad

Refs:
* https://wiki.php.net/rfc/mb_str_pad
* https://github.com/php/php-src/blob/655f116be57b46efe32221d7adfec6d6b81eeece/UPGRADING#L348-L349
* php/php-src#11284
* https://github.com/php/php-src/commit/68591632b22289962127cf777b4c3aeaea768bb6

Related to #1589