### PR TITLE
PHP 8.4 | NewClasses: handle classes introduced for resource to object conversion

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1000,6 +1000,32 @@ class NewClassesSniff extends Sniff
             '8.2'       => true,
             'extension' => 'random',
         ],
+
+        'Dba\Connection' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'dba',
+        ],
+        'Odbc\Connection' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'odbc',
+        ],
+        'Odbc\Result' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'odbc',
+        ],
+        'Soap\Sdl' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'soap',
+        ],
+        'Soap\Url' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'soap',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -58,6 +58,9 @@ class ReservedNamesSniff extends Sniff
         'PgSql'  => '8.1',
         'PSpell' => '8.1',
         'Random' => '8.2',
+        'Dba'    => '8.4',
+        'Odbc'   => '8.4',
+        'Soap'   => '8.4',
     ];
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -541,3 +541,7 @@ function my_pspell(
     PSpell\Config $config,
     PSpell\Dictionary $dictionary,
 ) {}
+
+function dba_get(Dba\Connection $connect) {}
+function odbc_get(Odbc\Connection $connect): Odbc\Result {}
+function soapy_goodness(Soap\Url $url): Soap\Sdl {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -258,6 +258,12 @@ class NewClassesUnitTest extends BaseSniffTestCase
             ['Random\Engine\Xoshiro256StarStar', '8.1', [477], '8.2'],
             ['Random\Engine\Secure', '8.1', [479], '8.2'],
 
+            ['Dba\Connection', '8.3', [545], '8.4'],
+            ['Odbc\Connection', '8.3', [546], '8.4'],
+            ['Odbc\Result', '8.3', [546], '8.4'],
+            ['Soap\Sdl', '8.3', [547], '8.4'],
+            ['Soap\Url', '8.3', [547], '8.4'],
+
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],
             ['dATeTiMe', '5.1', [148], '5.2'],

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
@@ -72,5 +72,10 @@ namespace Vtiful\Kernel\Sub;
 // Warning on PHP 7.4+.
 namespace Parle\Sub;
 
+// Error PHP 8.4+.
+namespace DBA;
+namespace Odbc\Connect;
+namespace Soap\Something;
+
 // Intentional parse error. This has to be the last test in the file.
 namespace PHP\Cli

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -68,6 +68,9 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [38, 'LDAP', '8.1', '8.0'],
             [39, 'PgSql', '8.1', '8.0'],
             [40, 'PSpell', '8.1', '8.0'],
+            [76, 'DBA', '8.4', '8.3'],
+            [77, 'Odbc', '8.4', '8.3'],
+            [78, 'Soap', '8.4', '8.3'],
         ];
     }
 
@@ -198,7 +201,7 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [30],
             [31],
             [32],
-            [76],
+            [81],
         ];
     }
 


### PR DESCRIPTION
There are on-going efforts to remove the use of resources and change these to opaque (final, non-serializable, non-constructable) objects.

This commit addresses detection of the use of these new classes introduced as part of these efforts in PHP 8.4.

As these classes are all namespaced and reserve additional top-level namespaces for PHP, the `Namespaces\ReservedNames` sniff has also been updated.

:point_right: Note: There is currently no sniff which examines how the return value of the affected function calls is handled. This could possible be added at some point in the future, though would be complicated, what with the many ways in which the return value could be checked.

Related to #1731

Refs:
* https://github.com/php/php-tasks/issues/6
* https://wiki.php.net/rfc/resource_to_object_conversion

## What's addressed in this commit

### DBA

> . dba_open() and dba_popen() will now return a Dba\Connection
>   object rather than a resource. Return value checks using is_resource()
>   should be replaced with checks for `false`.

Refs:
* https://github.com/php/php-src/blob/0f8259e896dd609aa9f5a8274ead17d81185a45c/UPGRADING#L48-L51
* php/php-src#14329
* https://github.com/php/php-src/commit/2097237da59f151491a984a864f9ae88b01180af

### ODBC

> . odbc_connect() and odbc_pconnect() will now return an Odbc\Connection
>   object rather than a resource. Return value checks using is_resource()
>   should be replaced with checks for `false`.
> . odbc_prepare(), odbc_exec(), and various other functions will now return
>   an Odbc\Result object rather than a resource. Return value checks using
>   is_resource() should be replaced with checks for `false`.

Refs:
* https://github.com/php/php-src/blob/e1c8329b8ca9222f7a5f48c1ca19e95129b807c0/UPGRADING#L86-L91
* php/php-src#12040
* https://github.com/php/php-src/commit/afd91fb9ac67dcd3125d2c618fbdb22b1f09539b

### SOAP

> . SoapClient::$httpurl is now a Soap\Url object rather than a resource.
>   Checks using is_resource() (i.e. is_resource($client->httpurl)) should be
>   replaced with checks for null (i.e. $client->httpurl !== null).
> . SoapClient::$sdl is now a Soap\Sdl object rather than a resource.
>   Checks using is_resource() (i.e. is_resource($client->sdl)) should be
>   replaced with checks for null (i.e. $client->sdl !== null).

Refs:
* https://github.com/php/php-src/blob/e1c8329b8ca9222f7a5f48c1ca19e95129b807c0/UPGRADING#L156-L161
* php/php-src#14121
* https://github.com/php/php-src/commit/44b3cb2a13aab761fad90001f4cb5e0a7e71406b
* https://github.com/php/php-src/commit/60336de2babc446522ab1cae9a2d367fbb38dc7b

---

## PHP 8.4 resource to object migrations not included in this commit

### COM

This conversion appears to be internal only and has no impact on userland.