### PR TITLE
NewFlexibleHeredocNowdoc: fix incorrect error code

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -183,7 +183,7 @@ class NewFlexibleHeredocNowdocSniff extends Sniff
     {
         $tokens    = $phpcsFile->getTokens();
         $error     = 'The body of a heredoc/nowdoc can not contain the heredoc/nowdoc closing marker as text at the start of a line since PHP 7.3.';
-        $errorCode = 'ClosingMarkerNoNewLine';
+        $errorCode = 'CloserFoundInBody';
 
         if (\PHP_VERSION_ID >= 70300) {
             $nextNonWhitespace = $phpcsFile->findNext(\T_WHITESPACE, ($stackPtr + 1), null, true, null, true);


### PR DESCRIPTION
Follow up on #736.

Each of the three errors this sniff throws was supposed to have their own error code, but this was implemented incorrectly (copy/paste error).

This commit fixes this oversight and effectively, splits the `ClosingMarkerNoNewLine` into two error codes:
* `ClosingMarkerNoNewLine` for when there is code after the closer of a heredoc/nowdoc (PHP < 7.2).
* `CloserFoundInBody` when text which looks like the heredoc/nowdoc closer is found in the body of the heredoc/nowdoc. (PHP 7.3+).

Fixes #1696