### PR TITLE
QA: remove redundant calls to `version_compare()`

### DIFF
--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -62,7 +62,7 @@ class NewPHPOpenTagEOFSniff extends Sniff
             $targets[] = \T_STRING;
         }
 
-        if (\version_compare(\PHP_VERSION_ID, '70399', '>')) {
+        if (\PHP_VERSION_ID >= 70400) {
             $targets[] = \T_OPEN_TAG;
         }
 

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -49,7 +49,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
      */
     public function register()
     {
-        if (\version_compare(\PHP_VERSION_ID, '70000', '<') === true) {
+        if (\PHP_VERSION_ID < 70000) {
             // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.asp_tagsRemoved
             $this->aspTags = (bool) \ini_get('asp_tags');
         }

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -47,7 +47,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
             \T_END_NOWDOC,
         ];
 
-        if (\version_compare(\PHP_VERSION_ID, '70299', '>') === false) {
+        if (\PHP_VERSION_ID < 70300) {
             // Start identifier of a PHP 7.3 flexible heredoc/nowdoc.
             $targets[] = \T_STRING;
         }
@@ -99,7 +99,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
         $trailingError     = 'Having code - other than a semi-colon or new line - after the closing marker of a heredoc/nowdoc is not supported in PHP 7.2 or earlier.';
         $trailingErrorCode = 'ClosingMarkerNoNewLine';
 
-        if (\version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
+        if (\PHP_VERSION_ID >= 70300) {
             /*
              * Check for indented closing marker.
              */
@@ -185,7 +185,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
         $error     = 'The body of a heredoc/nowdoc can not contain the heredoc/nowdoc closing marker as text at the start of a line since PHP 7.3.';
         $errorCode = 'ClosingMarkerNoNewLine';
 
-        if (\version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
+        if (\PHP_VERSION_ID >= 70300) {
             $nextNonWhitespace = $phpcsFile->findNext(\T_WHITESPACE, ($stackPtr + 1), null, true, null, true);
             if ($nextNonWhitespace === false
                 || $tokens[$nextNonWhitespace]['code'] === \T_SEMICOLON

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -50,7 +50,7 @@ class RemovedAlternativePHPTagsUnitTest extends BaseSniffTestCase
         // Run the parent `@beforeClass` method.
         parent::resetSniffFiles();
 
-        if (\version_compare(\PHP_VERSION_ID, '70000', '<')) {
+        if (\PHP_VERSION_ID < 70000) {
             // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.asp_tagsRemoved
             self::$aspTags = (bool) \ini_get('asp_tags');
         }

--- a/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
@@ -70,7 +70,7 @@ class NewNumericLiteralSeparatorUnitTest extends BaseSniffTestCase
 
         // The test case on line 39 is half a valid numeric literal with underscore, half parse error.
         // The sniff will behave differently on PHP 7.4 vs PHP < 7.4.
-        if (\version_compare(\PHP_VERSION_ID, '70399', '>')) {
+        if (\PHP_VERSION_ID >= 70400) {
             $data[] = [41];
         }
 
@@ -121,7 +121,7 @@ class NewNumericLiteralSeparatorUnitTest extends BaseSniffTestCase
 
         // The test case on line 39 is half a valid numeric literal with underscore, half parse error.
         // The sniff will behave differently on PHP 7.4 vs PHP < 7.4.
-        if (\version_compare(\PHP_VERSION_ID, '70399', '<=')) {
+        if (\PHP_VERSION_ID < 70400) {
             $data[] = [41];
         }
 

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -54,7 +54,7 @@ class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTestCase
             self::$php73plus = false;
             // When using PHP 7.3+, the closing marker will be misidentified if the
             // body contains the heredoc/nowdoc identifier.
-            if (\version_compare(\PHP_VERSION_ID, '70299', '>') === true) {
+            if (\PHP_VERSION_ID >= 70300) {
                 self::$php73plus = true;
             }
         }


### PR DESCRIPTION
The `PHP_VERSION_ID` constant is an integer, so we can just use a straight comparison.
And as the `PHP_VERSION_ID` constant doesn't include the "extra" bits, like `-alpha` etc, we also don't need to take the quirks from `version_compare()` related to that into account.