### PR TITLE
AbstractFunctionCallParameter: fix copy/pasta

### DIFF
--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -120,7 +120,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
 
         if (Context::inAttribute($phpcsFile, $stackPtr) === true) {
             // Class instantiation or constant in attribute, not function call.
-            return false;
+            return;
         }
 
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);


### PR DESCRIPTION
The sniff should bow out without returning a value (which would be interpreted as a stack pointer).