### PR TITLE
PHP 8.4 | OptionalToRequiredFunctionParameters: account for deprecation of overloaded pg_*() signatures (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -96,6 +96,36 @@ class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallPara
                 '8.0'  => true,
             ],
         ],
+        'pg_fetch_result' => [
+            2 => [
+                'name' => 'row',
+                '8.4'  => false,
+            ],
+            3 => [
+                'name' => 'field',
+                '8.4'  => false,
+            ],
+        ],
+        'pg_field_prtlen' => [
+            2 => [
+                'name' => 'row',
+                '8.4'  => false,
+            ],
+            3 => [
+                'name' => 'field',
+                '8.4'  => false,
+            ],
+        ],
+        'pg_field_is_null' => [
+            2 => [
+                'name' => 'row',
+                '8.4'  => false,
+            ],
+            3 => [
+                'name' => 'field',
+                '8.4'  => false,
+            ],
+        ],
         'stream_context_set_option' => [
             3 => [
                 'name' => 'option_name',

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.inc
@@ -44,3 +44,11 @@ $obj?->mktime();
 
 stream_context_set_option($context, $wrapper, $option_name, $value);
 stream_context_set_option($context, $options); // Error x 2.
+
+pg_fetch_result($result, $row, $field);
+pg_fetch_result($result, $field); // Error.
+pg_fetch_result($result, field: $field); // Error.
+pg_field_prtlen($result, $row, $field);
+pg_field_prtlen($result, $field); // Error.
+pg_field_is_null($result, $row, $field);
+pg_field_is_null($result, $field); // Error.

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -64,6 +64,10 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTestCase
         return [
             ['stream_context_set_option', 'option_name', '8.4', [46], '8.3'],
             ['stream_context_set_option', 'value', '8.4', [46], '8.3'],
+            ['pg_fetch_result', 'field', '8.4', [49], '8.3'],
+            ['pg_fetch_result', 'row', '8.4', [50], '8.3'],
+            ['pg_field_prtlen', 'field', '8.4', [52], '8.3'],
+            ['pg_field_is_null', 'field', '8.4', [54], '8.3'],
         ];
     }
 
@@ -196,6 +200,9 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTestCase
             [32],
             [43],
             [45],
+            [48],
+            [51],
+            [53],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -195,6 +195,7 @@ class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTestCase
             [21],
             [32],
             [43],
+            [45],
         ];
     }
 


### PR DESCRIPTION
### OptionalToRequiredFunctionParameters: add missing false positive test case

### PHP 8.4 | OptionalToRequiredFunctionParameters: account for deprecation of overloaded pg_*() signatures (RFC)

> - PgSQL:
>  . Calling pg_fetch_result() with 2 arguments is deprecated. Use the
>    3-parameter signature with a null $row parameter instead.
>  . Calling pg_field_prtlen() with 2 arguments is deprecated. Use the
>    3-parameter signature with a null $row parameter instead.
>  . Calling pg_field_is_null() with 2 arguments is deprecated. Use the
>    3-parameter signature with a null $row parameter instead.

Note: when named parameters are used, the sniff will use the correct parameter name in the deprecation warning.
When positional parameters are used, the sniff will flag `$field` as missing, even though in reality (due to the secondary signature), the `$row` parameter is missing.

This could possible be clarified by adding an "alternative" key to the array and using the value of that in the error message, but that's for later.

Refs:
* https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#pg_fetch_result_pg_field_prtlen_and_pg_field_is_null
* php/php-src#12728
* php/php-src@beaf1e8
* https://www.php.net/pg_fetch_result
* https://www.php.net/pg_field_prtlen
* https://www.php.net/pg_field_is_null

Related to #1589