### PR TITLE
PHP 8.3 | NewFunctionParameters: account for signature change for posix_getrlimit()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -724,6 +724,13 @@ class NewFunctionParametersSniff extends AbstractFunctionCallParameterSniff
                 '5.1.2' => true,
             ],
         ],
+        'posix_getrlimit' => [
+            1 => [
+                'name' => 'resource',
+                '8.2'  => false,
+                '8.3'  => true,
+            ],
+        ],
         'pg_escape_bytea' => [
             /*
              * Is in actual fact the first parameter, with a second required param.

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
@@ -146,3 +146,5 @@ parse_url(
     $url,
     PHP_URL_PATH // Error.
 );
+
+posix_getrlimit($res);

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -166,6 +166,7 @@ class NewFunctionParametersUnitTest extends BaseSniffTestCase
             ['openssl_verify', 'algorithm', '5.1', [63], '5.2'],
             ['parse_ini_file', 'scanner_mode', '5.2', [64], '5.3'],
             ['parse_url', 'component', '5.1.1', [65, 147], '5.2', '5.1'],
+            ['posix_getrlimit', 'resource', '8.2', [150], '8.3'],
             ['pg_escape_bytea', 'connection', '5.1', [123], '5.2'],
             ['pg_escape_string', 'connection', '5.1', [124], '5.2'],
             ['pg_fetch_all', 'mode', '7.0', [99], '7.1'],


### PR DESCRIPTION
>   . posix_getrlimit() now takes an optional $res parameter to allow fetching a
>     single resource limit.

Refs:
* https://github.com/php/php-src/blob/548fc6a8185625bf50c708a9337db01f14860ba1/UPGRADING#L103
* php/php-src#9790
* https://github.com/php/php-src/commit/d10a04b391bbdb1f5204c4318052d2776d094750
* https://www.php.net/manual/en/function.posix-getrlimit.php

Related to #1589