### PR TITLE
PHP 8.4 | ForbiddenExtendingFinalPHPClass: detect classes extending GMP class (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
@@ -18,6 +18,10 @@ use PHP_CodeSniffer\Files\File;
 /**
  * Detect extending of PHP native classes which became final at some point.
  *
+ * Note: classes which were final on their introduction are not included in this sniff
+ * as, in that case, there is no behavioural change across PHP versions
+ * (other than the class being available, which is for the `NewClasses` sniff to detect).
+ *
  * PHP version 8.0+
  *
  * @since 10.0.0
@@ -35,6 +39,7 @@ class ForbiddenExtendingFinalPHPClassSniff extends Sniff
      */
     protected $finalClasses = [
         '\__PHP_Incomplete_Class' => '8.0',
+        '\GMP'                    => '8.4',
     ];
 
     /**

--- a/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.inc
@@ -22,4 +22,5 @@ namespace MyNamespace {
 
     // Extending a final class.
     $anonClass = new class extends \__PHP_Incomplete_Class {};
+    class MyGMP extends \GMP {}
 }

--- a/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.php
@@ -59,6 +59,7 @@ class ForbiddenExtendingFinalPHPClassUnitTest extends BaseSniffTestCase
             ['__PHP_Incomplete_Class', '8.0', 12, '7.4'],
             ['__PHP_Incomplete_Class', '8.0', 13, '7.4'],
             ['__PHP_Incomplete_Class', '8.0', 24, '7.4'],
+            ['GMP', '8.4', 25, '8.3'],
         ];
     }
 


### PR DESCRIPTION


> . The GMP class is now final and cannot be extended anymore.
>   RFC: https://wiki.php.net/rfc/gmp-final

Refs:
* https://wiki.php.net/rfc/gmp-final
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L56-L57
* php/php-src#15121
* https://github.com/php/php-src/commit/a50adda19e69aeef9fb5cb3536fdeb305178efc3

Includes minor documentation clarification.

Related to #1731