### PR TITLE
Docs: various `@var`/`@param`/`@return` tag improvements

### DIFF
--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -44,10 +44,10 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @var array The only requirement for this array is that the top level
-     *            array keys are the names of the functions you're looking for.
-     *            Other than that, the array can have arbitrary content
-     *            depending on your needs.
+     * @var array<string, mixed> The only requirement for this array is that the top level
+     *                           array keys are the names of the functions you're looking for.
+     *                           Other than that, the array can have arbitrary content
+     *                           depending on your needs.
      */
     protected $targetFunctions = [];
 
@@ -59,7 +59,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @var array
+     * @var array<int|string, true>
      */
     private $ignoreTokens = [
         \T_NEW => true,

--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -71,7 +71,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/AbstractInitialValueSniff.php
+++ b/PHPCompatibility/AbstractInitialValueSniff.php
@@ -40,7 +40,7 @@ abstract class AbstractInitialValueSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array<string, string> Type indicator => suggested partial error phrase
+     * @var array<string, string> Type indicator => suggested partial error phrase.
      */
     protected $initialValueTypes = [
         'const'     => 'when defining constants using the const keyword',

--- a/PHPCompatibility/AbstractInitialValueSniff.php
+++ b/PHPCompatibility/AbstractInitialValueSniff.php
@@ -54,7 +54,7 @@ abstract class AbstractInitialValueSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Helpers/ComplexVersionDeprecatedRemovedFeatureTrait.php
+++ b/PHPCompatibility/Helpers/ComplexVersionDeprecatedRemovedFeatureTrait.php
@@ -98,7 +98,7 @@ trait ComplexVersionDeprecatedRemovedFeatureTrait
      * @param string   $itemBaseCode The basis for the error code.
      * @param string[] $versionInfo  Array of version info as received from the getVersionInfo() method.
      *
-     * @return array
+     * @return array<string, string|array>
      */
     protected function getMessageInfo($itemName, $itemBaseCode, array $versionInfo)
     {

--- a/PHPCompatibility/Helpers/ComplexVersionNewFeatureTrait.php
+++ b/PHPCompatibility/Helpers/ComplexVersionNewFeatureTrait.php
@@ -77,7 +77,7 @@ trait ComplexVersionNewFeatureTrait
      * @param string   $itemBaseCode The basis for the error code.
      * @param string[] $versionInfo  Array of version info as received from the getVersionInfo() method.
      *
-     * @return array
+     * @return array<string, string|array>
      */
     protected function getMessageInfo($itemName, $itemBaseCode, array $versionInfo)
     {

--- a/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
+++ b/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
@@ -41,7 +41,7 @@ trait HashAlgorithmsTrait
      * @since 7.0.7  Moved from the `RemovedHashAlgorithms` sniff to the base `Sniff` class.
      * @since 10.0.0 Moved from the base `Sniff` class to the `HashAlgorithmsTrait`.
      *
-     * @var array
+     * @var array<string, array<string, int|string>>
      */
     protected $hashAlgoFunctions = [
         'hash_file' => [

--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -40,7 +40,7 @@ trait PCRERegexTrait
      * @since 7.0.5  This array was originally contained within the `process()` method.
      * @since 10.0.0 Moved from the `RemovedPCREModifiersSniff` to this trait.
      *
-     * @var array
+     * @var array<string, string>
      */
     private $doublesSeparators = [
         '{' => '}',

--- a/PHPCompatibility/Helpers/ScannedCode.php
+++ b/PHPCompatibility/Helpers/ScannedCode.php
@@ -38,16 +38,16 @@ final class ScannedCode
      * Default testVersion if no valid testVersion was provided or
      * could be determined based on the provided information.
      *
-     * @var array
+     * @var array<string|null>
      */
     private static $testVersionsDefault = [null, null];
 
     /**
      * Test versions applicable for the current PHPCS run.
      *
-     * @var array Array with two values.
-     *            Index 0 contains the low end supported PHP version.
-     *            Index 1 contains the high end supported PHP version.
+     * @var array<string|null> Array with two values.
+     *                         Index 0 contains the low end supported PHP version.
+     *                         Index 1 contains the high end supported PHP version.
      */
     private static $testVersions;
 
@@ -82,9 +82,9 @@ final class ScannedCode
      *               - Will throw a PHP Exception instead of a warning for an invalid testVersion.
      *               - The method is now static.
      *
-     * @return array An array containing min/max version of PHP that we are checking
-     *               against (see above). If only a single version number is specified,
-     *               then this is used as both the min and max.
+     * @return array<string> An array containing min/max version of PHP that we are checking
+     *                       against (see above). If only a single version number is specified,
+     *                       then this is used as both the min and max.
      *
      * @throws \PHPCompatibility\Exceptions\InvalidTestVersionRange When the range in the testVersion is invalid.
      * @throws \PHPCompatibility\Exceptions\InvalidTestVersion      When the testVersion itself is invalid.

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -41,7 +41,7 @@ class NewAttributesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
@@ -42,7 +42,7 @@ class ForbiddenExtendingFinalPHPClassSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
@@ -30,8 +30,8 @@ class ForbiddenExtendingFinalPHPClassSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array(string => int) Key is the fully qualified classname.
-     *                           Value the PHP version in which the class became final.
+     * @var array<string, string> Key is the fully qualified classname.
+     *                            Value the PHP version in which the class became final.
      */
     protected $finalClasses = [
         '\__PHP_Incomplete_Class' => '8.0',

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -32,7 +32,7 @@ class NewAnonymousClassesSniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -53,7 +53,7 @@ class NewClassesSniff extends Sniff
      *
      * @since 5.5
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool|string>>
      */
     protected $newClasses = [
         'ArrayObject' => [
@@ -871,7 +871,7 @@ class NewClassesSniff extends Sniff
      *
      * @since 7.1.4
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool|string>>
      */
     protected $newExceptions = [
         'com_exception' => [

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1111,7 +1111,7 @@ class NewClassesSniff extends Sniff
      *               as return type declarations.
      * @since 10.0.0 `T_RETURN_TYPE` token removed after PHPCS < 3.7.1 version drop.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -34,7 +34,7 @@ class NewConstVisibilitySniff extends Sniff
      *
      * @since 7.0.7
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
@@ -34,7 +34,7 @@ final class NewConstructorPropertyPromotionSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/NewFinalConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewFinalConstantsSniff.php
@@ -34,7 +34,7 @@ class NewFinalConstantsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -40,7 +40,7 @@ class NewLateStaticBindingSniff extends Sniff
      * @since 7.0.3
      * @since 10.0.0 Now also sniffs for `T_STRING`.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
@@ -34,7 +34,7 @@ final class NewReadonlyClassesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
@@ -36,7 +36,7 @@ final class NewReadonlyPropertiesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -62,7 +62,7 @@ class NewTypedPropertiesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool>>
      */
     protected $newTypes = [
         'mixed' => [
@@ -93,7 +93,7 @@ class NewTypedPropertiesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array(string => string|false)
+     * @var array<string, string|false>
      */
     protected $invalidTypes = [
         'boolean'  => 'bool',
@@ -108,7 +108,7 @@ class NewTypedPropertiesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $unionOnlyTypes = [
         'false' => true,

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -121,7 +121,7 @@ class NewTypedPropertiesSniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -55,7 +55,7 @@ class RemovedClassesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool|string>>
      */
     protected $removedClasses = [
         'HW_API' => [
@@ -204,7 +204,7 @@ class RemovedClassesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool|string>>
      */
     protected $removedExceptions = [
         'SQLiteException' => [

--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -219,7 +219,7 @@ class RemovedClassesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -38,7 +38,7 @@ class RemovedOrphanedParentSniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsInTraitsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsInTraitsSniff.php
@@ -34,7 +34,7 @@ final class NewConstantsInTraitsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -7713,7 +7713,7 @@ class NewConstantsSniff extends Sniff
      *
      * @since 8.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -38,7 +38,7 @@ class NewConstantsSniff extends Sniff
      *
      * @since 8.1.0
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool|string>>
      */
     protected $newConstants = [
         'E_STRICT' => [

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -43,7 +43,7 @@ class NewMagicClassConstantSniff extends Sniff
      *
      * @since 7.1.4
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -2660,7 +2660,7 @@ class RemovedConstantsSniff extends Sniff
      *
      * @since 8.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -42,7 +42,7 @@ class RemovedConstantsSniff extends Sniff
      *
      * @since 8.1.0
      *
-     * @var array(string => array(string => bool|string))
+     * @var array<string, array<string, bool|string>>
      */
     protected $removedConstants = [
         'F_DUPFD' => [

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -85,7 +85,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -42,7 +42,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     protected $loopStructures = [
         \T_FOR     => \T_FOR,
@@ -57,7 +57,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     protected $caseTokens = [
         \T_CASE    => \T_CASE,
@@ -71,7 +71,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     protected $acceptedLevelTokens = [
         \T_LNUMBER           => \T_LNUMBER,

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -35,7 +35,7 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
      *
      * @since 7.0.7
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     protected $validLoopStructures = [
         \T_FOR     => \T_FOR,

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -50,7 +50,7 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
      *
      * @since 7.0.7
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -68,7 +68,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
      *
      * @since 5.5
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -43,7 +43,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
      * @since 7.0.5
      * @since 7.1.0 Changed from class constants to property.
      *
-     * @var array
+     * @var array<string, string>
      */
     private $errorTypes = [
         'variableArgument' => 'a variable argument',
@@ -55,7 +55,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $varArgTokens = [
         \T_VARIABLE => \T_VARIABLE,

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -32,7 +32,7 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -52,7 +52,7 @@ class NewExecutionDirectivesSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @var array(string => array(string => bool|string|array))
+     * @var array<string, array<string, bool|string|array>>
      */
     protected $newDirectives = [
         'ticks' => [

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -88,7 +88,7 @@ class NewExecutionDirectivesSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -35,7 +35,7 @@ class NewForeachExpressionReferencingSniff extends Sniff
      *
      * @since 9.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -33,7 +33,7 @@ class NewListInForeachSniff extends Sniff
      *
      * @since 9.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -33,7 +33,7 @@ class NewMultiCatchSniff extends Sniff
      *
      * @since 7.0.7
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ControlStructures/NewNonCapturingCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewNonCapturingCatchSniff.php
@@ -33,7 +33,7 @@ class NewNonCapturingCatchSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -212,7 +212,7 @@ class RemovedExtensionsSniff extends Sniff
      *
      * @since 5.5
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -58,7 +58,7 @@ class RemovedExtensionsSniff extends Sniff
      *
      * @since 7.0.2
      *
-     * @var array
+     * @var string[]
      */
     public $functionWhitelist;
 
@@ -70,7 +70,7 @@ class RemovedExtensionsSniff extends Sniff
      *
      * @since 5.5
      *
-     * @var array(string => array(string => bool|string|null))
+     * @var array<string, array<string, bool|string|null>>
      */
     protected $removedExtensions = [
         'activescript' => [

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
@@ -45,7 +45,7 @@ class AbstractPrivateMethodsSniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
@@ -42,7 +42,7 @@ class ForbiddenFinalPrivateMethodsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -37,7 +37,7 @@ class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
      * @since 7.1.3  Allows for closures.
      * @since 10.0.0 Allows for PHP 7.4+ arrow functions.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -35,7 +35,7 @@ class ForbiddenParametersWithSameNameSniff extends Sniff
      * @since 7.1.3  Allows for closures.
      * @since 10.0.0 Allows for PHP 7.4+ arrow functions.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -36,7 +36,7 @@ class ForbiddenToStringParametersSniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -39,7 +39,7 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
      *
      * @since 7.1.4
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -49,7 +49,7 @@ class NewClosureSniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -39,7 +39,7 @@ class NewExceptionsFromToStringSniff extends Sniff
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $docblockIgnoreTokens = [
         \T_WHITESPACE => \T_WHITESPACE,

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -50,7 +50,7 @@ class NewExceptionsFromToStringSniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -41,7 +41,7 @@ class NewNullableTypesSniff extends Sniff
      * @since 7.0.7
      * @since 10.0.0 Allows for PHP 7.4+ arrow functions.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -172,7 +172,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
      * @since 7.1.3  Now also checks closures.
      * @since 10.0.0 Now also checks PHP 7.4+ arrow functions.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -74,7 +74,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
      * @since 7.0.0
      * @since 7.0.3 Now lists all param type declarations, not just the PHP 7+ scalar ones.
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool>>
      */
     protected $newTypes = [
         'array' => [
@@ -144,7 +144,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @var array(string => string)
+     * @var array<string, string>
      */
     protected $invalidTypes = [
         'static'  => 'self',
@@ -157,7 +157,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $unionOnlyTypes = [
         'false' => true,

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -64,7 +64,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool>>
      */
     protected $newTypes = [
         'int' => [
@@ -152,7 +152,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $unionOnlyTypes = [
         'false' => true,
@@ -164,7 +164,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array Key: string type name, value: PHP version in which the type was introduced.
+     * @var array<string, string> Key: string type name, value: PHP version in which the type was introduced.
      */
     protected $standAloneTypes = [
         'void'  => '7.1',

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -180,7 +180,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
      * @since 7.1.2  Now also checks based on the function and closure keywords.
      * @since 10.0.0 Now also checks PHP 7.4+ arrow functions.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
@@ -34,7 +34,7 @@ class NewTrailingCommaSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -119,7 +119,7 @@ class NonStaticMagicMethodsSniff extends Sniff
      * @since 7.1.4  Now also checks anonymous classes.
      * @since 10.0.0 Switch to check based on T_FUNCTION token instead of OO construct token.
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -46,7 +46,7 @@ class NonStaticMagicMethodsSniff extends Sniff
      * @since 5.6 The array format has changed to allow the sniff to also verify the
      *            use of the correct visibility for a magic method.
      *
-     * @var array(string)
+     * @var array<string, array<string, string|bool>>
      */
     protected $magicMethods = [
         '__construct' => [

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -40,7 +40,7 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -41,7 +41,7 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $allowedInDefault = [
         \T_NULL => \T_NULL,

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -52,7 +52,7 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
@@ -35,7 +35,7 @@ class RemovedReturnByReferenceFromVoidSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -47,7 +47,7 @@ class NewMagicMethodsSniff extends Sniff
      *
      * @since 7.0.4
      *
-     * @var array(string => array(string => bool|string))
+     * @var array<string, array<string, bool|string>>
      */
     protected $newMagicMethods = [
         '__construct' => [

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -114,7 +114,7 @@ class NewMagicMethodsSniff extends Sniff
      *
      * @since 7.0.4
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -55,7 +55,7 @@ class RemovedMagicAutoloadSniff extends Sniff
      *
      * @since 8.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -44,7 +44,7 @@ class RemovedMagicAutoloadSniff extends Sniff
      *
      * @since 8.1.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $checkForScopes = [
         \T_NAMESPACE => \T_NAMESPACE,

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -45,7 +45,7 @@ class RemovedNamespacedAssertSniff extends Sniff
      *
      * @since 9.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -51,7 +51,7 @@ class RemovedPHP4StyleConstructorsSniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -37,7 +37,7 @@ class ReservedFunctionNamesSniff implements Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -115,7 +115,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      *
      * @since 9.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -44,7 +44,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      *
      * @since 9.1.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $changedFunctions = [
         'func_get_arg'          => true,
@@ -58,7 +58,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      *
      * @since 9.1.0
      *
-     * @var array
+     * @var array<string, true>
      */
     private $skipPastNested = [
         'T_CLASS'      => true,
@@ -74,7 +74,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      *
      * @since 9.1.0
      *
-     * @var array
+     * @var array<int|string, true>
      */
     private $plusPlusMinusMinus = [
         \T_DEC => true,
@@ -86,7 +86,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      *
      * @since 9.1.0
      *
-     * @var array
+     * @var array<int|string>
      */
     private $ignoreForStartOfStatement = [
         \T_COMMA,
@@ -100,7 +100,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<int|string>
      */
     private $ignoreForStartOfStatementVarUse = [
         \T_COMMA,

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -42,7 +42,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'func_get_args' => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -56,7 +56,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -45,7 +45,7 @@ class NewFunctionParametersSniff extends AbstractFunctionCallParameterSniff
      * @since 10.0.0 - The parameter offsets were changed from 0-based to 1-based.
      *               - The property was renamed from `$newFunctionParameters` to `$targetFunctions`.
      *
-     * @var array
+     * @var array<string, array<int, array<string, bool|string>>>
      */
     protected $targetFunctions = [
         'array_filter' => [

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4946,7 +4946,7 @@ class NewFunctionsSniff extends Sniff
      *
      * @since 5.6
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -45,7 +45,7 @@ class NewFunctionsSniff extends Sniff
      *              but that sniff is no longer being extended.
      * @since 7.0.8 Renamed from `$forbiddenFunctions` to the more descriptive `$newFunctions`.
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool|string>>
      */
     protected $newFunctions = [
         'class_implements' => [

--- a/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
@@ -34,7 +34,7 @@ class NewNamedParametersSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -48,7 +48,7 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
      *                 compatibility with the `AbstractFunctionCallParameterSniff` class.
      *               - The parameter offsets were changed from 0-based to 1-based.
      *
-     * @var array
+     * @var array<string, array<int, array<string, bool|string>>>
      */
     protected $targetFunctions = [
         'crypt' => [

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -51,7 +51,7 @@ class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
      * @since 10.0.0 - The parameter offsets were changed from 0-based to 1-based.
      *               - The property was renamed from `$removedFunctionParameters` to `$targetFunctions`.
      *
-     * @var array
+     * @var array<string, array<int, array<string, bool|string>>>
      */
     protected $targetFunctions = [
         'curl_version' => [

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5082,7 +5082,7 @@ class RemovedFunctionsSniff extends Sniff
      *
      * @since 5.6
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -49,7 +49,7 @@ class RemovedFunctionsSniff extends Sniff
      *              but that sniff is no longer being extended.
      * @since 7.0.8 Property renamed from `$forbiddenFunctions` to `$removedFunctions`.
      *
-     * @var array(string => array(string => bool|string|null))
+     * @var array<string, array<string, bool|string|null>>
      */
     protected $removedFunctions = [
         'crack_check' => [

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -48,7 +48,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractFunctionCallPara
      *                 compatibility with the `AbstractFunctionCallParameterSniff` class.
      *               - The parameter offsets were changed from 0-based to 1-based.
      *
-     * @var array
+     * @var array<string, array<int, array<string, bool|string>>>
      */
     protected $targetFunctions = [
         'array_diff_assoc' => [
@@ -410,7 +410,7 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractFunctionCallPara
      *
      * @param array $itemArray Version and other information about the item.
      *
-     * @return array
+     * @return array<string, string>
      */
     protected function getVersionInfo(array $itemArray)
     {

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -49,7 +49,7 @@ class NewGeneratorReturnSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -36,7 +36,7 @@ class NewGeneratorReturnSniff extends Sniff
      *
      * @since 9.0.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $validConditions = [
         \T_FUNCTION => \T_FUNCTION,

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -47,7 +47,7 @@ class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
      * @since 10.0.0 Moved from the base `Sniff` class to this sniff and renamed from
      *               `$iniFunctions` to `$targetFunctions`.
      *
-     * @var array
+     * @var array<string, array<string, int|string>>
      */
     protected $targetFunctions = [
         'ini_get' => [
@@ -69,7 +69,7 @@ class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
      * @since 5.5
      * @since 7.0.3 Support for 'alternative' has been added.
      *
-     * @var array(string)
+     * @var array<string, array<string, bool|string>>
      */
     protected $newIniDirectives = [
         'auto_globals_jit' => [

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -49,7 +49,7 @@ class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
      * @since 10.0.0 Moved from the base `Sniff` class to this sniff and renamed from
      *               `$iniFunctions` to `$targetFunctions`.
      *
-     * @var array
+     * @var array<string, array<string, int|string>>
      */
     protected $targetFunctions = [
         'ini_get' => [
@@ -71,7 +71,7 @@ class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
      * @since 5.5
      * @since 7.0.3 Support for 'alternative' has been added.
      *
-     * @var array(string)
+     * @var array<string, array<string, bool|string>>
      */
     protected $deprecatedIniDirectives = [
         'crack.default_dictionary' => [

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -36,7 +36,7 @@ class NewConstantArraysUsingConstSniff extends Sniff
      *
      * @since 7.1.4
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -38,7 +38,7 @@ class NewConstantArraysUsingDefineSniff extends AbstractFunctionCallParameterSni
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'define' => true,

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -56,7 +56,7 @@ class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
      *
      * @since 8.2.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     protected $safeOperands = [
         \T_LNUMBER                  => \T_LNUMBER,

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -81,7 +81,7 @@ class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
      *
      * @since 8.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -56,7 +56,7 @@ class NewHeredocSniff extends AbstractInitialValueSniff
      * @since 8.2.0
      * @since 10.0.0 Renamed from `$errorPhrases` to `$initialValueTypes`.
      *
-     * @var array
+     * @var array<string, string> Type indicator => suggested partial error phrase.
      */
     protected $initialValueTypes = [
         'const'     => 'constants',

--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
@@ -53,7 +53,7 @@ final class NewNewInInitializersSniff extends AbstractInitialValueSniff
      *
      * @since 10.0.0.
      *
-     * @var array
+     * @var array<string, string> Type indicator => suggested partial error phrase.
      */
     protected $initialValueTypes = [
         'const'     => 'global/namespaced constants declared using the const keyword',

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -66,7 +66,7 @@ class InternalInterfacesSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -37,7 +37,7 @@ class InternalInterfacesSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @var array(string => string)
+     * @var array<string, string>
      */
     protected $internalInterfaces = [
         'Traversable'       => 'shouldn\'t be implemented directly, implement the Iterator or IteratorAggregate interface instead.',
@@ -52,7 +52,7 @@ class InternalInterfacesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array(string => bool)
+     * @var array<string, true>
      */
     private $cannotBeExtended = [
         'DateTimeInterface' => true,

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -178,7 +178,7 @@ class NewInterfacesSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -46,7 +46,7 @@ class NewInterfacesSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool|string>>
      */
     protected $newInterfaces = [
         'Traversable' => [
@@ -164,7 +164,7 @@ class NewInterfacesSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @var array(string => array(string => string))
+     * @var array<string, array<string, string>>
      */
     protected $unsupportedMethods = [
         'Serializable' => [

--- a/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
@@ -112,7 +112,7 @@ class RemovedSerializableSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
@@ -73,7 +73,7 @@ class RemovedSerializableSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var string[]
      */
     private $phpSerializableInterfaces = [
         'serializable',
@@ -342,8 +342,8 @@ class RemovedSerializableSniff extends Sniff
      * @param int                         $stackPtr  The position of the current token in the
      *                                               stack passed in $tokens.
      *
-     * @return array Array with two keys: '__serialize' and '__unserialize'.
-     *               The values are boolean indicators of whether the method declarations were found.
+     * @return array<string, bool> Array with two keys: '__serialize' and '__unserialize'.
+     *                             The values are boolean indicators of whether the method declarations were found.
      */
     private function findMagicMethods($phpcsFile, $stackPtr)
     {

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -35,7 +35,7 @@ class CaseSensitiveKeywordsSniff extends Sniff
      *
      * @since 7.1.4
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -45,7 +45,7 @@ class ForbiddenNamesSniff extends Sniff
      *
      * @since 5.5
      *
-     * @var array(string => string)
+     * @var array<string, string>
      */
     protected $invalidNames = [
         'abstract'      => '5.0',
@@ -133,7 +133,7 @@ class ForbiddenNamesSniff extends Sniff
      * @since 7.0.8
      * @since 10.0.0 Moved from the ForbiddenNamesAsDeclared sniff to this sniff.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $otherForbiddenNames = [
         'null'     => '7.0',
@@ -159,7 +159,7 @@ class ForbiddenNamesSniff extends Sniff
      * @since 7.0.8
      * @since 10.0.0 Moved from the ForbiddenNamesAsDeclared sniff to this sniff.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $softReservedNames = [
         'resource' => '7.0',
@@ -179,7 +179,7 @@ class ForbiddenNamesSniff extends Sniff
      * @since 7.0.8
      * @since 10.0.0 Moved from the ForbiddenNamesAsDeclared sniff to this sniff.
      *
-     * @var array
+     * @var array<string, string>
      */
     private $allOtherForbiddenNames = [];
 
@@ -188,7 +188,7 @@ class ForbiddenNamesSniff extends Sniff
      *
      * @since 7.0.1
      *
-     * @var array(string => string)
+     * @var array<string, true>
      */
     protected $validUseNames = [
         'const'    => true,
@@ -200,7 +200,7 @@ class ForbiddenNamesSniff extends Sniff
      *
      * @since 7.1.4
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $allowedModifiers = [];
 
@@ -209,7 +209,7 @@ class ForbiddenNamesSniff extends Sniff
      *
      * @since 5.5
      *
-     * @var array
+     * @var array<int|string>
      */
     protected $targetedTokens = [
         \T_NAMESPACE,

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -229,7 +229,7 @@ class ForbiddenNamesSniff extends Sniff
      *
      * @since 5.5
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -182,7 +182,7 @@ class NewKeywordsSniff extends Sniff
      *
      * @since 5.5
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -58,7 +58,7 @@ class NewKeywordsSniff extends Sniff
      *               parent class. This index has been renamed to `callback` and now expect
      *               one of the PHP accepted callback formats.
      *
-     * @var array(string => array(string => bool|string))
+     * @var array<string, array<string, bool|string|callable>>
      */
     protected $newKeywords = [
         'T_HALT_COMPILER' => [
@@ -172,7 +172,7 @@ class NewKeywordsSniff extends Sniff
      *
      * @since 7.0.5
      *
-     * @var array(string => string)
+     * @var array<string, string>
      */
     protected $translateContentToToken = [];
 

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -39,7 +39,7 @@ class NewEmptyNonVariableSniff extends Sniff
      *
      * @since 7.0.4
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -62,7 +62,7 @@ class NewLanguageConstructsSniff extends Sniff
      *
      * @since 5.6
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -41,7 +41,7 @@ class NewLanguageConstructsSniff extends Sniff
      *
      * @since 5.6
      *
-     * @var array(string => array(string => bool|string))
+     * @var array<string, array<string, bool|string>>
      */
     protected $newConstructs = [
         'T_NS_SEPARATOR' => [

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -101,8 +101,8 @@ class AssignmentOrderSniff extends Sniff
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of a list-like token.
      *
-     * @return array Array with the variables being assigned to as values and the corresponding
-     *               stack pointer to the start of each variable as keys.
+     * @return array<int, string> Array with the variables being assigned to as values and the corresponding
+     *                            stack pointer to the start of each variable as keys.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified $stackPtr is not of
      *                                                      type T_LIST, T_OPEN_SHORT_ARRAY or

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -39,7 +39,7 @@ class AssignmentOrderSniff extends Sniff
      *
      * @since 9.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -36,7 +36,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -36,7 +36,7 @@ class NewKeyedListSniff extends Sniff
      *
      * @since 9.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -38,7 +38,7 @@ class NewListReferenceAssignmentSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -38,7 +38,7 @@ class NewShortListSniff extends Sniff
      *
      * @since 9.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
@@ -37,7 +37,7 @@ class ForbiddenToStringParametersSniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -38,7 +38,7 @@ class NewDirectCallsToCloneSniff extends Sniff
      *
      * @since 9.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -47,7 +47,7 @@ class NewPHPOpenTagEOFSniff extends Sniff
      *
      * @since 9.3.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -45,7 +45,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
      *
      * @since 7.0.4
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -57,7 +57,7 @@ class ReservedNamesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
@@ -33,7 +33,7 @@ class NewExplicitOctalNotationSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Numbers/NewNumericLiteralSeparatorSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/NewNumericLiteralSeparatorSniff.php
@@ -35,7 +35,7 @@ class NewNumericLiteralSeparatorSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
@@ -46,10 +46,10 @@ class RemovedHexadecimalNumericStringsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array<string, array|true> True if all arguments in the function call accept hex numeric
-     *                                strings. An array with 1-based parameter position (key) and
-     *                                names (value) for those functions which only accept
-     *                                hex numeric strings for select parameters.
+     * @var array<string, array<int, string>|true> True if all arguments in the function call accept hex numeric
+     *                                             strings. An array with 1-based parameter position (key) and
+     *                                             names (value) for those functions which only accept
+     *                                             hex numeric strings for select parameters.
      */
     private $excludedFunctions = [
         'gmp_abs'            => true,

--- a/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
@@ -107,7 +107,7 @@ class RemovedHexadecimalNumericStringsSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
@@ -160,9 +160,9 @@ class ValidIntegersSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @param array  $tokens     Token stack.
-     * @param int    $stackPtr   The current position in the token stack.
-     * @param string $numberInfo The information on the number to examine
+     * @param array                     $tokens     Token stack.
+     * @param int                       $stackPtr   The current position in the token stack.
+     * @param array<string, string|int> $numberInfo The information on the number to examine
      *
      * @return string|bool The invalid octal as a string or false when this is not an invalid octal.
      */

--- a/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
@@ -43,7 +43,7 @@ class ValidIntegersSniff extends Sniff
      *
      * @since 7.0.3
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
@@ -44,7 +44,7 @@ class ChangedConcatOperatorPrecedenceSniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @var array
+     * @var array<string, true>
      */
     private $tokensWithLowerPrecedence = [
         'T_BITWISE_AND' => true,

--- a/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
@@ -63,7 +63,7 @@ class ChangedConcatOperatorPrecedenceSniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -40,7 +40,7 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @var array
+     * @var array<int|string, true>
      */
     private $inclusiveStopPoints = [
         \T_COLON        => true,

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -55,7 +55,7 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
      * @since 7.0.0
      * @since 8.2.0 Now registers all bitshift tokens, not just bitshift right (`T_SR`).
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -82,7 +82,7 @@ class NewOperatorsSniff extends Sniff
      *
      * @since 5.6
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -42,7 +42,7 @@ class NewOperatorsSniff extends Sniff
      *
      * @since 5.6
      *
-     * @var array(string => array(string => bool|string))
+     * @var array<string, array<string, bool|string>>
      */
     protected $newOperators = [
         'T_POW' => [

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -38,7 +38,7 @@ class NewShortTernarySniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -55,7 +55,7 @@ class RemovedTernaryAssociativitySniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -39,7 +39,7 @@ class RemovedTernaryAssociativitySniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @var array
+     * @var array<string, true>
      */
     private $tokensWithLowerPrecedence = [
         'T_YIELD_FROM'  => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
@@ -35,7 +35,7 @@ class ChangedIntToBoolParamTypeSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, array<int, array<string, string>>>
      */
     protected $targetFunctions = [
         'ob_implicit_flush' => [

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
@@ -39,7 +39,7 @@ class ChangedObStartEraseFlagsSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'ob_start' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -34,7 +34,7 @@ class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'get_class' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
@@ -59,7 +59,7 @@ class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallParameterS
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
@@ -37,7 +37,7 @@ class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallParameterS
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'session_module_name' => true,
@@ -50,7 +50,7 @@ class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallParameterS
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $targetTokens = [];
 

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -33,7 +33,7 @@ class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCallParame
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'strip_tags' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarSniff.php
@@ -33,7 +33,7 @@ final class NewArrayMergeRecursiveWithGlobalsVarSniff extends AbstractFunctionCa
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'array_merge_recursive' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -34,7 +34,7 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'array_reduce' => true,
@@ -46,7 +46,7 @@ class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array
+     * @var array<int|string>
      */
     private $variableValueTokens = [
         \T_VARIABLE,

--- a/PHPCompatibility/Sniffs/ParameterValues/NewAssertCustomExceptionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewAssertCustomExceptionSniff.php
@@ -36,7 +36,7 @@ class NewAssertCustomExceptionSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'assert' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -32,7 +32,7 @@ class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'fopen' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
@@ -39,7 +39,7 @@ class NewHTMLEntitiesEncodingDefaultSniff extends AbstractFunctionCallParameterS
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, array<string, int|string>>
      */
     protected $targetFunctions = [
         'html_entity_decode' => [

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesFlagsDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesFlagsDefaultSniff.php
@@ -39,7 +39,7 @@ class NewHTMLEntitiesFlagsDefaultSniff extends AbstractFunctionCallParameterSnif
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, array<string, int|string>>
      */
     protected $targetFunctions = [
         'get_html_translation_table' => [

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -41,7 +41,7 @@ class NewHashAlgorithmsSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 7.0.7
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool>>
      */
     protected $newAlgorithms = [
         'md2' => [

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
@@ -39,7 +39,7 @@ class NewIDNVariantDefaultSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, array<string, int|string>>
      */
     protected $targetFunctions = [
         'idn_to_ascii' => [

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -50,7 +50,7 @@ class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterS
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, array<string, int|string>>
      */
     protected $targetFunctions = [
         'iconv_mime_decode_headers' => [

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -34,7 +34,7 @@ class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array Function name => 1-based parameter offset of the affected parameters => parameter name.
+     * @var array<string, array<int, string>> Function name => 1-based parameter offset of the affected parameters => parameter name.
      */
     protected $targetFunctions = [
         'file_get_contents'     => [

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
@@ -37,7 +37,7 @@ class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCallParame
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'number_format' => true,
@@ -50,7 +50,7 @@ class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCallParame
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $targetTokens = [];
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
@@ -59,7 +59,7 @@ class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCallParame
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -41,8 +41,8 @@ class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
      * @since 8.2.0
      * @since 10.0.0 Value changed from an irrelevant value to an array.
      *
-     * @var array Key is the function name, value an array containing the 1-based parameter position
-     *            and the official name of the parameter.
+     * @var array<string, array<string, int|string>> Key is the function name, value an array containing
+     *                                               the 1-based parameter position and the official name of the parameter.
      */
     protected $targetFunctions = [
         'preg_filter' => [
@@ -87,7 +87,7 @@ class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 8.2.0
      *
-     * @var array
+     * @var array<string, array<string, bool>>
      */
     protected $newModifiers = [
         'J' => [

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -34,7 +34,7 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'pack' => true,
@@ -45,7 +45,7 @@ class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array Regex pattern => Version array.
+     * @var array<string, array<string, bool>> Regex pattern => Version array.
      */
     protected $newFormats = [
         '`([Z])`'    => [

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -41,7 +41,7 @@ class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParameterSn
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, array<string, int|string>>
      */
     protected $targetFunctions = [
         'password_hash' => [
@@ -59,7 +59,7 @@ class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParameterSn
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<int|string, true>
      */
     private $invalidTokenTypes = [
         \T_NULL                     => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -37,7 +37,7 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'proc_open' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -35,7 +35,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'strip_tags' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
@@ -44,7 +44,7 @@ class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSni
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'assert' => true,
@@ -57,7 +57,7 @@ class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSni
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $targetTokens = [];
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
@@ -66,7 +66,7 @@ class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSni
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
@@ -35,7 +35,7 @@ class RemovedGetDefinedFunctionsExcludeDisabledFalseSniff extends AbstractFuncti
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'get_defined_functions' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -42,7 +42,7 @@ class RemovedHashAlgorithmsSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 7.0.7
      *
-     * @var array(string => array(string => bool))
+     * @var array<string, array<string, bool>>
      */
     protected $removedAlgorithms = [
         'salsa10' => [

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -39,7 +39,7 @@ class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'iconv_set_encoding' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -39,7 +39,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'implode' => true,
@@ -51,7 +51,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, true>
      */
     private $constantStrings = [
         'DIRECTORY_SEPARATOR' => true,
@@ -65,7 +65,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, true>
      */
     private $arrayFunctions = [
         'compact' => true,
@@ -78,7 +78,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, true>
      */
     private $arrayFunctionExceptions = [
         'array_key_exists'     => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbCheckEncodingNoArgsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbCheckEncodingNoArgsSniff.php
@@ -35,7 +35,7 @@ class RemovedMbCheckEncodingNoArgsSniff extends AbstractFunctionCallParameterSni
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'mb_check_encoding' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -49,7 +49,7 @@ class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParame
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'mb_strrpos' => true,
@@ -60,7 +60,7 @@ class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParame
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $numberTokens = [
         \T_LNUMBER => \T_LNUMBER,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -44,7 +44,7 @@ class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
      * @since 7.0.5
      * @since 8.2.0 Renamed from `$functions` to `$targetFunctions`.
      *
-     * @var array
+     * @var array<string, int>
      */
     protected $targetFunctions = [
         'mb_ereg_replace'      => 4,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -37,7 +37,7 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'hash_hmac'      => true,
@@ -51,7 +51,7 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $disabledCryptos = [
         'adler32' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -52,8 +52,8 @@ class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
      * @since 8.2.0  Renamed from `$functions` to `$targetFunctions`.
      * @since 10.0.0 Value changed from an irrelevant value to an array.
      *
-     * @var array Key is the function name, value an array containing the 1-based parameter position
-     *            and the official name of the parameter.
+     * @var array<string, array<string, int|string>> Key is the function name, value an array containing
+     *                                               the 1-based parameter position and the official name of the parameter.
      */
     protected $targetFunctions = [
         'preg_replace' => [

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -39,7 +39,7 @@ class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
      *
      * @since 9.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'setlocale' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
@@ -36,7 +36,7 @@ class RemovedSplAutoloadRegisterThrowFalseSniff extends AbstractFunctionCallPara
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'spl_autoload_register' => true,

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedVersionCompareOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedVersionCompareOperatorsSniff.php
@@ -37,7 +37,7 @@ class RemovedVersionCompareOperatorsSniff extends AbstractFunctionCallParameterS
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     protected $targetFunctions = [
         'version_compare' => true,
@@ -50,7 +50,7 @@ class RemovedVersionCompareOperatorsSniff extends AbstractFunctionCallParameterS
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<string, true>
      */
     private $unsupportedOperators = [
         ''  => true,

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -43,7 +43,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
      *
      * @since 8.1.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $assignOrCompare = [];
 

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -52,7 +52,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
      *
      * @since 5.5
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -46,7 +46,7 @@ class NewArrayStringDereferencingSniff extends Sniff
      *
      * @since 7.1.4
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -48,7 +48,7 @@ class NewArrayUnpackingSniff extends Sniff
      *
      * @since 9.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -35,7 +35,7 @@ class NewArrayUnpackingSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $arrayTokens = [
         \T_ARRAY               => \T_ARRAY,

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -47,7 +47,7 @@ class NewClassMemberAccessSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -36,7 +36,7 @@ class NewDynamicAccessToStaticSniff extends Sniff
      *
      * @since 8.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
@@ -33,7 +33,7 @@ final class NewFirstClassCallablesSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -38,7 +38,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
      *
      * @since 9.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -46,7 +46,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -35,7 +35,7 @@ class NewFunctionCallTrailingCommaSniff extends Sniff
      *
      * @since 8.2.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
@@ -35,7 +35,7 @@ class NewInterpolatedStringDereferencingSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
@@ -33,7 +33,7 @@ class NewMagicConstantDereferencingSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
@@ -38,7 +38,7 @@ class NewNestedStaticAccessSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -35,7 +35,7 @@ class NewShortArraySniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -44,11 +44,11 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
     private $newArrayStringDereferencing;
 
     /**
-     * Target tokens as register by the NewArrayStringDereferencing sniff.
+     * Target tokens as registered by the NewArrayStringDereferencing sniff.
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<int|string>
      */
     private $newArrayStringDereferencingTargets;
 
@@ -62,11 +62,11 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
     private $newClassMemberAccess;
 
     /**
-     * Target tokens as register by the NewClassMemberAccess sniff.
+     * Target tokens as registered by the NewClassMemberAccess sniff.
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<int|string>
      */
     private $newClassMemberAccessTargets;
 
@@ -80,11 +80,11 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
     private $newFunctionArrayDereferencing;
 
     /**
-     * Target tokens as register by the NewFunctionArrayDereferencing sniff.
+     * Target tokens as registered by the NewFunctionArrayDereferencing sniff.
      *
      * @since 9.3.0
      *
-     * @var array
+     * @var array<int|string>
      */
     private $newFunctionArrayDereferencingTargets;
 

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -107,7 +107,7 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
      *
      * @since 9.3.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -37,7 +37,7 @@ class RemovedNewReferenceSniff extends Sniff
      *
      * @since 5.5
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
@@ -39,7 +39,7 @@ class NewUnicodeEscapeSequenceSniff extends Sniff
      *
      * @since 9.3.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/TextStrings/RemovedDollarBraceStringEmbedsSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/RemovedDollarBraceStringEmbedsSniff.php
@@ -42,7 +42,7 @@ class RemovedDollarBraceStringEmbedsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -37,7 +37,7 @@ class NewTypeCastsSniff extends Sniff
      *
      * @since 8.0.1
      *
-     * @var array(string => array(string => bool|string))
+     * @var array<string, array<string, bool|string>>
      */
     protected $newTypeCasts = [
         'T_UNSET_CAST' => [

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -58,7 +58,7 @@ class NewTypeCastsSniff extends Sniff
      *
      * @since 8.0.1
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -41,7 +41,7 @@ class RemovedTypeCastsSniff extends Sniff
      *
      * @since 8.0.1
      *
-     * @var array(string => array(string => bool|string))
+     * @var array<string, array<string, bool|string>>
      */
     protected $deprecatedTypeCasts = [
         'T_UNSET_CAST' => [

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -64,7 +64,7 @@ class RemovedTypeCastsSniff extends Sniff
      *
      * @since 8.0.1
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -74,7 +74,7 @@ class LowPHPSniff extends Sniff
      *
      * @since 9.3.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -42,7 +42,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -51,7 +51,7 @@ class NewUseConstFunctionSniff extends Sniff
      *
      * @since 7.1.4
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -39,7 +39,7 @@ class NewUseConstFunctionSniff extends Sniff
      *
      * @since 7.1.4
      *
-     * @var array(string => string)
+     * @var array<string, bool>
      */
     protected $validUseNames = [
         'const'    => true,

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -34,7 +34,7 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
      *
      * @since 7.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -60,7 +60,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
      *
      * @since 9.1.0
      *
-     * @var array
+     * @var array<int|string, true>
      */
     private $skipOverScopes = [
         \T_FUNCTION => true,
@@ -72,7 +72,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
      *
      * @since 9.1.0
      *
-     * @var array
+     * @var array<int|string, true>
      */
     private $validUseOutsideObject = [
         \T_ISSET => true,

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -84,7 +84,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
      *
      * @since 9.1.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -35,7 +35,7 @@ class NewUniformVariableSyntaxSniff extends Sniff
      *
      * @since 7.1.2
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
@@ -65,7 +65,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -110,7 +110,7 @@ class RemovedPredefinedGlobalVariablesSniff extends Sniff
      * @since 5.5
      * @since 7.0
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -51,7 +51,7 @@ class RemovedPredefinedGlobalVariablesSniff extends Sniff
      * @since 5.5
      * @since 7.0
      *
-     * @var array(string => array(string => bool|string))
+     * @var array<string, array<string, bool|string>>
      */
     protected $removedGlobalVariables = [
         'HTTP_POST_VARS' => [

--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -48,7 +48,7 @@ abstract class BaseSniffTestCase extends TestCase
      *
      * @since 7.0.4
      *
-     * @var array
+     * @var array<string, array<string, File>>
      */
     public static $sniffFiles = [];
 
@@ -305,7 +305,7 @@ abstract class BaseSniffTestCase extends TestCase
      *
      * @param \PHP_CodeSniffer\Files\File $file Codesniffer file object.
      *
-     * @return array
+     * @return array<string, array>
      */
     public function showViolations(File $file)
     {

--- a/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.php
@@ -32,7 +32,7 @@ class ForbiddenExtendingFinalPHPClassUnitTest extends BaseSniffTestCase
      *
      * @param string $className Class name.
      * @param string $finalIn   The PHP version in which the class was made final.
-     * @param array  $line      The line number in the test file which apply to this class.
+     * @param int    $line      The line number in the test file which apply to this class.
      * @param string $okVersion A PHP version in which the class was ok to be extended.
      *
      * @return void

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -30,8 +30,8 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataNewTypedProperties
      *
-     * @param array $line            The line number on which the error should occur.
-     * @param bool  $testNoViolation Whether or not to test noViolation for PHP 7.4.
+     * @param int  $line            The line number on which the error should occur.
+     * @param bool $testNoViolation Whether or not to test noViolation for PHP 7.4.
      *
      * @return void
      */
@@ -152,7 +152,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataInvalidPropertyType
      *
-     * @param array  $line The line number on which the error should occur.
+     * @param int    $line The line number on which the error should occur.
      * @param string $type The invalid type which should be detected.
      *
      * @return void
@@ -192,7 +192,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
      *
      * @param string $type              The declared type.
      * @param string $lastVersionBefore The PHP version just *before* the type hint was introduced.
-     * @param array  $line              The line number where the error is expected.
+     * @param int    $line              The line number where the error is expected.
      * @param string $okVersion         A PHP version in which the type hint was ok to be used.
      * @param bool   $testNoViolation   Whether or not to test noViolation.
      *                                  Defaults to true.
@@ -264,7 +264,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
      * @dataProvider dataNewUnionTypes
      *
      * @param string $type            The declared type.
-     * @param array  $line            The line number where the error is expected.
+     * @param int    $line            The line number where the error is expected.
      * @param bool   $testNoViolation Whether or not to test noViolation.
      *                                Defaults to true.
      *
@@ -379,7 +379,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
      * @dataProvider dataNewIntersectionTypes
      *
      * @param string $type            The declared type.
-     * @param array  $line            The line number where the error is expected.
+     * @param int    $line            The line number where the error is expected.
      * @param bool   $testNoViolation Whether or not to test noViolation.
      *                                Defaults to true.
      *

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -33,7 +33,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
      *
      * @param string $type              The declared type.
      * @param string $lastVersionBefore The PHP version just *before* the type hint was introduced.
-     * @param array  $line              The line number where the error is expected.
+     * @param int    $line              The line number where the error is expected.
      * @param string $okVersion         A PHP version in which the type hint was ok to be used.
      * @param bool   $testNoViolation   Whether or not to test noViolation.
      *                                  Defaults to true.
@@ -271,7 +271,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
      * @dataProvider dataNewUnionTypes
      *
      * @param string $type            The declared type.
-     * @param array  $line            The line number where the error is expected.
+     * @param int    $line            The line number where the error is expected.
      * @param bool   $testNoViolation Whether or not to test noViolation.
      *                                Defaults to true.
      *
@@ -419,7 +419,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
      * @dataProvider dataNewIntersectionTypes
      *
      * @param string $type            The declared type.
-     * @param array  $line            The line number where the error is expected.
+     * @param int    $line            The line number where the error is expected.
      * @param bool   $testNoViolation Whether or not to test noViolation.
      *                                Defaults to true.
      *

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -33,7 +33,7 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
      *
      * @param string $returnType        The return type.
      * @param string $lastVersionBefore The PHP version just *before* the type was introduced.
-     * @param array  $line              The line number in the test file where the error should occur.
+     * @param int    $line              The line number in the test file where the error should occur.
      * @param string $okVersion         A PHP version in which the return type was ok to be used.
      * @param bool   $testNoViolation   Whether or not to test noViolation.
      *                                  Defaults to true.
@@ -178,8 +178,8 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
      * @dataProvider dataInvalidStandAloneType
      *
      * @param string $type        The declared type.
-     * @param array  $line        The line number where the error is expected.
-     * @param bool   $testVersion The PHP version in which the type was first allowed to be used.
+     * @param int    $line        The line number where the error is expected.
+     * @param string $testVersion The PHP version in which the type was first allowed to be used.
      *
      * @return void
      */
@@ -227,7 +227,7 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
      * @dataProvider dataNewUnionTypes
      *
      * @param string $type            The declared type.
-     * @param array  $line            The line number where the error is expected.
+     * @param int    $line            The line number where the error is expected.
      * @param bool   $testNoViolation Whether or not to test noViolation.
      *                                Defaults to true.
      *
@@ -341,7 +341,7 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
      * @dataProvider dataNewIntersectionTypes
      *
      * @param string $type            The declared type.
-     * @param array  $line            The line number where the error is expected.
+     * @param int    $line            The line number where the error is expected.
      * @param bool   $testNoViolation Whether or not to test noViolation.
      *                                Defaults to true.
      *

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -30,7 +30,7 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataValueChanged
      *
-     * @param array  $line         The line number where an error is expected.
+     * @param int    $line         The line number where an error is expected.
      * @param string $functionName The name of the function to which the error applies.
      * @param string $variableName The variable which was detected as having been changed.
      *

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -29,7 +29,7 @@ class NewConstantScalarExpressionsUnitTest extends BaseSniffTestCase
     /**
      * Error phrases.
      *
-     * @var array
+     * @var array<string, string>
      */
     private $errorPhrases = [
         'const'    => 'when defining constants using the const keyword',

--- a/PHPCompatibility/Tests/InitialValue/NewNewInInitializersUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewNewInInitializersUnitTest.php
@@ -30,7 +30,7 @@ final class NewNewInInitializersUnitTest extends BaseSniffTestCase
      *
      * @since 10.0.0.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $initialValueTypes = [
         'const'     => 'global/namespaced constants declared using the const keyword',

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -35,7 +35,7 @@ class InternalInterfacesUnitTest extends BaseSniffTestCase
     /**
      * Interface error messages.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $messages = [
         'Traversable'       => 'The interface Traversable shouldn\'t be implemented directly, implement the Iterator or IteratorAggregate interface instead.',
@@ -64,7 +64,7 @@ class InternalInterfacesUnitTest extends BaseSniffTestCase
      * @dataProvider dataInternalInterfaces
      *
      * @param string $type Interface name.
-     * @param array  $line The line number in the test file.
+     * @param int    $line The line number in the test file.
      *
      * @return void
      */

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -94,7 +94,7 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataUnsupportedMethods
      *
-     * @param array  $line       The line number.
+     * @param int    $line       The line number.
      * @param string $methodName The name of the unsupported method which should be detected.
      *
      * @return void

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -48,7 +48,7 @@ class ForbiddenNamesUnitTest extends BaseSniffTestCase
      *
      * This array should be kept in sync with the same in the "generate-forbidden-names-test-files" script.
      *
-     * @var array
+     * @var array<string, true>
      */
     private $testsForOtherInvalidNames = [
         // Declarations.
@@ -116,7 +116,7 @@ class ForbiddenNamesUnitTest extends BaseSniffTestCase
     /**
      * Provides use cases to test with each keyword.
      *
-     * @return array
+     * @return array<string, string[]>
      */
     public static function usecaseProvider()
     {
@@ -201,7 +201,7 @@ class ForbiddenNamesUnitTest extends BaseSniffTestCase
     /**
      * Provides use cases to test with each keyword.
      *
-     * @return array
+     * @return array<string, string[]>
      */
     public static function usecaseProviderPHP5vs7()
     {
@@ -270,7 +270,7 @@ class ForbiddenNamesUnitTest extends BaseSniffTestCase
     /**
      * Provides use cases to test with each keyword.
      *
-     * @return array
+     * @return array<string, string[]>
      */
     public static function usecaseProviderNamespaceNamePHP57vs8()
     {

--- a/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.php
@@ -30,7 +30,7 @@ class NewExplicitOctalNotationUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataExplicitOctalNotation
      *
-     * @param array $line The line number on which the error should occur.
+     * @param int $line The line number on which the error should occur.
      *
      * @return void
      */

--- a/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
@@ -31,7 +31,7 @@ class NewNumericLiteralSeparatorUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataNewNumericLiteralSeparator
      *
-     * @param array $line The line number on which the error should occur.
+     * @param int $line The line number on which the error should occur.
      *
      * @return void
      */

--- a/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.php
@@ -30,7 +30,7 @@ class ChangedConcatOperatorPrecedenceUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataChangedConcatOperatorPrecedence
      *
-     * @param array $line The line number on which the warning/error should occur.
+     * @param int $line The line number on which the warning/error should occur.
      *
      * @return void
      */

--- a/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
@@ -35,7 +35,7 @@ class RemovedTernaryAssociativityUnitTest extends BaseSniffTestCase
     /**
      * Lines on which to expect errors.
      *
-     * @var array
+     * @var int[]
      */
     protected static $problemLines = [
         3,

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -34,7 +34,7 @@ class NewHashAlgorithmsUnitTest extends BaseSniffTestCase
      *
      * @param string $algorithm         Name of the algorithm.
      * @param string $lastVersionBefore The PHP version just *before* the algorithm was introduced.
-     * @param array  $line              The line number in the test file on which an error should occur.
+     * @param int    $line              The line number in the test file on which an error should occur.
      * @param string $okVersion         A PHP version in which the algorithm was valid.
      *
      * @return void

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
@@ -34,7 +34,7 @@ class RemovedHashAlgorithmsUnitTest extends BaseSniffTestCase
      *
      * @param string $algorithm Name of the algorithm.
      * @param string $removedIn The PHP version in which the algorithm was removed.
-     * @param array  $line      The line number on which the error should occur.
+     * @param int    $line      The line number on which the error should occur.
      * @param string $okVersion A PHP version in which the algorithm was still valid.
      *
      * @return void

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
@@ -30,7 +30,7 @@ class NewArrayUnpackingUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataNewArrayUnpacking
      *
-     * @param array $line The line number on which the error should occur.
+     * @param int $line The line number on which the error should occur.
      *
      * @return void
      */

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -89,7 +89,7 @@ class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataDeprecatedRemovedPHPErrorMsg
      *
-     * @param array $line The line number in the test file where a warning is expected.
+     * @param int $line The line number in the test file where a warning is expected.
      *
      * @return void
      */

--- a/PHPCompatibility/Util/Tests/Helpers/ScannedCodeUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ScannedCodeUnitTest.php
@@ -76,8 +76,8 @@ final class ScannedCodeUnitTest extends TestCase
      *
      * @covers \PHPCompatibility\Helpers\ScannedCode::getTestVersion
      *
-     * @param string $testVersion The testVersion as normally set via the command line or ruleset.
-     * @param string $expected    The expected testVersion array.
+     * @param string|null $testVersion The testVersion as normally set via the command line or ruleset.
+     * @param array       $expected    The expected testVersion array.
      *
      * @return void
      */
@@ -100,8 +100,8 @@ final class ScannedCodeUnitTest extends TestCase
      *
      * @covers \PHPCompatibility\Helpers\ScannedCode::getTestVersion
      *
-     * @param string $testVersion The testVersion as normally set via the command line or ruleset.
-     * @param string $expected    The expected testVersion array.
+     * @param string|null $testVersion The testVersion as normally set via the command line or ruleset.
+     * @param string      $expected    The expected testVersion array.
      *
      * @return void
      */
@@ -244,9 +244,9 @@ final class ScannedCodeUnitTest extends TestCase
      *
      * @covers \PHPCompatibility\Helpers\ScannedCode::shouldRunOnOrAbove
      *
-     * @param string $phpVersion  The PHP version we want to test.
-     * @param string $testVersion The testVersion as normally set via the command line or ruleset.
-     * @param bool   $expected    Expected result.
+     * @param string      $phpVersion  The PHP version we want to test.
+     * @param string|null $testVersion The testVersion as normally set via the command line or ruleset.
+     * @param bool        $expected    Expected result.
      *
      * @return void
      */
@@ -289,9 +289,9 @@ final class ScannedCodeUnitTest extends TestCase
      *
      * @covers \PHPCompatibility\Helpers\ScannedCode::shouldRunOnOrBelow
      *
-     * @param string $phpVersion  The PHP version we want to test.
-     * @param string $testVersion The testVersion as normally set via the command line or ruleset.
-     * @param bool   $expected    Expected result.
+     * @param string      $phpVersion  The PHP version we want to test.
+     * @param string|null $testVersion The testVersion as normally set via the command line or ruleset.
+     * @param bool        $expected    Expected result.
      *
      * @return void
      */


### PR DESCRIPTION
### Docs: improve `@return` tags for register() methods

... and make them consistent across the sniffs.

### Docs: various `@var`/`@param`/`@return` tag improvements

Definitely not claiming completeness. This is just another iteration step in improving the documented types.