### PR TITLE
PCRERegexTrait::getRegexModifiers(): bug fix - ignore text within brackets

### DIFF
--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -163,6 +163,22 @@ trait PCRERegexTrait
          * and function calls. We are only concerned with the strings.
          */
         for ($i = $patternInfo['start']; $i <= $patternInfo['end']; $i++) {
+            // Ignore anything within square brackets.
+            if (isset($tokens[$i]['bracket_opener'], $tokens[$i]['bracket_closer'])
+                && $i === $tokens[$i]['bracket_opener']
+            ) {
+                $i = $tokens[$i]['bracket_closer'];
+                continue;
+            }
+
+            // Skip past nested arrays, function calls and arbitrary groupings.
+            if ($tokens[$i]['code'] === \T_OPEN_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_closer'])
+            ) {
+                $i = $tokens[$i]['parenthesis_closer'];
+                continue;
+            }
+
             if (isset(Collections::textStringStartTokens()[$tokens[$i]['code']]) === false) {
                 continue;
             }

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
@@ -58,3 +58,7 @@ preg_match('{.(?P<test>.).}n', 'abc', $m);
 preg_match('/.(.)./ri', 'abc', $m);
 preg_match('`.(?P<test>.).`r', 'abc', $m);
 preg_match('{A\x{17f}\x{212a}Z}xr', 'abc', $m);
+
+// Issue #1764 - safeguard against false positives for text within brackets.
+preg_match_all( $my->get_regex('_regexp'), $text, $matches );
+preg_match_all( $regexes[ $type . '_regexp' ], $text, $matches );

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -100,6 +100,8 @@ class NewPCREModifiersUnitTest extends BaseSniffTestCase
             [18],
             [28],
             [49],
+            [63],
+            [64],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.inc
@@ -233,3 +233,7 @@ preg_replace( limit: $limit, count: $count, pattern: '/some text/emS', replaceme
 
 // Test handling of more complex embedded variables and expressions.
 preg_replace("/double-quoted/${e->{$z}}", $Replace, $Source); // Ok.
+
+// Safeguard against false positives for text within brackets.
+preg_replace( $my->get_regex('_regexp'), $replace, $subject );
+preg_replace( $regexes[ $type . '_regexp' ], $replace, $subject );

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -193,6 +193,10 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTestCase
 
             // Named parameters.
             [231],
+
+            // Issue #1764 - text within brackets should be ignored.
+            [238],
+            [239],
         ];
     }
 


### PR DESCRIPTION
When the regex pattern is retrieved via a function call, an unrelated - i.e. not part of the actual regex - text parameter may be passed.
When the regex pattern is retrieved from an array, the key may contain a text string. Again, this text string would not be part of the actual regex.

In both cases, any such text string should be ignored when collecting the regex parts to eventually determine if there are modifiers we can examine.

Fixed now by skipping over anything within brackets.

Includes tests.