### PR TITLE
PHP 8.4 | ✨ New `PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/FunctionDeclarations/RemovedImplicitlyNullableParamStandard.xml
+++ b/PHPCompatibility/Docs/FunctionDeclarations/RemovedImplicitlyNullableParamStandard.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed Implicitly Nullable Parameter"
+    >
+    <standard>
+    <![CDATA[
+    Implicitly marking a typed parameter as nullable via a "null" default value, without giving it a nullable type, is deprecated since PHP 8.4.
+
+    The parameter type should be made explicitly nullable.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: parameter with a null default value is explicitly nullable.">
+        <![CDATA[
+function noTypeMeansMixed(<em></em>$a = null) {}
+function noDefaultValue(<em>Countable</em> $a) {}
+
+// PHP 7.1+: using a nullable type.
+function foo(<em>?Countable</em> $a = null) {}
+
+// PHP 8.0+: using a union type with null
+// or the explicit mixed type.
+function bar(<em>mixed</em> $a = null) {}
+function baz(<em>Countable|null</em> $a = null) {}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: parameter with a null default value is not declared as nullable.">
+        <![CDATA[
+function foo(<em>Countable</em> $a = <em>null</em>) {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedImplicitlyNullableParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedImplicitlyNullableParamSniff.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Declaring an implicitly nullable parameter is deprecated since PHP 8.4.
+ *
+ * Implicitly nullable parameters are parameters with a `null` default value, but
+ * without a nullable type.
+ * Support is expected to be removed in PHP 9.0.
+ *
+ * These parameters may now also hit the PHP 8.0 "optional before required" deprecation.
+ * That deprecation is handled separately via the RemovedOptionalBeforeRequiredParam sniff.
+ *
+ * PHP version 8.4
+ *
+ * @link https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
+ *
+ * @since 10.0.0
+ */
+final class RemovedImplicitlyNullableParamSniff extends Sniff
+{
+
+    /**
+     * Tokens allowed in the default value.
+     *
+     * This property will be enriched in the register() method.
+     *
+     * @since 10.0.0
+     *
+     * @var array<int|string, int|string>
+     */
+    private $allowedInDefault = [
+        \T_NULL => \T_NULL,
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        $this->allowedInDefault += Tokens::$emptyTokens;
+
+        return Collections::functionDeclarationTokens();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrAbove('8.4') === false) {
+            return;
+        }
+
+        // Get all parameters from the function signature.
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        if (empty($parameters)) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Parenthesis closer will be defined, otherwise we'd have received an empty parameters array.
+        $closeParens = $tokens[$stackPtr]['parenthesis_closer'];
+
+        foreach ($parameters as $key => $param) {
+            if (isset($param['property_visibility'])) {
+                /*
+                 * Implicitly nullable parameters were never allowed for promoted properties
+                 * and always resulted in a fatal error. Ignore as this is outside the scope of this sniff.
+                 */
+                continue;
+            }
+
+            if (isset($param['default']) === false
+                || $param['type_hint'] === ''
+                || $param['type_hint_token'] === false
+            ) {
+                // If there is no default value or no type hint, there is no issue.
+                continue;
+            }
+
+            if ($param['nullable_type'] === true
+                || $param['type_hint'] === 'null'
+                || $param['type_hint'] === 'mixed'
+                || $phpcsFile->findNext(\T_NULL, $param['type_hint_token'], ($param['type_hint_end_token'] + 1)) !== false
+            ) {
+                // Type is nullable, no issue.
+                continue;
+            }
+
+            /*
+             * Non-nullable type, now check if the default value is `null`.
+             *
+             * We can ignore `null` when it is part of a constant expression or in new in initializers,
+             * as PHP does not regard parameters with that kind of default value as nullable and
+             * would throw a fatal when the function is called. This behaviour is not changed by the
+             * PHP 8.4 deprecation of implicitly nullable parameters, so those parameters should be
+             * ignored by this sniff.
+             * Also see: https://github.com/php/php-src/issues/13752
+             */
+
+            // Determine the end of the parameter.
+            $paramEnd   = ($param['comma_token'] === false) ? $closeParens : $param['comma_token'];
+            $hasNull    = $phpcsFile->findNext(\T_NULL, $param['default_token'], $paramEnd);
+            $hasNonNull = $phpcsFile->findNext($this->allowedInDefault, $param['default_token'], $paramEnd, true);
+            if ($hasNull === false || $hasNonNull !== false) {
+                // No null default value, we're okay.
+                continue;
+            }
+
+            $error = 'Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: %s.';
+            $code  = 'Deprecated';
+            $data  = [$param['name']];
+
+            $phpcsFile->addWarning($error, $param['token'], $code, $data);
+        }
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.inc
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * OK on all versions.
+ */
+function noDefaultValue(Type $var) {}
+function noDefaultValueWithNullableType(?Type $var) {}
+
+function noNullDefaultValue(int $var = 10) {}
+function noNullDefaultValueButContainsNull(Type $var = new Type(null)) {}
+
+function nullDefaultNoType($var = null) {}
+function nullDefaultWithNullableType(?T $var = null) {}
+function nullDefaultWithNullInUnionType(Countable|null $var = null) {}
+function nullDefaultWithNullInDNFType((Foo&Bar)|null $var = /*comment*/ null) {}
+function nullDefaultWithNullType(null $var = null /*comment*/ ) {}
+function nullDefaultWithMixedType(mixed $var = null) {}
+function nullDefaultWithMixedTypeAndComments( /*comment*/ mixed /*comment*/ $var = null) {}
+
+// Fatal error on all versions.
+// The old exception did not apply to properties. A non-nullable typed property with a non-null default value
+// was always a fatal error, so these should be ignored by the sniff as this is not part of the new deprecation.
+class ConstructorPropertyPromotion {
+    public function __construct(
+        public Foo|Bar $propA = null,
+        protected array $propB = null,
+        int $param = 10,
+    ) {}
+}
+
+// Test handling of constant expression which includes null in default value.
+// These were never recognized by PHP as implicitly nullable and would throw a fatal
+// TypeError when the function was called, so this is outside the scope of the new deprecation.
+// Issue about this in PHP Core: https://github.com/php/php-src/issues/13752
+function constantExpressionInDefault( int $a = MY_CONST ? 10 : NULL) {}
+function constantExpressionWithNewInDefault(Type $var = (MY_CONST ? new Type() : null)) {}
+
+
+/*
+ * Deprecated in PHP 8.4.
+ */
+function nullDefaultWithNonNullableType(Type $var = /*comment*/ null) {}
+
+$closure = function (
+    callable $callable = null,
+    int $scalarType = null /*comment*/,
+    int|float $scalarUnionType = null,
+    Child|Adult $objectUnionType = /*comment*/ null,
+    Foo & /*comment*/ Bar $intersectionType = null,
+    (A&B)|string $dnfType = null,
+    $requiredParam,
+) {};
+
+$arrow = fn(iterable $i = null): bool => doSomething($i);
+
+// Intentional parse error. This has to be the last test in the file.
+$closure = function( Type $a = null, $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedImplicitlyNullableParam sniff.
+ *
+ * @group removedImplicitlyNullableParam
+ * @group functiondeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\RemovedImplicitlyNullableParamSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedImplicitlyNullableParamUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify that the sniff throws a warning for implicitly nullable parameters.
+     *
+     * @dataProvider dataRemovedImplicitlyNullableParam
+     *
+     * @param int $line The line number where a warning is expected.
+     *
+     * @return void
+     */
+    public function testRemovedImplicitlyNullableParam($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertWarning($file, $line, 'Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedImplicitlyNullableParam()
+     *
+     * @return array
+     */
+    public static function dataRemovedImplicitlyNullableParam()
+    {
+        return [
+            [42],
+            [45],
+            [46],
+            [47],
+            [48],
+            [49],
+            [50],
+            [54],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        $cases = [];
+        // No errors expected on the first 38 lines.
+        for ($line = 1; $line <= 38; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [51];
+
+        // Parse error test case.
+        $cases[] = [57];
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
### PHP 8.4 | ✨ New `PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam` sniff (RFC)

> - Core:
>   . Implicitly nullable parameter types are now deprecated.
>     RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

As this deprecation looks to be high frequency - 880 packages out of the top 2000 Composer packages affected and that's just the tip of the iceberg -, I figured it would be good to have a sniff available early.

The fix for the issue is relatively easy and there are multiple options available, though some could result in BC-breaks for the package making the fix.

Includes tests and documentation.

Refs:
* https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
* https://github.com/php/php-src/blob/330cc5cdb2096c5d41041eaae1f1cc0ed7e36898/UPGRADING#L271C1-L273C70
* php/php-src#12959
* php/php-src@330cc5c


Closes #1689