### PR TITLE
PHP 8.3 | NewFunctions: recognize ldap_connect_wallet() and ldap_exop_sync() (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4919,6 +4919,11 @@ class NewFunctionsSniff extends Sniff
             '8.3'       => true,
             'extension' => 'json',
         ],
+        'ldap_connect_wallet' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'ldap',
+        ],
         'mb_str_pad' => [
             '8.2'       => false,
             '8.3'       => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4924,6 +4924,11 @@ class NewFunctionsSniff extends Sniff
             '8.3'       => true,
             'extension' => 'ldap',
         ],
+        'ldap_exop_sync' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'ldap',
+        ],
         'mb_str_pad' => [
             '8.2'       => false,
             '8.3'       => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1041,3 +1041,4 @@ imap_is_open();
 
 json_validate();
 mb_str_pad();
+ldap_connect_wallet();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1042,3 +1042,4 @@ imap_is_open();
 json_validate();
 mb_str_pad();
 ldap_connect_wallet();
+ldap_exop_sync();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1103,6 +1103,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['json_validate', '8.2', 1042, '8.3'],
             ['mb_str_pad', '8.2', 1043, '8.3'],
             ['ldap_connect_wallet', '8.2', 1044, '8.3'],
+            ['ldap_exop_sync', '8.2', 1045, '8.3'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1102,6 +1102,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
 
             ['json_validate', '8.2', 1042, '8.3'],
             ['mb_str_pad', '8.2', 1043, '8.3'],
+            ['ldap_connect_wallet', '8.2', 1044, '8.3'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.3 | NewFunctions: recognize ldap_connect_wallet() (RFC)

> - LDAP:
>   . Added ldap_connect_wallet().

Note: the same (accepted) RFC which introduced this new function, also deprecates the signature of the `ldap_connect()` function with 3+ parameters, but that deprecation won't take effect until PHP 8.4.

I do have an adjustment to the (new) `PHPCompatibility.ParameterValues.RemovedLdapConnectSignatures` (PR #1620) sniff ready to handle this, but won't pull that update until the deprecation has been merged into PHP itself.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#ldap_connect
* https://github.com/php/php-src/blob/548fc6a8185625bf50c708a9337db01f14860ba1/UPGRADING#L343-L344
* php/php-src#11703
* php/php-src@72aada3
* https://www.php.net/ldap_connect

### PHP 8.3 | NewFunctions: recognize ldap_exop_sync() (RFC)

> - LDAP:
>   . Added ldap_exop_sync().

Note: the same (accepted) RFC which introduced this new function, also deprecates the signature of the `ldap_exop()` function with 5/6 parameters, but that deprecation won't take effect until PHP 8.4.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#ldap_exop
* https://github.com/php/php-src/blob/548fc6a8185625bf50c708a9337db01f14860ba1/UPGRADING#L345
* php/php-src#11703
* php/php-src@b3bd55f
* https://www.php.net/ldap_exop

Related to #1589