### PR TITLE
Constants/NewMagicClassConstant: bug fix

### DIFF
--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -15,6 +15,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Context;
 
 /**
  * Detect usage of the magic `::class` constant introduced in PHP 5.5.
@@ -70,6 +71,11 @@ class NewMagicClassConstantSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         if (\strtolower($tokens[$stackPtr]['content']) !== 'class') {
+            return;
+        }
+
+        if (Context::inAttribute($phpcsFile, $stackPtr) === true) {
+            // If the syntax is used within an attribute, it will be interpreted as a comment on PHP < 8.0, so not an issue.
             return;
         }
 

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -61,7 +61,6 @@ class NewMagicClassConstantUnitTest extends BaseSniffTestCase
             [30],
             [31],
             [32],
-            [67],
         ];
     }
 
@@ -100,6 +99,8 @@ class NewMagicClassConstantUnitTest extends BaseSniffTestCase
         for ($line = 54; $line <= 61; $line++) {
             $data[] = [$line];
         }
+
+        $data[] = [67];
 
         return $data;
     }


### PR DESCRIPTION
Follow up on #1500 which added a test for the use of `::class` within an attribute.

At the time, this was set to be flagged. However, as attributes are interpreted as comments on PHP < 8.0, using `::class` within an attribute is not actually problematic.

Fixed now.