### PR TITLE
PHP 8.2 | Detect DNF types in all type declaration related sniffs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To start contributing, fork the repository, create a new branch in your fork, ma
 
 Please make sure that your pull request contains unit tests covering what's being addressed by it.
 
-* All code should be compatible with PHPCS >= 3.9.0.
+* All code should be compatible with PHPCS >= 3.10.0.
 * All code should be compatible with PHP 5.4 to PHP nightly.
 * All code should comply with the PHPCompatibility coding standards.
     The [ruleset used by PHPCompatibility](https://github.com/PHPCSStandards/PHPCSDevCS) is largely based on PSR-12 with minor variations and some additional checks for array layout and documentation and such.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
 
         include:
           - php: '7.2'
-            phpcs_version: '^3.9.0'
+            phpcs_version: '^3.10.0'
             custom_ini: true
             experimental: false
 

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -169,3 +169,18 @@ class EdgeCase {
 class ShouldBeDetected {
     public int $property;
 }
+
+// PHP 8.2 DNF types.
+class DNFTypes {
+    public (Foo&Bar)|null $dnf1;
+    public readonly (A&B)|(C&D) $dnf2;
+
+    // Intentional fatal error - &/| reversed, but that's not the concern of the sniff.
+    public B&(D|W) $illegalDnf;
+
+    // Intentional fatal error - segments are not unique, but that's not the concern of the sniff.
+    public (A&B)|(B&A) $duplicateNotAllowed;
+
+    // Intentional fatal error - segments which are strict subsets of others are disallowed, but that's not the concern of the sniff.
+    public (A&self)|A $nonSubsetNotAllowedPlusSelf;
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -103,6 +103,11 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             [161],
             [165],
             [170],
+            [175],
+            [176],
+            [179],
+            [182],
+            [185],
         ];
     }
 
@@ -231,6 +236,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             ['false', '7.4', 99, '8.0'],
             ['mixed', '7.4', 116, '8.0', false],
             ['true', '8.1', 147, '8.2'],
+            ['null', '7.4', 175, '8.2'],
         ];
     }
 
@@ -338,6 +344,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
         return [
             [93, 'null'],
             [96, 'false'],
+            [175, 'null'],
         ];
     }
 
@@ -409,6 +416,44 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             ['self&\Fully\Qualified\SomeInterface', 138],
             ['Qualified\SomeInterface&parent', 139],
             ['A&B&A', 142],
+        ];
+    }
+
+
+    /**
+     * Verify that an error is thrown for DNF types.
+     *
+     * @dataProvider dataNewDNFTypes
+     *
+     * @param string $type The declared type.
+     * @param int    $line The line number where the error is expected.
+     *
+     * @return void
+     */
+    public function testNewDNFTypes($type, $line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertError($file, $line, "Disjunctive Normal Form types are not present in PHP version 8.1 or earlier. Found: $type");
+
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewDNFTypes()
+     *
+     * @return array
+     */
+    public static function dataNewDNFTypes()
+    {
+        return [
+            ['(Foo&Bar)|null', 175],
+            ['(A&B)|(C&D)', 176],
+            ['B&(D|W)', 179],
+            ['(A&B)|(B&A)', 182],
+            ['(A&self)|A', 185],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -168,3 +168,19 @@ enum Suit implements Colorful
         A&B $intersection,
     ): mixed {}
 }
+
+// PHP 8.2 DNF types.
+function NOTDnfTypeParamDefault($param = (CONST_A & CONST_B) | CONST_C) {}
+
+function DNFTypes((Foo&Bar)|null $a, int|(\A&\B) $b) {}
+$closure = function($a, (A&B)|(C&D) $b) {};
+
+// Intentional fatal error - &/| reversed, but that's not the concern of the sniff.
+$arrow = fn(B&(D|W)|null $a) => $a;
+
+// Intentional fatal error - segments are not unique, but that's not the concern of the sniff.
+$arrow = fn((A&B)|(B&A) $a) => $a;
+
+// Intentional fatal error - segments which are strict subsets of others are disallowed, but that's not the concern of the sniff.
+// Intentional fatal error - using self type outside a class is invalid.
+$arrow = fn((A&self)|A $a) => $a;

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -137,3 +137,17 @@ enum Suit implements Colorful
     public function shape(): mixed {}
     public function union(): A|B {}
 }
+
+// PHP 8.2 DNF types.
+function DNFTypes($var): (Foo&Bar)|null {}
+$closure = function($a) : (A&B)|(C&D) {};
+
+// Intentional fatal error - &/| reversed, but that's not the concern of the sniff.
+$arrow = fn($a):B&(D|W)|int => $a;
+
+// Intentional fatal error - segments are not unique, but that's not the concern of the sniff.
+$arrow = fn() : (A&B)|(B&A) => $a;
+
+// Intentional fatal error - segments which are strict subsets of others are disallowed, but that's not the concern of the sniff.
+// Intentional fatal error - using self type outside a class is invalid.
+$arrow = fn($a) : (A&self)|A => $a;

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -136,6 +136,11 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
             ['string', '5.6', 136, '7.0'],
             ['mixed', '7.4', 137, '8.0'],
             ['Class name', '5.6', 138, '8.0'],
+
+            // DNF types - OK version is 8.2.
+            ['null', '7.4', 142, '8.2'],
+            ['int', '5.6', 146, '8.2'],
+            ['self', '5.6', 153, '8.2'],
         ];
     }
 
@@ -295,6 +300,7 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
         return [
             [70, 'null'],
             [73, 'false'],
+            [142, 'null'],
         ];
     }
 
@@ -367,6 +373,44 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
             ['Qualified\SomeInterface&parent', 123],
             ['static&SomeInterface', 124],
             ['A&B&A', 128],
+        ];
+    }
+
+
+    /**
+     * Verify that an error is thrown for DNF types.
+     *
+     * @dataProvider dataNewDNFTypes
+     *
+     * @param string $type The declared type.
+     * @param int    $line The line number where the error is expected.
+     *
+     * @return void
+     */
+    public function testNewDNFTypes($type, $line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertError($file, $line, "Disjunctive Normal Form types are not present in PHP version 8.1 or earlier. Found: $type");
+
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewDNFTypes()
+     *
+     * @return array
+     */
+    public static function dataNewDNFTypes()
+    {
+        return [
+            ['(Foo&Bar)|null', 142],
+            ['(A&B)|(C&D)', 143],
+            ['B&(D|W)|int', 146],
+            ['(A&B)|(B&A)', 149],
+            ['(A&self)|A', 153],
         ];
     }
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Requirements
 -------
 
 * PHP 5.4+
-* PHP CodeSniffer: 3.9.0+.
+* PHP CodeSniffer: 3.10.0+.
 
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP CodeSniffer. You should get consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on a recent PHP version in combination with a recent PHP_CodeSniffer version.
 
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP CodeSniffer 3.x.
 As of version 9.0.0, support for PHP CodeSniffer 1.5.x and low 2.x versions < 2.3.0 has been dropped.
-As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 3.9.0 has been dropped.
+As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 3.10.0 has been dropped.
 
 
 Thank you

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
   },
   "require": {
     "php": ">=5.4",
-    "squizlabs/php_codesniffer": "^3.9.0",
-    "phpcsstandards/phpcsutils": "^1.0.9"
+    "squizlabs/php_codesniffer": "^3.10.0",
+    "phpcsstandards/phpcsutils": "^1.0.12"
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.3.2",


### PR DESCRIPTION
### Composer: raise the minimum supported PHPCS + PHPCSUtils versions

Up the minimum supported PHPCS version to 3.10.0 and the minimum supported PHPCSUtils version to 1.0.12 to benefit from improved PHP 8.2 syntax support (Disjunctive Normal Types).

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

### PHP 8.2 | FunctionDeclarations/NewParamTypeDeclarations: detect DNF types

> Type System Improvements
>
> It is now possible to combine intersection and union types. The type needs to be written in DNF.

This updates the sniff to detect DNF types.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.type-system
* https://wiki.php.net/rfc/dnf_types
* php/php-src#8725
* php/php-src@f905590

### PHP 8.2 | FunctionDeclarations/NewReturnTypeDeclarations: detect DNF types

> Type System Improvements
>
> It is now possible to combine intersection and union types. The type needs to be written in DNF.

This updates the sniff to detect DNF types.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.type-system
* https://wiki.php.net/rfc/dnf_types
* php/php-src#8725
* php/php-src@f905590

### PHP 8.2 | Classes/NewTypedProperties: detect DNF types

> Type System Improvements
>
> It is now possible to combine intersection and union types. The type needs to be written in DNF.

This updates the sniff to detect DNF types.

Includes unit tests.

Refs:
* https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.type-system
* https://wiki.php.net/rfc/dnf_types
* php/php-src#8725
* php/php-src@f905590


Related to #1348