### PR TITLE
Add new sniff for PHP 8.4 deprecation - implicit nullable parameter types

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedImplicitNullableParameterTypeSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedImplicitNullableParameterTypeSniff.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2024 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Detect implicit nullable parameter types in function declarations. These have been deprecated in PHP 8.4 and will be removed in PHP 9.0.
+ *
+ * PHP version 8.4
+ *
+ * @link https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
+ *
+ * @since 10.0.0
+ */
+class RemovedImplicitNullableParameterTypeSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return Collections::functionDeclarationTokens();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrAbove('8.4') === false) {
+            return;
+        }
+
+        // Get all parameters from the function signature.
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        if (empty($parameters)) {
+            return;
+        }
+
+        $isError = ScannedCode::shouldRunOnOrAbove('9.0');
+        $error   = 'Implicitly marking parameter %s as nullable is deprecated since PHP 8.4';
+        if ($isError) {
+            $error .= ', and removed in PHP 9.0';
+        }
+
+        foreach ($parameters as $param) {
+            if (!isset($param['default'])) {
+                // No default value set.
+                continue;
+            }
+
+            if ($param['default'] !== 'null') {
+                // Non-null default value.
+                continue;
+            }
+
+            if ($param['type_hint'] === '') {
+                // No type definition
+                continue;
+            }
+
+            if ($param['nullable_type'] === true) {
+                // Null is already explicitly included in the type definition.
+                continue;
+            }
+
+            if ($phpcsFile->findNext(\T_NULL, $param['type_hint_token'], ($param['type_hint_end_token'] + 1)) !== false) {
+                // Union type which includes null.
+                continue;
+            }
+
+            $data = [
+                $param['name'],
+            ];
+
+            if ($isError) {
+                $fix = $phpcsFile->addFixableError($error, $param['token'], 'Removed', $data);
+            } else {
+                $fix = $phpcsFile->addFixableWarning($error, $param['token'], 'Deprecated', $data);
+            }
+
+            if ($fix) {
+                $typeHint = $param['type_hint'];
+
+                if ($param['type_hint_token'] === $param['type_hint_end_token']) {
+                    // Simple type, like 'int' or 'string'.
+                    $typeHint = '?' . $typeHint;
+                } elseif (strpos($typeHint, '&') === false) {
+                    // This is a union type, like 'A|B'.
+                    $typeHint .= '|null';
+                } elseif (strpos($typeHint, '|') === false) {
+                    // This is an intersection type, like 'A&B' or '(A&B)'.
+                    if ($typeHint[0] !== '(') {
+                        $typeHint = '(' . $typeHint . ')';
+                    }
+                    $typeHint .= '|null';
+                } else {
+                    // Disjunctive Normal Form, like 'A|(B&C)', or '(A&B)|C'.
+                    // TODO: better handling here to avoid wrapping the whole type in parenthesis unnecessarily.
+                    if (substr($typeHint, -1) !== ')') {
+                        $typeHint = '(' . $typeHint . ')';
+                    }
+                    $typeHint .= '|null';
+                }
+
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->replaceToken($param['type_hint_token'], $typeHint);
+                for ($i = $param['type_hint_token'] + 1; $i <= $param['type_hint_end_token']; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -377,4 +377,45 @@ abstract class BaseSniffTestCase extends TestCase
 
         return $allIssues;
     }
+
+    /**
+     * Run assertions that the fixer output matches the ".fixed" file for a particular sniff.
+     *
+     * @since 10.0.0
+     *
+     * @param string $pathToTestFile   Absolute path to the file to sniff.
+     *                                 Allows for passing __FILE__ from the unit test
+     *                                 file. In that case, the test case file is presumed
+     *                                 to have the same name, but with an `inc` extension.
+     * @param string $targetPhpVersion Value of 'testVersion' to set on PHPCS object.
+     *
+     * @return void
+     */
+    protected function assertFixerOutputMatches($pathToTestFile, $targetPhpVersion = 'none')
+    {
+        $pathToFixedFile = $pathToTestFile . '.fixed';
+
+        $this->assertTrue(file_exists($pathToTestFile), 'Test file exists');
+        $this->assertTrue(file_exists($pathToFixedFile), 'Fixed file exists');
+
+        $phpcsFile = $this->sniffFile($pathToTestFile, $targetPhpVersion);
+
+        $this->assertGreaterThan(0, $phpcsFile->getFixableCount(), 'There are fixable errors or warnings');
+
+        // Attempt to fix the errors.
+        $phpcsFile->fixer->fixFile();
+        $fixable = $phpcsFile->getFixableCount();
+
+        $this->assertSame(0, $fixable, 'Sniff can actually fix all "fixable" errors');
+
+        if ($phpcsFile->fixer->getContents() !== file_get_contents($pathToFixedFile)) {
+            // Only generate the (expensive) diff if a difference is expected.
+            $diff = $phpcsFile->fixer->generateDiff($pathToFixedFile);
+            if (trim($diff) !== '') {
+                $fixedFilename = basename($pathToFixedFile);
+                $testFilename  = basename($pathToTestFile);
+                $this->fail("Fixed version of $testFilename does not match expected version in $fixedFilename; the diff is\n$diff");
+            }
+        }
+    }
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitNullableParameterTypeUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitNullableParameterTypeUnitTest.inc
@@ -1,0 +1,37 @@
+<?php
+
+// These should not be a problem.
+function testNoType($noType = null) {}
+function testNoTypeNoDefault($noDefault) {}
+function testScalarNoDefault(int $number) {}
+function testNonNullDefault(int $number = 0) {}
+function testScalarWithQuestion(
+    ?string $word = null,
+    ?int $number = null
+) {}
+function testUnionWithNull(
+    string|null $word = null,
+    int|float|null $number = null,
+    Child|Adult|null $person = null
+) {}
+function testDNFWithNull(
+    A|(B&C)|null $one = null,
+    (A&B)|C|null $two = null
+) {}
+
+// These should all trigger a problem.
+function testSimpleClass(T $thing = null) {}
+function testSimpleScalar(int $number = null) {}
+function testUnionScalar(
+    int|float $number = null,
+    int|bool $numberOrBool = null
+) {}
+function testUnionObject(Child|Adult $person = null) {}
+function testIntersection(
+    A&B $one = null,
+    (A&B) $two = null
+) {}
+function testDNF(
+    A|(B&C) $one = null,
+    (A&B)|C $two = null
+) {}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitNullableParameterTypeUnitTest.inc.fixed
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitNullableParameterTypeUnitTest.inc.fixed
@@ -1,0 +1,37 @@
+<?php
+
+// These should not be a problem.
+function testNoType($noType = null) {}
+function testNoTypeNoDefault($noDefault) {}
+function testScalarNoDefault(int $number) {}
+function testNonNullDefault(int $number = 0) {}
+function testScalarWithQuestion(
+    ?string $word = null,
+    ?int $number = null
+) {}
+function testUnionWithNull(
+    string|null $word = null,
+    int|float|null $number = null,
+    Child|Adult|null $person = null
+) {}
+function testDNFWithNull(
+    A|(B&C)|null $one = null,
+    (A&B)|C|null $two = null
+) {}
+
+// These should all trigger a problem.
+function testSimpleClass(?T $thing = null) {}
+function testSimpleScalar(?int $number = null) {}
+function testUnionScalar(
+    int|float|null $number = null,
+    int|bool|null $numberOrBool = null
+) {}
+function testUnionObject(Child|Adult|null $person = null) {}
+function testIntersection(
+    (A&B)|null $one = null,
+    (A&B)|null $two = null,
+) {}
+function testDNF(
+    A|(B&C)|null $one = null,
+    ((A&B)|C)|null $two = null
+) {}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitNullableParameterTypeUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitNullableParameterTypeUnitTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2024 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedOptionalBeforeRequiredParam sniff.
+ *
+ * @group removedOptionalBeforeRequiredParam
+ * @group functiondeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\RemovedOptionalBeforeRequiredParamSniff
+ *
+ * @since 10.0.0
+ */
+class RemovedImplicitNullableParameterTypeUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify that the sniff throws a warning for optional parameters before required.
+     *
+     * @dataProvider dataImplicitNullableParam
+     *
+     * @param int    $line  The line number where a warning is expected.
+     * @param string $param The parameter name used in the message.
+     *
+     * @return void
+     */
+    public function testImplicitNullableParam($line, $param)
+    {
+        $error = 'Implicitly marking parameter %s as nullable is deprecated since PHP 8.4';
+        $file  = $this->sniffFile(__FILE__, '8.4');
+        $this->assertWarning($file, $line, sprintf($error, $param));
+
+        $error .= ', and removed in PHP 9.0';
+        $file   = $this->sniffFile(__FILE__, '9.0');
+        $this->assertError($file, $line, sprintf($error, $param));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testImplicitNullableParam()
+     *
+     * @return array
+     */
+    public static function dataImplicitNullableParam()
+    {
+        return [
+            'class' => [23, '$thing'],
+            'scalar' => [24, '$number'],
+            'union1' => [26, '$number'],
+            'union2' => [27, '$numberOrBool'],
+            'union3' => [29, '$person'],
+            'intersection1' => [31, '$one'],
+            'intersection2' => [32, '$two'],
+            'disjunctive normal form 1' => [35, '$one'],
+            'disjunctive normal form 2' => [36, '$two'],
+        ];
+    }
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        return [
+            'no type' => [4],
+            'no type and no default value' => [5],
+            'no default value' => [6],
+            'default not null' => [7],
+            'scalar with question 1' => [9],
+            'scalar with question 2' => [10],
+            'union with null 1' => [13],
+            'union with null 2' => [14],
+            'union with null 3' => [15],
+            'disjunctive normal form 1' => [18],
+            'disjunctive normal form 2' => [19],
+        ];
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Ensure that the fixer produces expected output
+     *
+     * @return void
+     */
+    public function testFixer()
+    {
+        $this->assertFixerOutputMatches(str_replace('.php', '.inc', __FILE__));
+    }
+}


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

Implicit nullable parameter types are now deprecated as of PHP 8.4 and will stop working as of PHP 9.0. This pull request adds a warning when the deprecation applies and an error when the feature will stop working. I have included a fixer for this change.

There is currently only one other ".fixed" file in this repository, but it does not appear to be used by anything. I have added a method to the base test class to allow testing the fixer against ".fixed" files. I have opened https://github.com/PHPCompatibility/PHPCompatibility/pull/1690 to ensure that file gets suitable test coverage. That pull request contains the same method to the base test class.

The test-suite here will not work yet, as there is at least one bug in `\PHPCSUtils\Utils\FunctionDeclarations::getParameters()`. I intend to investigate that next. It's likely that we will need to bump the minimum version of that package as part of this pull request after that's fixed.