### PR TITLE
PHP 8.4 | NewClasses: detect use of new StreamBucket class (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1026,6 +1026,11 @@ class NewClassesSniff extends Sniff
             '8.4'       => true,
             'extension' => 'soap',
         ],
+        'StreamBucket' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'streams',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -545,3 +545,4 @@ function my_pspell(
 function dba_get(Dba\Connection $connect) {}
 function odbc_get(Odbc\Connection $connect): Odbc\Result {}
 function soapy_goodness(Soap\Url $url): Soap\Sdl {}
+function accessStreamBucket(StreamBucket $bucket) {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -263,6 +263,7 @@ class NewClassesUnitTest extends BaseSniffTestCase
             ['Odbc\Result', '8.3', [546], '8.4'],
             ['Soap\Sdl', '8.3', [547], '8.4'],
             ['Soap\Url', '8.3', [547], '8.4'],
+            ['StreamBucket', '8.3', [548], '8.4'],
 
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],


### PR DESCRIPTION
> . stream_bucket_make_writeable() and stream_bucket_new() will now return a
>   StreamBucket instance instead of an stdClass instance.
>   RFC: https://wiki.php.net/rfc/dedicated_stream_bucket

Note: this commit only adds detection of referencing of the new class (as a type declaration and such).

It does **not** check usage of the above mentioned functions, as the return value is still an object and has the same properties (and one extra) as the previous `stdClass` object, so code calling those functions should still work without any cross-version compatibility issues.

Also note that the RFC includes a proposal to deprecate the `$datalen` property in the return value in favour of the (new) `$dataLength` property. This proposal, however, is slated for the _next_ PHP version (8.5 or 9.0), not for PHP 8.4.

Refs:
* https://wiki.php.net/rfc/dedicated_stream_bucket
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L361-L363
* php/php-src#13111
* https://github.com/php/php-src/commit/be2f454d6ebcaf6f58c41544f21f53a5109b1e5d

Related to #1731