### PR TITLE
PHP 8.4 | ParameterValues/RemovedLdapConnectSignatures: account for deprecation of three+ param signature (RFC)

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedLdapConnectSignaturesStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedLdapConnectSignaturesStandard.xml
@@ -8,7 +8,7 @@
     Calling ldap_connect() with its two-parameter signature is deprecated since PHP 8.3 and support will be removed in PHP 9.0.
 
     Call ldap_connect() with an LDAP-URI as the first (and only) parameter instead.
-    Or in case the underlying library is Oracle and one wants to add wallet-details, pass an LDAP-URI as the $uri parameter and pass `null` as the $port parameter.
+    Or in case the underlying library is Oracle and one wants to add wallet-details, pass an LDAP-URI as the $uri parameter and pass `null` as the $port parameter (PHP < 8.4).
     ]]>
     </standard>
     <code_comparison>
@@ -24,7 +24,7 @@ ldap_connect(<em>$host</em>, <em>$port</em>);
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Cross-version compatible: calling ldap_connect() with wallet-details with an LDAP-URI in the $uri parameter and null for the $port value.">
+        <code title="Cross-version compatible up to PHP 8.3: calling ldap_connect() with wallet-details with an LDAP-URI in the $uri parameter and null for the $port value..">
         <![CDATA[
 ldap_connect(
     <em>"ldap://$host:$port??369"</em>,
@@ -38,6 +38,47 @@ ldap_connect(
         <code title="PHP &lt; 8.3: calling ldap_connect() with wallet-details with separate $host and $port parameters.">
         <![CDATA[
 ldap_connect(
+    <em>$host</em>,
+    <em>369</em>,
+    $wallet,
+    $password,
+    $auth_mode,
+);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Calling ldap_connect() with its three-or-more-parameter signature is deprecated since PHP 8.4 and support will be removed in PHP 9.0.
+
+    Call the PHP 8.3+ function ldap_connect_wallet() instead.
+    Either use an if/else to call the correct function for cross-version compatible code or polyfill the ldap_connect_wallet() function for PHP < 8.3.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: calling ldap_connect() with an LDAP-URI in the $uri parameter.">
+        <![CDATA[
+if (function_exists('ldap_connect_wallet')) {
+    <em>ldap_connect_wallet</em>(
+        "ldap://$host:$port??369",
+        $wallet,
+        $password,
+        $auth_mode,
+    );
+} else {
+    <em>ldap_connect</em>(
+        "ldap://$host:$port??369",
+        <em>null</em>,
+        $wallet,
+        $password,
+        $auth_mode,
+    );
+}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: calling ldap_connect() with its three-or-more parameter signature.">
+        <![CDATA[
+<em>ldap_connect</em>(
     <em>$host</em>,
     <em>369</em>,
     $wallet,

--- a/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.inc
@@ -21,25 +21,14 @@ ldap_connect( /*comment */ );
 LDAP_Connect($uri);
 \ldap_connect( "ldap://$host:$port??369" );
 
-// Signature still supported in PHP 8.3, will be deprecated in PHP 8.4.
-ldap_connect($uri, null, $wallet, $password, $auth_mode); // Port value null is okay.
-ldap_connect(
-    $uri,
-    $port, // Value undetermined, so ignore.
-    $wallet,
-    $password,
-    $auth_mode,
-);
-ldap_connect($uri, MY_PORT, $wallet, $password, $auth_mode); // Port value undetermined, so ignore.
-ldap_connect($uri, get_port(), $wallet, $password, $auth_mode); // Port value undetermined, so ignore.
-ldap_connect($uri, 369 + $offset, $wallet, $password, $auth_mode); // Port value undetermined, so ignore.
-
 // Invalid function calls (missing required param(s)). Ignore as not our target.
 \ldap_connect(port: $port);
-\ldap_connect(port: $port, wallet: $wallet);
-\ldap_connect(uri: $uri, wallet: $wallet);
-\ldap_connect(auth_mode: $auth_mode, wallet: $wallet);
-\ldap_connect(auth_mode: $auth_mode, wallet: $wallet, password: $password);
+
+// Invalid function calls (missing required param(s) due to incorrect param names used). Ignore as not our target.
+\ldap_connect(hosts: $hosts, port: $port, wall: $wallet);
+\ldap_connect(hosts: $hosts, port: $port, passw: $password);
+\ldap_connect(hosts: $hosts, port: $port, authmode: $auth_mode);
+\ldap_connect(hosts: $hosts, port: $port, wall: $wallet, passw: $password);
 
 /*
  * PHP 8.3: calling ldap_connect() with 2 parameters.
@@ -53,3 +42,26 @@ Ldap_Connect(port: $port, host: $host);
 
 // Three-plus param signature passing a port is also deprecated.
 ldap_connect($uri, 369, $wallet, $password, $auth_mode);
+
+/*
+ * PHP 8.4: calling ldap_connect() with 3 or more parameters.
+ */
+
+// Signature still supported in PHP 8.3, but deprecated in PHP 8.4.
+ldap_connect($uri, null, $wallet, $password, $auth_mode); // Port value null is okay in PHP 8.3.
+ldap_connect(
+    $uri,
+    $port, // Value undetermined, so ignore.
+    $wallet,
+    $password,
+    $auth_mode,
+);
+Ldap_Connect($uri, MY_PORT, $wallet, $password, $auth_mode); // Port value undetermined, so ignore for PHP 8.3 deprecation check.
+ldap_connect($uri, get_port(), $wallet, $password, $auth_mode); // Port value undetermined, so ignore for PHP 8.3 deprecation check.
+ldap_connect($uri, 369 + $offset, $wallet, $password, $auth_mode); // Port value undetermined, so ignore for PHP 8.3 deprecation check.
+
+// Make sure the notice still triggers if not all three PHP 8.4 deprecated params are present.
+\ldap_connect(port: null, wallet: $wallet);
+\ldap_connect(uri: $uri, wallet: $wallet);
+\ldap_connect(auth_mode: $auth_mode, wallet: $wallet);
+\ldap_connect(auth_mode: $auth_mode, wallet: $wallet, password: $password);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.php
@@ -50,9 +50,9 @@ final class RemovedLdapConnectSignaturesUnitTest extends BaseSniffTestCase
     public static function dataRemovedLdapConnectSignatureTwoParams()
     {
         return [
-            [47],
-            [51],
-            [52],
+            [36],
+            [40],
+            [41],
         ];
     }
 
@@ -68,8 +68,38 @@ final class RemovedLdapConnectSignaturesUnitTest extends BaseSniffTestCase
      */
     public function testRemovedLdapConnectSignatureMoreParamsSecondNotNull($line)
     {
-        $file = $this->sniffFile(__FILE__, '8.3');
-        $this->assertWarning($file, $line, 'Calling ldap_connect() with a $port which is not `null` is deprecated since PHP 8.3.');
+        $message = 'Calling ldap_connect() with a $port which is not `null` is deprecated since PHP 8.3.';
+        $file    = $this->sniffFile(__FILE__, '8.3');
+        $this->assertWarning($file, $line, $message);
+
+        /*
+         * This notice should not show for PHP 8.4 as the PHP 8.4 deprecation takes precedence.
+         * This needs special handling as the base test class doesn't handle this.
+         */
+        $file     = $this->sniffFile(__FILE__, '8.4');
+        $warnings = $this->gatherWarnings($file);
+
+        if (isset($warnings[$line]) === false) {
+            $this->assertTrue(true);
+        } else {
+            $found = 0;
+            foreach ($warnings[$line] as $issue) {
+                if (\strpos($issue['message'], $message) !== false) {
+                    ++$found;
+                }
+            }
+
+            $this->assertSame(
+                0,
+                $found,
+                \sprintf(
+                    'Found unexpected warning "%s" (%d times) on line %d when testing against PHP 8.4',
+                    $message,
+                    $found,
+                    $line
+                )
+            );
+        }
     }
 
     /**
@@ -82,7 +112,7 @@ final class RemovedLdapConnectSignaturesUnitTest extends BaseSniffTestCase
     public static function dataRemovedLdapConnectSignatureMoreParamsSecondNotNull()
     {
         return [
-            [55],
+            [44],
         ];
     }
 
@@ -113,8 +143,87 @@ final class RemovedLdapConnectSignaturesUnitTest extends BaseSniffTestCase
     {
         $data = [];
 
-        // No errors expected on the first 43 lines.
-        for ($line = 1; $line <= 43; $line++) {
+        // No errors expected on the first 31 lines.
+        for ($line = 1; $line <= 31; $line++) {
+            $data[] = [$line];
+        }
+
+        // Also no errors expected on the lines dealing with the PHP 8.4 deprecation.
+        for ($line = 49; $line <= 66; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify that the two parameter signature of ldap_connect() is correctly detected.
+     *
+     * @dataProvider dataRemovedLdapConnectSignatureThreePlusParams
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedLdapConnectSignatureThreePlusParams($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertWarning($file, $line, 'Calling ldap_connect() with three or more parameters is deprecated since PHP 8.4.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedLdapConnectSignatureThreePlusParams()
+     *
+     * @return array
+     */
+    public static function dataRemovedLdapConnectSignatureThreePlusParams()
+    {
+        return [
+            [44],
+            [51],
+            [52],
+            [59],
+            [60],
+            [61],
+            [64],
+            [65],
+            [66],
+            [67],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for valid code for the two param signature check.
+     *
+     * @dataProvider dataNoFalsePositivesThreePlusParams
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesThreePlusParams($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesThreePlusParams()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositivesThreePlusParams()
+    {
+        $data = [];
+
+        // No errors expected on the first 31 lines.
+        for ($line = 1; $line <= 31; $line++) {
             $data[] = [$line];
         }
 


### PR DESCRIPTION
> - LDAP:
>  . Calling ldap_connect() with more than 2 arguments is deprecated. Use
>    ldap_connect_wallet() instead.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#ldap_connect
* php/php-src#12728
* https://github.com/php/php-src/commit/1d41eb301408883d1badb5f6eef046fed4a054a8
* https://www.php.net/ldap_connect

Includes updated tests and documentation.

Related to #1589