### PR TITLE
FunctionDeclarations/RemovedOptionalBeforeRequiredParam: bug fix for nullable types

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -107,8 +107,12 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
                 }
 
                 if (isset($firstOptional) === false) {
-                    // Check if it's typed and has a null default value, in which case we can ignore it.
-                    if ($param['type_hint'] !== '') {
+                    // Check if it's typed with a non-nullable type and has a null default value, in which case we can ignore it.
+                    if ($param['type_hint'] !== ''
+                        && $param['nullable_type'] === false
+                        // Check for union types which include null.
+                        && $phpcsFile->findNext(\T_NULL, $param['type_hint_token'], ($param['type_hint_end_token'] + 1)) === false
+                    ) {
                         $hasNull    = $phpcsFile->findNext(\T_NULL, $param['default_token'], $param['comma_token']);
                         $hasNonNull = $phpcsFile->findNext(
                             $this->allowedInDefault,

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -5,7 +5,7 @@
  */
 function requiredBeforeOptional($a, $b, $c = null, $d = true) {}
 function requiredBeforeOptionalWithTypes(?int $a, string $b, callable $c = null, bool $d = /*comment*/ true) {}
-function nullableTypedOptionalBeforeRequired(Foo $a = /* comment */ null, ?int $b = null, $c, $d) {}
+function requiredTypedWithNullDefaultBeforeRequired(Foo $a = /* comment */ null, int $b = null, $c, $d) {}
 
 /*
  * Deprecated in PHP 8.
@@ -46,6 +46,17 @@ class MixedWithOptionalParam {
         $normalParam = 10, // OK.
     ) {}
 }
+
+function nonNullableTypedWithNullDefaultValueBeforeRequired(T1 $a, T2 $b = null, T3 $c) {} // This is fine.
+function nullableTypedWithNullDefaultValueBeforeOptional(T1 $a, ?T2 $b = null, T3 $c = null) {} // This is fine.
+// Deprecated as of PHP 8.0, but only emits a deprecation notice in PHP itself as of PHP 8.1.
+function nullableTypedOptionalBeforeRequired(T1 $a, ?T2 $b = /* comment */ null, T3 $c) {}
+
+function nullLastUnionTypedWithNullDefaultValueBeforeOptional(T1 $a, T2|null $b = null, T3 $c = null) {} // This is fine.
+function nullFirstUnionTypedWithNullDefaultValueBeforeOptional(T1 $a, null|T2 $b = null, T3 $c = null) {} // This is fine.
+// Deprecated as of PHP 8.0, but only emits a deprecation notice in PHP itself as of PHP 8.3.
+function nullLastUnionTypedWithNullDefaultValueBeforeRequired(T1 $a, T2|null $b = null, T3 $c) {}
+function nullFirstUnionTypedWithNullDefaultValueBeforeRequired(T1 $a, null|T2 $b = null, T3 $c) {}
 
 // Intentional parse error. This has to be the last test in the file.
 $closure = function( $a = [], $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -57,6 +57,9 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
             [20],
             [32],
             [39],
+            [53],
+            [58],
+            [59],
         ];
     }
 


### PR DESCRIPTION
The [recent RFC proposing to deprecate implicit nullable types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types) brough an oversight in the `PHPCompatibility.FunctionDeclarations.RemovedOptionalBeforeRequiredParam` sniff to my attention.

To quote [the RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types):
> Even though signatures which contain an optional parameter before a required one were deprecated in PHP 8.0, the case of implicitly nullable types was left alone at that time due to BC concerns. This exclusion caused some bugs in the detection of which signatures should emit the deprecation notice. Indeed, the following signature only emits a deprecation as of PHP 8.1:
>
> `function bar(T1 $a, ?T2 $b = null, T3 $c) {}`
>
> And the signature that uses the generalized union type signature:
>
> `function test(T1 $a, T2|null $b = null, T3 $c) {}`
>
> only emits the deprecation notice properly as of PHP 8.3.

At the time of writing this sniff those additional two deprecation notices were not yet in place and were therefore not taken into account.

This commit updates the sniff to _also_ throw deprecation notices for these two additional code patterns.

Includes unit tests safeguarding the fix.

**Open question:**

As PHP itself only throws deprecation notices for these patterns as of PHP 8.1 and 8.3 respectively, we _could_ consider doing the same. However, based on the description in the above mentioned RFC, the _actual_ deprecation was as of PHP 8.0 and the fact that the deprecation notices weren't thrown for these two situations was an oversight/bug in PHP, which is why I have chosen not to make this distinction in the sniff.