### PR TITLE
ParameterValues/NewNumberFormatMultibyteSeparators: empty string is not multi-byte

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
@@ -146,8 +146,8 @@ class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCallParame
             }
         }
 
-        if ($length === 1) {
-            // Single-byte, we're good.
+        if ($length <= 1) {
+            // Single-byte or empty string, we're good.
             return;
         }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.inc
@@ -34,3 +34,7 @@ EOD
 ::
 EOT
 ); // Both multi-byte.
+
+// Bug #1679: empty string was incorrectly being flagged as multi-byte.
+number_format($number, $decimals, '', ''); // OK.
+number_format($number, $decimals, "", ""); // OK.

--- a/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.php
@@ -62,16 +62,38 @@ class NewNumberFormatMultibyteSeparatorsUnitTest extends BaseSniffTestCase
     /**
      * Verify there are no false positives on valid code.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        $cases = [];
 
         // No errors expected on the first 16 lines.
         for ($line = 1; $line <= 16; $line++) {
-            $this->assertNoViolation($file, $line);
+            $cases[] = [$line];
         }
+
+        $cases[] = [39];
+        $cases[] = [40];
+
+        return $cases;
     }
 
 


### PR DESCRIPTION
Oops... the sniff presumed there would always be a value for either of the separator parameters and didn't take the possibility of an empty string into account.

Fixed now.

Includes tests.

Fixes #1679