### PR TITLE
PHP 8.4 | RequiredToOptionalFunctionParameters: account for pg_select() change

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -310,6 +310,13 @@ class RequiredToOptionalFunctionParametersSniff extends AbstractFunctionCallPara
                 '8.0'  => false,
             ],
         ],
+        'pg_select' => [
+            3 => [
+                'name' => 'conditions',
+                '8.3'  => true,
+                '8.4'  => false,
+            ],
+        ],
         'preg_match_all' => [
             3 => [
                 'name' => 'matches',

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
@@ -85,3 +85,6 @@ array_diff_uassoc(key_compare_func: $callback, array: $array, ); // Error.
 
 ftp_fget( ftp: $ftp_stream, stream: $handle, remote_filename: $remote_file, mode: $mode, offset: $resumepos ); // OK.
 ftp_fget( ftp: $ftp_stream, stream: $handle, remote_filename: $remote_file, offset: $resumepos ); // PHP 7.3+.
+
+pg_select($conn, 'phptests.bar', $conditions); // OK.
+pg_select($conn, 'phptests.bar'); // PHP 8.4+.

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.inc
@@ -84,4 +84,4 @@ array_diff_uassoc(rest: ...$arrays, key_compare_func: $callback, array: $array, 
 array_diff_uassoc(key_compare_func: $callback, array: $array, ); // Error.
 
 ftp_fget( ftp: $ftp_stream, stream: $handle, remote_filename: $remote_file, mode: $mode, offset: $resumepos ); // OK.
-ftp_fget( ftp: $ftp_stream, stream: $handle, remote_filename: $remote_file, offset: $resumepos ); // PHP 7.3+
+ftp_fget( ftp: $ftp_stream, stream: $handle, remote_filename: $remote_file, offset: $resumepos ); // PHP 7.3+.

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -153,6 +153,9 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTestCase
             [57],
             [58],
             [79],
+            [82],
+            [83],
+            [86],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -102,6 +102,7 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTestCase
             ['array_uintersect_assoc', 'rest', '7.4', [73], '8.0'],
             ['array_uintersect_uassoc', 'rest', '7.4', [74], '8.0'],
             ['array_uintersect', 'rest', '7.4', [75], '8.0'],
+            ['pg_select', 'conditions', '8.3', [90], '8.4'],
         ];
     }
 
@@ -156,6 +157,7 @@ class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTestCase
             [82],
             [83],
             [86],
+            [89],
         ];
     }
 


### PR DESCRIPTION
### RequiredToOptionalFunctionParameters: add missing false positive test cases

These test cases were previously already added, but were forgotten to be listed in the data provider for the "no false positives" test.

### PHP 8.4 | RequiredToOptionalFunctionParameters: account for pg_select() change

> - PGSQL:
>  . pg_select, the conditions arguments accepts an empty array and is optional.

This commit accounts for this change.

Refs:
* https://github.com/php/php-src/blob/b56f81cddcb2c0642bbc6c4a8de5731dd3956995/UPGRADING#L648
* php/php-src#5332
* php/php-src@75da0d7
* https://www.php.net/manual/en/function.pg-select.php

Related to #1731