### PR TITLE
Composer: update PHP Parallel Lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "phpcsstandards/phpcsutils": "^1.0.12"
   },
   "require-dev": {
-    "php-parallel-lint/php-parallel-lint": "^1.3.2",
+    "php-parallel-lint/php-parallel-lint": "^1.4.0",
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
     "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.1.0",
     "phpcsstandards/phpcsdevcs": "^1.1.3",


### PR DESCRIPTION
PHP Parallel Lint released a new version a while ago with (preliminary, but probably full) PHP 8.4 support.

Lets'set that version as the minimum.

Ref: https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.4.0