### PR TITLE
Add test coverage for ".fixed" file

### DIFF
--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -377,4 +377,45 @@ abstract class BaseSniffTestCase extends TestCase
 
         return $allIssues;
     }
+
+    /**
+     * Run assertions that the fixer output matches the ".fixed" file for a particular sniff.
+     *
+     * @since 10.0.0
+     *
+     * @param string $pathToTestFile   Absolute path to the file to sniff.
+     *                                 Allows for passing __FILE__ from the unit test
+     *                                 file. In that case, the test case file is presumed
+     *                                 to have the same name, but with an `inc` extension.
+     * @param string $targetPhpVersion Value of 'testVersion' to set on PHPCS object.
+     *
+     * @return void
+     */
+    protected function assertFixerOutputMatches($pathToTestFile, $targetPhpVersion = 'none')
+    {
+        $pathToFixedFile = $pathToTestFile . '.fixed';
+
+        $this->assertTrue(file_exists($pathToTestFile), 'Test file exists');
+        $this->assertTrue(file_exists($pathToFixedFile), 'Fixed file exists');
+
+        $phpcsFile = $this->sniffFile($pathToTestFile, $targetPhpVersion);
+
+        $this->assertGreaterThan(0, $phpcsFile->getFixableCount(), 'There are fixable errors or warnings');
+
+        // Attempt to fix the errors.
+        $phpcsFile->fixer->fixFile();
+        $fixable = $phpcsFile->getFixableCount();
+
+        $this->assertSame(0, $fixable, 'Sniff can actually fix all "fixable" errors');
+
+        if ($phpcsFile->fixer->getContents() !== file_get_contents($pathToFixedFile)) {
+            // Only generate the (expensive) diff if a difference is expected.
+            $diff = $phpcsFile->fixer->generateDiff($pathToFixedFile);
+            if (trim($diff) !== '') {
+                $fixedFilename = basename($pathToFixedFile);
+                $testFilename  = basename($pathToTestFile);
+                $this->fail("Fixed version of $testFilename does not match expected version in $fixedFilename; the diff is\n$diff");
+            }
+        }
+    }
 }

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
@@ -132,7 +132,7 @@ echo testClass::another_test()[0];
 echo $foo->bar()->baz()[0][2];
 echo $foo->bar()->baz()[0][2];
 
-// No false positive with PHP 8.0 nullsafe object operator and curlies.
+// No false negative with PHP 8.0 nullsafe object operator and curlies.
 echo $obj?->array_num[1], PHP_EOL;
 
 /* Live coding. Intentional parse error. This has to be the last test in the file. */

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
@@ -132,4 +132,14 @@ class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTestCase
         $file = $this->sniffFile(__FILE__, '7.3');
         $this->assertNoViolation($file);
     }
+
+    /**
+     * Ensure that the fixer produces expected output
+     *
+     * @return void
+     */
+    public function testFixer()
+    {
+        $this->assertFixerOutputMatches(str_replace('.php', '.inc', __FILE__));
+    }
 }


### PR DESCRIPTION
While working on https://github.com/PHPCompatibility/PHPCompatibility/pull/1689, I noticed that there is one existing ".fixed" file in this repository, however there was no code that did anything with the file. This pull request adds the ability to verify fixer output with an expected file.

It looks like the ".fixed" file has already diverged from its corresponding source file. I have fixed that in the same commit as I'm adding the test as the divergence was trivial. Please let me know if you would prefer this in a separate commit.