### PR TITLE
Keywords/ForbiddenNames: fix bug in enum special casing

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -289,6 +289,9 @@ class ForbiddenNamesSniff extends Sniff
                 if (\strtolower($tokens[$stackPtr]['content']) === 'enum') {
                     $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
                     if ($tokens[$prevNonEmpty]['code'] === \T_DOUBLE_COLON
+                        || $tokens[$prevNonEmpty]['code'] === \T_CLASS
+                        || $tokens[$prevNonEmpty]['code'] === \T_INTERFACE
+                        || $tokens[$prevNonEmpty]['code'] === \T_TRAIT
                         || $tokens[$prevNonEmpty]['code'] === \T_EXTENDS
                         || $tokens[$prevNonEmpty]['code'] === \T_IMPLEMENTS
                         || $tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
@@ -403,3 +403,11 @@ namespace Foo\Match\Bar;
 namespace Foo\Readonly\Bar;
 namespace Foo\Never\Bar;
 namespace Foo\Enum\Bar;
+
+// Issue #1724: no false positive when a class named "enum" (allowed) extends or implements.
+// Disabling the warning about the use of the soft reserved enum keyword as a class/interface name as this test
+// is specifically testing against false positives (errors) for implements/extends as declaration name for an enum.
+// phpcs:disable PHPCompatibility.Keywords.ForbiddenNames.enumFound
+class enum implements Foo {}
+interface Enum extends Foo {}
+// phpcs:enable


### PR DESCRIPTION
Follow up on #1407, #1434 and #1475.

This commit further hardens the special casing of `enum` keywords against false positives.

As `enum` is a soft reserved keyword, it is allowed to be used for a class/interface/trait name. The special casing did not handle this correctly.

Includes tests.

Fixes #1724