### PR TITLE
PHP 8.3 | NewFunctions: detect use of `socket_atmark()`

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4983,6 +4983,11 @@ class NewFunctionsSniff extends Sniff
             '8.3'       => true,
             'extension' => 'posix',
         ],
+        'socket_atmark' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'sockets',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1053,3 +1053,4 @@ pg_enter_pipeline_mode();
 pg_exit_pipeline_mode();
 pg_pipeline_sync();
 pg_pipeline_status();
+socket_atmark();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1114,6 +1114,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['pg_exit_pipeline_mode', '8.2', 1053, '8.3'],
             ['pg_pipeline_sync', '8.2', 1054, '8.3'],
             ['pg_pipeline_status', '8.2', 1055, '8.3'],
+            ['socket_atmark', '8.2', 1056, '8.3'],
         ];
     }
 


### PR DESCRIPTION
>   . Added socket_atmark to checks if the socket is OOB marked.

Refs:
* https://github.com/php/php-src/blob/655f116be57b46efe32221d7adfec6d6b81eeece/UPGRADING#L371
* php/php-src#9846
* https://github.com/php/php-src/commit/4c4e72f14943355b4115b1dad80f4a5d0fd18036

Related to #1589