### PR TITLE
Removed old-style RemovedExtensionsSniff for FDF

### DIFF
--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -106,10 +106,6 @@ class RemovedExtensionsSniff extends Sniff
             '5.3' => true,
             'alternative' => null,
         ],
-        'fdf' => [
-            '5.3' => true,
-            'alternative' => 'pecl/fdf',
-        ],
         'filepro' => [
             '5.2' => true,
             'alternative' => null,


### PR DESCRIPTION
We need to add this commit to complete the already well done work of #1060, related to #1022

Without that we still get issues for ugly-named methods such fdfWhatever().