### PR TITLE
PHP 8.4 | RemovedFunctions: account for deprecation of intlgregcal_create_instance() (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5080,6 +5080,11 @@ class RemovedFunctionsSniff extends Sniff
             'alternative' => 'IntlCalendar::setDate() or IntlCalendar::setDateTime()',
             'extension'   => 'intl',
         ],
+        'intlgregcal_create_instance' => [
+            '8.4'         => false,
+            'alternative' => 'IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime()',
+            'extension'   => 'intl',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1237,3 +1237,4 @@ utf8_decode();
 assert_options();
 
 intlcal_set();
+intlgregcal_create_instance();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -212,6 +212,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['utf8_decode', '8.2', 'mb_convert_encoding(), UConverter::transcode() or iconv', 1235, '8.1'],
 
             ['intlcal_set', '8.4', 'IntlCalendar::setDate() or IntlCalendar::setDateTime()', 1239, '8.3'],
+            ['intlgregcal_create_instance', '8.4', 'IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime()', 1240, '8.3'],
         ];
     }
 


### PR DESCRIPTION

>   . Calling intlgregcal_create_instance() as well as calling
>     IntlGregorianCalendar::__construct() with more than 2 arguments is
>     deprecated. Use either IntlGregorianCalendar::createFromDate() or
>     IntlGregorianCalendar::createFromDateTime() instead.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#intlgregoriancalendarconstruct
* php/php-src#12728
* https://github.com/php/php-src/commit/811245d2e03f03021b289bdde4360ab1846854d5
* https://www.php.net/manual/en/intlcalendar.set.php

Related to #1589