### PR TITLE
PHP 8.4 | NewFunctions: detect use of new http_*_last_response_header() functions (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4969,6 +4969,14 @@ class NewFunctionsSniff extends Sniff
             'extension' => 'sockets',
         ],
 
+        'http_clear_last_response_header' => [
+            '8.3' => false,
+            '8.4' => true,
+        ],
+        'http_get_last_response_header' => [
+            '8.3' => false,
+            '8.4' => true,
+        ],
         'bcceil' => [
             '8.3'       => false,
             '8.4'       => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1057,3 +1057,5 @@ bcround();
 grapheme_str_split();
 mb_lcfirst();
 mb_ucfirst();
+http_get_last_response_header();
+http_clear_last_response_header();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1118,6 +1118,8 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['grapheme_str_split', '8.3', 1057, '8.4'],
             ['mb_lcfirst', '8.3', 1058, '8.4'],
             ['mb_ucfirst', '8.3', 1059, '8.4'],
+            ['http_get_last_response_header', '8.3', 1060, '8.4'],
+            ['http_clear_last_response_header', '8.3', 1061, '8.4'],
         ];
     }
 


### PR DESCRIPTION

> . Added the http_get_last_response_headers() and
>   http_clear_last_response_headers() that allows retrieving the same content
>   as the magic $http_response_header variable.

Refs:
* https://wiki.php.net/rfc/http-last-response-headers
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L722-L724
* php/php-src#12500
* https://github.com/php/php-src/commit/47a199c8b43dbf84e66ff6b63f665541ab4eb1d0

Related to #1731