### PR TITLE
Classes/RemovedClasses: detect removed classes in PHP 8.2 DNF types

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -412,7 +412,7 @@ class RemovedClassesSniff extends Sniff
     {
         // Strip off potential nullable indication.
         $typeString = \ltrim($typeString, '?');
-        $types      = \preg_split('`[|&]`', $typeString, -1, \PREG_SPLIT_NO_EMPTY);
+        $types      = \preg_split('`[|&()]`', $typeString, -1, \PREG_SPLIT_NO_EMPTY);
 
         if (empty($types) === true) {
             return;

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
@@ -105,3 +105,12 @@ class IntersectionTypes {
 function CheckAllTypeParts(
     NotATarget|SWFButton $a
 ) : NotATarget|SQLiteException {}
+
+// Test support for PHP 8.2 DNF types.
+class DNFTypes {
+    public function paramTypeA(NotATarget&AlsoNotATarget $okay) {}
+
+    public int|(SWFMorph&SWFMovie) $property;
+    public function paramTypeB((SWFSprite&\SWFText)|false $param) {}
+    public function returnType($param) : SomethingElse|(HW_API_Object&HW_API_Attribute) {}
+}

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
@@ -65,8 +65,8 @@ class RemovedClassesUnitTest extends BaseSniffTestCase
     {
         return [
             ['HW_API', '5.2', [59], '5.1'],
-            ['HW_API_Object', '5.2', [60, 102], '5.1'],
-            ['HW_API_Attribute', '5.2', [61, 102], '5.1'],
+            ['HW_API_Object', '5.2', [60, 102, 115], '5.1'],
+            ['HW_API_Attribute', '5.2', [61, 102, 115], '5.1'],
             ['HW_API_Error', '5.2', [62], '5.1'],
             ['HW_API_Content', '5.2', [63, 91], '5.1'],
             ['HW_API_Reason', '5.2', [64, 91], '5.1'],
@@ -79,14 +79,14 @@ class RemovedClassesUnitTest extends BaseSniffTestCase
             ['SWFFont', '5.3', [41, 92], '5.2'],
             ['SWFFontChar', '5.3', [44], '5.2'],
             ['SWFGradient', '5.3', [45], '5.2'],
-            ['SWFMorph', '5.3', [46, 100], '5.2'],
-            ['SWFMovie', '5.3', [47, 100], '5.2'],
+            ['SWFMorph', '5.3', [46, 100, 113], '5.2'],
+            ['SWFMovie', '5.3', [47, 100, 113], '5.2'],
             ['SWFPrebuiltClip', '5.3', [48], '5.2'],
             ['SWFShape', '5.3', [49], '5.2'],
             ['SWFSound', '5.3', [50], '5.2'],
             ['SWFSoundInstance', '5.3', [51], '5.2'],
-            ['SWFSprite', '5.3', [52, 101], '5.2'],
-            ['SWFText', '5.3', [55, 101], '5.2'],
+            ['SWFSprite', '5.3', [52, 101, 114], '5.2'],
+            ['SWFText', '5.3', [55, 101, 114], '5.2'],
             ['SWFTextField', '5.3', [56, 85], '5.2'],
             ['SWFVideoStream', '5.3', [57], '5.2'],
 
@@ -133,6 +133,7 @@ class RemovedClassesUnitTest extends BaseSniffTestCase
         $data[] = [77];
         $data[] = [89];
         $data[] = [98];
+        $data[] = [111];
 
         return $data;
     }


### PR DESCRIPTION
This updates the sniff to also detect removed classes when used in DNF types.

Includes unit tests.

Related to #1348

--- 

Note: this PR has been opened as draft as it depends on PR #1714 due to the need for PHPCS 3.10.0 (and will need a rebase once that PR has been merged). Having said that, the PR in itself is ready.