### PR TITLE
PHP 8.4 | NewFunctions: detect use of new BCMath functions (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4968,6 +4968,22 @@ class NewFunctionsSniff extends Sniff
             '8.3'       => true,
             'extension' => 'sockets',
         ],
+
+        'bcceil' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'bcmath',
+        ],
+        'bcfloor' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'bcmath',
+        ],
+        'bcround' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'bcmath',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1050,3 +1050,7 @@ posix_fpathconf();
 posix_eaccess();
 pg_set_error_context_visibility();
 socket_atmark();
+
+bcceil();
+bcfloor();
+bcround();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1111,6 +1111,10 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['posix_eaccess', '8.2', 1050, '8.3'],
             ['pg_set_error_context_visibility', '8.2', 1051, '8.3'],
             ['socket_atmark', '8.2', 1052, '8.3'],
+
+            ['bcceil', '8.3', 1054, '8.4'],
+            ['bcfloor', '8.3', 1055, '8.4'],
+            ['bcround', '8.3', 1056, '8.4'],
         ];
     }
 


### PR DESCRIPTION
>  . Added bcfloor(), bcceil(), bcround().
>    RFC: https://wiki.php.net/rfc/adding_bcround_bcfloor_bcceil_to_bcmath

Refs:
* https://wiki.php.net/rfc/adding_bcround_bcfloor_bcceil_to_bcmath
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L656-L658
* php/php-src#13096
* https://github.com/php/php-src/commit/5359392717bf8dfe7b0289424853fd017b6d3d30

Related to #1731