### PR TITLE
Interfaces/NewInterfaces: detect new interfaces in PHP 8.2 DNF types

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -478,7 +478,7 @@ class NewInterfacesSniff extends Sniff
     {
         // Strip off potential nullable indication.
         $typeHint = \ltrim($typeHint, '?');
-        $types    = \preg_split('`[|&]`', $typeHint, -1, \PREG_SPLIT_NO_EMPTY);
+        $types    = \preg_split('`[|&()]`', $typeHint, -1, \PREG_SPLIT_NO_EMPTY);
 
         if (empty($types) === true) {
             return;

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -203,6 +203,15 @@ function CheckAllTypeParts(
     NotATarget|Stringable $a
 ) : NotATarget|DOMParentNode {}
 
+// Test support for PHP 8.2 DNF types.
+class DNFTypes {
+    public function paramTypeA(NotATarget&AlsoNotATarget $okay) {}
+
+    public true|(DOMChildNode&DOMParentNode) $property;
+    public function paramTypeB((UnitEnum&BackedEnum)|string $param) {}
+    public function returnType($param) : (Stringable&DOMChildNode)|(A&B) {}
+}
+
 // Test parse error/live coding.
 // This MUST be the last test in the file!
 try {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -80,11 +80,11 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             ['SessionIdInterface', '5.5.0', [89, 117, 146], '5.6', '5.5'],
             ['Throwable', '5.6', [37, 52, 62, 93, 98, 103, 162, 186], '7.0'],
             ['SessionUpdateTimestampHandlerInterface', '5.6', [90, 142, 162], '7.0'],
-            ['Stringable', '7.4', [112, 179, 203], '8.0'],
-            ['DOMChildNode', '7.4', [196], '8.0'],
-            ['DOMParentNode', '7.4', [196, 204], '8.0'],
-            ['UnitEnum', '8.0', [198], '8.1'],
-            ['BackedEnum', '8.0', [198], '8.1'],
+            ['Stringable', '7.4', [112, 179, 203, 212], '8.0'],
+            ['DOMChildNode', '7.4', [196, 210, 212], '8.0'],
+            ['DOMParentNode', '7.4', [196, 204, 210], '8.0'],
+            ['UnitEnum', '8.0', [198, 211], '8.1'],
+            ['BackedEnum', '8.0', [198, 211], '8.1'],
             ['Random\Engine', '8.1', [200], '8.2'],
             ['Random\CryptoSafeEngine', '8.1', [200], '8.2'],
         ];
@@ -219,7 +219,8 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             [177],
             [185],
             [189],
-            [209],
+            [208],
+            [219],
         ];
     }
 


### PR DESCRIPTION
This updates the sniff to also detect new interfaces when used in DNF types.

Includes unit tests.

Related to #1348

--- 

Note: this PR has been opened as draft as it depends on PR #1714 due to the need for PHPCS 3.10.0 (and will need a rebase once that PR has been merged). Having said that, the PR in itself is ready.