### PR TITLE
Backwards compatible Attributes returns warning

### DIFF
--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -68,7 +68,7 @@ class NewAttributesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         if (isset($tokens[$stackPtr]['attribute_closer']) === false) {
-            // Live coding or parse error. Shouldn't be possible, as shouldn't have retokenized in that case.
+            // Live coding or parse error. Shouldn't be possible as shouldn't have retokenized in that case.
             return; // @codeCoverageIgnore
         }
 
@@ -94,9 +94,10 @@ class NewAttributesSniff extends Sniff
     /**
      * Determines if an attribute is likely to be backwards compatible.
      *
-     * @param  \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param  int                         $stackPtr  The position of the current token in the stack.
-     * @param  array                       $tokens    The array of tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the stack.
+     * @param array                       $tokens    The array of tokens.
+     *
      * @return bool
      */
     protected function isBackwardsCompatibleAttribute($phpcsFile, $stackPtr, $tokens)

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -68,7 +68,7 @@ class NewAttributesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         if (isset($tokens[$stackPtr]['attribute_closer']) === false) {
-            // Live coding or parse error. Shouldn't be possible as shouldn't have retokenized in that case.
+            // Live coding or parse error. Shouldn't be possible, as shouldn't have retokenized in that case.
             return; // @codeCoverageIgnore
         }
 

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -68,7 +68,7 @@ class NewAttributesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         if (isset($tokens[$stackPtr]['attribute_closer']) === false) {
-	        // Live coding or parse error. Shouldn't be possible as shouldn't have retokenized in that case.
+            // Live coding or parse error. Shouldn't be possible as shouldn't have retokenized in that case.
             return; // @codeCoverageIgnore
         }
 

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -68,7 +68,7 @@ class NewAttributesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         if (isset($tokens[$stackPtr]['attribute_closer']) === false) {
-            // Live coding or parse error.
+	        // Live coding or parse error. Shouldn't be possible as shouldn't have retokenized in that case.
             return; // @codeCoverageIgnore
         }
 

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -68,15 +68,67 @@ class NewAttributesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         if (isset($tokens[$stackPtr]['attribute_closer']) === false) {
-            // Live coding or parse error. Shouldn't be possible as shouldn't have retokenized in that case.
+            // Live coding or parse error.
             return; // @codeCoverageIgnore
         }
 
-        $phpcsFile->addError(
-            'Attributes are not supported in PHP 7.4 or earlier. Found: %s',
-            $stackPtr,
-            'Found',
-            [GetTokensAsString::compact($phpcsFile, $stackPtr, $tokens[$stackPtr]['attribute_closer'], true)]
-        );
+        $content = GetTokensAsString::compact($phpcsFile, $stackPtr, $tokens[$stackPtr]['attribute_closer'], true);
+
+        if ($this->isBackwardsCompatibleAttribute($phpcsFile, $stackPtr, $tokens)) {
+            $phpcsFile->addWarning(
+                'Backwards compatible attribute detected. This may not cause parse errors in PHP < 8.0: Found: %s',
+                $stackPtr,
+                'Found',
+                [$content]
+            );
+        } else {
+            $phpcsFile->addError(
+                'Attributes are not supported in PHP 7.4 or earlier. Found: %s',
+                $stackPtr,
+                'Found',
+                [$content]
+            );
+        }
+    }
+
+    /**
+     * Determines if an attribute is likely to be backwards compatible.
+     *
+     * @param  \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param  int                         $stackPtr  The position of the current token in the stack.
+     * @param  array                       $tokens    The array of tokens.
+     * @return bool
+     */
+    protected function isBackwardsCompatibleAttribute($phpcsFile, $stackPtr, $tokens)
+    {
+        $currentLine = $tokens[$stackPtr]['line'];
+
+        // Check if the attribute starts the line (ignoring whitespace)
+        $startOfLineToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        if ($tokens[$startOfLineToken]['line'] < $currentLine) {
+            // The attribute starts a new line
+            $attributeCloser = $tokens[$stackPtr]['attribute_closer'];
+
+            if ($tokens[$attributeCloser]['line'] == $currentLine) {
+                // Check for any token after the attribute on the same line
+                $nextToken = $phpcsFile->findNext(T_WHITESPACE, ($attributeCloser + 1), null, true);
+                if ($nextToken === false || $tokens[$nextToken]['line'] > $currentLine) {
+                    // No non-whitespace token after the attribute on the same line
+                    for ($i = $stackPtr; $i <= $attributeCloser; $i++) {
+                        // Check for a closing tag within a string
+                        if ($tokens[$i]['type'] === 'T_CONSTANT_ENCAPSED_STRING' && strpos($tokens[$i]['content'], '?>') !== false) {
+                            return false;
+                        }
+                    }
+
+                    // No problematic closing tag found in the attribute
+                    return true;
+                }
+            }
+        }
+
+        // Attribute does not start its own line, is multi-line,
+        // or has problematic tokens.
+        return false;
     }
 }

--- a/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
+++ b/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
@@ -47,6 +47,27 @@ class NewAttributesUnitTest extends BaseSniffTestCase
     }
 
     /**
+     * testNewAttributes
+     *
+     * @dataProvider dataBackwardsCompatibleAttributes
+     *
+     * @param int    $line  The line number.
+     * @param string $found Optional. Found attribute contents.
+     *
+     * @return void
+     */
+    public function testBackwardsCompatibleNewAttributes($line, $found = '')
+    {
+        $file    = $this->sniffFile(__FILE__, '7.4');
+        $warning = 'Backwards compatible attribute detected. This may not cause parse errors in PHP < 8.0:';
+        if ($found !== '') {
+            $warning .= ' Found: ' . $found;
+        }
+
+        $this->assertWarning($file, $line, $warning);
+    }
+
+    /**
      * Data provider.
      *
      * @see testNewAttributes()
@@ -54,6 +75,33 @@ class NewAttributesUnitTest extends BaseSniffTestCase
      * @return array
      */
     public static function dataNewAttributes()
+    {
+        $data = [
+            [38],
+            [46],
+            [48],
+            // There are backwards compatible but the sniffer can't parse multiple arguments in one line.
+            [50, '#[WithoutArgument]'],
+            [50, '#[SingleArgument(0)]'],
+            [50, "#[FewArguments('Hello', 'World')]"],
+            [56, '#[ORM\Id]'],
+            [56, '#[ORM\Column("integer")]'],
+            [56, '#[ORM\GeneratedValue]'],
+            // End multiple Attributes in one line.
+            [67, '#[Attr2("foo"), Attr2("bar")]'],
+            [73, '#[ Attr1("foo"), Attr2("bar"), ]'],
+            [83, '#[MyAttr([1, 2])]'],
+            [86, '#[ ORM\Entity, ORM\Table("user") ]'],
+            [96, '#[Assert\Email(["message" => "text"])]'],
+            [96, '#[Assert\Text(["message" => "text"]), Assert\Domain(["message" => "text"]), Assert\Id(Assert\Id::REGEX[10]), ]'],
+            [104],
+            [109],
+        ];
+
+        return $data;
+    }
+
+    public static function dataBackwardsCompatibleAttributes()
     {
         $data = [
             [17],
@@ -66,33 +114,16 @@ class NewAttributesUnitTest extends BaseSniffTestCase
             [31],
             [32],
             [35],
-            [38],
             [40],
             [41],
             [42],
             [43],
-            [46],
-            [48],
-            [50, '#[WithoutArgument]'],
-            [50, '#[SingleArgument(0)]'],
-            [50, "#[FewArguments('Hello', 'World')]"],
             [53],
-            [56, '#[ORM\Id]'],
-            [56, '#[ORM\Column("integer")]'],
-            [56, '#[ORM\GeneratedValue]'],
             [59],
             [60],
             [64],
-            [67, '#[Attr2("foo"), Attr2("bar")]'],
-            [73, '#[ Attr1("foo"), Attr2("bar"), ]'],
-            [83, '#[MyAttr([1, 2])]'],
-            [86, '#[ ORM\Entity, ORM\Table("user") ]'],
             [92],
             [95],
-            [96, '#[Assert\Email(["message" => "text"])]'],
-            [96, '#[Assert\Text(["message" => "text"]), Assert\Domain(["message" => "text"]), Assert\Id(Assert\Id::REGEX[10]), ]'],
-            [104],
-            [109],
         ];
 
         return $data;

--- a/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
+++ b/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
@@ -101,6 +101,13 @@ class NewAttributesUnitTest extends BaseSniffTestCase
         return $data;
     }
 
+    /**
+     * Data provider.
+     *
+     * @see testBackwardsCompatibleNewAttributes
+     *
+     * @return array
+     */
     public static function dataBackwardsCompatibleAttributes()
     {
         $data = [

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -295,7 +295,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             ['MyClassA|\Package\MyClassB', 80],
             ['array|bool|int|float|NULL|object|string', 81],
             ['false|mixed|self|parent|iterable|Resource', 84],
-            ['callable||void', 87, false],
+            ['callable|void', 87, false],
             ['?int|float', 90],
             ['bool|FALSE', 99],
             ['object|ClassName', 102],


### PR DESCRIPTION
This PR tries to improve the `NewAttributeSniff` to differentiate between what is backwards compatible attributes and what is not.

It defines backwards compatible attributes as:

- Starts on it's own line
- Finishes on the same line
- Does not have anything after the attribute

It updates the existing testing cases to match the new desired behavior.

Known limitation: Multiple attributes in the same line. Even though they are backwards compatible, due to a matter of development effort trade-off, this PR does not consider multiple attributes in the same line as backwards, as we would need to iterate over each newly found attribute to see if they are backwards compatible, and we would need to differentiate anything after the closing attribute marker as being another attribute or anything else.

**Maintainers: Take this PR with a grain of salt. I've GPT'ed my way through it and I have no idea what I'm doing.**

Partially solves https://github.com/PHPCompatibility/PHPCompatibility/issues/1480