### PR TITLE
Interfaces/NewInterfaces: bug fix - check all parts of a type

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -452,12 +452,12 @@ class NewInterfacesSniff extends Sniff
             $type = \ltrim($type, '\\');
 
             if ($type === '') {
-                return;
+                continue;
             }
 
             $typeLc = \strtolower($type);
             if (isset($this->newInterfaces[$typeLc]) === false) {
-                return;
+                continue;
             }
 
             $itemInfo = [

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -199,6 +199,10 @@ function ExpectsEnumParams(UnitEnum $enum1, BackedEnum $enum2) {}
 
 function useRandomExtension( Random\Engine $paramA, Random\CryptoSafeEngine $paramB ) {}
 
+function CheckAllTypeParts(
+    NotATarget|Stringable $a
+) : NotATarget|DOMParentNode {}
+
 // Test parse error/live coding.
 // This MUST be the last test in the file!
 try {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -79,9 +79,9 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             ['SessionIdInterface', '5.5.0', [89, 117, 146], '5.6', '5.5'],
             ['Throwable', '5.6', [37, 52, 62, 93, 98, 103, 162, 186], '7.0'],
             ['SessionUpdateTimestampHandlerInterface', '5.6', [90, 142, 162], '7.0'],
-            ['Stringable', '7.4', [112, 179], '8.0'],
+            ['Stringable', '7.4', [112, 179, 203], '8.0'],
             ['DOMChildNode', '7.4', [196], '8.0'],
-            ['DOMParentNode', '7.4', [196], '8.0'],
+            ['DOMParentNode', '7.4', [196, 204], '8.0'],
             ['UnitEnum', '8.0', [198], '8.1'],
             ['BackedEnum', '8.0', [198], '8.1'],
             ['Random\Engine', '8.1', [200], '8.2'],
@@ -218,7 +218,7 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             [177],
             [185],
             [189],
-            [205],
+            [209],
         ];
     }
 


### PR DESCRIPTION
All parts of a type should be checked, the sniff should not bow out if the first part of the type is not a new interface.

Fixed now.

Includes test.