### PR TITLE
Namespaces/ReservedNames: various improvements

### DIFF
--- a/PHPCompatibility/Docs/Namespaces/ReservedNamesStandard.xml
+++ b/PHPCompatibility/Docs/Namespaces/ReservedNamesStandard.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Reserved Namespace Names"
+    >
+    <standard>
+    <![CDATA[
+    Userland PHP code should not use top-level namespace names reserved by PHP as this can cause naming conflicts ("class already declared" and the likes) as well as unexpected behaviour (extension code overruling the user-defined code with different behaviour).
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: namespace declaration using a vendor name for the top-level namespace.">
+        <![CDATA[
+namespace <em>MyCompany\LDAP\Sub</em>;
+        ]]>
+        </code>
+        <code title="Cross-version INcompatible: namespace declaration using a top-level namespace reserved by PHP.">
+        <![CDATA[
+// The LDAP namespace is in use since PHP 8.1.
+namespace <em>LDAP\Sub</em>;
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    Along the same lines, it is strongly discouraged to use a top-level namespace name reserved by a PECL PHP extension.
+    While, in most cases, this will be less problematic as the chances of the PECL extension being active on the server running the code are much smaller, there is still a risk and this risk will increase exponentially if/when the PECL extension would be promoted to a bundled extension.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: namespace declaration using a vendor name for the top-level namespace.">
+        <![CDATA[
+namespace <em>MyCompany\UI\Elements</em>;
+        ]]>
+        </code>
+        <code title="Cross-version INcompatible: namespace declaration using a top-level namespace reserved by a PECL extension.">
+        <![CDATA[
+namespace <em>UI\Elements</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -18,12 +18,12 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
- * Detect declarations of namespace names reserved or in use by PHP.
+ * Detect declarations of namespace names reserved for, or in use by, PHP.
  *
  * > The Namespace name PHP, and compound names starting with this name (like PHP\Classes) are reserved
  * > for internal language use and should not be used in the userspace code.
  *
- * Also includes names actually in use by PHP.
+ * Also includes namespace names actually in use by PHP.
  *
  * PHP version 5.3+
  *
@@ -124,7 +124,7 @@ class ReservedNamesSniff extends Sniff
 
         // Throw an error for other reserved names.
         $phpcsFile->addError(
-            'The top-level namespace name "%s" is reserved by and in use by PHP since PHP version %s. Found: %s',
+            'The top-level namespace name "%s" is reserved for, and in use by, PHP since PHP version %s. Found: %s',
             $firstNonEmpty,
             MessageHelper::stringToErrorCode($firstPart, true) . 'Found',
             [

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -28,6 +28,7 @@ use PHP_CodeSniffer\Util\Tokens;
  * PHP version 5.3+
  *
  * @link https://www.php.net/manual/en/language.namespaces.rationale.php
+ * @link https://wiki.php.net/rfc/namespaces_in_bundled_extensions
  *
  * @since 10.0.0
  */
@@ -48,6 +49,8 @@ class ReservedNamesSniff extends Sniff
          * of namespaces in PHP 5.3, but not yet in use.
          */
         'PHP'    => '5.3',
+
+        // Top-level namespace names in use in bundled extensions.
         'FFI'    => '7.4',
         'FTP'    => '8.1',
         'IMAP'   => '8.1',
@@ -55,6 +58,57 @@ class ReservedNamesSniff extends Sniff
         'PgSql'  => '8.1',
         'PSpell' => '8.1',
         'Random' => '8.2',
+    ];
+
+    /**
+     * A list of namespace names which are in use by PHP extensions which are not bundled with PHP.
+     *
+     * Extensions are often initially developed in PECL, but may be moved to PHP src at a later point.
+     *
+     * For most users, conflicts with these top level names will not be problematic, but they can be
+     * if the server the code runs on happens to have that particular extension installed and enabled.
+     *
+     * As these extensions are not bundled with PHP, we cannot relate the incompatibility to a PHP version,
+     * unless the extension is only available for a certain PHP version (and higher).
+     *
+     * When these names are detected as being declared, a warning will be thrown.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, string>
+     */
+    protected $peclReservedNames = [
+        // Top-level namespace names in use in PECL extensions which are documented in the PHP manual.
+        'CommonMark'    => '*',
+        'Componere'     => '*',
+        'Ds'            => '7.0', // Data Structures extension.
+        'Gender'        => '*',
+        'HRTime'        => '*',
+        'MongoDB'       => '*',
+        'mysql_xdevapi' => '*',
+        'parallel'      => '*',
+        'Parle'         => '7.4',
+        'Swoole'        => '*',
+        'UI'            => '*',
+        // Officially the prefix is Vtiful\Kernel, but the Vtiful namespace is a vendor name, so should not be
+        // used in a declarative way by userland code anyway (aside from userland code writen by the Vtiful vendor).
+        'Vtiful'        => '7.0', // XLSWriter extension.
+        'wkhtmltox'     => '*',
+        'XMLDiff'       => '*',
+
+        // These extensions are not in the manual, but mentioned in the "namespaces in bundled extensions" RFC.
+        'Aerospike'     => '*',
+        'Cassandra'     => '*',
+        'Couchbase'     => '*',
+        'Crypto'        => '*',
+        'Decimal'       => '*',
+        'Grpc'          => '*',
+        'http'          => '*',
+        'Mosquitto'     => '*',
+        'pcov'          => '*',
+        'pq'            => '*',
+        'RdKafka'       => '*',
+        'Zstd'          => '*',
     ];
 
     /**
@@ -67,7 +121,8 @@ class ReservedNamesSniff extends Sniff
     public function register()
     {
         // Handle case-insensitivity of namespace names.
-        $this->reservedNames = \array_change_key_case($this->reservedNames, \CASE_LOWER);
+        $this->reservedNames     = \array_change_key_case($this->reservedNames, \CASE_LOWER);
+        $this->peclReservedNames = \array_change_key_case($this->peclReservedNames, \CASE_LOWER);
 
         return [
             \T_NAMESPACE,
@@ -100,38 +155,65 @@ class ReservedNamesSniff extends Sniff
 
         $nameParts = \explode('\\', $name);
         $firstPart = \strtolower($nameParts[0]);
-        if (isset($this->reservedNames[$firstPart]) === false) {
-            return;
-        }
 
-        if (ScannedCode::shouldRunOnOrAbove($this->reservedNames[$firstPart]) === false) {
-            return;
-        }
+        /*
+         * Handle names reserved by PHP.
+         */
+        if (isset($this->reservedNames[$firstPart])) {
+            if (ScannedCode::shouldRunOnOrAbove($this->reservedNames[$firstPart]) === false) {
+                return;
+            }
 
-        // Throw the message on the first part of the namespace name.
-        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            // Throw the message on the first part of the namespace name.
+            $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
-        // Special case "PHP" to a warning with a custom message.
-        if ($firstPart === 'php') {
-            $phpcsFile->addWarning(
-                'Namespace name "%s" is discouraged; PHP has reserved the namespace name "PHP" and compound names starting with "PHP" for internal language use.',
+            // Special case "PHP" to a warning with a custom message.
+            if ($firstPart === 'php') {
+                $phpcsFile->addWarning(
+                    'Namespace name "%s" is discouraged; PHP has reserved the namespace name "PHP" and compound names starting with "PHP" for internal language use.',
+                    $firstNonEmpty,
+                    'phpFound',
+                    [$name]
+                );
+                return;
+            }
+
+            // Throw an error for other reserved names.
+            $phpcsFile->addError(
+                'The top-level namespace name "%s" is reserved for, and in use by, PHP since PHP version %s. Found: %s',
                 $firstNonEmpty,
-                'phpFound',
-                [$name]
+                MessageHelper::stringToErrorCode($firstPart, true) . 'Found',
+                [
+                    $nameParts[0],
+                    $this->reservedNames[$firstPart],
+                    $name,
+                ]
             );
-            return;
         }
 
-        // Throw an error for other reserved names.
-        $phpcsFile->addError(
-            'The top-level namespace name "%s" is reserved for, and in use by, PHP since PHP version %s. Found: %s',
-            $firstNonEmpty,
-            MessageHelper::stringToErrorCode($firstPart, true) . 'Found',
-            [
+        /*
+         * Handle names reserved by PECL extensions.
+         */
+        if (isset($this->peclReservedNames[$firstPart])) {
+            if ($this->peclReservedNames[$firstPart] !== '*'
+                && ScannedCode::shouldRunOnOrAbove($this->peclReservedNames[$firstPart]) === false
+            ) {
+                return;
+            }
+
+            // Throw the message on the first part of the namespace name.
+            $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+
+            $warning = 'The top-level namespace name "%s" is reserved for, and in use by, a PECL extension%s. Found: %s';
+            $code    = MessageHelper::stringToErrorCode($firstPart, true) . 'PeclReserved';
+            $data    = [
                 $nameParts[0],
-                $this->reservedNames[$firstPart],
+                $this->peclReservedNames[$firstPart] === '*' ? '' : ' since PHP version ' . $this->peclReservedNames[$firstPart],
                 $name,
-            ]
-        );
+            ];
+
+            // Throw a warning for namespace names reserved for PECL extensions.
+            $phpcsFile->addWarning($warning, $firstNonEmpty, $code, $data);
+        }
     }
 }

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -49,6 +49,11 @@ class ReservedNamesSniff extends Sniff
          */
         'PHP'    => '5.3',
         'FFI'    => '7.4',
+        'FTP'    => '8.1',
+        'IMAP'   => '8.1',
+        'LDAP'   => '8.1',
+        'PgSql'  => '8.1',
+        'PSpell' => '8.1',
         'Random' => '8.2',
     ];
 

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
@@ -22,5 +22,14 @@ namespace FFI\MyClass;
 namespace Random;
 namespace Random\Generator;
 
+// Verify the sniff handles case-insensitivety correctly.
+namespace php\something; // Warning.
+namespace rANdOm; // Error.
+
+// Verify the sniff ignores use of the namespace keyword when not used for a declaration.
+namespace My\namespace; // Allowed since PHP 8.0.
+namespace\php\function_call(); // Use of the keyword as an operator.
+echo namespace\random\SomeConstant; // Use of the keyword as an operator.
+
 // Intentional parse error. This has to be the last test in the file.
 namespace PHP\Cli

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
@@ -39,5 +39,38 @@ namespace LDAP;
 namespace PgSql\Sub;
 namespace PSpell;
 
+// Warning on all PHP versions.
+namespace CommonMark\Sub;
+namespace Componere\Sub;
+namespace Gender\Sub;
+namespace HRTime\Sub;
+namespace MongoDB\Sub;
+namespace mysql_xdevapi\Sub;
+namespace parallel\Sub;
+namespace Swoole\Sub;
+namespace UI\Sub;
+namespace wkhtmltox\Sub;
+namespace XMLDiff\Sub;
+namespace Aerospike\Sub;
+namespace Cassandra\Sub;
+namespace Couchbase\Sub;
+namespace Crypto\Sub;
+namespace Decimal\Sub;
+namespace Grpc\Sub;
+namespace HTTP\Sub;
+namespace Mosquitto\Sub;
+namespace pcov\Sub;
+namespace pq\Sub;
+namespace RdKafka\Sub;
+namespace Zstd\Sub;
+
+// Warning on PHP 7.0+.
+namespace Ds\Sub;
+namespace Vtiful\Kernel;
+namespace Vtiful\Kernel\Sub;
+
+// Warning on PHP 7.4+.
+namespace Parle\Sub;
+
 // Intentional parse error. This has to be the last test in the file.
 namespace PHP\Cli

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
@@ -31,5 +31,13 @@ namespace My\namespace; // Allowed since PHP 8.0.
 namespace\php\function_call(); // Use of the keyword as an operator.
 echo namespace\random\SomeConstant; // Use of the keyword as an operator.
 
+// Error PHP 8.1+.
+namespace FTP;
+namespace FTP\Connect;
+namespace IMAP\Something;
+namespace LDAP;
+namespace PgSql\Sub;
+namespace PSpell;
+
 // Intentional parse error. This has to be the last test in the file.
 namespace PHP\Cli

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -61,6 +61,7 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [19, 'FFI', '7.4', '7.3'],
             [22, 'Random', '8.2', '8.1'],
             [23, 'Random', '8.2', '8.1'],
+            [27, 'rANdOm', '8.2', '8.1'],
         ];
     }
 
@@ -92,6 +93,7 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [11],
             [12],
             [13],
+            [26],
         ];
     }
 
@@ -124,7 +126,10 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [4],
             [5],
             [6],
-            [26],
+            [30],
+            [31],
+            [32],
+            [35],
         ];
     }
 

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -62,6 +62,12 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [22, 'Random', '8.2', '8.1'],
             [23, 'Random', '8.2', '8.1'],
             [27, 'rANdOm', '8.2', '8.1'],
+            [35, 'FTP', '8.1', '8.0'],
+            [36, 'FTP', '8.1', '8.0'],
+            [37, 'IMAP', '8.1', '8.0'],
+            [38, 'LDAP', '8.1', '8.0'],
+            [39, 'PgSql', '8.1', '8.0'],
+            [40, 'PSpell', '8.1', '8.0'],
         ];
     }
 
@@ -129,7 +135,7 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [30],
             [31],
             [32],
-            [35],
+            [43],
         ];
     }
 

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -43,7 +43,7 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
         $this->assertNoViolation($file, $line);
 
         $file  = $this->sniffFile(__FILE__, $version);
-        $error = "The top-level namespace name \"{$name}\" is reserved by and in use by PHP since PHP version {$version}.";
+        $error = "The top-level namespace name \"{$name}\" is reserved for, and in use by, PHP since PHP version {$version}.";
         $this->assertError($file, $line, $error);
     }
 

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -105,6 +105,69 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
 
 
     /**
+     * Verify correctly detecting reserved namespace name for a PECL extension.
+     *
+     * @dataProvider dataReservedNamePECL
+     *
+     * @param int    $line      The line number in the test file.
+     * @param string $name      The reserved name which should be detected.
+     * @param string $version   The PHP version in which the name became reserved.
+     * @param string $okVersion A PHP version in which the name was not reserved.
+     *
+     * @return void
+     */
+    public function testReservedNamePECL($line, $name, $version = '5.3', $okVersion = '5.2')
+    {
+        $file = $this->sniffFile(__FILE__, $okVersion);
+        $this->assertNoViolation($file, $line);
+
+        $file    = $this->sniffFile(__FILE__, $version);
+        $warning = "The top-level namespace name \"{$name}\" is reserved for, and in use by, a PECL extension";
+        $this->assertWarning($file, $line, $warning);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testReservedNamePECL()
+     *
+     * @return array
+     */
+    public static function dataReservedNamePECL()
+    {
+        return [
+            [43, 'CommonMark'],
+            [44, 'Componere'],
+            [45, 'Gender'],
+            [46, 'HRTime'],
+            [47, 'MongoDB'],
+            [48, 'mysql_xdevapi'],
+            [49, 'parallel'],
+            [50, 'Swoole'],
+            [51, 'UI'],
+            [52, 'wkhtmltox'],
+            [53, 'XMLDiff'],
+            [54, 'Aerospike'],
+            [55, 'Cassandra'],
+            [56, 'Couchbase'],
+            [57, 'Crypto'],
+            [58, 'Decimal'],
+            [59, 'Grpc'],
+            [60, 'HTTP'],
+            [61, 'Mosquitto'],
+            [62, 'pcov'],
+            [63, 'pq'],
+            [64, 'RdKafka'],
+            [65, 'Zstd'],
+            [68, 'Ds', '7.0', '5.6'],
+            [69, 'Vtiful', '7.0', '5.6'],
+            [70, 'Vtiful', '7.0', '5.6'],
+            [73, 'Parle', '7.4', '7.3'],
+        ];
+    }
+
+
+    /**
      * Verify the sniff does not throw false positives on valid code.
      *
      * @dataProvider dataNoFalsePositives
@@ -135,7 +198,7 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [30],
             [31],
             [32],
-            [43],
+            [76],
         ];
     }
 


### PR DESCRIPTION
### Namespaces/ReservedNames: add extra tests

1. Add tests to safeguard that the sniff handles namespace names case-INsensitively.
2. Add tests to safeguard that the sniff does not throw false positives for the `namespace` keyword being used as an operator or when it is used as part of a namespaced name.

### Namespaces/ReservedNames: update the list of reserved names

The "Namespaces in bundled PHP extensions" policy RFC which was voted on during the PHP 8.1 dev cycle, opened the door to more bundled PHP extensions using their own dedicated top-level namespace.

These namespaces being reserved can cause clashes with userland code, as well as unexpected behaviour (the PHP native class being used instead of the expected userland class), so we should flag them.

This updates the list of reserved namespace names in use by PHP based on the currently available PHP documentation.

Most of these were added as part of the "resources to object" migration to hold the opaque object to replace the resource.

Includes tests.

Related to #1299

### Namespaces/ReservedNames: fix grammar in error message

Also includes minor, similar fix to the documentation.

### Namespaces/ReservedNames: also flag namespaces reserved by PECL extensions

PECL extensions are PHP extensions which are not bundled with PHP releases.
Extensions are often initially developed on as PECL extensions, but if they are widely adopted, stable and maintained they can be moved to PHP src.
Along the same lines, unmaintained extensions may be unbundled from PHP and moved to PECL.

Userland packages using a top-level namespace in use by a PECL extension could run into trouble as:
1. The server the software runs on may have the extension enabled.
    This can lead to nasty bugs and unexpected runtime behaviour as PHP will favour the code in the extension over any userland code, so if there is a same-named class, function, constant, the autoloader for the userland package will not kick in and the extension version will be used instead.
    Additionally, if the code is loaded without an autoloader, it can lead to fatal "class already declared" errors and such.
2. PECL extensions may at some point be moved to and bundled with PHP itself, at which point, the problem outlined in [1] becomes even more widespread.

With this in mind and with the "Namespaces in bundled extensions" policy RFC having been accepted during the PHP 8.1 dev cycle and actively encouraging use of namespaces in PHP extensions, I propose we also start flagging top-level namespace names in use by PECL extensions.
Though, as it is not a given that this use will be problematic, I propose flagging these only with a "warning".

The error code for the warning is modular and will include the name flagged, allowing for selective exclusion of the warnings for just one particular namespace name.

The error code suffix - `PECLReserved` - is also different from the error code suffix for other errors/warnings thrown by this sniff (`Found`). This is deliberate to ensure that if a PECL extension becomes a bundled extension and a user of PHPCompatibility would have excluded the warning, they will still get to see the _error_ once the extension has been moved to PHP.

Includes unit tests.

Note: this commit will be easier to review while ignoring whitespace.

:point_right: **Open questions:**
1. Should we check flag namespaces used by both the PECL extensions listed in the PHP manual as well as the RFC ? Or only those listed in the manual ?
2. Should the warning be thrown at severity 5 (current implementation) ? Or should we lower the severity for these warnings to, for instance, 3 ?
    Lowering the severity would mean that people would not see the warning by default and would need to explicitly set `--severity=3` to see them, making the warning less effective.
    For now, I've implemented the feature with the normal severity of `5`, but with modular error codes, which means that selectively ignoring a particular warning from a ruleset or via an inline ignore annotation is straight-forward.

Ref:
* https://wiki.php.net/rfc/namespaces_in_bundled_extensions

Related to #1299

### Namespaces/ReservedNames: add documentation

To view:
```bash
phpcs --generator=Text --standard=PHPCompatibility --sniffs=PHPCompatibility.Namespaces.ReservedNames
```