### PR TITLE
PHP 8.4 | NewFunctions: detect use of new array functions (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4969,6 +4969,22 @@ class NewFunctionsSniff extends Sniff
             'extension' => 'sockets',
         ],
 
+        'array_all' => [
+            '8.3' => false,
+            '8.4' => true,
+        ],
+        'array_any' => [
+            '8.3' => false,
+            '8.4' => true,
+        ],
+        'array_find' => [
+            '8.3' => false,
+            '8.4' => true,
+        ],
+        'array_find_key' => [
+            '8.3' => false,
+            '8.4' => true,
+        ],
         'http_clear_last_response_header' => [
             '8.3' => false,
             '8.4' => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1063,3 +1063,7 @@ request_parse_body();
 mb_ltrim();
 mb_rtrim();
 mb_trim();
+array_all();
+array_any();
+array_find();
+\array_find_key();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1124,6 +1124,10 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['mb_ltrim', '8.3', 1063, '8.4'],
             ['mb_rtrim', '8.3', 1064, '8.4'],
             ['mb_trim', '8.3', 1065, '8.4'],
+            ['array_all', '8.3', 1066, '8.4'],
+            ['array_any', '8.3', 1067, '8.4'],
+            ['array_find', '8.3', 1068, '8.4'],
+            ['array_find_key', '8.3', 1069, '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . Added functions array_find(), array_find_key(), array_all(), and
>   array_any().
>   RFC: https://wiki.php.net/rfc/array_find

Refs:
* https://wiki.php.net/rfc/array_find
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L726-L728
* php/php-src#14108
* https://github.com/php/php-src/commit/e4a8d5b16fe6f6f6f910173dde42119bd41ca299

Related to #1731