### PR TITLE
Keywords/ForbiddenNames: bug fix for method names

### DIFF
--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/method-declare.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/method-declare.inc
@@ -31,7 +31,6 @@ class Foobar { function exit() { } }
 class Foobar { function extends() { } }
 class Foobar { function final() { } }
 class Foobar { function finally() { } }
-class Foobar { function fn() { } }
 class Foobar { function for() { } }
 class Foobar { function foreach() { } }
 class Foobar { function function() { } }
@@ -46,7 +45,6 @@ class Foobar { function insteadof() { } }
 class Foobar { function interface() { } }
 class Foobar { function isset() { } }
 class Foobar { function list() { } }
-class Foobar { function match() { } }
 class Foobar { function namespace() { } }
 class Foobar { function new() { } }
 class Foobar { function or() { } }

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
@@ -380,3 +380,9 @@ class EnumSpecialCasingTest
 
 // Issue #1474: more protection against `enum` false positives.
 use Elao\Enum\Bridge\Symfony\Validator\Constraint\Enum as AssertEnum;
+
+// Ensure there are no false positives when a keyword which became reserved in PHP >= 7.0 is used as a method name.
+class ReservedKeywordsAsMethodNames {
+    public function fn() {}
+    public function match() {}
+}

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -379,7 +379,7 @@ class ForbiddenNamesUnitTest extends BaseSniffTestCase
      */
     public function testCorrectUsageOfKeywords($path)
     {
-        $file = $this->sniffFile($path, '7.4');
+        $file = $this->sniffFile($path, '5.0-');
         $this->assertNoViolation($file);
     }
 

--- a/bin/generate-forbidden-names-test-files
+++ b/bin/generate-forbidden-names-test-files
@@ -180,11 +180,13 @@ $tests = [
         }
     },
     // Only pre-PHP 7!
-    'method-declare'                         => function ($name) {
-        if ($name === 'readonly') {
-            // Tested separately as there is an exception in place.
-            return '';
-        } else {
+    'method-declare'                         => function ($name) use ($invalidNames) {
+        if ($name === 'Baz'
+            || isset($invalidNames[$name]) === false
+            || $invalidNames[$name] === 'all'
+            || $invalidNames[$name][0] === '4'
+            || $invalidNames[$name][0] === '5'
+        ) {
             $name = strtolower($name);
             return "class Foobar { function $name() { } }\n";
         }


### PR DESCRIPTION
Brought to my attention during WordCamp The Netherlands by @tfrommen.

When a keyword only became reserved in PHP 7.0 or later, it doesn't matter whether the code needs to run on PHP < 7.0 or not, when determining whether to flag a method declaration.

For example:
* `match` became a reserved keyword in PHP 8.0.
* Method names can be a reserved keyword since PHP 7.0.
* The code needs to run on PHP 5.5 and higher.

Given the above, a method declared with the name `match` should not be flagged, as in PHP < 8.0 it was not a reserved keyword yet, so the fact that reserved keywords cannot be used for methods names in PHP < 7.0 is irrelevant.

This commit fixes this issue.

Note: this was previously not an issue as PHP didn't introduce new (single word) hard reserved keywords between PHP 7.0 - 7.3.

Includes updated tests.