### PR TITLE
ParameterValues/RemovedMbStrrposEncodingThirdParam: fix false positive

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -163,9 +163,10 @@ class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParame
             return;
         }
 
-        $error   = 'Passing the encoding to mb_strrpos() as third parameter is soft deprecated since PHP 5.2';
-        $isError = false;
-        $code    = 'Deprecated';
+        $error     = 'Passing the encoding to mb_strrpos() as third parameter is soft deprecated since PHP 5.2';
+        $isError   = false;
+        $code      = 'Deprecated';
+        $realStart = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
 
         if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
             $error  .= ', hard deprecated since PHP 7.4 and removed since PHP 8.0';
@@ -177,6 +178,6 @@ class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParame
 
         $error .= '. Use an explicit 0 as the offset in the third parameter.';
 
-        MessageHelper::addMessage($phpcsFile, $error, $targetParam['start'], $isError, $code);
+        MessageHelper::addMessage($phpcsFile, $error, $realStart, $isError, $code);
     }
 }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.inc
@@ -26,3 +26,20 @@ mb_strrpos('abc abc abc', 'abc', 'utf-' . $utfType);
 // Safeguard support for PHP 8 named parameters.
 mb_strrpos(haystack: 'abc abc abc', needle: 'abc', encoding: 'UTF-8'); // OK.
 mb_strrpos(offset: 'UTF-8', haystack: 'abc abc abc', needle: 'abc',); // Error, not that it would make sense to pass this.
+
+// Issue #1721: ignore as undetermined.
+mb_strrpos('abc abc abc', 'abc', $pos['offset']);
+mb_strrpos('abc abc abc', 'abc', \get_offset_or_encoding('foo'));
+mb_strrpos('abc abc abc', 'abc', fn($a = 'default') => get_offset_or_encoding() ?? $a);
+mb_strrpos('abc abc abc', 'abc', function ($a = 'default') { return get_offset_or_encoding() ?? $a . 'text'; });
+
+// ... but still flag this as we can be sure that the resulting param value is a string.
+mb_strrpos('abc abc abc', 'abc', (string) $encoding);
+mb_strrpos('abc abc abc', 'abc', $utf . $nr);
+mb_strrpos(
+    'abc abc abc',
+    'abc',
+    <<<EOD
+$utf
+EOD
+);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
@@ -65,7 +65,7 @@ class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTestCase
             [28],
             [37],
             [38],
-            [41],
+            [42],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
@@ -63,6 +63,9 @@ class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTestCase
             [23],
             [24],
             [28],
+            [37],
+            [38],
+            [41],
         ];
     }
 
@@ -99,6 +102,10 @@ class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTestCase
         }
 
         $data[] = [27];
+        $data[] = [31];
+        $data[] = [32];
+        $data[] = [33];
+        $data[] = [34];
 
         return $data;
     }


### PR DESCRIPTION
### ParameterValues/RemovedMbStrrposEncodingThirdParam: fix false positive

Harden the sniff against false positives for text string tokens being used as part of array access or as a parameter passed to a function call etc, while also improving false negative prevention by flagging a parameter when the value is cast to `string`.

Includes unit tests.

Fixes #1721

### ParameterValues/RemovedMbStrrposEncodingThirdParam: improve message precision

Throw the error on the first non-empty token of the parameter which is being flagged, instead of on the first token, which, in most cases, would be whitespace following the comma separating the parameter from the previous token.
This will more clearly indicate the issue when people use the PHPCS `code` view, especially for multi-line function calls.