### PR TITLE
Various minor cs tweaks

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1431,13 +1431,13 @@ class NewClassesSniff extends Sniff
         $splitUseStatement = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
 
         foreach ($splitUseStatement['name'] as $name => $fullyQualifiedName) {
-            $lowerFullyQualifiedName = strtolower($fullyQualifiedName);
+            $lowerFullyQualifiedName = \strtolower($fullyQualifiedName);
 
             if (isset($this->newClasses[$lowerFullyQualifiedName])) {
                 continue;
             }
 
-            $this->importedClasses[strtolower($name)] = true;
+            $this->importedClasses[\strtolower($name)] = true;
         }
     }
 

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
@@ -11,7 +11,6 @@
 namespace PHPCompatibility\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\FunctionDeclarations;

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
 use PHPCSUtils\Utils\Variables;

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -53,7 +53,7 @@ class NonStaticMagicMethodsSniff extends Sniff
             'static' => false,
         ],
         '__destruct' => [
-            'static'     => false,
+            'static' => false,
         ],
         '__clone' => [
             'static' => false,

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -13,7 +13,6 @@ namespace PHPCompatibility\Sniffs\Generators;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
 

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -180,14 +180,14 @@ class InternalInterfacesSniff extends Sniff
         $splitUseStatement = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
 
         foreach ($splitUseStatement['name'] as $name => $fullyQualifiedName) {
-            $lowerFullyQualifiedName = strtolower($fullyQualifiedName);
+            $lowerFullyQualifiedName = \strtolower($fullyQualifiedName);
 
             // If the imported declaration is imported from the internal namespace it will not be excluded.
             if (isset($this->internalInterfaces[$lowerFullyQualifiedName])) {
                 continue;
             }
 
-            $this->importedDeclarations[strtolower($name)] = true;
+            $this->importedDeclarations[\strtolower($name)] = true;
         }
     }
 }

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -569,14 +569,14 @@ class NewInterfacesSniff extends Sniff
         $splitUseStatement = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
 
         foreach ($splitUseStatement['name'] as $name => $fullyQualifiedName) {
-            $lowerFullyQualifiedName = strtolower($fullyQualifiedName);
+            $lowerFullyQualifiedName = \strtolower($fullyQualifiedName);
 
             // If the imported declaration is imported from the internal namespace it will not be excluded.
             if (isset($this->newInterfaces[$lowerFullyQualifiedName])) {
                 continue;
             }
 
-            $this->importedDeclaration[strtolower($name)] = true;
+            $this->importedDeclaration[\strtolower($name)] = true;
         }
     }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -111,7 +111,7 @@ class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
                 return;
             }
 
-            $secondParamContent = ltrim($secondParam['clean'], ' \\'); // Trim off potential leading namespace separator for FQN.
+            $secondParamContent = \ltrim($secondParam['clean'], ' \\'); // Trim off potential leading namespace separator for FQN.
             if ($secondParamContent !== 'HASH_HMAC'
                 && $secondParamContent !== (string) \HASH_HMAC
             ) {

--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -11,7 +11,10 @@
 namespace PHPCompatibility\Tests;
 
 use PHPUnit\Framework\TestCase;
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Ruleset;
 use PHPCSUtils\BackCompat\Helper;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 
@@ -145,7 +148,7 @@ abstract class BaseSniffTestCase extends TestCase
         if (isset(self::$sniffFiles[$pathToFile]['only_parsed']) === false) {
             try {
                 // PHPCS 3.x, 4.x.
-                $config            = new \PHP_CodeSniffer\Config();
+                $config            = new Config();
                 $config->cache     = false;
                 $config->standards = [self::STANDARD_NAME];
                 $config->sniffs    = [$this->getSniffCode()];
@@ -153,9 +156,9 @@ abstract class BaseSniffTestCase extends TestCase
 
                 self::$lastConfig = $config;
 
-                $ruleset = new \PHP_CodeSniffer\Ruleset($config);
+                $ruleset = new Ruleset($config);
 
-                self::$sniffFiles[$pathToFile]['only_parsed'] = new \PHP_CodeSniffer\Files\LocalFile($pathToFile, $ruleset, $config);
+                self::$sniffFiles[$pathToFile]['only_parsed'] = new LocalFile($pathToFile, $ruleset, $config);
                 self::$sniffFiles[$pathToFile]['only_parsed']->parse();
             } catch (\Exception $e) {
                 $this->fail('An unexpected exception has been caught when parsing file "' . $pathToFile . '" : ' . $e->getMessage());

--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -51,7 +51,7 @@ abstract class BaseSniffTestCase extends TestCase
      *
      * @since 7.0.4
      *
-     * @var array<string, array<string, File>>
+     * @var array<string, array<string, \PHP_CodeSniffer\Files\File>>
      */
     public static $sniffFiles = [];
 

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -347,7 +347,7 @@ class NewClassesUnitTest extends BaseSniffTestCase
         $sharedConfig  = $file->config;
 
         $forgedLocalFile = new \PHP_CodeSniffer\Files\LocalFile(
-            realpath(__DIR__ . '/NewClassesUsesNoLeakUnitTest.inc'),
+            \realpath(__DIR__ . '/NewClassesUsesNoLeakUnitTest.inc'),
             $sharedRuleSet,
             $sharedConfig
         );

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
+use PHP_CodeSniffer\Files\LocalFile;
 use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
@@ -346,7 +347,7 @@ class NewClassesUnitTest extends BaseSniffTestCase
         $sharedRuleSet = $file->ruleset;
         $sharedConfig  = $file->config;
 
-        $forgedLocalFile = new \PHP_CodeSniffer\Files\LocalFile(
+        $forgedLocalFile = new LocalFile(
             \realpath(__DIR__ . '/NewClassesUsesNoLeakUnitTest.inc'),
             $sharedRuleSet,
             $sharedConfig

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -176,7 +176,7 @@ class InternalInterfacesUnitTest extends BaseSniffTestCase
         $sharedConfig  = $file->config;
 
         $forgedLocalFile = new \PHP_CodeSniffer\Files\LocalFile(
-            realpath(__DIR__ . '/InternalInterfacesUnitTest.inc'),
+            \realpath(__DIR__ . '/InternalInterfacesUnitTest.inc'),
             $sharedRuleSet,
             $sharedConfig
         );

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Tests\Interfaces;
 
+use PHP_CodeSniffer\Files\LocalFile;
 use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
@@ -175,7 +176,7 @@ class InternalInterfacesUnitTest extends BaseSniffTestCase
         $sharedRuleSet = $file->ruleset;
         $sharedConfig  = $file->config;
 
-        $forgedLocalFile = new \PHP_CodeSniffer\Files\LocalFile(
+        $forgedLocalFile = new LocalFile(
             \realpath(__DIR__ . '/InternalInterfacesUnitTest.inc'),
             $sharedRuleSet,
             $sharedConfig

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -240,7 +240,7 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
         $sharedConfig  = $file->config;
 
         $forgedLocalFile = new \PHP_CodeSniffer\Files\LocalFile(
-            realpath(__DIR__ . '/NewInterfacesUnitTest.inc'),
+            \realpath(__DIR__ . '/NewInterfacesUnitTest.inc'),
             $sharedRuleSet,
             $sharedConfig
         );

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Tests\Interfaces;
 
+use PHP_CodeSniffer\Files\LocalFile;
 use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
@@ -239,7 +240,7 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
         $sharedRuleSet = $file->ruleset;
         $sharedConfig  = $file->config;
 
-        $forgedLocalFile = new \PHP_CodeSniffer\Files\LocalFile(
+        $forgedLocalFile = new LocalFile(
             \realpath(__DIR__ . '/NewInterfacesUnitTest.inc'),
             $sharedRuleSet,
             $sharedConfig


### PR DESCRIPTION
Clean up after some recent merges.

### CS: various minor tweaks

### CS/QA: use use statements

Follow up on #1357 which removed support for PHPCS 2.x from the base test case.

### Docs: use FQN in docblocks 