### PR TITLE
PHP 8.4 | RemovedFunctions: detect use of mysqli_ping (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5385,6 +5385,11 @@ class RemovedFunctionsSniff extends Sniff
             'alternative' => 'IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime()',
             'extension'   => 'intl',
         ],
+        'mysqli_ping' => [
+            '8.4'         => false,
+            'alternative' => 'exception catching on normal queries or, for long running processes, sending a "DO 1" query',
+            'extension'   => 'mysqli',
+        ],
         'oci_bind_array_by_name' => [
             '8.4'       => true,
             'extension' => 'oci8',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1389,3 +1389,4 @@ pspell_store_replacement();
 pspell_suggest();
 
 xml_set_object();
+mysqli_ping();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -165,6 +165,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['intlcal_set', '8.4', 'IntlCalendar::setDate() or IntlCalendar::setDateTime()', 1239, '8.3'],
             ['intlgregcal_create_instance', '8.4', 'IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime()', 1240, '8.3'],
             ['xml_set_object', '8.4', 'a fully formed callback in a xml_set_*_handler() function', 1391, '8.3'],
+            ['mysqli_ping', '8.4', 'exception catching on normal queries or, for long running processes, sending a "DO 1" query', 1392, '8.3'],
         ];
     }
 


### PR DESCRIPTION
> . The mysqli_ping() function and mysqli::ping() method are now deprecated,
>   as the reconnect feature was removed in PHP 8.2.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4#mysqli_ping_and_mysqliping

This commit accounts for the deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#mysqli_ping_and_mysqliping
* https://github.com/php/php-src/blob/634708a14f9546cc81bc5f9bf269ec0c46743a0f/UPGRADING#L451-L453
* php/php-src#11945
* https://github.com/php/php-src/commit/cbcad9fdaf816e4512cecfb6c1d50fcc0ea7294d

Related to #1731