### PR TITLE
PHP 8.4 | NewFunctions: detect use of new grapheme_str_split() function (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4984,6 +4984,11 @@ class NewFunctionsSniff extends Sniff
             '8.4'       => true,
             'extension' => 'bcmath',
         ],
+        'grapheme_str_split' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'intl',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1054,3 +1054,4 @@ socket_atmark();
 bcceil();
 bcfloor();
 bcround();
+grapheme_str_split();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1115,6 +1115,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['bcceil', '8.3', 1054, '8.4'],
             ['bcfloor', '8.3', 1055, '8.4'],
             ['bcround', '8.3', 1056, '8.4'],
+            ['grapheme_str_split', '8.3', 1057, '8.4'],
         ];
     }
 


### PR DESCRIPTION
> .  Added grapheme_str_split which allow to support emoji and Variation
>    Selectors.

Refs:
* https://wiki.php.net/rfc/grapheme_str_split
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L670-L671
* php/php-src#13580
* https://github.com/php/php-src/commit/44e8301cf6ec73cd15c62f01a01e248cca5395d2

Related to #1731