### PR TITLE
PHP 8.4 | NewClasses: detect use of `BcMath\Number` (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1001,6 +1001,11 @@ class NewClassesSniff extends Sniff
             'extension' => 'random',
         ],
 
+        'BcMath\Number' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'bcmath',
+        ],
         'Dba\Connection' => [
             '8.3'       => false,
             '8.4'       => true,

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -51,6 +51,7 @@ class ReservedNamesSniff extends Sniff
         'PHP'    => '5.3',
 
         // Top-level namespace names in use in bundled extensions.
+        'BcMath' => '8.4',
         'FFI'    => '7.4',
         'FTP'    => '8.1',
         'IMAP'   => '8.1', // Unbundled from PHP in PHP 8.4.

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -557,3 +557,5 @@ $anon = new class extends \Pdo\Firebird {
 
 try {
 } catch(RequestParseBodyException) {}
+
+function mycalc( BcMath\Number $number) {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -270,6 +270,7 @@ class NewClassesUnitTest extends BaseSniffTestCase
             ['Pdo\Odbc', '8.3', [553], '8.4'],
             ['Pdo\Pgsql', '8.3', [554], '8.4'],
             ['Pdo\Sqlite', '8.3', [556], '8.4'],
+            ['BcMath\Number', '8.3', [561], '8.4'],
 
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
@@ -77,6 +77,7 @@ namespace DBA;
 namespace Odbc\Connect;
 namespace Soap\Something;
 NAMESPACE Pdo\Subbie;
+namespace BcMath;
 
 // Intentional parse error. This has to be the last test in the file.
 namespace PHP\Cli

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -72,6 +72,7 @@ class ReservedNamesUnitTest extends BaseSniffTestCase
             [77, 'Odbc', '8.4', '8.3'],
             [78, 'Soap', '8.4', '8.3'],
             [79, 'Pdo', '8.4', '8.3'],
+            [80, 'BcMath', '8.4', '8.3'],
         ];
     }
 


### PR DESCRIPTION
> - BCMath:
>  . Added BcMath\Number class. It is an immutable object, has methods that are
>    equivalent to existing BCMath calculation functions, and can also be calculated
>    using operators.
>    The existing BCMath function returned a string for each calculation, but this
>    class returns an object.
>    RFC: https://wiki.php.net/rfc/support_object_type_in_bcmath,
>    https://wiki.php.net/rfc/fix_up_bcmath_number_class

This commit accounts for the new class.

As this class is namespaced and reserves an additional top-level namespaces for PHP, the `Namespaces\ReservedNames` sniff has also been updated.

Refs:
* https://wiki.php.net/rfc/support_object_type_in_bcmath
* https://wiki.php.net/rfc/fix_up_bcmath_number_class
* https://github.com/php/php-src/blob/e358634cdce6a7505b7d422c23ec205a483ad2fc/UPGRADING#L876-L883
* php/php-src#13741
* https://github.com/php/php-src/commit/fad899e5662d0a929d8462dd8239b0489dd9b53f

Related to #1731