### PR TITLE
FunctionDeclarations/RemovedOptionalBeforeRequiredParam: review + bug fix for nullable types

### DIFF
--- a/PHPCompatibility/Docs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamStandard.xml
+++ b/PHPCompatibility/Docs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamStandard.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed Optional Before Required Parameter"
+    >
+    <standard>
+    <![CDATA[
+    Declaring an optional function parameter before a required parameter is deprecated since PHP 8.0.
+    
+    Either remove the default parameter value to change the optional parameter to a required one; or make the parameters after the optional parameter also optional by giving them a default value.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: optional parameters are declared after required parameters.">
+        <![CDATA[
+function foo($a, <em>$b = 0</em>) {}
+
+function bar(string $a, <em>int $b = 0</em>) {}
+
+// Exception: non-nullable typed parameters
+// with a default value of `null` are still
+// allowed.
+function nullDefault(<em>Foo $a = null</em>, $b) {}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.0: optional parameter before required parameter.">
+        <![CDATA[
+function foo(<em>$a = 0</em>, $b) {}
+
+function bar(<em>string $a = 'foo'</em>, int $b) {}
+
+// Deprecated in 8.0, shows notice since 8.1.
+function typed(<em>?string $a = null</em>, int $b) {}
+
+// Deprecated in 8.0, shows notice since 8.3.
+function typed(<em>string|null $a = null</em>, int $b) {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -25,14 +25,40 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * > a required one continues to be allowed, because this pattern was sometimes
  * > used to achieve nullable types in older PHP versions.
  *
+ * While deprecated since PHP 8.0, optional parameters with an explicitly nullable type
+ * and a null default value, and found before a required parameter, are only flagged since PHP 8.1.
+ *
  * PHP version 8.0
+ * PHP version 8.1
  *
  * @link https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L145-L151
+ * @link https://github.com/php/php-src/commit/c939bd2f10b41bced49eb5bf12d48c3cf64f984a
  *
  * @since 10.0.0
  */
 class RemovedOptionalBeforeRequiredParamSniff extends Sniff
 {
+
+    /**
+     * Base message for the PHP 8.0 deprecation.
+     *
+     * @var string
+     */
+    const PHP80_MSG = 'Declaring an optional parameter before a required parameter is deprecated since PHP 8.0.';
+
+    /**
+     * Base message for the PHP 8.1 deprecation.
+     *
+     * @var string
+     */
+    const PHP81_MSG = 'Declaring an optional parameter with a nullable type before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.1';
+
+    /**
+     * Message template for detailed information about the deprecation.
+     *
+     * @var string
+     */
+    const MSG_DETAILS = ' Parameter %1$s is optional, while parameter %2$s is required. The %1$s parameter is implicitly treated as a required parameter.';
 
     /**
      * Tokens allowed in the default value.
@@ -84,8 +110,6 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
             return;
         }
 
-        $error = 'Declaring an optional parameter before a required parameter is deprecated since PHP 8.0. Parameter %1$s is optional, while parameter %2$s is required. The %1$s parameter is implicitly treated as a required parameter.';
-
         $requiredParam = null;
         $parameters    = \array_reverse($parameters);
 
@@ -111,29 +135,37 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
             }
 
             // Okay, so we have an optional parameter before a required one.
-            // Check if it's typed and has a null default value, in which case we can ignore it.
             // Note: as this will never be the _last_ parameter, we can be sure the 'comma_token' will be set to a token and not `false`.
-            if ($param['type_hint'] !== '') {
-                $hasNull    = $phpcsFile->findNext(\T_NULL, $param['default_token'], $param['comma_token']);
-                $hasNonNull = $phpcsFile->findNext(
-                    $this->allowedInDefault,
-                    $param['default_token'],
-                    $param['comma_token'],
-                    true
-                );
+            $hasNull    = $phpcsFile->findNext(\T_NULL, $param['default_token'], $param['comma_token']);
+            $hasNonNull = $phpcsFile->findNext($this->allowedInDefault, $param['default_token'], $param['comma_token'], true);
 
-                if ($hasNull !== false && $hasNonNull === false) {
-                    continue;
-                }
+            // Check if it's typed with a non-nullable type and has a null default value, in which case we can ignore it.
+            if ($param['type_hint'] !== ''
+                && $param['nullable_type'] === false
+                && ($hasNull !== false && $hasNonNull === false)
+            ) {
+                continue;
             }
 
             // Found an optional parameter with a required param after it.
-            $data = [
+            $error = self::PHP80_MSG . self::MSG_DETAILS;
+            $code  = 'Deprecated80';
+            $data  = [
                 $param['name'],
                 $requiredParam,
             ];
 
-            $phpcsFile->addWarning($error, $param['token'], 'Deprecated', $data);
+            if ($param['nullable_type'] === true && $hasNull !== false) {
+                // Skip flagging the issue if the codebase doesn't need to run on PHP 8.1+.
+                if (ScannedCode::shouldRunOnOrAbove('8.1') === false) {
+                    continue;
+                }
+
+                $error = self::PHP81_MSG . self::MSG_DETAILS;
+                $code  = 'Deprecated81';
+            }
+
+            $phpcsFile->addWarning($error, $param['token'], $code, $data);
         }
     }
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -75,12 +75,33 @@ class ConstructorPropertyPromotionWithNullableType {
     public function __construct(public ?NotOkay $prop = null, $b) {}
 }
 
-// Combination: contains both a parameter flagged in PHP 8.0, as well as one flagged in PHP 8.1.
-function optionalBeforeRequiredAndNullableTypedOptionalBeforeRequired(
-    T1 $a,
-    ?T2 $b = null, // PHP 8.1 deprecation.
-    int $c = 10, // PHP 8.0 deprecation.
-    T4 $d,
+/*
+ * Deprecated in PHP 8.0, but only flagged as of PHP 8.3.
+ */
+function nullLastUnionTypedWithNullDefaultValueBeforeOptional(T1 $a, T2|null $b = null, T3 $c = null) {} // This is fine.
+$nullFirstUnionTypedWithNullDefaultValueBeforeOptional = fn(T1 $a, null|T2 $b = null, T3 $c = null) => dosomething(); // This is fine.
+$nonNullableIntersectionTypeWithNullDefaultBeforeRequired = function ( Foo&Bar $c = null, $d) {}; // This is fine.
+
+// Deprecated as of PHP 8.0, but only emits a deprecation notice in PHP itself as of PHP 8.3.
+function nullLastUnionTypedWithNullDefaultValueBeforeRequired(Okay $a, NotOkay|null $b = null, Required $c) {}
+function nullFirstUnionTypedWithNullDefaultValueBeforeRequired(Okay $a, null|NotOkay $b = null, Required $c) {}
+$nullInDNFTypeWithNullDefaultValueBeforeRequired = function ( (Foo&NotOkay)|null $e = null, $f) {};
+function nullStandAloneTypedWithNullDefaultValueBeforeRequired(Okay $a, null $b = null, Required $c) {}
+$nullStandAloneTypedWithNullDefaultValueBeforeRequiredWithComment = fn (/*comment*/ null $b = null, Required $c) => $c;
+function mixedTypedWithNullDefaultValueBeforeRequired(Okay $a, mixed /*comment*/ $b = null, Required $c) {}
+
+// PHP 8.3 deprecation notice also applies to constructor property promotion.
+class ConstructorPropertyPromotionWithUnionTypedWithNull {
+    public function __construct(public null|NotOkay $prop = null, $b) {}
+}
+
+// Combination: contains parameters for all deprecations.
+function combinationOfAllDeprecations(
+    Okay $a,
+    NotOkay|null $b = null, // PHP 8.3 deprecation.
+    ?NotOkay $c = null, // PHP 8.1 deprecation.
+    int $d = 10, // PHP 8.0 deprecation.
+    Required $e,
 ) {}
 
 // Intentional parse error. This has to be the last test in the file.

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -47,5 +47,9 @@ class MixedWithOptionalParam {
     ) {}
 }
 
+// Test handling of constant expression in default value. This should throw a deprecation notice.
+function constantExpressionInDefault( int $a = MY_CONST ? 10 : /*comment*/ NULL, $b) {}
+function constantExpressionInDefaultNoRequireAfter( $a, ?int $b = MY_CONST ? /*comment*/ 10 : NULL, $c = 10) {} // This should be okay.
+
 // Intentional parse error. This has to be the last test in the file.
 $closure = function( $a = [], $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -51,5 +51,15 @@ class MixedWithOptionalParam {
 function constantExpressionInDefault( int $a = MY_CONST ? 10 : /*comment*/ NULL, $b) {}
 function constantExpressionInDefaultNoRequireAfter( $a, ?int $b = MY_CONST ? /*comment*/ 10 : NULL, $c = 10) {} // This should be okay.
 
+// Check handling of PHP 8.1 new in initializers when `null` is passed as a parameter.
+// $a - $d should all be flagged for 8.0, the fact that new in initializers is not supported on PHP 8.0 is irrelevant and handled by another sniff.
+function newInInitializers(
+    OkayNoParens $a = new OkayNoParens,
+    NullAsParamInInitializer $b = new NullAsParamInInitializer(null),
+    string $c = 'text' . new ClassWithToStringMethod(null),
+    Required $d,
+    OkayOptionalIsLast $e = new OkayOptionalIsLast,
+) {}
+
 // Intentional parse error. This has to be the last test in the file.
 $closure = function( $a = [], $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -5,10 +5,10 @@
  */
 function requiredBeforeOptional($a, $b, $c = null, $d = true) {}
 function requiredBeforeOptionalWithTypes(?int $a, string $b, callable $c = NULL, bool $d = /*comment*/ true) {}
-function nullableTypedOptionalBeforeRequired(Foo $a = /* comment */ null, ?int $b = null, $c, $d) {}
+function requiredTypedWithNullDefaultBeforeRequired(Foo $a = /* comment */ null, int $b = null, $c, $d) {}
 
 /*
- * Deprecated in PHP 8.
+ * Deprecated in PHP 8.0.
  */
 function optionalBeforeRequired($a = [], $b, $c) {}
 function nonNullTypedOptionalBeforeRequired(int $a = 1, bool $b) {}
@@ -59,6 +59,28 @@ function newInInitializers(
     string $c = 'text' . new ClassWithToStringMethod(null),
     Required $d,
     OkayOptionalIsLast $e = new OkayOptionalIsLast,
+) {}
+
+/*
+ * Deprecated in PHP 8.0, but only flagged as of PHP 8.1.
+ */
+function nonNullableTypedWithNullDefaultValueBeforeRequired(T1 $a, T2 $b = null, T3 $c) {} // This is fine.
+$nullableTypedWithNullDefaultValueBeforeOptional = function (T1 $a, ?T2 $b = null, T3 $c = null) {}; // This is fine.
+
+// Deprecated as of PHP 8.0, but only emits a deprecation notice in PHP itself as of PHP 8.1.
+function nullableTypedOptionalBeforeRequired(Okay $a, ?NotOkay $b = /* comment */ null, Required $c) {}
+
+// PHP 8.1 deprecation notice also applies to constructor property promotion.
+class ConstructorPropertyPromotionWithNullableType {
+    public function __construct(public ?NotOkay $prop = null, $b) {}
+}
+
+// Combination: contains both a parameter flagged in PHP 8.0, as well as one flagged in PHP 8.1.
+function optionalBeforeRequiredAndNullableTypedOptionalBeforeRequired(
+    T1 $a,
+    ?T2 $b = null, // PHP 8.1 deprecation.
+    int $c = 10, // PHP 8.0 deprecation.
+    T4 $d,
 ) {}
 
 // Intentional parse error. This has to be the last test in the file.

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -4,7 +4,7 @@
  * OK on all versions.
  */
 function requiredBeforeOptional($a, $b, $c = null, $d = true) {}
-function requiredBeforeOptionalWithTypes(?int $a, string $b, callable $c = null, bool $d = /*comment*/ true) {}
+function requiredBeforeOptionalWithTypes(?int $a, string $b, callable $c = NULL, bool $d = /*comment*/ true) {}
 function nullableTypedOptionalBeforeRequired(Foo $a = /* comment */ null, ?int $b = null, $c, $d) {}
 
 /*
@@ -21,7 +21,7 @@ $closure = function ($a = /*comment*/, $b) {};
 
 // Prevent false positives on variadic parameters.
 function variadicIsOptionalByNature($a, int ...$b) {}
-function variadicIsOptionalByNatureWithExtraOptional($a, $b = null, ...$c) {}
+function variadicIsOptionalByNatureWithExtraOptional($a, $b = NULL, ...$c) {}
 // Intentional parse error. This has always been an error though, so ignore for this sniff.
 function variadicBeforeRequiredWasAlwaysAnError(...$a, $b) {}
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -26,28 +26,42 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
 {
 
     /**
+     * Base message for the PHP 8.0 deprecation.
+     *
+     * @var string
+     */
+    const PHP80_MSG = 'Declaring an optional parameter before a required parameter is deprecated since PHP 8.0.';
+
+    /**
+     * Base message for the PHP 8.1 deprecation.
+     *
+     * @var string
+     */
+    const PHP81_MSG = 'Declaring an optional parameter with a nullable type before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.1';
+
+    /**
      * Verify that the sniff throws a warning for optional parameters before required.
      *
-     * @dataProvider dataRemovedOptionalBeforeRequiredParam
+     * @dataProvider dataRemovedOptionalBeforeRequiredParam80
      *
      * @param int $line The line number where a warning is expected.
      *
      * @return void
      */
-    public function testRemovedOptionalBeforeRequiredParam($line)
+    public function testRemovedOptionalBeforeRequiredParam80($line)
     {
         $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertWarning($file, $line, 'Declaring an optional parameter before a required parameter is deprecated since PHP 8.0');
+        $this->assertWarning($file, $line, self::PHP80_MSG);
     }
 
     /**
      * Data provider.
      *
-     * @see testRemovedOptionalBeforeRequiredParam()
+     * @see testRemovedOptionalBeforeRequiredParam80()
      *
      * @return array
      */
-    public static function dataRemovedOptionalBeforeRequiredParam()
+    public static function dataRemovedOptionalBeforeRequiredParam80()
     {
         return [
             [13],
@@ -61,6 +75,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
             [57],
             [58],
             [59],
+            [82],
         ];
     }
 
@@ -68,13 +83,13 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
     /**
      * Verify the sniff does not throw false positives for valid code.
      *
-     * @dataProvider dataNoFalsePositives
+     * @dataProvider dataNoFalsePositives80
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoFalsePositives($line)
+    public function testNoFalsePositives80($line)
     {
         $file = $this->sniffFile(__FILE__, '8.0');
         $this->assertNoViolation($file, $line);
@@ -83,11 +98,11 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
     /**
      * Data provider.
      *
-     * @see testNoFalsePositives()
+     * @see testNoFalsePositives80()
      *
      * @return array
      */
-    public static function dataNoFalsePositives()
+    public static function dataNoFalsePositives80()
     {
         $cases = [];
         // No errors expected on the first 9 lines.
@@ -110,8 +125,85 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases['line 60 - new in initializers'] = [60];
         $cases['line 61 - new in initializers'] = [61];
 
+        // Not deprecated, false positive checks for PHP 8.1 deprecation.
+        $cases['line 67 - related to PHP 8.1 deprecation'] = [67];
+        $cases['line 68 - related to PHP 8.1 deprecation'] = [68];
+
+        // Deprecated, but only flagged as of PHP 8.1.
+        $cases['line 71 - deprecated in PHP 8.1'] = [71];
+        $cases['line 75 - deprecated in PHP 8.1'] = [75];
+        $cases['line 81 - deprecated in PHP 8.1'] = [81];
+
         // Add parse error test case.
-        $cases['line 65 - parse error'] = [65];
+        $cases['line 87 - parse error'] = [87];
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify that the sniff throws a warning for optional parameters with a nullable type before required.
+     *
+     * @dataProvider dataRemovedOptionalBeforeRequiredParam81
+     *
+     * @param int    $line The line number where a warning is expected.
+     * @param string $msg  The expected warning message.
+     *
+     * @return void
+     */
+    public function testRemovedOptionalBeforeRequiredParam81($line, $msg = self::PHP80_MSG)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertWarning($file, $line, $msg);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedOptionalBeforeRequiredParam81()
+     *
+     * @return array
+     */
+    public static function dataRemovedOptionalBeforeRequiredParam81()
+    {
+        $data   = self::dataRemovedOptionalBeforeRequiredParam80();
+        $data[] = [71, self::PHP81_MSG];
+        $data[] = [75, self::PHP81_MSG];
+        $data[] = [81, self::PHP81_MSG];
+        return $data;
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives81
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives81($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives81()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives81()
+    {
+        $cases = self::dataNoFalsePositives80();
+        unset(
+            $cases['line 71 - deprecated in PHP 8.1'],
+            $cases['line 75 - deprecated in PHP 8.1'],
+            $cases['line 81 - deprecated in PHP 8.1']
+        );
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -89,22 +89,22 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases = [];
         // No errors expected on the first 9 lines.
         for ($line = 1; $line <= 9; $line++) {
-            $cases[] = [$line];
+            $cases['line ' . $line] = [$line];
         }
 
         // Don't error on variadic parameters.
-        $cases[] = [23];
-        $cases[] = [24];
-        $cases[] = [26];
+        $cases['line 23 - variadic params'] = [23];
+        $cases['line 24 - variadic params'] = [24];
+        $cases['line 26 - variadic params'] = [26];
 
         // Constructor property promotion - valid example.
-        $cases[] = [46];
+        $cases['line 46 - constructor property promotion'] = [46];
 
         // Constant expression containing null in default value for optional param.
-        $cases[] = [52];
+        $cases['line 52 - constant expression'] = [52];
 
         // Add parse error test case.
-        $cases[] = [55];
+        $cases['line 55 - parse error'] = [55];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -57,6 +57,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
             [20],
             [32],
             [39],
+            [51],
         ];
     }
 
@@ -99,8 +100,11 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         // Constructor property promotion - valid example.
         $cases[] = [46];
 
+        // Constant expression containing null in default value for optional param.
+        $cases[] = [52];
+
         // Add parse error test case.
-        $cases[] = [51];
+        $cases[] = [55];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -40,6 +40,13 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
     const PHP81_MSG = 'Declaring an optional parameter with a nullable type before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.1';
 
     /**
+     * Base message for the PHP 8.3 deprecation.
+     *
+     * @var string
+     */
+    const PHP83_MSG = 'Declaring an optional parameter with a null stand-alone type or a union type including null before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.3';
+
+    /**
      * Verify that the sniff throws a warning for optional parameters before required.
      *
      * @dataProvider dataRemovedOptionalBeforeRequiredParam80
@@ -75,7 +82,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
             [57],
             [58],
             [59],
-            [82],
+            [103],
         ];
     }
 
@@ -130,12 +137,27 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases['line 68 - related to PHP 8.1 deprecation'] = [68];
 
         // Deprecated, but only flagged as of PHP 8.1.
-        $cases['line 71 - deprecated in PHP 8.1'] = [71];
-        $cases['line 75 - deprecated in PHP 8.1'] = [75];
-        $cases['line 81 - deprecated in PHP 8.1'] = [81];
+        $cases['line 71 - deprecated in PHP 8.1']  = [71];
+        $cases['line 75 - deprecated in PHP 8.1']  = [75];
+        $cases['line 102 - deprecated in PHP 8.1'] = [102];
+
+        // Not deprecated, false positive checks for PHP 8.3 deprecation.
+        $cases['line 81 - related to PHP 8.3 deprecation'] = [81];
+        $cases['line 82 - related to PHP 8.3 deprecation'] = [82];
+        $cases['line 83 - related to PHP 8.3 deprecation'] = [83];
+
+        // Deprecated, but only flagged as of PHP 8.3.
+        $cases['line 86 - deprecated in PHP 8.3']  = [86];
+        $cases['line 87 - deprecated in PHP 8.3']  = [87];
+        $cases['line 88 - deprecated in PHP 8.3']  = [88];
+        $cases['line 89 - deprecated in PHP 8.3']  = [89];
+        $cases['line 90 - deprecated in PHP 8.3']  = [90];
+        $cases['line 91 - deprecated in PHP 8.3']  = [91];
+        $cases['line 95 - deprecated in PHP 8.3']  = [95];
+        $cases['line 101 - deprecated in PHP 8.3'] = [101];
 
         // Add parse error test case.
-        $cases['line 87 - parse error'] = [87];
+        $cases['line 108 - parse error'] = [108];
 
         return $cases;
     }
@@ -169,7 +191,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $data   = self::dataRemovedOptionalBeforeRequiredParam80();
         $data[] = [71, self::PHP81_MSG];
         $data[] = [75, self::PHP81_MSG];
-        $data[] = [81, self::PHP81_MSG];
+        $data[] = [102, self::PHP81_MSG];
         return $data;
     }
 
@@ -202,7 +224,85 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         unset(
             $cases['line 71 - deprecated in PHP 8.1'],
             $cases['line 75 - deprecated in PHP 8.1'],
-            $cases['line 81 - deprecated in PHP 8.1']
+            $cases['line 102 - deprecated in PHP 8.1']
+        );
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify that the sniff throws a warning for optional parameters with a union type which includes null before required.
+     *
+     * @dataProvider dataRemovedOptionalBeforeRequiredParam83
+     *
+     * @param int    $line The line number where a warning is expected.
+     * @param string $msg  The expected warning message.
+     *
+     * @return void
+     */
+    public function testRemovedOptionalBeforeRequiredParam83($line, $msg = self::PHP80_MSG)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertWarning($file, $line, $msg);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedOptionalBeforeRequiredParam83()
+     *
+     * @return array
+     */
+    public static function dataRemovedOptionalBeforeRequiredParam83()
+    {
+        $data   = self::dataRemovedOptionalBeforeRequiredParam81();
+        $data[] = [86, self::PHP83_MSG];
+        $data[] = [87, self::PHP83_MSG];
+        $data[] = [88, self::PHP83_MSG];
+        $data[] = [89, self::PHP83_MSG];
+        $data[] = [90, self::PHP83_MSG];
+        $data[] = [91, self::PHP83_MSG];
+        $data[] = [95, self::PHP83_MSG];
+        $data[] = [101, self::PHP83_MSG];
+        return $data;
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives83
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives83($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives83()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives83()
+    {
+        $cases = self::dataNoFalsePositives81();
+        unset(
+            $cases['line 86 - deprecated in PHP 8.3'],
+            $cases['line 87 - deprecated in PHP 8.3'],
+            $cases['line 88 - deprecated in PHP 8.3'],
+            $cases['line 89 - deprecated in PHP 8.3'],
+            $cases['line 90 - deprecated in PHP 8.3'],
+            $cases['line 91 - deprecated in PHP 8.3'],
+            $cases['line 95 - deprecated in PHP 8.3'],
+            $cases['line 101 - deprecated in PHP 8.3']
         );
 
         return $cases;

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -37,7 +37,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
     public function testRemovedOptionalBeforeRequiredParam($line)
     {
         $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertWarning($file, $line, 'Declaring a required parameter after an optional one is deprecated since PHP 8.0');
+        $this->assertWarning($file, $line, 'Declaring an optional parameter before a required parameter is deprecated since PHP 8.0');
     }
 
     /**
@@ -50,13 +50,13 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
     public static function dataRemovedOptionalBeforeRequiredParam()
     {
         return [
-            [13], // Warning x 2.
+            [13],
             [14],
             [16],
             [17],
             [20],
-            [32],
-            [39],
+            [31],
+            [38],
             [51],
         ];
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -58,6 +58,9 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
             [31],
             [38],
             [51],
+            [57],
+            [58],
+            [59],
         ];
     }
 
@@ -103,8 +106,12 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         // Constant expression containing null in default value for optional param.
         $cases['line 52 - constant expression'] = [52];
 
+        // New in initializers tests.
+        $cases['line 60 - new in initializers'] = [60];
+        $cases['line 61 - new in initializers'] = [61];
+
         // Add parse error test case.
-        $cases['line 55 - parse error'] = [55];
+        $cases['line 65 - parse error'] = [65];
 
         return $cases;
     }


### PR DESCRIPTION
This PR replaces PR #1669

---

### FunctionDeclarations/RemovedOptionalBeforeRequiredParam: test with uppercase null

No functional changes needed, this just is an extra safeguard that the sniff handles this correctly.

### FunctionDeclarations/RemovedOptionalBeforeRequiredParam: add extra tests/constant expressions

Add some extra tests with `null` in the default value, but not as a stand-alone value, but as part of a constant expression.

PHP itself will only evaluate constant expressions at runtime (when the function is called), not at compile time (when the deprecation is flagged).
In practice, this means that a default value containing a constant expression which evaluates to `null` will always be flagged as deprecated by PHP if the parameter is before a required one and that the exception for typed properties with a `null` default does not apply to constant expressions.

This means that the sniffs should also disregard any `null` token within a constant expression, as the only thing that's relevant is that case, is that there is a default value.
Given that, the sniff is handling this correctly as-is.

Also see: https://github.com/php/php-src/issues/13752

### FunctionDeclarations/RemovedOptionalBeforeRequiredParam: use named test cases

... in the false positives data provider.

This will make some changes in follow-up commits easier.

### FunctionDeclarations/RemovedOptionalBeforeRequiredParam: flag the optional param, not the required param

Originally, the sniff would walk from the first param to the last, keeping track of whether an optional parameter has been seen and flag any required parameter found after it.

This commit changes the logic in the sniff to flag the actual issue with higher precision, by walking from the last parameter back to the first, keeping track of seen required parameters and flagging any optional parameters found before these.

It also updates the error message to more closely match the error message used in PHP itself.
PHP 8.0 would flag issues with "Deprecated: Required parameter $b follows optional parameter $a".
As of PHP 8.1, the message was changed to read: "Deprecated: Optional parameter $a declared before required parameter $b is implicitly treated as a required parameter".

### FunctionDeclarations/RemovedOptionalBeforeRequiredParam: add tests with PHP 8.1 new in initializers

PHP 8.1 introduced the ability to use `new` in initializers. This now opens up the possibility that `null` is passed to an initializer.

In practice though, this has no impact on the sniff as the "`new` object" is a default value making the parameter optional, so should still be flagged when used before a required parameter.

### FunctionDeclarations/RemovedOptionalBeforeRequiredParam: flag nullable types / PHP 8.1

The [recent RFC proposing to deprecate implicit nullable types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types) brough an oversight in the `PHPCompatibility.FunctionDeclarations.RemovedOptionalBeforeRequiredParam` sniff to my attention.

To quote [the RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types):
> Even though signatures which contain an optional parameter before a required one were deprecated in PHP 8.0, the case of implicitly nullable types was left alone at that time due to BC concerns. This exclusion caused some bugs in the detection of which signatures should emit the deprecation notice. Indeed, the following signature only emits a deprecation as of PHP 8.1:
>
> `function bar(T1 $a, ?T2 $b = null, T3 $c) {}`

At the time of writing this sniff this additional deprecation notice was not yet in place and was therefore not taken into account.

This commit updates the sniff to _also_ throw deprecation notices for optional parameters before required ones, where the default value is `null` and the type is nullable.

Includes unit tests safeguarding the fix.

Ref: php/php-src@c939bd2

### FunctionDeclarations/RemovedOptionalBeforeRequiredParam: flag union types with null / PHP 8.3

The [recent RFC proposing to deprecate implicit nullable types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types) brough an oversight in the `PHPCompatibility.FunctionDeclarations.RemovedOptionalBeforeRequiredParam` sniff to my attention.

To quote [the RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types):
> Even though signatures which contain an optional parameter before a required one were deprecated in PHP 8.0, the case of implicitly nullable types was left alone at that time due to BC concerns. This exclusion caused some bugs in the detection of which signatures should emit the deprecation notice.
> <snip>
> And the signature that uses the generalized union type signature:
>
> `function test(T1 $a, T2|null $b = null, T3 $c) {}`
>
> only emits the deprecation notice properly as of PHP 8.3.

At the time of writing this sniff this additional deprecation notice was not yet in place and was therefore not taken into account.

This commit updates the sniff to _also_ throw deprecation notices for optional parameters before required ones, where the default value is `null` and the type is `null` or a union/DNF type which includes `null`.

Includes unit tests safeguarding the fix.

Refs:
* php/php-src#11488
* php/php-src#11497
* php/php-src@68ef393

### FunctionDeclarations/RemovedOptionalBeforeRequiredParam: add documentation