### PR TITLE
PHP 8.4 | OptionalToRequiredFunctionParameters: account for deprecation of overloaded stream_context_set_option() signature (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -96,6 +96,16 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
                 '8.0'  => true,
             ],
         ],
+        'stream_context_set_option' => [
+            3 => [
+                'name' => 'option_name',
+                '8.4'  => false,
+            ],
+            4 => [
+                'name' => 'value',
+                '8.4'  => false,
+            ],
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
@@ -41,3 +41,6 @@ openssl_seal( $data, $sealed_data, iv: $iv, encrypted_keys: $encrypted_keys, pub
 
 // Prevent false positives on PHP 8.0+ nullsafe method calls.
 $obj?->mktime();
+
+stream_context_set_option($context, $wrapper, $option_name, $value);
+stream_context_set_option($context, $options); // Error x 2.

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -26,6 +26,49 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTestCase
 {
 
     /**
+     * testOptionalRequiredParameterDeprecated
+     *
+     * @dataProvider dataOptionalRequiredParameterDeprecated
+     *
+     * @param string $functionName     Function name.
+     * @param string $parameterName    Parameter name.
+     * @param string $softRequiredFrom The last PHP version in which the parameter was still optional (deprecated).
+     * @param array  $lines            The line numbers in the test file which apply to this class.
+     * @param string $okVersion        A PHP version in which to test for no violation.
+     *
+     * @return void
+     */
+    public function testOptionalRequiredParameterDeprecated($functionName, $parameterName, $softRequiredFrom, $lines, $okVersion)
+    {
+        $file  = $this->sniffFile(__FILE__, $softRequiredFrom);
+        $error = "The \"{$parameterName}\" parameter for function {$functionName}() is missing. Passing this parameter is no longer optional. The optional nature of the parameter is deprecated since PHP {$softRequiredFrom}";
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, $error);
+        }
+
+        $file = $this->sniffFile(__FILE__, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testOptionalRequiredParameterDeprecated()
+     *
+     * @return array
+     */
+    public static function dataOptionalRequiredParameterDeprecated()
+    {
+        return [
+            ['stream_context_set_option', 'option_name', '8.4', [46], '8.3'],
+            ['stream_context_set_option', 'value', '8.4', [46], '8.3'],
+        ];
+    }
+
+
+    /**
      * testOptionalRequiredParameterDeprecatedRemoved
      *
      * @dataProvider dataOptionalRequiredParameterDeprecatedRemoved


### PR DESCRIPTION
> - Standard:
>  . Calling stream_context_set_option() with 2 arguments is deprecated.
>    Use stream_context_set_options() instead.

**Note:** the PHP native deprecation notice recommends using the `stream_context_set_options()` function instead. This sniff, as it is, does not allow for recommending an alternative (other than passing the now required parameters). Support for including an alternative could be added if deemed a good idea.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#stream_context_set_option
* php/php-src#12769
* https://github.com/php/php-src/commit/2d057757c46f4b16a890dea9763b25ffd807aea5
* https://www.php.net/stream_context_set_option

Related to #1589