### PR TITLE
PHP 8.3 | NewFunctions: detect use of `pg_send_flush_request()`

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4963,6 +4963,11 @@ class NewFunctionsSniff extends Sniff
             '8.3'       => true,
             'extension' => 'pgsql',
         ],
+        'pg_send_flush_request' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'pgsql',
+        ],
         'posix_sysconf' => [
             '8.2'       => false,
             '8.3'       => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1054,3 +1054,4 @@ pg_exit_pipeline_mode();
 pg_pipeline_sync();
 pg_pipeline_status();
 socket_atmark();
+pg_send_flush_request();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1114,6 +1114,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['pg_exit_pipeline_mode', '8.2', 1053, '8.3'],
             ['pg_pipeline_sync', '8.2', 1054, '8.3'],
             ['pg_pipeline_status', '8.2', 1055, '8.3'],
+            ['pg_send_flush_request', '8.2', 1057, '8.3'],
             ['socket_atmark', '8.2', 1056, '8.3'],
         ];
     }


### PR DESCRIPTION
>   Added pg_send_flush_request().

Refs:
* https://github.com/php/php-src/blob/PHP-8.3/UPGRADING#L440
* php/php-src#12644
* https://github.com/php/php-src/commit/63898008c0153b4b89d166b647694d5ec45d7797

Related to #1589

(not sure what feature freeze means as this was added only two days ago... 🤷🏻‍♀️)