### PR TITLE
PHP 8.4 | :sparkles: New PHPCompatibility.ParameterValues.RemovedXmlSetHandlerCallbackUnset sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedXmlSetHandlerCallbackUnsetStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedXmlSetHandlerCallbackUnsetStandard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed xml_set_*_handler() callback unset"
+    >
+    <standard>
+    <![CDATA[
+    Passing an empty string to an xml_set_*_handler() callback parameter to unset a previously set handler is deprecated since PHP 8.4. Pass `null` instead.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: resetting the $handler to its default state by passing null.">
+        <![CDATA[
+xml_set_default_handler($parser, <em>null</em>);
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: resetting the $handler to its default state by passing an empty string.">
+        <![CDATA[
+xml_set_default_handler($parser, <em>''</em>);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedXmlSetHandlerCallbackUnsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedXmlSetHandlerCallbackUnsetSniff.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\PassedParameters;
+use PHPCSUtils\Utils\TextStrings;
+
+/**
+ * Detect calls to xml_set_*_handler() functions which try to unset the handler by passing an empty string.
+ *
+ * PHP version 8.4
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names
+ *
+ * @since 10.0.0
+ */
+final class RemovedXmlSetHandlerCallbackUnsetSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, array<int, string>>
+     */
+    protected $targetFunctions = [
+        'xml_set_character_data_handler' => [
+            2 => 'handler',
+        ],
+        'xml_set_default_handler' => [
+            2 => 'handler',
+        ],
+        'xml_set_element_handler' => [
+            2 => 'start_handler',
+            3 => 'end_handler',
+        ],
+        'xml_set_end_namespace_decl_handler' => [
+            2 => 'handler',
+        ],
+        'xml_set_external_entity_ref_handler' => [
+            2 => 'handler',
+        ],
+        'xml_set_notation_decl_handler' => [
+            2 => 'handler',
+        ],
+        'xml_set_processing_instruction_handler' => [
+            2 => 'handler',
+        ],
+        'xml_set_start_namespace_decl_handler' => [
+            2 => 'handler',
+        ],
+        'xml_set_unparsed_entity_decl_handler' => [
+            2 => 'handler',
+        ],
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrAbove('8.4') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File                  $phpcsFile    The file being scanned.
+     * @param int                                          $stackPtr     The position of the current token in the stack.
+     * @param string                                       $functionName The token content (function name) which was matched.
+     * @param array<int|string, array<string, int|string>> $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $tokens       = $phpcsFile->getTokens();
+        $functionLC   = \strtolower($functionName);
+        $functionInfo = $this->targetFunctions[$functionLC];
+
+        foreach ($functionInfo as $offset => $paramName) {
+            $targetParam = PassedParameters::getParameterFromStack($parameters, $offset, $paramName);
+            if ($targetParam === false) {
+                continue;
+            }
+
+            $callback = '';
+            for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
+                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
+                    continue;
+                }
+
+                if ($tokens[$i]['code'] === \T_STRING_CONCAT
+                    || $tokens[$i]['code'] === \T_START_HEREDOC
+                    || $tokens[$i]['code'] === \T_END_HEREDOC
+                    || $tokens[$i]['code'] === \T_START_NOWDOC
+                    || $tokens[$i]['code'] === \T_END_NOWDOC
+                ) {
+                    // Ignore.
+                    continue;
+                }
+
+                if ($tokens[$i]['code'] === \T_CONSTANT_ENCAPSED_STRING) {
+                    $callback .= TextStrings::stripQuotes($tokens[$i]['content']);
+                    continue;
+                }
+
+                if ($tokens[$i]['code'] === \T_HEREDOC || $tokens[$i]['code'] === \T_NOWDOC) {
+                    $callback .= $tokens[$i]['content'];
+                    continue;
+                }
+
+                // Anything else, variable/function call etc. Ignore. Either valid callback or undetermined.
+                continue 2;
+            }
+
+            // Allow for multi-line empty strings.
+            $callback = TextStrings::stripQuotes($callback);
+            $callback = \trim($callback);
+            if ($callback !== '') {
+                continue;
+            }
+
+            $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+
+            $msg  = 'Passing an empty string to reset the $%s for %s() is deprecated since PHP 8.4. Pass `null` instead.';
+            $code = 'Deprecated';
+            $data = [
+                $paramName,
+                $functionLC,
+            ];
+
+            $phpcsFile->addWarning($msg, $firstNonEmpty, $code, $data);
+        }
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedXmlSetHandlerCallbackUnsetUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedXmlSetHandlerCallbackUnsetUnitTest.inc
@@ -1,0 +1,75 @@
+<?php
+
+// Not our target.
+$obj->xml_set_default_handler($parser, '');
+MyClass::xml_set_default_handler($parser, '');
+My\Ns\xml_set_default_handler($parser, '');
+
+// Ignore, required param(s) missing, but that's not our concern.
+xml_set_notation_decl_handler();
+xml_set_end_namespace_decl_handler($parser);
+xml_set_external_entity_ref_handler(handlers: $handlerCallback, parser: $parser); // Typo in param name.
+
+// OK, valid callbacks.
+xml_set_character_data_handler($parser, 'callback_function');
+xml_set_element_handler($parser, [$this, 'method'], array('Class', 'method'));
+xml_set_start_namespace_decl_handler($parser, first_class_callable(...));
+xml_set_notation_decl_handler($parser, '' . 'trim');
+xml_set_notation_decl_handler($parser, 'trim' . '');
+
+xml_set_object($parser, $object);
+xml_set_default_handler($parser, 'callback_method_on_object'); // Well, not really, but that's not the concern of this sniff.
+
+\xml_set_unparsed_entity_decl_handler(
+    $parser,
+    function(XMLParser $parser, string $data): void {
+        do_something();
+    }
+);
+
+// Valid unset.
+xml_set_processing_instruction_handler($parser, null);
+
+// Undetermined. Ignore.
+xml_set_character_data_handler($parser, $invokableObject);
+xml_set_default_handler($parser, CALLBACK_IN_CONSTANT);
+xml_set_element_handler($parser, getCallBack(), $obj->callbackInProperty);
+
+// Not OK - deprecated in PHP >= 8.4.
+xml_set_character_data_handler($parser, '');
+XML_Set_Default_Handler($parser, /*comment*/''           /*comment*/);
+\xml_set_end_namespace_decl_handler(handler: '', parser: $parser);
+xml_set_element_handler(
+    $parser,
+    '',
+    '',
+);
+
+xml_set_notation_decl_handler($parser, <<<EOD
+EOD
+);
+xml_set_processing_instruction_handler($parser, <<<'EOD'
+
+EOD
+);
+
+// The below are of a slightly different nature.
+// In these cases, PHP doesn't throw the deprecation notice for passing a non-callable (empty string),
+// but actually interprets this as a callable string, then still throws the deprecation notice for
+// the string not being a valid callable and then also throws a Fatal Error on the (non-)"callback"
+// for the method lookup on an xml_set_object passed object failing.
+// As this is exactly what the change in PHP 8.4 is about, IMO it is fine for the sniff to flag these,
+// even though we do not do any tracing of whether a callable is actually callable.
+// In these specific cases, we can still be sure that the resulting "callable" will never be a valid
+// callable, so let's flag them.
+xml_set_external_entity_ref_handler($parser, handler: '' . '  ');
+xml_set_start_namespace_decl_handler($parser, "
+");
+xml_set_unparsed_entity_decl_handler($parser, '    ');
+xml_set_start_namespace_decl_handler($parser, <<<'EOD'
+
+
+
+
+EOD
+);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedXmlSetHandlerCallbackUnsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedXmlSetHandlerCallbackUnsetUnitTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedXmlSetHandlerCallbackUnset sniff.
+ *
+ * @group removedXmlSetHandlerCallbackUnset
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedXmlSetHandlerCallbackUnsetSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedXmlSetHandlerCallbackUnsetUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test the sniff correctly detects an empty string being passed as a callback parameter.
+     *
+     * @dataProvider dataRemovedXmlSetHandlerCallbackUnset
+     *
+     * @param int    $line         Line number where the error should occur.
+     * @param string $functionName Expected function name.
+     * @param string $paramName    Optional. Expected parameter name.
+     *                             Defaults to [$]handler.
+     *
+     * @return void
+     */
+    public function testRemovedXmlSetHandlerCallbackUnset($line, $functionName, $paramName = 'handler')
+    {
+        $file  = $this->sniffFile(__FILE__, '8.4');
+        $error = \sprintf(
+            'Passing an empty string to reset the $%s for %s() is deprecated since PHP 8.4. Pass `null` instead.',
+            $paramName,
+            $functionName
+        );
+
+        $this->assertWarning($file, $line, $error);
+
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedXmlSetHandlerCallbackUnset()
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataRemovedXmlSetHandlerCallbackUnset()
+    {
+        return [
+            [39, 'xml_set_character_data_handler'],
+            [40, 'xml_set_default_handler'],
+            [41, 'xml_set_end_namespace_decl_handler'],
+            [44, 'xml_set_element_handler', 'start_handler'],
+            [45, 'xml_set_element_handler', 'end_handler'],
+            [48, 'xml_set_notation_decl_handler'],
+            [51, 'xml_set_processing_instruction_handler'],
+            [65, 'xml_set_external_entity_ref_handler'],
+            [66, 'xml_set_start_namespace_decl_handler'],
+            [68, 'xml_set_unparsed_entity_decl_handler'],
+            [69, 'xml_set_start_namespace_decl_handler'],
+        ];
+    }
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 37 lines.
+        for ($line = 1; $line <= 37; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> . Passing non-callable strings to the xml_set_*_handler() functions is now
>   deprecated.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names

While PHPCS is not particularly suitable to validate whether a string is callable or not, the _"This would also mean to unset a handler the value of null must be used instead of an empty string which is also currently allowed."_ part of the RFC should be sniffable.

This commit introduces a new sniff to detect and flag this.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L496-L497
* php/php-src#15293
* https://github.com/php/php-src/commit/25b4696530c5dfad6b04a57c274200beec51ab0d

Related to #1731