### PR TITLE
PHP 8.4 | RemovedFunctions: detect use of xml_set_object (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5669,6 +5669,11 @@ class RemovedFunctionsSniff extends Sniff
             '8.4'       => true,
             'extension' => 'pspell',
         ],
+        'xml_set_object' => [
+            '8.4'         => false,
+            'alternative' => 'a fully formed callback in a xml_set_*_handler() function',
+            'extension'   => 'xml',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1387,3 +1387,5 @@ pspell_new_personal();
 pspell_save_wordlist();
 pspell_store_replacement();
 pspell_suggest();
+
+xml_set_object();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -164,6 +164,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
 
             ['intlcal_set', '8.4', 'IntlCalendar::setDate() or IntlCalendar::setDateTime()', 1239, '8.3'],
             ['intlgregcal_create_instance', '8.4', 'IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime()', 1240, '8.3'],
+            ['xml_set_object', '8.4', 'a fully formed callback in a xml_set_*_handler() function', 1391, '8.3'],
         ];
     }
 


### PR DESCRIPTION
> . The xml_set_object() function has been deprecated.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names

This commit accounts for the deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L496-L497
* php/php-src#15293
* https://github.com/php/php-src/commit/25b4696530c5dfad6b04a57c274200beec51ab0d

Related to #1731