### PR TITLE
Variables/ForbiddenThisUseContexts: fix false positive for $this in unset

### DIFF
--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -243,6 +243,12 @@ class ForbiddenThisUseContextsSniff extends Sniff
                 }
 
                 for ($i = ($openParenthesis + 1); $i < $tokens[$openParenthesis]['parenthesis_closer']; $i++) {
+                    // Ignore anything within square brackets (array access keys).
+                    if (isset($tokens[$i]['bracket_closer'])) {
+                        $i = $tokens[$i]['bracket_closer'];
+                        continue;
+                    }
+
                     if ($tokens[$i]['code'] !== \T_VARIABLE || $tokens[$i]['content'] !== '$this') {
                         continue;
                     }

--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.inc
@@ -168,6 +168,12 @@ enum Suit: string implements Colorful
     }
 }
 
+// Issue #1666 - $this in unset, but not being unset.
+class NotUnsettingThis {
+    public function delete() {
+        unset($array[get_array_key($this)]); // OK.
+    }
+}
 
 /*
  * ====================================================================

--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
@@ -369,6 +369,7 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTestCase
             [92],
             [100],
             [101],
+            [174],
         ];
     }
 
@@ -437,7 +438,10 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTestCase
             [133],
             [138],
             [164],
-            [219], // Exception to the rule / static __call() magic method.
+
+            // Exception to the rule / static __call() magic method.
+            [224],
+            [225],
         ];
     }
 
@@ -452,7 +456,7 @@ class ForbiddenThisUseContextsUnitTest extends BaseSniffTestCase
         $file = $this->sniffFile(__FILE__, '7.1');
 
         // No errors expected on the last group of lines.
-        for ($line = 172; $line <= 226; $line++) {
+        for ($line = 178; $line <= 232; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }


### PR DESCRIPTION
... when `$this` is a parameter passed to a function call which will retrieve an array access key for determining the array key to be unset.

Fixed by always skipping over anything within square brackets (array access keys).

Includes test.

Fixed #1666