### PR TITLE
PHP 8.4 | :sparkles: New PHPCompatibility.Classes.ForbiddenClassNameUnderscore sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/Classes/ForbiddenClassNameUnderscoreStandard.xml
+++ b/PHPCompatibility/Docs/Classes/ForbiddenClassNameUnderscoreStandard.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Forbidden ClassName Underscore"
+    >
+    <standard>
+    <![CDATA[
+    Using a single underscore - "_" - as the name for a class, interface, trait or enum is deprecated since PHP 8.4.
+    In the future, this symbol may be used by PHP for other purposes.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: OO structures not using &quot;_&quot; as their name.">
+        <![CDATA[
+class <em>MyClass</em> {}
+
+namespace Foo\Bar;
+trait <em>___</em> {}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: OO structures with the name &quot;_&quot;.">
+        <![CDATA[
+interface <em>_</em> {}
+
+namespace Foo\Bar;
+enum <em>_</em> {}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Classes/ForbiddenClassNameUnderscoreSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenClassNameUnderscoreSniff.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Utils\ObjectDeclarations;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Detect OO structures using a single underscore as the class name.
+ *
+ * The single underscore symbol is now reserved for PHP for future use (in pattern matching).
+ *
+ * PHP version 8.4
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_using_a_single_underscore_as_a_class_name
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenClassNameUnderscoreSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        $targets = Tokens::$ooScopeTokens;
+        unset($targets[\T_ANON_CLASS]);
+
+        return $targets;
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrAbove('8.4') === false) {
+            return;
+        }
+
+        $name = ObjectDeclarations::getName($phpcsFile, $stackPtr);
+        if (empty($name)) {
+            // Live coding/parse error.
+            return;
+        }
+
+        if ($name !== '_') {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $phpcsFile->addWarning(
+            'Using a single underscore, "_", as %s name is deprecated since PHP 8.4.',
+            $stackPtr,
+            'Deprecated',
+            [\strtolower($tokens[$stackPtr]['content'])]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreUnitTest.inc
@@ -1,0 +1,32 @@
+<?php
+
+// Not our target.
+function _() {}
+
+// OK.
+class __ {}
+interface ____ {}
+trait ___ {}
+enum _H_ {}
+
+class ClassName {}
+interface InterfaceName {}
+Trait TraitName {}
+enum EnumName {}
+
+// Not OK - deprecated in PHP >= 8.4.
+class _ {}
+INTERFACE _ {}
+trait _ {}
+enum /*comment*/_ {}
+
+// This deprecation also applies to namespaced OO structures!
+namespace Foo\Bar;
+
+class _ {}
+interface _ {}
+Trait _ {}
+eNuM /*comment*/_ {}
+
+// Live coding, this has to be the last test in the file.
+class

--- a/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreUnitTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenClassNameUnderscore sniff.
+ *
+ * @group forbiddenClassNameUnderscore
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\ForbiddenClassNameUnderscoreSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenClassNameUnderscoreUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test the sniff correctly detects OO structures named "_".
+     *
+     * @dataProvider dataForbiddenClassNameUnderscore
+     *
+     * @param int    $line Line number where the error should occur.
+     * @param string $type Type of OO structure.
+     *
+     * @return void
+     */
+    public function testForbiddenClassNameUnderscore($line, $type)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.4');
+        $error = \sprintf('Using a single underscore, "_", as %s name is deprecated since PHP 8.4.', $type);
+
+        $this->assertWarning($file, $line, $error);
+
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenClassNameUnderscore()
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataForbiddenClassNameUnderscore()
+    {
+        return [
+            [18, 'class'],
+            [19, 'interface'],
+            [20, 'trait'],
+            [21, 'enum'],
+            [26, 'class'],
+            [27, 'interface'],
+            [28, 'trait'],
+            [29, 'enum'],
+        ];
+    }
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 16 lines.
+        for ($line = 1; $line <= 16; $line++) {
+            $data[] = [$line];
+        }
+
+        $data[] = [32];
+
+        return $data;
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> . Using "_" as a class name is now deprecated.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_using_a_single_underscore_as_a_class_name

This commit introduces a new sniff to detect and flag this.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_using_a_single_underscore_as_a_class_name
* https://github.com/php/php-src/blob/81150187fb91b38e9437b12bfff467607c458c14/UPGRADING#L417-L418
* php/php-src#15360
* https://github.com/php/php-src/commit/0a23b0678da5534e33d3482c0b13924f7e924ab5

Related to #1731