### PR TITLE
PHP 8.4 | RemovedFunctionParameters: account for deprecation of overloaded ldap_exop() signature (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -111,6 +111,18 @@ class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
                 '8.0'  => true,
             ],
         ],
+        'ldap_exop' => [
+            5 => [
+                'name'        => 'response_data',
+                '8.4'         => false,
+                'alternative' => 'the PHP 8.3+ ldap_exop_sync() function',
+            ],
+            6 => [
+                'name'        => 'response_oid',
+                '8.4'         => false,
+                'alternative' => 'the PHP 8.3+ ldap_exop_sync() function',
+            ],
+        ],
         'ldap_first_attribute' => [
             3 => [
                 'name'  => 'ber_identifier',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -61,3 +61,5 @@ ldap_first_attribute(
 
 imagerotate($image, $angle, $bg_color); // OK.
 imagerotate($image, $angle, $bg_color, $ignore_transparent); // Error.
+
+ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); // Error x 2.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -177,6 +177,8 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             ['imageopenpolygon', 'num_points', '8.1', [37], '8.0'],
             ['imagefilledpolygon', 'num_points', '8.1', [38], '8.0'],
             ['mysqli_get_client_info', 'mysql', '8.1', [40], '8.0'],
+            ['ldap_exop', 'response_data', '8.4', [65], '8.3'],
+            ['ldap_exop', 'response_oid', '8.4', [65], '8.3'],
         ];
     }
 


### PR DESCRIPTION
> - LDAP:
>   . Calling ldap_exop() with more than 4 arguments is deprecated. Use
>     ldap_exop_sync() instead.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#ldap_exop
* php/php-src#12728
* https://github.com/php/php-src/commit/682c2366be09e40be8e404503037a39ff924ba38
* https://www.php.net/ldap_exop

Related to #1589