### PR TITLE
PHP 8.4 | NewClasses: add support for PDO driver specific subclasses (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1016,6 +1016,36 @@ class NewClassesSniff extends Sniff
             '8.4'       => true,
             'extension' => 'odbc',
         ],
+        'Pdo\DbLib' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'pdo',
+        ],
+        'Pdo\Firebird' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'pdo',
+        ],
+        'Pdo\Mysql' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'pdo',
+        ],
+        'Pdo\Odbc' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'pdo',
+        ],
+        'Pdo\Pgsql' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'pdo',
+        ],
+        'Pdo\Sqlite' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'pdo',
+        ],
         'Soap\Sdl' => [
             '8.3'       => false,
             '8.4'       => true,

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -60,6 +60,7 @@ class ReservedNamesSniff extends Sniff
         'Random' => '8.2',
         'Dba'    => '8.4',
         'Odbc'   => '8.4',
+        'Pdo'    => '8.4',
         'Soap'   => '8.4',
     ];
 

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -546,3 +546,11 @@ function dba_get(Dba\Connection $connect) {}
 function odbc_get(Odbc\Connection $connect): Odbc\Result {}
 function soapy_goodness(Soap\Url $url): Soap\Sdl {}
 function accessStreamBucket(StreamBucket $bucket) {}
+
+$db = new Pdo\DbLib();
+$anon = new class extends \Pdo\Firebird {
+    public Pdo\Mysql $prop;
+    public function ParamType(\Pdo\Odbc $param) {}
+    public function ReturnType( $a ) : Pdo\Pgsql {}
+};
+\Pdo\Sqlite::CLASS_CONSTANT;

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -264,6 +264,12 @@ class NewClassesUnitTest extends BaseSniffTestCase
             ['Soap\Sdl', '8.3', [547], '8.4'],
             ['Soap\Url', '8.3', [547], '8.4'],
             ['StreamBucket', '8.3', [548], '8.4'],
+            ['Pdo\DbLib', '8.3', [550], '8.4'],
+            ['Pdo\Firebird', '8.3', [551], '8.4'],
+            ['Pdo\Mysql', '8.3', [552], '8.4'],
+            ['Pdo\Odbc', '8.3', [553], '8.4'],
+            ['Pdo\Pgsql', '8.3', [554], '8.4'],
+            ['Pdo\Sqlite', '8.3', [556], '8.4'],
 
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
@@ -76,6 +76,7 @@ namespace Parle\Sub;
 namespace DBA;
 namespace Odbc\Connect;
 namespace Soap\Something;
+NAMESPACE Pdo\Subbie;
 
 // Intentional parse error. This has to be the last test in the file.
 namespace PHP\Cli

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -71,6 +71,7 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [76, 'DBA', '8.4', '8.3'],
             [77, 'Odbc', '8.4', '8.3'],
             [78, 'Soap', '8.4', '8.3'],
+            [79, 'Pdo', '8.4', '8.3'],
         ];
     }
 


### PR DESCRIPTION
> - PDO:
>  . Added support for driver-specific subclasses.
>    RFC: https://wiki.php.net/rfc/pdo_driver_specific_subclasses
>    This RFC adds subclasses for PDO in order to better support
>    database-specific functionalities. The new classes are
>    instantiatable either via calling the PDO::connect() method
>    or by invoking their constructor directly.
>
> - PDO_DBLIB:
>  . Added class Pdo\DbLib.
>
> - PDO_FIREBIRD:
>  . Added class Pdo\Firebird.
>
> - PDO_MYSQL:
>  . Added class Pdo\Mysql.
>
> - PDO_ODBC:
>  . Added class Pdo\Odbc.
>
> - PDO_PGSQL:
>  . Added class Pdo\Pgsql.
>
> - PDO_SQLITE:
>  . Added class Pdo\Sqlite.

This RFC was accepted during the PHP 8.3 dev round, but the PR wasn't ready before feature freeze.

As these classes are all namespaced and reserve additional top-level namespaces for PHP, the `Namespaces\ReservedNames` sniff has also been updated.

Refs:
* https://wiki.php.net/rfc/pdo_driver_specific_subclasses
* https://github.com/php/php-src/blob/b56f81cddcb2c0642bbc6c4a8de5731dd3956995/UPGRADING#L338-L362
* php/php-src#12804
* https://github.com/php/php-src/commit/d6a0b3af68a55836ad7d24d4d832898c5b8c2d8e
* php/php-src#14069
* https://github.com/php/php-src/commit/6ec4220148b10d2102baf2e0cd2d6d60bbb3f709

Related to #1731