### PR TITLE
Documentation: minor consistency fixes

### DIFF
--- a/PHPCompatibility/Docs/FunctionNameRestrictions/ReservedFunctionNamesStandard.xml
+++ b/PHPCompatibility/Docs/FunctionNameRestrictions/ReservedFunctionNamesStandard.xml
@@ -14,7 +14,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Valid: function name without double underscore prefix and declaration of magic methods">
+        <code title="Valid: function name without double underscore prefix and declaration of magic methods.">
         <![CDATA[
 function <em>existsUserName</em>($userName) {}
 
@@ -24,7 +24,7 @@ class ItsAKindOfMagic {
 }
         ]]>
         </code>
-        <code title="Invalid: function name with double underscore prefix while not a magic function/method">
+        <code title="Invalid: function name with double underscore prefix while not a magic function/method.">
         <![CDATA[
 function <em>__existsUserName</em>($userName) {}
 

--- a/PHPCompatibility/Docs/FunctionUse/ArgumentFunctionsReportCurrentValueStandard.xml
+++ b/PHPCompatibility/Docs/FunctionUse/ArgumentFunctionsReportCurrentValueStandard.xml
@@ -13,7 +13,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Cross-version compatible: code NOT affected by the change">
+        <code title="Cross-version compatible: code NOT affected by the change.">
         <![CDATA[
 // func_get_args() called BEFORE change of $a.
 function foo($a, $b = null) {
@@ -49,7 +49,7 @@ $closure = <em>function()</em> {
 };
         ]]>
         </code>
-        <code title="Cross-version INcompatible: code affected by the change">
+        <code title="Cross-version INcompatible: code affected by the change.">
         <![CDATA[
 // func_get_args() called AFTER change of $a.
 function foo($a, $b = null) {
@@ -99,7 +99,7 @@ $closure = function(<em>$abc</em>) {
     ]]>
     </standard>
     <code_comparison>
-        <code title="Cross-version compatible: original value of $array is not changed prior to call to func_get_args()">
+        <code title="Cross-version compatible: original value of $array is not changed prior to call to func_get_args().">
         <![CDATA[
 function foo($array) {
     $args = <em>func_get_args()</em>;
@@ -108,7 +108,7 @@ function foo($array) {
 }
         ]]>
         </code>
-        <code title="Cross-version INcompatible: original value of $array is changed by reference prior to call to func_get_args()">
+        <code title="Cross-version INcompatible: original value of $array is changed by reference prior to call to func_get_args().">
         <![CDATA[
 function foo($array) {
     // Changes $array by reference.
@@ -120,7 +120,7 @@ function foo($array) {
     </code_comparison>
 
     <code_comparison>
-        <code title="Cross-version compatible: original value of $email is not changed prior to call to func_get_arg()">
+        <code title="Cross-version compatible: original value of $email is not changed prior to call to func_get_arg().">
         <![CDATA[
 function myFunction($email) {
     $newEmail = $email;
@@ -129,7 +129,7 @@ function myFunction($email) {
 }
         ]]>
         </code>
-        <code title="Cross-version INcompatible: original value of $email is potentially be changed (by reference) prior to call to func_get_arg()">
+        <code title="Cross-version INcompatible: original value of $email is potentially be changed (by reference) prior to call to func_get_arg().">
         <![CDATA[
 function myFunction($email) {
     // Unclear: Is $email changed by reference?

--- a/PHPCompatibility/Docs/ParameterValues/RemovedLdapConnectSignaturesStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedLdapConnectSignaturesStandard.xml
@@ -24,7 +24,7 @@ ldap_connect(<em>$host</em>, <em>$port</em>);
         </code>
     </code_comparison>
     <code_comparison>
-        <code title="Cross-version compatible up to PHP 8.3: calling ldap_connect() with wallet-details with an LDAP-URI in the $uri parameter and null for the $port value..">
+        <code title="Cross-version compatible up to PHP 8.3: calling ldap_connect() with wallet-details with an LDAP-URI in the $uri parameter and null for the $port value.">
         <![CDATA[
 ldap_connect(
     <em>"ldap://$host:$port??369"</em>,

--- a/PHPCompatibility/Docs/ParameterValues/RemovedPCREModifiersStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedPCREModifiersStandard.xml
@@ -10,7 +10,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Cross-version compatible: using preg_replace_callback()">
+        <code title="Cross-version compatible: using preg_replace_callback().">
         <![CDATA[
 <em>preg_replace_callback</em>(
     '/^(.?)/',
@@ -21,7 +21,7 @@
 );
         ]]>
         </code>
-        <code title="PHP &lt; 7.0: using the /e modifier">
+        <code title="PHP &lt; 7.0: using the /e modifier.">
         <![CDATA[
 preg_replace(
     <em>'/^(.?)/e'</em>,

--- a/PHPCompatibility/Docs/TextStrings/RemovedDollarBraceStringEmbedsStandard.xml
+++ b/PHPCompatibility/Docs/TextStrings/RemovedDollarBraceStringEmbedsStandard.xml
@@ -17,7 +17,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Cross-version compatible: Embedding simple variables and complex expressions in text strings using plain variables or the `{$...}` syntax.">
+        <code title="Cross-version compatible: embedding simple variables and complex expressions in text strings using plain variables or the `{$...}` syntax.">
         <![CDATA[
 echo <em>"hello $world"</em>;
 
@@ -30,7 +30,7 @@ echo <em>"hello {$world["${bar['baz']}"]}"</em>;
 echo <em>"hello {${world->{${'bar'}}}}"</em>;
         ]]>
         </code>
-        <code title="PHP &lt; 8.2: Embedding simple variables and complex expressions in text strings using the `${...}` syntax">
+        <code title="PHP &lt; 8.2: embedding simple variables and complex expressions in text strings using the `${...}` syntax.">
         <![CDATA[
 echo <em>"hello ${world}"</em>;
 

--- a/PHPCompatibility/Docs/Variables/NewUniformVariableSyntaxStandard.xml
+++ b/PHPCompatibility/Docs/Variables/NewUniformVariableSyntaxStandard.xml
@@ -13,7 +13,7 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Cross-version compatible: Using curly braces to explicitly enforce a specific evaluation order.">
+        <code title="Cross-version compatible: using curly braces to explicitly enforce a specific evaluation order.">
         <![CDATA[
 echo $<em>{</em>$var['key1']['key2']<em>}</em>;
 echo $obj-><em>{</em>$var['key']<em>}</em>;
@@ -21,7 +21,7 @@ echo $obj-><em>{</em>$var['key']<em>}</em>();
 echo MyClass::<em>{</em>$var['key']<em>}</em>();
         ]]>
         </code>
-        <code title="Cross-version INcompatible: Without curly braces the interpretation of these indirect accesses to variables, properties and methods will behave different in PHP &lt;= 5.6 versus PHP 7.0+.">
+        <code title="Cross-version INcompatible: without curly braces the interpretation of these indirect accesses to variables, properties and methods will behave different in PHP &lt;= 5.6 versus PHP 7.0+.">
         <![CDATA[
 echo <em>$$var['key1']['key2']</em>;
 echo <em>$obj->$var['key']</em>;


### PR DESCRIPTION
* Double checked that all existing XML docs have the `xsi` attributes and schema reference on the `<documentation>` element.
* Verified that the contents of `<standard>` elements is consistently indented (with four spaces).
* Verified that all `<code>` `title` attributes use proper capitalization and punctuation.

Only found a few punctuation fixes to made ;-)