### PR TITLE
PHP 8.4 | RemovedFunctionParameters: detect use of mysqli_store_result $mode (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -154,6 +154,12 @@ class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
                 '8.1'  => false,
             ],
         ],
+        'mysqli_store_result' => [
+            2 => [
+                'name' => 'mode',
+                '8.4'  => false,
+            ],
+        ],
         'odbc_do' => [
             3 => [
                 'name' => 'flags',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -66,3 +66,6 @@ ldap_exop($ldap, $request_oid, $request_data, $controls, $response_data, $respon
 
 session_set_save_handler($handler, true); // OK.
 session_set_save_handler($open, $close, $read, $write, $destroy, $gc, $create_sid, $validate_sid, $update_timestamp); // Error x 7.
+
+mysqli_store_result($mysql); // OK.
+mysqli_store_result($mysql, $mode); // Warning.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -186,6 +186,7 @@ class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             ['session_set_save_handler', 'create_sid', '8.4', [68], '8.3'],
             ['session_set_save_handler', 'validate_sid', '8.4', [68], '8.3'],
             ['session_set_save_handler', 'update_timestamp', '8.4', [68], '8.3'],
+            ['mysqli_store_result', 'mode', '8.4', [71], '8.3'],
         ];
     }
 


### PR DESCRIPTION

> . Passing explicitly the $mode parameter to mysqli_store_result() has been
>   deprecated. As the MYSQLI_STORE_RESULT_COPY_DATA constant was only used in
>   conjunction with this function it has also been deprecated.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_the_second_parameter_to_mysqli_store_result

This commit accounts for the parameter deprecation.

The constant was already marked as deprecated in PHPCompatibility for PHP 8.1 and up based on the changelog entry regarding this in PHP 8.1.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_the_second_parameter_to_mysqli_store_result
* https://github.com/php/php-src/blob/634708a14f9546cc81bc5f9bf269ec0c46743a0f/UPGRADING#L460-L463
* php/php-src#15311
* https://github.com/php/php-src/commit/4f58d5b0df823dbdc4e629d98b3d564050e9173e

Related to #1731