### PR TITLE
Classes/RemovedClasses: bug fix - check all parts of a type

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -423,12 +423,12 @@ class RemovedClassesSniff extends Sniff
             $type = \ltrim($type, '\\');
 
             if ($type === '') {
-                return;
+                continue;
             }
 
             $typeLc = \strtolower($type);
             if (isset($this->removedClasses[$typeLc]) === false) {
-                return;
+                continue;
             }
 
             $itemInfo = [

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
@@ -101,3 +101,7 @@ class IntersectionTypes {
     public function paramType(SWFSprite&\SWFText $param) {}
     public function returnType($param) : HW_API_Object&HW_API_Attribute {}
 }
+
+function CheckAllTypeParts(
+    NotATarget|SWFButton $a
+) : NotATarget|SQLiteException {}

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
@@ -73,7 +73,7 @@ class RemovedClassesUnitTest extends BaseSniffTestCase
 
             ['SWFAction', '5.3', [32, 33, 34, 35], '5.2'],
             ['SWFBitmap', '5.3', [37], '5.2'],
-            ['SWFButton', '5.3', [38], '5.2'],
+            ['SWFButton', '5.3', [38, 106], '5.2'],
             ['SWFDisplayItem', '5.3', [39, 84], '5.2'],
             ['SWFFill', '5.3', [40, 92], '5.2'],
             ['SWFFont', '5.3', [41, 92], '5.2'],
@@ -93,7 +93,7 @@ class RemovedClassesUnitTest extends BaseSniffTestCase
             ['SQLiteDatabase', '5.4', [66, 80], '5.3'],
             ['SQLiteResult', '5.4', [67, 93], '5.3'],
             ['SQLiteUnbuffered', '5.4', [68, 93], '5.3'],
-            ['SQLiteException', '5.4', [69], '5.3'],
+            ['SQLiteException', '5.4', [69, 107], '5.3'],
 
             ['XmlRpcServer', '8.0', [71, 74], '7.4'],
         ];


### PR DESCRIPTION
All parts of a type should be checked, the sniff should not bow out if the first part of the type is not a removed class.

Fixed now.

Includes test.