### PR TITLE
PHP 8.4 | :sparkles: New PHPCompatibility.ParameterValues.RemovedTriggerErrorLevel sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedTriggerErrorLevelStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedTriggerErrorLevelStandard.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed trigger_error() Level"
+    >
+    <standard>
+    <![CDATA[
+    Calling trigger_error() with the error level E_USER_ERROR is deprecated since PHP 8.4.
+
+    Either throw an exception, call exit() or die() with a status message or pass a lower error level to trigger_error().
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: throwing an exception.">
+        <![CDATA[
+if ($errorCondition) {
+    <em>throw new Exception('message')</em>;
+}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: calling trigger_error() with E_USER_ERROR.">
+        <![CDATA[
+if ($errorCondition) {
+    <em>trigger_error('message', E_USER_ERROR)</em>;
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Cross-version compatible: exiting out of the script.">
+        <![CDATA[
+if ($errorCondition) {
+    <em>exit('message')</em>;
+}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: calling trigger_error() with E_USER_ERROR.">
+        <![CDATA[
+if ($errorCondition) {
+    <em>trigger_error('message', E_USER_ERROR)</em>;
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Cross-version compatible: using a lower error level.">
+        <![CDATA[
+if ($errorCondition) {
+    <em>trigger_error('message', E_USER_WARNING)</em>;
+}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: calling trigger_error() with E_USER_ERROR.">
+        <![CDATA[
+if ($errorCondition) {
+    <em>trigger_error('message', E_USER_ERROR)</em>;
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedTriggerErrorLevelSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedTriggerErrorLevelSniff.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Detect calling trigger_error() with E_USER_ERROR.
+ *
+ * PHP version 8.4
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error
+ * @link https://www.php.net/trigger_error
+ *
+ * @since 10.0.0
+ */
+final class RemovedTriggerErrorLevelSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, true>
+     */
+    protected $targetFunctions = [
+        'trigger_error' => true,
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrAbove('8.4') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File                  $phpcsFile    The file being scanned.
+     * @param int                                          $stackPtr     The position of the current token in the stack.
+     * @param string                                       $functionName The token content (function name) which was matched.
+     * @param array<int|string, array<string, int|string>> $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 2, 'error_level');
+        if ($targetParam === false) {
+            return;
+        }
+
+        $paramContent = \ltrim($targetParam['clean'], ' \\'); // Trim off potential leading namespace separator for FQN.
+        if ($paramContent !== 'E_USER_ERROR'
+            && $paramContent !== (string) \E_USER_ERROR
+        ) {
+            return;
+        }
+
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+
+        $phpcsFile->addWarning(
+            'Passing E_USER_ERROR to trigger_error() is deprecated since 8.4. Throw an exception or call exit with a string message instead.',
+            $firstNonEmpty,
+            'Deprecated'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedTriggerErrorLevelUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedTriggerErrorLevelUnitTest.inc
@@ -1,0 +1,36 @@
+<?php
+
+// Not our target.
+$obj?->trigger_error($message, E_USER_ERROR);
+MyClass::trigger_error($message, E_USER_ERROR);
+My\Ns\trigger_error($message, E_USER_ERROR);
+$class = new trigger_error($message, E_USER_ERROR);
+
+// Ignore, optional target param not passed.
+trigger_error($message);
+trigger_error($message, level: false); // Typo in param name.
+
+// OK.
+trigger_error($message, E_USER_WARNING);
+trigger_error($message, /*comment*/ E_USER_NOTICE /*comment*/);
+trigger_error($message, \E_USER_DEPRECATED);
+trigger_error($message, 1024);
+
+// Invalid, but not our concern.
+trigger_error($message, e_user_error); // Invalid, undefined constant.
+trigger_error($message, 'invalid, error_level must be an integer'); // Invalid, type error.
+
+// Undetermined. Ignore.
+trigger_error($message, $error_level);
+trigger_error($message, MyClass::E_USER_ERROR);
+trigger_error($message, \get_error_level());
+
+// Not OK - deprecated in PHP >= 8.4.
+trigger_error($message, E_USER_ERROR);
+trigger_error($message, 256);
+trigger_error(
+    $message,
+    // Comment.
+    \E_USER_ERROR // phpcs:ignore Stnd.Cat.Sniff -- for (testing) reasons.
+);
+trigger_error(error_level: E_USER_ERROR, message: $message);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedTriggerErrorLevelUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedTriggerErrorLevelUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedTriggerErrorLevel sniff.
+ *
+ * @group removedTriggerErrorLevel
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedTriggerErrorLevelSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedTriggerErrorLevelUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test the sniff correctly detects passing E_USER_ERROR to trigger_error().
+     *
+     * @dataProvider dataRemovedTriggerErrorLevel
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedTriggerErrorLevel($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.4');
+        $error = 'Passing E_USER_ERROR to trigger_error() is deprecated since 8.4. Throw an exception or call exit with a string message instead.';
+
+        $this->assertWarning($file, $line, $error);
+
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedTriggerErrorLevel()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataRemovedTriggerErrorLevel()
+    {
+        return [
+            [29],
+            [30],
+            [34],
+            [36],
+        ];
+    }
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 27 lines.
+        for ($line = 1; $line <= 27; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> . Passing E_USER_ERROR to trigger_error() is now deprecated.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error

This commit introduces a new sniff to detect and flag this.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error
* https://github.com/php/php-src/blob/634708a14f9546cc81bc5f9bf269ec0c46743a0f/UPGRADING#L409-L410
* php/php-src#15308
* https://github.com/php/php-src/commit/1e3d918936d715466475434e7a4d7db2f36afa10

Related to #1731