### PR TITLE
PHP 8.3 | Classes/NewReadonlyClasses: detect PHP 8.3+ anonymous readonly classes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To start contributing, fork the repository, create a new branch in your fork, ma
 
 Please make sure that your pull request contains unit tests covering what's being addressed by it.
 
-* All code should be compatible with PHPCS >= 3.8.0.
+* All code should be compatible with PHPCS >= 3.9.0.
 * All code should be compatible with PHP 5.4 to PHP nightly.
 * All code should comply with the PHPCompatibility coding standards.
     The [ruleset used by PHPCompatibility](https://github.com/PHPCSStandards/PHPCSDevCS) is largely based on PSR-12 with minor variations and some additional checks for array layout and documentation and such.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
 
         include:
           - php: '7.2'
-            phpcs_version: '^3.8.0'
+            phpcs_version: '^3.9.0'
             custom_ini: true
             experimental: false
 

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
@@ -13,16 +13,19 @@ namespace PHPCompatibility\Sniffs\Classes;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
  * Declaring classes as readonly is supported since PHP 8.2.
  *
  * PHP version 8.2
+ * PHP version 8.3
  *
  * @link https://wiki.php.net/rfc/readonly_classes
  * @link https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.readonly-classes
  * @link https://www.php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.readonly
+ * @link https://www.php.net/manual/en/migration83.new-features.php#migration83.new-features.core.readonly-modifier-improvements
  *
  * @since 10.0.0
  */
@@ -38,7 +41,10 @@ final class NewReadonlyClassesSniff extends Sniff
      */
     public function register()
     {
-        return [\T_CLASS];
+        return [
+            \T_CLASS,
+            \T_ANON_CLASS,
+        ];
     }
 
     /**
@@ -54,19 +60,38 @@ final class NewReadonlyClassesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if (ScannedCode::shouldRunOnOrBelow('8.1') === false) {
-            return;
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === \T_CLASS) {
+            if (ScannedCode::shouldRunOnOrBelow('8.1') === false) {
+                return;
+            }
+
+            $properties = ObjectDeclarations::getClassProperties($phpcsFile, $stackPtr);
+            if ($properties['is_readonly'] === false) {
+                return;
+            }
+
+            $phpcsFile->addError(
+                'Readonly classes are not supported in PHP 8.1 or earlier.',
+                $properties['readonly_token'],
+                'Found'
+            );
         }
 
-        $properties = ObjectDeclarations::getClassProperties($phpcsFile, $stackPtr);
-        if ($properties['is_readonly'] === false) {
-            return;
-        }
+        if ($tokens[$stackPtr]['code'] === \T_ANON_CLASS) {
+            if (ScannedCode::shouldRunOnOrBelow('8.2') === false) {
+                return;
+            }
 
-        $phpcsFile->addError(
-            'Readonly classes are not supported in PHP 8.1 or earlier.',
-            $properties['readonly_token'],
-            'Found'
-        );
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            if ($tokens[$prevNonEmpty]['code'] === \T_READONLY) {
+                $phpcsFile->addError(
+                    'Readonly anonymous classes are not supported in PHP 8.2 or earlier.',
+                    $prevNonEmpty,
+                    'AnonClass'
+                );
+            }
+        }
     }
 }

--- a/PHPCompatibility/Tests/Classes/NewReadonlyClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyClassesUnitTest.inc
@@ -12,7 +12,7 @@ abstract class AbstractClass {
     function class() {}
 }
 
-// Anon classes do not take keywords (and are not mentioned in the RFC).
+// Prior to PHP 8.3, anon classes do not take keywords (and are not mentioned in the RFC).
 $anon = new class () {};
 
 /**
@@ -50,3 +50,14 @@ ClassName {}
 
 // Duplicate readonly modifier is not allowed, but that's not the concern of this sniff.
 readonly readonly class DoubleReadonly {}
+
+/**
+ * PHP 8.3+: readonly anonymous classes.
+ */
+$anon = new Readonly class {};
+$anon = new readonly class() {};
+$anon = new
+// comment
+ReadOnly
+// phpcs:ignore Stnd.Cat.Sniff
+class {};

--- a/PHPCompatibility/Tests/Classes/NewReadonlyClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyClassesUnitTest.php
@@ -64,6 +64,38 @@ final class NewReadonlyClassesUnitTest extends BaseSniffTestCase
 
 
     /**
+     * Test that an error is thrown for class constants declared with visibility.
+     *
+     * @dataProvider dataReadonlyAnonymousClass
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testReadonlyAnonymousClass($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertError($file, $line, 'Readonly anonymous classes are not supported in PHP 8.2 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testReadonlyAnonymousClass()
+     *
+     * @return array
+     */
+    public static function dataReadonlyAnonymousClass()
+    {
+        return [
+            [57],
+            [58],
+            [61],
+        ];
+    }
+
+
+    /**
      * Verify that there are no false positives for valid code.
      *
      * @dataProvider dataNoFalsePositives
@@ -103,7 +135,7 @@ final class NewReadonlyClassesUnitTest extends BaseSniffTestCase
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '8.2');
+        $file = $this->sniffFile(__FILE__, '8.3');
         $this->assertNoViolation($file);
     }
 }

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Requirements
 -------
 
 * PHP 5.4+
-* PHP CodeSniffer: 3.8.0+.
+* PHP CodeSniffer: 3.9.0+.
 
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP CodeSniffer. You should get consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on a recent PHP version in combination with a recent PHP_CodeSniffer version.
 
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP CodeSniffer 3.x.
 As of version 9.0.0, support for PHP CodeSniffer 1.5.x and low 2.x versions < 2.3.0 has been dropped.
-As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 3.8.0 has been dropped.
+As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 3.9.0 has been dropped.
 
 
 Thank you

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require": {
     "php": ">=5.4",
-    "squizlabs/php_codesniffer": "^3.8.0",
+    "squizlabs/php_codesniffer": "^3.9.0",
     "phpcsstandards/phpcsutils": "^1.0.9"
   },
   "require-dev": {


### PR DESCRIPTION
### Composer: raise the minimum supported PHPCS version to 3.9.0

... to benefit from improved PHP 8.3 syntax support.

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

### PHP 8.3 | Classes/NewReadonlyClasses: detect PHP 8.3+ anonymous readonly classes

> Anonymous classes may now be marked as readonly.

This commit updates the `PHPCompatibility.Classes.ReadonlyClasses` sniff to detect this.

Includes tests.

Refs:
* https://www.php.net/manual/en/migration83.new-features.php#migration83.new-features.core.readonly-modifier-improvements
* php/php-src@e52684e

Related to #1589