### PR TITLE
PHP 8.4 | RemovedIniDirectives: detect use of session.sid_* (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -730,6 +730,14 @@ class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.4'       => true,
             'extension' => 'oci8',
         ],
+        'session.sid_length' => [
+            '8.4'       => false,
+            'extension' => 'session',
+        ],
+        'session.sid_bits_per_character' => [
+            '8.4'       => false,
+            'extension' => 'session',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -514,3 +514,9 @@ $test = ini_get('oci8.privileged_connect');
 
 ini_set('oci8.statement_cache_size', 0);
 $test = ini_get('oci8.statement_cache_size');
+
+ini_set('session.sid_length', 1);
+$test = ini_get('session.sid_length');
+
+ini_set('session.sid_bits_per_character', 1);
+$test = ini_get('session.sid_bits_per_character');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -162,6 +162,9 @@ class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
             ['date.sunset_zenith', '8.1', [442, 443], '8.0'],
             ['filter.default', '8.1', [445, 446], '8.0'],
             ['filter.default_options', '8.1', [448, 449], '8.0'],
+
+            ['session.sid_length', '8.4', [518, 519], '8.3'],
+            ['session.sid_bits_per_character', '8.4', [521, 522], '8.3'],
         ];
     }
 


### PR DESCRIPTION
> . Changing the INI settings session.sid_length and session.sid_bits_per_character
>   is deprecated. Update the session storage backend to accept 32 character
>   hexadecimal session IDs and stop changing these two INI settings.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4

This commit accounts for the deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#sessionsid_length_and_sessionsid_bits_per_character
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L471-L474
* php/php-src#15213
* https://github.com/php/php-src/commit/e8ff7c70f9669f1a54c47c018ccc0f80bc0c929b

Related to #1731