### PR TITLE
PHP 8.4 | RemovedFunctionParameters: account for deprecation of overloaded session_set_save_handler() signature (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -181,6 +181,43 @@ class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
                 '8.0'  => true,
             ],
         ],
+        'session_set_save_handler' => [
+            3 => [
+                'name'        => 'read',
+                '8.4'         => false,
+                'alternative' => 'a SessionHandlerInterface implementation for the callbacks instead',
+            ],
+            4 => [
+                'name'        => 'write',
+                '8.4'         => false,
+                'alternative' => 'a SessionHandlerInterface implementation for the callbacks instead',
+            ],
+            5 => [
+                'name'        => 'destroy',
+                '8.4'         => false,
+                'alternative' => 'a SessionHandlerInterface implementation for the callbacks instead',
+            ],
+            6 => [
+                'name'        => 'gc',
+                '8.4'         => false,
+                'alternative' => 'a SessionHandlerInterface implementation for the callbacks instead',
+            ],
+            7 => [
+                'name'        => 'create_sid',
+                '8.4'         => false,
+                'alternative' => 'a SessionHandlerInterface implementation for the callbacks instead',
+            ],
+            8 => [
+                'name'        => 'validate_sid',
+                '8.4'         => false,
+                'alternative' => 'a SessionHandlerInterface implementation for the callbacks instead',
+            ],
+            9 => [
+                'name'        => 'update_timestamp',
+                '8.4'         => false,
+                'alternative' => 'a SessionHandlerInterface implementation for the callbacks instead',
+            ],
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -63,3 +63,6 @@ imagerotate($image, $angle, $bg_color); // OK.
 imagerotate($image, $angle, $bg_color, $ignore_transparent); // Error.
 
 ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $response_oid); // Error x 2.
+
+session_set_save_handler($handler, true); // OK.
+session_set_save_handler($open, $close, $read, $write, $destroy, $gc, $create_sid, $validate_sid, $update_timestamp); // Error x 7.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -179,6 +179,13 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             ['mysqli_get_client_info', 'mysql', '8.1', [40], '8.0'],
             ['ldap_exop', 'response_data', '8.4', [65], '8.3'],
             ['ldap_exop', 'response_oid', '8.4', [65], '8.3'],
+            ['session_set_save_handler', 'read', '8.4', [68], '8.3'],
+            ['session_set_save_handler', 'write', '8.4', [68], '8.3'],
+            ['session_set_save_handler', 'destroy', '8.4', [68], '8.3'],
+            ['session_set_save_handler', 'gc', '8.4', [68], '8.3'],
+            ['session_set_save_handler', 'create_sid', '8.4', [68], '8.3'],
+            ['session_set_save_handler', 'validate_sid', '8.4', [68], '8.3'],
+            ['session_set_save_handler', 'update_timestamp', '8.4', [68], '8.3'],
         ];
     }
 
@@ -219,6 +226,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             [50],
             [53],
             [62],
+            [67],
         ];
     }
 


### PR DESCRIPTION

> - Session:
>   . Calling session_set_save_handler() with more than 2 arguments is
>     deprecated. Use the 2-parameter signature instead.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#session_set_save_handler
* php/php-src#12769
* https://github.com/php/php-src/commit/b36eac94d26bdced150d9d2178f6209893d9961f
* https://www.php.net/ldap_exop

Related to #1589