### PR TITLE
PHP 8.4 | RemovedFunctions: account for deprecation of intlcal_set() (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5074,6 +5074,12 @@ class RemovedFunctionsSniff extends Sniff
         'assert_options' => [
             '8.3' => false,
         ],
+
+        'intlcal_set' => [
+            '8.4'         => false,
+            'alternative' => 'IntlCalendar::setDate() or IntlCalendar::setDateTime()',
+            'extension'   => 'intl',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1235,3 +1235,5 @@ utf8_encode();
 utf8_decode();
 
 assert_options();
+
+intlcal_set();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -210,6 +210,8 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['mhash', '8.1', 'the hash_*() functions', 1228, '8.0'],
             ['utf8_encode', '8.2', 'mb_convert_encoding(), UConverter::transcode() or iconv', 1234, '8.1'],
             ['utf8_decode', '8.2', 'mb_convert_encoding(), UConverter::transcode() or iconv', 1235, '8.1'],
+
+            ['intlcal_set', '8.4', 'IntlCalendar::setDate() or IntlCalendar::setDateTime()', 1239, '8.3'],
         ];
     }
 


### PR DESCRIPTION
> - Intl:
>   . Calling intlcal_set() as well as calling IntlCalendar::set() with
>     more than 2 arguments is deprecated. Use either IntlCalendar::setDate()
>     or IntlCalendar::setDateTime() instead.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#intlcalendarset
* php/php-src#12728
* https://github.com/php/php-src/commit/f4df37af3d1cecc23d9ce2adb8b865c9e4ac4012
* https://www.php.net/manual/en/intlcalendar.set.php

Related to #1589