### PR TITLE
PHP 8.3 | NewFunctions: recognize `stream_context_set_options()` (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4914,6 +4914,10 @@ class NewFunctionsSniff extends Sniff
             'extension' => 'imap',
         ],
 
+        'stream_context_set_options' => [
+            '8.2' => false,
+            '8.3' => true,
+        ],
         'json_validate' => [
             '8.2'       => false,
             '8.3'       => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1043,3 +1043,4 @@ json_validate();
 mb_str_pad();
 ldap_connect_wallet();
 ldap_exop_sync();
+stream_context_set_options();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1104,6 +1104,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['mb_str_pad', '8.2', 1043, '8.3'],
             ['ldap_connect_wallet', '8.2', 1044, '8.3'],
             ['ldap_exop_sync', '8.2', 1045, '8.3'],
+            ['stream_context_set_options', '8.2', 1046, '8.3'],
         ];
     }
 


### PR DESCRIPTION
>   . Added stream_context_set_options() as a replacement for
>     stream_context_set_option() when passed an array of options.

Note: the same (accepted) RFC which introduced this new function, also deprecates the alternative signature of the `stream_context_set_option()` function, but that deprecation won't take effect until PHP 8.4.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#stream_context_set_option
* https://github.com/php/php-src/blob/548fc6a8185625bf50c708a9337db01f14860ba1/UPGRADING#L380-L381
* php/php-src#11703
* https://github.com/php/php-src/commit/a5ad7e09d59ad06a34c9d83579cf3c5d8edc4eba

Related to #1589