### PR TITLE
PHP 8.4 | NewFunctions/NewClasses: detect use of new request_parse_body() functionality (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1300,6 +1300,11 @@ class NewClassesSniff extends Sniff
             '8.2'       => true,
             'extension' => 'random',
         ],
+
+        'RequestParseBodyException' => [
+            '8.3' => false,
+            '8.4' => true,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4977,6 +4977,10 @@ class NewFunctionsSniff extends Sniff
             '8.3' => false,
             '8.4' => true,
         ],
+        'request_parse_body' => [
+            '8.3' => false,
+            '8.4' => true,
+        ],
         'bcceil' => [
             '8.3'       => false,
             '8.4'       => true,

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -554,3 +554,6 @@ $anon = new class extends \Pdo\Firebird {
     public function ReturnType( $a ) : Pdo\Pgsql {}
 };
 \Pdo\Sqlite::CLASS_CONSTANT;
+
+try {
+} catch(RequestParseBodyException) {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -320,6 +320,7 @@ class NewClassesUnitTest extends BaseSniffTestCase
             ['Random\RandomError', '8.1', [481], '8.2'],
             ['Random\BrokenRandomEngineError', '8.1', [481], '8.2'],
             ['Random\RandomException', '8.1', [482], '8.2'],
+            ['RequestParseBodyException', '8.3', [559], '8.4'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1059,3 +1059,4 @@ mb_lcfirst();
 mb_ucfirst();
 http_get_last_response_header();
 http_clear_last_response_header();
+request_parse_body();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1120,6 +1120,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['mb_ucfirst', '8.3', 1059, '8.4'],
             ['http_get_last_response_header', '8.3', 1060, '8.4'],
             ['http_clear_last_response_header', '8.3', 1061, '8.4'],
+            ['request_parse_body', '8.3', 1062, '8.4'],
         ];
     }
 


### PR DESCRIPTION

> . Added request_parse_body() function that allows parsing RFC1867 (multipart)
>   requests in non-POST HTTP requests.
>   RFC: https://wiki.php.net/rfc/rfc1867-non-post

This commit accounts for the new function introduced via the RFC, as well as for the new `RequestParseBodyException` class.

Refs:
* https://wiki.php.net/rfc/rfc1867-non-post
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L222
* php/php-src#11472
* https://github.com/php/php-src/commit/cd66fcc68be96408423e49ae01de5719c02c86d1

Related to #1731