### PR TITLE
FunctionDeclarations/NewParamTypeDeclarations: split "invalid type" error

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -140,7 +140,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
     ];
 
     /**
-     * Invalid types
+     * Invalid types. These will throw an error.
      *
      * The array lists : the invalid type hint => what was probably intended/alternative.
      *
@@ -149,7 +149,19 @@ class NewParamTypeDeclarationsSniff extends Sniff
      * @var array<string, string>
      */
     protected $invalidTypes = [
-        'static'  => 'self',
+        'static' => 'self',
+    ];
+
+    /**
+     * Invalid "long" types which are likely typos. These will throw a warning.
+     *
+     * The array lists : the invalid type hint => what was probably intended/alternative.
+     *
+     * @since 10.0.0 Split off from the `$invalidTypes` property.
+     *
+     * @var array<string, string>
+     */
+    protected $invalidLongTypes = [
         'boolean' => 'bool',
         'integer' => 'int',
     ];
@@ -321,13 +333,24 @@ class NewParamTypeDeclarationsSniff extends Sniff
                 }
 
                 if (isset($this->invalidTypes[$type])) {
-                    $error = "'%s' is not a valid type declaration. Did you mean %s ?";
+                    $error = "'%s' is not a valid parameter type declaration. Did you mean %s ?";
                     $data  = [
                         $type,
                         $this->invalidTypes[$type],
                     ];
 
                     $phpcsFile->addError($error, $param['token'], 'InvalidTypeHintFound', $data);
+                    continue;
+                }
+
+                if (isset($this->invalidLongTypes[$type])) {
+                    $error = "'%s' is not a valid parameter type declaration. Did you mean %s ?";
+                    $data  = [
+                        $type,
+                        $this->invalidLongTypes[$type],
+                    ];
+
+                    $phpcsFile->addWarning($error, $param['token'], 'InvalidLongTypeFound', $data);
                 }
             }
         }

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -160,7 +160,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
     public function testInvalidTypeDeclaration($type, $alternative, $line)
     {
         $file = $this->sniffFile(__FILE__, '5.0'); // Lowest version in which this message will show.
-        $this->assertError($file, $line, "'{$type}' is not a valid type declaration. Did you mean {$alternative} ?");
+        $this->assertError($file, $line, "'{$type}' is not a valid parameter type declaration. Did you mean {$alternative} ?");
     }
 
     /**
@@ -173,9 +173,40 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
     public static function dataInvalidTypeDeclaration()
     {
         return [
+            ['static', 'self', 25],
+        ];
+    }
+
+
+    /**
+     * Verify that invalid "long" type declarations are flagged correctly.
+     *
+     * @dataProvider dataInvalidLongTypeDeclaration
+     *
+     * @param string $type        The declared type.
+     * @param string $alternative Alternative for the invalid type hint.
+     * @param int    $line        Line number on which to expect an error.
+     *
+     * @return void
+     */
+    public function testInvalidLongTypeDeclaration($type, $alternative, $line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.0'); // Lowest version in which this message will show.
+        $this->assertWarning($file, $line, "'{$type}' is not a valid parameter type declaration. Did you mean {$alternative} ?");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidLongTypeDeclaration()
+     *
+     * @return array
+     */
+    public static function dataInvalidLongTypeDeclaration()
+    {
+        return [
             ['boolean', 'bool', 20],
             ['integer', 'int', 21],
-            ['static', 'self', 25],
             ['integer', 'int', 81],
         ];
     }


### PR DESCRIPTION
Splits the `InvalidTypeHintFound` error into two:
* An `error` for `static` which cannot be used as a parameter type under any circumstance.
* A `warning` for the "long" types, which are likely typos, but _could_ be valid class names.

The warning now has its own error code `InvalidLongTypeFound` to allow for excluding it selectively.

Includes minor tweaks to the test file to account for this change.

Fixes #1726