### PR TITLE
Syntax/NewArrayUnpacking: Bow out for attributes on PHP < 8.0

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -16,6 +16,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
+use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\GetTokensAsString;
 
 /**
@@ -57,6 +58,11 @@ class NewArrayUnpackingSniff extends Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         if (ScannedCode::shouldRunOnOrBelow('7.3') === false) {
+            return;
+        }
+
+        if (Context::inAttribute($phpcsFile, $stackPtr) === true) {
+            // If the syntax is used within an attribute, it will be interpreted as a comment on PHP < 8.0, so not an issue.
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\GetTokensAsString;
 
@@ -31,19 +32,6 @@ class NewArrayUnpackingSniff extends Sniff
 {
 
     /**
-     * Array target tokens.
-     *
-     * @since 10.0.0
-     *
-     * @var array<int|string, int|string>
-     */
-    private $arrayTokens = [
-        \T_ARRAY               => \T_ARRAY,
-        \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
-        \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
-    ];
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 9.2.0
@@ -52,7 +40,7 @@ class NewArrayUnpackingSniff extends Sniff
      */
     public function register()
     {
-        return $this->arrayTokens;
+        return Collections::arrayOpenTokensBC();
     }
 
     /**
@@ -90,7 +78,7 @@ class NewArrayUnpackingSniff extends Sniff
             $nestingLevel = \count($tokens[($opener + 1)]['nested_parenthesis']);
         }
 
-        $find              = $this->arrayTokens;
+        $find              = Collections::arrayOpenTokensBC();
         $find[\T_ELLIPSIS] = \T_ELLIPSIS;
 
         for ($i = $opener; $i < $closer;) {

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -84,8 +84,9 @@ class NewArrayUnpackingSniff extends Sniff
             $nestingLevel = \count($tokens[($opener + 1)]['nested_parenthesis']);
         }
 
-        $find              = Collections::arrayOpenTokensBC();
-        $find[\T_ELLIPSIS] = \T_ELLIPSIS;
+        $find                        = Collections::arrayOpenTokensBC();
+        $find[\T_ELLIPSIS]           = \T_ELLIPSIS;
+        $find[\T_OPEN_CURLY_BRACKET] = \T_OPEN_CURLY_BRACKET;
 
         for ($i = $opener; $i < $closer;) {
             $i = $phpcsFile->findNext($find, ($i + 1), $closer);

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.inc
@@ -47,6 +47,11 @@ class Foo {
     public function __construct() {}
 }
 
+// Intentional parse error. These are not valid syntax. We should not identify any errors here.
+$array = [(...$test)];
+$array = array({...$test});
+$array = [{];
+
 // Intentional parse error. This has to be the last test in the file.
 $arr5 = array(
     ...$arr1,

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.inc
@@ -40,6 +40,13 @@ $arr2 = [...&$arr1];
 // Short list, not short array. Parse error. Ignore.
 [$a, ...$b] = $array;
 
+// Attributes were introduced after PHP 7.4, so we can safely ignore them for this sniff,
+// as these will always be treated as comments prior to PHP 8.0.
+class Foo {
+    #[IsValid([0, ...[1, 2, 3]])]
+    public function __construct() {}
+}
+
 // Intentional parse error. This has to be the last test in the file.
 $arr5 = array(
     ...$arr1,

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
@@ -102,9 +102,14 @@ class NewArrayUnpackingUnitTest extends BaseSniffTestCase
         // Attribute
         $data[] = [46];
 
-        // Don't report for live coding.
+        // Parse errors, but not necessarily live coding.
+        $data[] = [51];
         $data[] = [52];
         $data[] = [53];
+
+        // Don't report for live coding.
+        $data[] = [57];
+        $data[] = [58];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
@@ -99,9 +99,12 @@ class NewArrayUnpackingUnitTest extends BaseSniffTestCase
         // Short list.
         $data[] = [41];
 
-        // Don't report for live coding.
-        $data[] = [45];
+        // Attribute
         $data[] = [46];
+
+        // Don't report for live coding.
+        $data[] = [52];
+        $data[] = [53];
 
         return $data;
     }


### PR DESCRIPTION
This pull request is related to https://github.com/PHPCompatibility/PHPCompatibility/issues/1687