### PR TITLE
PHP 8.4 | ParameterValues/NewPCREModifiers: account for new `r` modifier

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -20,7 +20,7 @@ use PHPCSUtils\Utils\PassedParameters;
  * Check for the use of newly added regex modifiers for PCRE functions.
  *
  * Initially just checks for the PHP 7.2 new `J` modifier.
- * As of PHPCompatibility 10.0.0 also check for the PHP 8.2 `n` modifier.
+ * As of PHPCompatibility 10.0.0 also check for the PHP 8.2 `n` and the PHP 8.4 `r` modifiers.
  *
  * PHP version 7.2+
  *
@@ -98,6 +98,10 @@ class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
             '8.1' => false,
             '8.2' => true,
         ],
+        'r' => [
+            '8.3' => false,
+            '8.4' => true,
+        ],
     ];
 
 
@@ -112,7 +116,7 @@ class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
     {
         // Version used here should be the highest version from the `$newModifiers` array,
         // i.e. the last PHP version in which a new modifier was introduced.
-        return (ScannedCode::shouldRunOnOrBelow('8.2') === false);
+        return (ScannedCode::shouldRunOnOrBelow('8.4') === false);
     }
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
@@ -53,3 +53,8 @@ preg_grep(array: $input, pattern: '#some text#Ji', flags: $flags); // Error.
 preg_match('/.(.)./n', 'abc', $m);
 preg_match('`.(?P<test>.).`n', 'abc', $m);
 preg_match('{.(?P<test>.).}n', 'abc', $m);
+
+// Recognize use of the PHP 8.4 "r" modifier.
+preg_match('/.(.)./ri', 'abc', $m);
+preg_match('`.(?P<test>.).`r', 'abc', $m);
+preg_match('{A\x{17f}\x{212a}Z}xr', 'abc', $m);

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -67,6 +67,7 @@ class NewPCREModifiersUnitTest extends BaseSniffTestCase
         return [
             ['J', '7.1', [3, 4, 10, 17, 19, 25, 43, 50], '7.2'],
             ['n', '8.1', [53, 54, 55], '8.2'],
+            ['r', '8.3', [58, 59, 60], '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . Added support for the "r" (PCRE2_EXTRA_CASELESS_RESTRICT) modifier, as well
>   as the (?r) mode modifier. When enabled along with the case-insensitive
>   modifier ("i"), the expression locks out mixing of ASCII and non-ASCII
>   characters.

This commit updates the existing sniff to recognize and flag the new modifier when used with PHP < 8.4.

Refs:
* https://github.com/php/php-src/blob/b56f81cddcb2c0642bbc6c4a8de5731dd3956995/UPGRADING#L333-L336
* php/php-src#13583
* https://github.com/php/php-src/commit/7b23470666a82e411db9fbd1299a7ec301a7aeae

Related to #1731