### PR TITLE
PHP 8.4 | :sparkles: New PHPCompatibility.ParameterValues.RemovedDbaKeySplitNullFalse sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedDbaKeySplitNullFalseStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedDbaKeySplitNullFalseStandard.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed dba_key_split() null/false"
+    >
+    <standard>
+    <![CDATA[
+    Passing false or null as the $key to dba_key_split() is deprecated since PHP 8.4.
+
+    Make sure a valid (string) key is available before calling the dba_key_split() function.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: making sure that the key is not false or null before passing it to dba_key_split().">
+        <![CDATA[
+$key = dba_firstkey($dba);
+if (<em>$key !== false</em>) {
+    $split = dba_key_split(<em>$key</em>);
+}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: passing a potential false value, i.e. the result of a call to dba_firstkey() or dba_nextkey(), straight into a call to dba_key_split().">
+        <![CDATA[
+$split = dba_key_split(<em>dba_firstkey($dba)</em>);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedDbaKeySplitNullFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedDbaKeySplitNullFalseSniff.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Detect calls to dba_key_split() passing `false` or `null` as the key.
+ *
+ * PHP version 8.4
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_null_and_false_to_dba_key_split
+ * @link https://www.php.net/dba_key_split
+ *
+ * @since 10.0.0
+ */
+final class RemovedDbaKeySplitNullFalseSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, true>
+     */
+    protected $targetFunctions = [
+        'dba_key_split' => true,
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrAbove('8.4') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File                  $phpcsFile    The file being scanned.
+     * @param int                                          $stackPtr     The position of the current token in the stack.
+     * @param string                                       $functionName The token content (function name) which was matched.
+     * @param array<int|string, array<string, int|string>> $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 1, 'key');
+        if ($targetParam === false) {
+            return;
+        }
+
+        /*
+         * First try to determine if the parameter contents matches a function call to a dba_*key() function.
+         * We do this by basically getting a string representation of the parameter, but without
+         * whatever tokens are between parentheses.
+         */
+        $tokens                       = $phpcsFile->getTokens();
+        $contentToMatchAgainstPattern = '';
+        $firstNonEmpty                = null;
+
+        for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
+                continue;
+            }
+
+            if (isset($firstNonEmpty) === false) {
+                $firstNonEmpty = $i;
+            }
+
+            $contentToMatchAgainstPattern .= $tokens[$i]['content'];
+
+            if ($tokens[$i]['code'] === \T_OPEN_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_closer'])
+            ) {
+                $i = $tokens[$i]['parenthesis_closer'];
+                $contentToMatchAgainstPattern .= $tokens[$i]['content'];
+            }
+        }
+
+        if (\preg_match('`^[\\\\]?dba_(first|next)key\(\)$`i', $contentToMatchAgainstPattern) !== 1) {
+            /*
+             * The parameter value didn't match a call to one of the typical dba_*key() functions.
+             * Check if a hard-coded null or false was passed.
+             */
+            $contentLc = \strtolower($targetParam['clean']);
+            if ($contentLc !== 'null' && $contentLc !== 'false') {
+                return;
+            }
+        }
+
+        /*
+         * If we're still here, it means the parameter contained either a function call to a dba_*key() function
+         * or a hard-coded false/null value.
+         * In both cases, throwing the deprecation is warranted.
+         */
+        $msg  = 'Passing false or null as the $key to dba_key_split() is deprecated since PHP 8.4. Found: %s';
+        $code = 'Deprecated';
+        $data = [$targetParam['clean']];
+
+        $phpcsFile->addWarning($msg, $firstNonEmpty, $code, $data);
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.inc
@@ -1,0 +1,43 @@
+<?php
+
+// Not our target.
+$obj?->dba_key_split(false);
+MyClass::dba_key_split(null);
+My\Ns\dba_key_split(false);
+$class = new dba_key_split(\dba_firstkey($dba));
+
+// Ignore, required param(s) missing, but that's not our concern.
+dba_key_split();
+dba_key_split( keys: false); // Typo in param name.
+dba_key_split( /*comment*/ );
+
+// OK.
+dba_key_split('[key1]name1');
+\dba_key_split( /*comment*/ '[key1]name1' . '[key2]name2');
+
+// Undetermined. Ignore.
+dba_key_split($key);
+dba_key_split(KEY_IN_CONSTANT);
+dba_key_split(myDbaGetKey());
+
+// Not OK - deprecated in PHP >= 8.4.
+dba_key_split(false);
+DBA_KEY_SPLIT(key:   NULL );
+dba_key_split(
+    // phpcs:ignore Stnd.Cat.Sniff -- for (testing) reasons.
+    FALSE
+);
+\dba_key_split( /*comment*/ null /*comment*/ );
+
+// Typical real world code which would typically trigger the deprecation when the end of the DB is reached.
+// Even though this code is fine while not at the end of the DB, the sniff should still flag it as
+// without a check against the return value of `dba_[first|next]key()` before passing it to `dba_key_split()`,
+// this code _will_ result in the deprecation notice once the end of the DB is reached (or when an empty DB
+// is queried).
+dba_key_split(dba_firstkey($dba));
+dba_key_split(key: dba_nextkey($obj->get_dba()));
+dba_key_split(\dba_firstkey($this->dba));
+dba_key_split(
+    // Comment.
+    \dba_NextKey($dba)
+);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedDbaKeySplitNullFalse sniff.
+ *
+ * @group removedDbaKeySplitNullFalse
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedDbaKeySplitNullFalseSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedDbaKeySplitNullFalseUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test the sniff correctly detects null or false being passed as the $key parameter.
+     *
+     * @dataProvider dataRemovedDbaKeySplitNullFalse
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testRemovedDbaKeySplitNullFalse($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.4');
+        $error = 'Passing false or null as the $key to dba_key_split() is deprecated since PHP 8.4.';
+
+        $this->assertWarning($file, $line, $error);
+
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedDbaKeySplitNullFalse()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataRemovedDbaKeySplitNullFalse()
+    {
+        return [
+            [24],
+            [25],
+            [28],
+            [30],
+            [37],
+            [38],
+            [39],
+            [42],
+        ];
+    }
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 22 lines.
+        for ($line = 1; $line <= 22; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> . Passing null or false to dba_key_split() is deprecated.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_null_and_false_to_dba_key_split

This commit introduces a new sniff to detect and flag this.

The sniff checks for calls to the typical `dba_firstkey()` and `dba_nextkey()` functions being passed straight into a call to `dba_key_split()`. Both `dba_firstkey()` and `dba_nextkey()` can return `false`, so their return value needs to be checked before passing it on to `dba_key_split()`.

As a fall-back, though much less likely to match real-world code, the sniff also checks for hard-coded `false` or `null` values being passed to a call to `dba_key_split()`.

When the key is passed as a variable, the sniff will stay silent (undetermined).

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_null_and_false_to_dba_key_split
* https://github.com/php/php-src/blob/634708a14f9546cc81bc5f9bf269ec0c46743a0f/UPGRADING#L423-L425
* php/php-src#15297
* https://github.com/php/php-src/commit/bb2836eced81cdf7aeeddafb20c487cea0b5dfc8

Related to #1731