### PR TITLE
Classes/NewTypedProperties: bug fix - don't skip too far

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -162,7 +162,7 @@ class NewTypedPropertiesSniff extends Sniff
 
             $this->checkType($phpcsFile, $properties['type_token'], $properties);
 
-            $endOfStatement = $phpcsFile->findNext(\T_SEMICOLON, ($stackPtr + 1));
+            $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
             if ($endOfStatement !== false) {
                 // Don't throw the same error multiple times for multi-property declarations.
                 return ($endOfStatement + 1);

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -165,3 +165,7 @@ class EdgeCase {
     public int $property ?>
     <?php
 }
+
+class ShouldBeDetected {
+    public int $property;
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -102,6 +102,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             [160],
             [161],
             [165],
+            [170],
         ];
     }
 


### PR DESCRIPTION
Follow up on #1498, which added a test and concluded the edge case was already handled correctly, while it was not.

Basically, it comes down to the sniff trying to skip to the end of a multi-property statement, but not taking PHP close tags into account correctly, meaning too much code was being skipped.

It's unlikely this bug will have been seen in the wild, but the sniff should still handle things correctly.

Fixed now, including a test safeguarding the fix.