### PR TITLE
Classes/ForbiddenClassNameUnderscore: small test tweak

### DIFF
--- a/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreUnitTest.php
@@ -41,9 +41,6 @@ final class ForbiddenClassNameUnderscoreUnitTest extends BaseSniffTestCase
         $error = \sprintf('Using a single underscore, "_", as %s name is deprecated since PHP 8.4.', $type);
 
         $this->assertWarning($file, $line, $error);
-
-        $file = $this->sniffFile(__FILE__, '8.3');
-        $this->assertNoViolation($file, $line);
     }
 
     /**


### PR DESCRIPTION
Just noticed while looking at the merged PRs that this assertion is not needed, as this is already covered for the complete file in one go via the `testNoViolationsInFileOnValidVersion()` test method.