### PR TITLE
PHP 8.4 | RemovedFunctions: detect use of mysqli_refresh (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5390,6 +5390,11 @@ class RemovedFunctionsSniff extends Sniff
             'alternative' => 'exception catching on normal queries or, for long running processes, sending a "DO 1" query',
             'extension'   => 'mysqli',
         ],
+        'mysqli_refresh' => [
+            '8.4'         => false,
+            'alternative' => 'a FLUSH SQL statement',
+            'extension'   => 'mysqli',
+        ],
         'oci_bind_array_by_name' => [
             '8.4'       => true,
             'extension' => 'oci8',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1390,3 +1390,4 @@ pspell_suggest();
 
 xml_set_object();
 mysqli_ping();
+mysqli_refresh();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -166,6 +166,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['intlgregcal_create_instance', '8.4', 'IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime()', 1240, '8.3'],
             ['xml_set_object', '8.4', 'a fully formed callback in a xml_set_*_handler() function', 1391, '8.3'],
             ['mysqli_ping', '8.4', 'exception catching on normal queries or, for long running processes, sending a "DO 1" query', 1392, '8.3'],
+            ['mysqli_refresh', '8.4', 'a FLUSH SQL statement', 1393, '8.3'],
         ];
     }
 


### PR DESCRIPTION
> . The mysqli_refresh() function and mysqli::refresh() method are now deprecated.
>   If this functionality is needed a SQL "FLUSH" command can be used instead.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_mysqli_refresh

This commit accounts for the deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_mysqli_refresh
* https://github.com/php/php-src/blob/634708a14f9546cc81bc5f9bf269ec0c46743a0f/UPGRADING#L457-L460
* php/php-src#11929
* https://github.com/php/php-src/commit/42336e135962f80924c83746d36d6f04949a0cea

Related to #1731