### PR TITLE
Switch to PHPCSStandards/PHP_CodeSniffer & raise minimum supported version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To start contributing, fork the repository, create a new branch in your fork, ma
 
 Please make sure that your pull request contains unit tests covering what's being addressed by it.
 
-* All code should be compatible with PHPCS >= 3.7.1.
+* All code should be compatible with PHPCS >= 3.8.0.
 * All code should be compatible with PHP 5.4 to PHP nightly.
 * All code should comply with the PHPCompatibility coding standards.
     The [ruleset used by PHPCompatibility](https://github.com/PHPCSStandards/PHPCSDevCS) is largely based on PSR-12 with minor variations and some additional checks for array layout and documentation and such.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
 
         include:
           - php: '7.2'
-            phpcs_version: '^3.7.1'
+            phpcs_version: '^3.8.0'
             custom_ini: true
             experimental: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,7 +294,7 @@ Also as of this version, [Juliette Reinders Folmer] is now officially a co-maint
 ### Upgrade instructions
 
 * If you have `<exclude name="..."/>` directives in your own project's custom ruleset which relate to sniffs from the PHPCompatibility library, you will need to update your ruleset to use the new sniff names.
-* If you use the new [PHPCS 3.2+ inline annotations](https://github.com/squizlabs/PHP_CodeSniffer/releases/3.2.0), i.e. `// phpcs:ignore Standard.Category.SniffName`, in combination with PHPCompatibility sniff names, you will need to update these annotations.
+* If you use the new [PHPCS 3.2+ inline annotations](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/3.2.0), i.e. `// phpcs:ignore Standard.Category.SniffName`, in combination with PHPCompatibility sniff names, you will need to update these annotations.
 * If you use neither of the above, you should be fine and upgrading should be painless.
 
 ### Overview of all the sniff renames:

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -295,7 +295,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             ['MyClassA|\Package\MyClassB', 80],
             ['array|bool|int|float|NULL|object|string', 81],
             ['false|mixed|self|parent|iterable|Resource', 84],
-            ['callable||void', 87, false],
+            ['callable|void', 87, false],
             ['?int|float', 90],
             ['bool|FALSE', 99],
             ['object|ClassName', 102],

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PHP Compatibility Coding Standard for PHP CodeSniffer
 [![Tested on PHP 5.4 to nightly](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%20nightly%20-brightgreen.svg?maxAge=2419200)](https://github.com/PHPCompatibility/PHPCompatibility/actions?query=workflow%3ATest)
 
 
-This is a set of sniffs for [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) that checks for PHP cross-version compatibility.
+This is a set of sniffs for [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) that checks for PHP cross-version compatibility.
 It will allow you to analyse your code for compatibility with higher and lower versions of PHP. 
 
 * [PHP Version Support](#php-version-support)
@@ -63,9 +63,9 @@ Thanks to [WP Engine](https://wpengine.com) for their support on the PHP 7.0 sni
 --------
 This library has been reorganized. All sniffs have been placed in categories and a significant number of sniffs have been renamed.
 
-If you use the complete `PHPCompatibility` standard without `exclude` directives in a custom ruleset and do not (yet) use the new-style PHP_CodeSniffer annotation as introduced in [PHP_CodeSniffer 3.2.0](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.2.0), this will have no noticeable effect and everything should work as before.
+If you use the complete `PHPCompatibility` standard without `exclude` directives in a custom ruleset and do not (yet) use the new-style PHP_CodeSniffer annotation as introduced in [PHP_CodeSniffer 3.2.0](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.2.0), this will have no noticeable effect and everything should work as before.
 
-However, if you do use `exclude` directives for PHPCompatibility sniffs in a custom ruleset or if you use the [new-style PHP_CodeSniffer inline annotations](https://github.com/squizlabs/PHP_CodeSniffer/releases/3.2.0), you will need to update these when upgrading. This should be a one-time only change.
+However, if you do use `exclude` directives for PHPCompatibility sniffs in a custom ruleset or if you use the [new-style PHP_CodeSniffer inline annotations](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/3.2.0), you will need to update these when upgrading. This should be a one-time only change.
 The changelog contains detailed information about all the sniff renames.
 
 Please read the changelog for version [9.0.0](https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0) carefully before upgrading.
@@ -110,7 +110,7 @@ Installation in a Composer project (method 1)
 Installation via a git check-out to an arbitrary directory (method 2)
 -----------------------
 
-* Install [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation).
+* Install [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) via [your preferred method](https://github.com/PHPCSStandards/PHP_CodeSniffer#installation).
 
     PHP CodeSniffer offers a variety of installation methods to suit your work-flow: Composer, [PEAR](http://pear.php.net/PHP_CodeSniffer), a Phar file, zipped/tarred release archives or checking the repository out using Git.
 
@@ -122,7 +122,7 @@ Installation via a git check-out to an arbitrary directory (method 2)
    ```bash
    phpcs --config-set installed_paths /path/to/PHPCompatibility
    ```
-   I.e. if you placed the `PHPCompatibility` repository in the `/my/custom/standards/PHPCompatibility` directory, you will need to add that directory to the PHP CodeSniffer [`installed_paths` configuration variable](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
+   I.e. if you placed the `PHPCompatibility` repository in the `/my/custom/standards/PHPCompatibility` directory, you will need to add that directory to the PHP CodeSniffer [`installed_paths` configuration variable](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
 
    **Warning**: :warning: The `installed_paths` command overwrites any previously set `installed_paths`. If you have previously set `installed_paths` for other external standards, run `phpcs --config-show` first and then run the `installed_paths` command with all the paths you need separated by commas, i.e.:
    ```bash
@@ -148,7 +148,7 @@ Sniffing your code for compatibility with specific PHP version(s)
     - You can also specify a range of PHP versions that your code needs to support. In this situation, compatibility issues that affect any of the PHP versions in that range will be reported: `--runtime-set testVersion 5.3-5.5`.
     - As of PHPCompatibility 7.1.3, you can omit one part of the range if you want to support everything above or below a particular version, i.e. use `--runtime-set testVersion 7.0-` to run all the checks for PHP 7.0 and above.
 * By default the report will be sent to the console, if you want to save the report to a file, add the following to the command line command: `--report-full=path/to/report-file`.
-    For more information and other reporting options, check the [PHP CodeSniffer wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting).
+    For more information and other reporting options, check the [PHP CodeSniffer wiki](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Reporting).
 
 
 ### Using a framework/CMS/polyfill specific ruleset
@@ -191,7 +191,7 @@ You can also set the `testVersion` from within the ruleset:
     <config name="testVersion" value="5.6-"/>
 ```
 
-Other advanced options, such as changing the message type or severity of select sniffs, as described in the [PHPCS Annotated ruleset](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) wiki page are, of course, also supported.
+Other advanced options, such as changing the message type or severity of select sniffs, as described in the [PHPCS Annotated ruleset](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) wiki page are, of course, also supported.
 
 ### `testVersion` in the ruleset versus command-line
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Requirements
 -------
 
 * PHP 5.4+
-* PHP CodeSniffer: 3.7.1+.
+* PHP CodeSniffer: 3.8.0+.
 
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP CodeSniffer. You should get consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on a recent PHP version in combination with a recent PHP_CodeSniffer version.
 
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP CodeSniffer 3.x.
 As of version 9.0.0, support for PHP CodeSniffer 1.5.x and low 2.x versions < 2.3.0 has been dropped.
-As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 3.7.1 has been dropped.
+As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 3.8.0 has been dropped.
 
 
 Thank you

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
   },
   "require": {
     "php": ">=5.4",
-    "squizlabs/php_codesniffer": "^3.7.1",
-    "phpcsstandards/phpcsutils": "^1.0.5"
+    "squizlabs/php_codesniffer": "^3.8.0",
+    "phpcsstandards/phpcsutils": "^1.0.9"
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.3.2",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,7 @@
     <!--
     #############################################################################
     COMMAND LINE ARGUMENTS
-    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+    https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
     #############################################################################
     -->
 


### PR DESCRIPTION
⚠️  **_This is a DRAFT PR on purpose as it references releases which have not yet been tagged. Once the PHPCS 3.8.0 tag is available ~~(which contains the Composer `replace` directive)~~, this can/should be merged ~~and released ASAP~~._** ⚠️ 

---

### Switch to PHPCSStandards/PHP_CodeSniffer

The Squizlabs repo has been abandoned. The project continues in a fork in the PHPCSStandards organisation.

Ref:
* squizlabs/PHP_CodeSniffer#3932

### ~~Composer: raise the minimum supported PHPCS version to 3.8.0~~

~~... to prevent end-users from running into trouble with the name change.

~~The files in the Composer `vendor/bin` will only be replaced when the `replace...` directive is found and that is only available in the 3.8.0 tag.~~
~~When the files in the Composer `vendor/bin` are not replaced, they will continue to point to the `vendor/squizlabs/php_codesniffer` directory which will no longer exist, leading to fatal "File not found" errors for end-users trying to run PHPCS/PHPCBF.~~

**Update**: The Composer package name will not change, so while this PR should still be merged at our convenience (after the 3.8.0 release, expected this Friday), we will not need to do a release to unblock end-users.

### Composer: raise the minimum supported PHPCS + PHPCSUtils versions

... to benefit from improved PHP 8.2 syntax support.

Includes updating references to the PHPCS version whenever relevant throughout the codebase.


### 🆕 NewTypedPropertiesUnitTest: minor tweak

... to account for an upstream change.

This particular test is testing an invalid syntax (parse error) as `static` is not a valid type for property declarations.

With that in mind, I'm perfecly fine with this test expectation changing.


Fixes #1661