### PR TITLE
PHP 8.4 | NewClasses: detect use of ReflectionConstant

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1051,6 +1051,11 @@ class NewClassesSniff extends Sniff
             '8.4'       => true,
             'extension' => 'pdo',
         ],
+        'ReflectionConstant' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'reflection',
+        ],
         'Soap\Sdl' => [
             '8.3'       => false,
             '8.4'       => true,

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -559,3 +559,4 @@ try {
 } catch(RequestParseBodyException) {}
 
 function mycalc( BcMath\Number $number) {}
+$c = new ReflectionConstant($name);

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -271,6 +271,7 @@ class NewClassesUnitTest extends BaseSniffTestCase
             ['Pdo\Pgsql', '8.3', [554], '8.4'],
             ['Pdo\Sqlite', '8.3', [556], '8.4'],
             ['BcMath\Number', '8.3', [561], '8.4'],
+            ['ReflectionConstant', '8.3', [562], '8.4'],
 
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],


### PR DESCRIPTION
> - Reflection:
>  . ReflectionConstant was introduced.

This commit accounts for the new class.

Refs:
* https://github.com/php/php-src/blob/b56f81cddcb2c0642bbc6c4a8de5731dd3956995/UPGRADING#L376
* php/php-src#13669
* https://github.com/php/php-src/commit/e23440e5a64879ba00c8755e24b7a9ce0560fd08

Related to #1731