### PR TITLE
PHP 8.4 | NewFunctionParameters: detect use of `$serial_hex` for openssl_csr_sign()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -628,6 +628,13 @@ class NewFunctionParametersSniff extends AbstractFunctionCallParameterSniff
                 '5.3'  => true,
             ],
         ],
+        'openssl_csr_sign' => [
+            7 => [
+                'name' => 'serial_hex',
+                '8.3'  => false,
+                '8.4'  => true,
+            ],
+        ],
         'openssl_decrypt' => [
             5 => [
                 'name'  => 'iv',

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
@@ -149,3 +149,5 @@ parse_url(
 
 posix_getrlimit($res);
 strrchr($haystack, $needle, $before_needle);
+$cert2 = openssl_csr_sign($csrdata, null, $privkey, 365, $args, serial_hex: 'DEADBEEF');
+$cert3 = openssl_csr_sign($csrdata, null, $privkey, 365, $args, 10, 'DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF');

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -150,6 +150,7 @@ class NewFunctionParametersUnitTest extends BaseSniffTestCase
             ['mysqli_rollback', 'flags', '5.4', [57], '5.5'],
             ['mysqli_rollback', 'name', '5.4', [57], '5.5'],
             ['nl2br', 'use_xhtml', '5.2', [58], '5.3'],
+            ['openssl_csr_sign', 'serial_hex', '8.3', [152, 153], '8.4'],
             ['openssl_decrypt', 'iv', '5.3.2', [59], '7.1', '5.3'], // OK version > version in which last parameter was added to the function.
             ['openssl_decrypt', 'tag', '7.0', [59], '7.1'],
             ['openssl_decrypt', 'aad', '7.0', [59], '7.1'],


### PR DESCRIPTION

> - OpenSSL:
>  . New serial_hex parameter added to openssl_csr_sign to allow setting serial
>    number in the hexadecimal format.

This commit accounts for the new function parameter.

Refs:
* https://github.com/php/php-src/blob/b56f81cddcb2c0642bbc6c4a8de5731dd3956995/UPGRADING#L606-L607
* php/php-src#13023
* https://github.com/php/php-src/commit/e0679f3d5ee939e6b68c03185efeed9e44c13717
* https://www.php.net/manual/en/function.openssl-csr-sign.php

Related to #1731