### PR TITLE
PHP 8.4 | NewFunctions: detect use of new mb_[uc|lc]first() functions (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4989,6 +4989,16 @@ class NewFunctionsSniff extends Sniff
             '8.4'       => true,
             'extension' => 'intl',
         ],
+        'mb_lcfirst' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'mbstring',
+        ],
+        'mb_ucfirst' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'mbstring',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1055,3 +1055,5 @@ bcceil();
 bcfloor();
 bcround();
 grapheme_str_split();
+mb_lcfirst();
+mb_ucfirst();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1116,6 +1116,8 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['bcfloor', '8.3', 1055, '8.4'],
             ['bcround', '8.3', 1056, '8.4'],
             ['grapheme_str_split', '8.3', 1057, '8.4'],
+            ['mb_lcfirst', '8.3', 1058, '8.4'],
+            ['mb_ucfirst', '8.3', 1059, '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . Added mb_ucfirst and mb_lcfirst functions.
>   RFC: https://wiki.php.net/rfc/mb_ucfirst

Refs:
* https://wiki.php.net/rfc/mb_ucfirst
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L681-L682
* php/php-src#13161
* https://github.com/php/php-src/commit/4d51bfa2702c0a6d3375f6358b7c8d9611fd72e9

Related to #1731