### PR TITLE
PHP 8.4 | FunctionDeclarations/RemovedOptionalBeforeRequiredParam: flag implicitly nullable parameters

### DIFF
--- a/PHPCompatibility/Docs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamStandard.xml
+++ b/PHPCompatibility/Docs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamStandard.xml
@@ -19,7 +19,7 @@ function bar(string $a, <em>int $b = 0</em>) {}
 
 // Exception: non-nullable typed parameters
 // with a default value of `null` are still
-// allowed.
+// allowed prior to PHP 8.4.
 function nullDefault(<em>Foo $a = null</em>, $b) {}
         ]]>
         </code>
@@ -34,6 +34,26 @@ function typed(<em>?string $a = null</em>, int $b) {}
 
 // Deprecated in 8.0, shows notice since 8.3.
 function typed(<em>string|null $a = null</em>, int $b) {}
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Declaring a function with an implicitly nullable, typed parameter before a required parameter, is deprecated since PHP 8.4.
+
+    Aside from making the parameter type explicitly nullable, the default value of `null` should be removed as well.
+    Alternatively, parameters after the implicitly nullable parameter could be made optional.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: required parameter is declared as nullable and doesn't have a default value.">
+        <![CDATA[
+function foo(<em>?Countable</em> $a, $b) {}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: required parameter is not declared as explicitly nullable and has a null default value.">
+        <![CDATA[
+function foo(<em>Countable</em> $a = <em>null</em>, $b) {}
         ]]>
         </code>
     </code_comparison>

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -5,7 +5,7 @@
  */
 function requiredBeforeOptional($a, $b, $c = null, $d = true) {}
 function requiredBeforeOptionalWithTypes(?int $a, string $b, callable $c = NULL, bool $d = /*comment*/ true) {}
-function requiredTypedWithNullDefaultBeforeRequired(Foo $a = /* comment */ null, int $b = null, $c, $d) {}
+
 
 /*
  * Deprecated in PHP 8.0.
@@ -64,8 +64,8 @@ function newInInitializers(
 /*
  * Deprecated in PHP 8.0, but only flagged as of PHP 8.1.
  */
-function nonNullableTypedWithNullDefaultValueBeforeRequired(T1 $a, T2 $b = null, T3 $c) {} // This is fine.
-$nullableTypedWithNullDefaultValueBeforeOptional = function (T1 $a, ?T2 $b = null, T3 $c = null) {}; // This is fine.
+function nonNullableTypedWithNullDefaultValueBeforeRequired(T1 $a, T2 $b = null, T3 $c) {} // This is fine until PHP 8.4.
+$nullableTypedWithNullDefaultValueBeforeOptional = function (T1 $a, ?T2 $b = null, T3 $c = null) {}; // This is fine, even on PHP 8.4.
 
 // Deprecated as of PHP 8.0, but only emits a deprecation notice in PHP itself as of PHP 8.1.
 function nullableTypedOptionalBeforeRequired(Okay $a, ?NotOkay $b = /* comment */ null, Required $c) {}
@@ -78,9 +78,9 @@ class ConstructorPropertyPromotionWithNullableType {
 /*
  * Deprecated in PHP 8.0, but only flagged as of PHP 8.3.
  */
-function nullLastUnionTypedWithNullDefaultValueBeforeOptional(T1 $a, T2|null $b = null, T3 $c = null) {} // This is fine.
-$nullFirstUnionTypedWithNullDefaultValueBeforeOptional = fn(T1 $a, null|T2 $b = null, T3 $c = null) => dosomething(); // This is fine.
-$nonNullableIntersectionTypeWithNullDefaultBeforeRequired = function ( Foo&Bar $c = null, $d) {}; // This is fine.
+function nullLastUnionTypedWithNullDefaultValueBeforeOptional(T1 $a, T2|null $b = null, T3 $c = null) {} // This is fine, even on PHP 8.4.
+$nullFirstUnionTypedWithNullDefaultValueBeforeOptional = fn(T1 $a, null|T2 $b = null, T3 $c = null) => dosomething(); // This is fine, even on PHP 8.4.
+$nonNullableIntersectionTypeWithNullDefaultBeforeRequired = function ( Foo&Bar $c = null, $d) {}; // This is fine until PHP 8.4.
 
 // Deprecated as of PHP 8.0, but only emits a deprecation notice in PHP itself as of PHP 8.3.
 function nullLastUnionTypedWithNullDefaultValueBeforeRequired(Okay $a, NotOkay|null $b = null, Required $c) {}
@@ -95,13 +95,36 @@ class ConstructorPropertyPromotionWithUnionTypedWithNull {
     public function __construct(public null|NotOkay $prop = null, $b) {}
 }
 
+/*
+ * Deprecated in PHP 8.4.
+ */
+// These should still be fine, even on PHP 8.4.
+function untypedWithDefaultValue($a = null, $b = true) {} // = mixed type.
+$explicitlyNullableWithDefaultValue = function (?T $var = null) {};
+function explicitlyNullableUnionWithDefaultValue(T|null $var = null, int $var2 = 10) {}
+$explicitNullableTypeNull = fn (null $var = null): Type => new Type;
+ // Will trigger implicitly nullable deprecation for $call, but that's not the concern of this sniff.
+function explicitNullableTypeMixed(mixed $var = null, callable $call = null) {}
+
+// Deprecated as of PHP 8.4.
+function typedWithNullDefaultBeforeRequired(
+    Foo $a = /* comment */ null,
+    int $b = null,
+    $c,
+    $d,
+) {} // Deprecated x2.
+function implicitNullableTypeClass(T $var = null, $c) {}
+$implicitNullableTypeString = function (string $var = null, $c) {};
+function implicitNullableTypeUnion(string|int $var = null, $c) {}
+
 // Combination: contains parameters for all deprecations.
 function combinationOfAllDeprecations(
     Okay $a,
-    NotOkay|null $b = null, // PHP 8.3 deprecation.
-    ?NotOkay $c = null, // PHP 8.1 deprecation.
-    int $d = 10, // PHP 8.0 deprecation.
-    Required $e,
+    ShouldBeNullable $b = null, // PHP 8.4 deprecation.
+    NotOkay|null $c = null, // PHP 8.3 deprecation.
+    ?NotOkay $d = null, // PHP 8.1 deprecation.
+    int $e = 10, // PHP 8.0 deprecation.
+    Required $f,
 ) {}
 
 // Intentional parse error. This has to be the last test in the file.

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -47,6 +47,13 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
     const PHP83_MSG = 'Declaring an optional parameter with a null stand-alone type or a union type including null before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.3';
 
     /**
+     * Base message for the PHP 8.4 deprecation.
+     *
+     * @var string
+     */
+    const PHP84_MSG = 'Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4';
+
+    /**
      * Verify that the sniff throws a warning for optional parameters before required.
      *
      * @dataProvider dataRemovedOptionalBeforeRequiredParam80
@@ -82,7 +89,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
             [57],
             [58],
             [59],
-            [103],
+            [126],
         ];
     }
 
@@ -139,7 +146,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         // Deprecated, but only flagged as of PHP 8.1.
         $cases['line 71 - deprecated in PHP 8.1']  = [71];
         $cases['line 75 - deprecated in PHP 8.1']  = [75];
-        $cases['line 102 - deprecated in PHP 8.1'] = [102];
+        $cases['line 125 - deprecated in PHP 8.1'] = [125];
 
         // Not deprecated, false positive checks for PHP 8.3 deprecation.
         $cases['line 81 - related to PHP 8.3 deprecation'] = [81];
@@ -154,10 +161,27 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases['line 90 - deprecated in PHP 8.3']  = [90];
         $cases['line 91 - deprecated in PHP 8.3']  = [91];
         $cases['line 95 - deprecated in PHP 8.3']  = [95];
-        $cases['line 101 - deprecated in PHP 8.3'] = [101];
+        $cases['line 124 - deprecated in PHP 8.3'] = [124];
+
+        // Not deprecated, false positive checks for PHP 8.4 deprecation.
+        $cases['line 102 - related to PHP 8.4 deprecation'] = [102];
+        $cases['line 103 - related to PHP 8.4 deprecation'] = [103];
+        $cases['line 104 - related to PHP 8.4 deprecation'] = [104];
+        $cases['line 105 - related to PHP 8.4 deprecation'] = [105];
+        $cases['line 107 - related to PHP 8.4 deprecation'] = [107];
+        $cases['line 113 - related to PHP 8.4 deprecation'] = [113];
+        $cases['line 114 - related to PHP 8.4 deprecation'] = [114];
+
+        // Deprecated as of PHP 8.4.
+        $cases['line 111 - deprecated in PHP 8.4'] = [111];
+        $cases['line 112 - deprecated in PHP 8.4'] = [112];
+        $cases['line 116 - deprecated in PHP 8.4'] = [116];
+        $cases['line 117 - deprecated in PHP 8.4'] = [117];
+        $cases['line 118 - deprecated in PHP 8.4'] = [118];
+        $cases['line 123 - deprecated in PHP 8.4'] = [123];
 
         // Add parse error test case.
-        $cases['line 108 - parse error'] = [108];
+        $cases['line 131 - parse error'] = [131];
 
         return $cases;
     }
@@ -191,7 +215,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $data   = self::dataRemovedOptionalBeforeRequiredParam80();
         $data[] = [71, self::PHP81_MSG];
         $data[] = [75, self::PHP81_MSG];
-        $data[] = [102, self::PHP81_MSG];
+        $data[] = [125, self::PHP81_MSG];
         return $data;
     }
 
@@ -224,7 +248,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         unset(
             $cases['line 71 - deprecated in PHP 8.1'],
             $cases['line 75 - deprecated in PHP 8.1'],
-            $cases['line 102 - deprecated in PHP 8.1']
+            $cases['line 125 - deprecated in PHP 8.1']
         );
 
         return $cases;
@@ -264,7 +288,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $data[] = [90, self::PHP83_MSG];
         $data[] = [91, self::PHP83_MSG];
         $data[] = [95, self::PHP83_MSG];
-        $data[] = [101, self::PHP83_MSG];
+        $data[] = [124, self::PHP83_MSG];
         return $data;
     }
 
@@ -302,7 +326,85 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
             $cases['line 90 - deprecated in PHP 8.3'],
             $cases['line 91 - deprecated in PHP 8.3'],
             $cases['line 95 - deprecated in PHP 8.3'],
-            $cases['line 101 - deprecated in PHP 8.3']
+            $cases['line 124 - deprecated in PHP 8.3']
+        );
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify that the sniff throws a warning for optional parameters with a union type which includes null before required.
+     *
+     * @dataProvider dataRemovedOptionalBeforeRequiredParam84
+     *
+     * @param int    $line The line number where a warning is expected.
+     * @param string $msg  The expected warning message.
+     *
+     * @return void
+     */
+    public function testRemovedOptionalBeforeRequiredParam84($line, $msg = self::PHP80_MSG)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertWarning($file, $line, $msg);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedOptionalBeforeRequiredParam84()
+     *
+     * @return array
+     */
+    public static function dataRemovedOptionalBeforeRequiredParam84()
+    {
+        $data   = self::dataRemovedOptionalBeforeRequiredParam83();
+        $data[] = [67, self::PHP84_MSG];
+        $data[] = [83, self::PHP84_MSG];
+        $data[] = [111, self::PHP84_MSG];
+        $data[] = [112, self::PHP84_MSG];
+        $data[] = [116, self::PHP84_MSG];
+        $data[] = [117, self::PHP84_MSG];
+        $data[] = [118, self::PHP84_MSG];
+        $data[] = [123, self::PHP84_MSG];
+        return $data;
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives84
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives84($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives84()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives84()
+    {
+        $cases = self::dataNoFalsePositives83();
+        unset(
+            $cases['line 67 - related to PHP 8.1 deprecation'],
+            $cases['line 83 - related to PHP 8.3 deprecation'],
+            $cases['line 111 - deprecated in PHP 8.4'],
+            $cases['line 112 - deprecated in PHP 8.4'],
+            $cases['line 116 - deprecated in PHP 8.4'],
+            $cases['line 117 - deprecated in PHP 8.4'],
+            $cases['line 118 - deprecated in PHP 8.4'],
+            $cases['line 123 - deprecated in PHP 8.4']
         );
 
         return $cases;


### PR DESCRIPTION
Follow up on #1692 and #1694

:point_right: **Opinion needed.** /cc @fredden @MarkMaldaba 

> - Core:
>   . Implicitly nullable parameter types are now deprecated.
>     RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

The above mentioned deprecation also impacts this sniff, as implicitly nullable parameters were previously the one exception for the "removed optional before required parameter" deprecation.

While PHP 8.4 will only flag implicitly nullable parameters with a non-nullable type with a deprecation notice about these being implicitly nullable and needing a nullable type, as soon as the nullability operator is added or the type is changed to a union type which includes `null` (and the `null` default value not removed), PHP will start throwing the deprecation notice about an optional parameter being declared before a required parameter.

So, in PHP itself, one deprecation notice is effectively "hiding" behind another one. In terms of sniffs, it is considered bad practice to hide one notice behind another one as it makes the sniff output less immediately actionable.

With that in mind, I'm proposing to flag implicitly nullable parameters which are declared before required parameters anyway. While this doesn't match PHP exactly, I still feel this is justified so as to provide end-users with all the information they need (both deprecations) to fix the issue properly in one go.

If this would turn out to be controversial, I'd suggest lowering the severity of the issue to `3` rather than removing the change. A lower severity will hide the warning from _most_ users, but will allow discerning users to still receive it.

Includes updated tests.
Includes an update to the docs.

Refs:
* https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
* https://github.com/php/php-src/blob/330cc5cdb2096c5d41041eaae1f1cc0ed7e36898/UPGRADING#L271C1-L273C70
* php/php-src#12959
* https://github.com/php/php-src/commit/330cc5cdb2096c5d41041eaae1f1cc0ed7e36898