### PR TITLE
FunctionDeclarations/NewReturnTypeDeclarations: minor clean up

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -226,22 +226,18 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataNewUnionTypes
      *
-     * @param string $type            The declared type.
-     * @param int    $line            The line number where the error is expected.
-     * @param bool   $testNoViolation Whether or not to test noViolation.
-     *                                Defaults to true.
+     * @param string $type The declared type.
+     * @param int    $line The line number where the error is expected.
      *
      * @return void
      */
-    public function testNewUnionTypes($type, $line, $testNoViolation = true)
+    public function testNewUnionTypes($type, $line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
         $this->assertError($file, $line, "Union types are not present in PHP version 7.4 or earlier. Found: $type");
 
-        if ($testNoViolation === true) {
-            $file = $this->sniffFile(__FILE__, '8.0');
-            $this->assertNoViolation($file, $line);
-        }
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
     }
 
     /**
@@ -340,14 +336,12 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataNewIntersectionTypes
      *
-     * @param string $type            The declared type.
-     * @param int    $line            The line number where the error is expected.
-     * @param bool   $testNoViolation Whether or not to test noViolation.
-     *                                Defaults to true.
+     * @param string $type The declared type.
+     * @param int    $line The line number where the error is expected.
      *
      * @return void
      */
-    public function testNewIntersectionTypes($type, $line, $testNoViolation = true)
+    public function testNewIntersectionTypes($type, $line)
     {
         $file = $this->sniffFile(__FILE__, '8.0');
         $this->assertError($file, $line, "Intersection types are not present in PHP version 8.0 or earlier. Found: $type");


### PR DESCRIPTION
Clean up some copy/paste artifacts - the `$testNoViolation` parameter is not needed and not used for these tests.