### PR TITLE
PHP 8.3 | NewFunctionParameters: account for signature change for strrchr()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -950,6 +950,13 @@ class NewFunctionParametersSniff extends AbstractFunctionCallParameterSniff
                 '5.3'  => true,
             ],
         ],
+        'strrchr' => [
+            3 => [
+                'name' => 'before_needle',
+                '8.2'  => false,
+                '8.3'  => true,
+            ],
+        ],
         'strstr' => [
             3 => [
                 'name' => 'before_needle',

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
@@ -148,3 +148,4 @@ parse_url(
 );
 
 posix_getrlimit($res);
+strrchr($haystack, $needle, $before_needle);

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -198,6 +198,7 @@ class NewFunctionParametersUnitTest extends BaseSniffTestCase
             ['stream_get_contents', 'offset', '5.0', [83], '5.1'],
             ['stream_wrapper_register', 'flags', '5.2.3', [84], '5.3', '5.2'],
             ['stristr', 'before_needle', '5.2', [85], '5.3'],
+            ['strrchr', 'before_needle', '8.2', [151], '8.3'],
             ['strstr', 'before_needle', '5.2', [86], '5.3'],
             ['str_word_count', 'characters', '5.0', [87], '5.1'],
             ['substr_count', 'offset', '5.0', [88], '5.1'],


### PR DESCRIPTION
>   . The $before_needle argument added to strrchr() which works in the same way
>     like its counterpart in strstr() or stristr().

Refs:
* https://github.com/php/php-src/blob/49980ee89dcdf71d062e9cfb94a24b515399d5cf/UPGRADING#L371-L372
* php/php-src#11430
* https://github.com/php/php-src/commit/f25474f7f2954db5bc49fb4c0dabd220069fce6e
* https://www.php.net/manual/en/function.strrchr

Related to #1589