### PR TITLE
PHP 8.4 | NewFunctions: detect use of new mb_*trim() functions (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5011,6 +5011,21 @@ class NewFunctionsSniff extends Sniff
             '8.4'       => true,
             'extension' => 'mbstring',
         ],
+        'mb_ltrim' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'mbstring',
+        ],
+        'mb_rtrim' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'mbstring',
+        ],
+        'mb_trim' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'mbstring',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1060,3 +1060,6 @@ mb_ucfirst();
 http_get_last_response_header();
 http_clear_last_response_header();
 request_parse_body();
+mb_ltrim();
+mb_rtrim();
+mb_trim();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1121,6 +1121,9 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['http_get_last_response_header', '8.3', 1060, '8.4'],
             ['http_clear_last_response_header', '8.3', 1061, '8.4'],
             ['request_parse_body', '8.3', 1062, '8.4'],
+            ['mb_ltrim', '8.3', 1063, '8.4'],
+            ['mb_rtrim', '8.3', 1064, '8.4'],
+            ['mb_trim', '8.3', 1065, '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . Added mb_trim, mb_ltrim and mb_rtrim functions.
>   RFC: https://wiki.php.net/rfc/mb_trim
>   Note: this was amended by GH-13820 to fix GH-13815.

Refs:
* https://wiki.php.net/rfc/mb_trim
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L678-L680
* php/php-src#12459
* https://github.com/php/php-src/commit/a80b6d7b99ae885cb450a563a788f57917cef74e
* php/php-src#13820
* https://github.com/php/php-src/commit/f81370847c63f5a6675a1747e2235b774eb9ca8c

Related to #1731