### PR TITLE
PHP 8.4 | NewFunctions: detect use of new fpow() function (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -4985,6 +4985,10 @@ class NewFunctionsSniff extends Sniff
             '8.3' => false,
             '8.4' => true,
         ],
+        'fpow' => [
+            '8.3' => false,
+            '8.4' => true,
+        ],
         'http_clear_last_response_header' => [
             '8.3' => false,
             '8.4' => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1067,3 +1067,4 @@ array_all();
 array_any();
 array_find();
 \array_find_key();
+fpow();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1128,6 +1128,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['array_any', '8.3', 1067, '8.4'],
             ['array_find', '8.3', 1068, '8.4'],
             ['array_find_key', '8.3', 1069, '8.4'],
+            ['fpow', '8.3', 1070, '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . Added function fpow() following rules of IEEE 754.
>   RFC: https://wiki.php.net/rfc/raising_zero_to_power_of_negative_number

This commit accounts for the new function introduced via the RFC.

In my opinion, the associated deprecation of `**` and `pow()` operations for `0` with a negative power is unsniffable as it is extremely unlikely that any such calculations with both numbers hard-coded will ever be found and PHPCS is not suitable for variable value tracing throughout a codebase.

Refs:
* https://wiki.php.net/rfc/raising_zero_to_power_of_negative_number
* https://github.com/php/php-src/blob/c42615782334323511cda18a8f0dd3dc19ed6256/UPGRADING#L725
* php/php-src#13128
* https://github.com/php/php-src/commit/23afe57f01e0915eef246eba60e60fda74fd2dcf

Related to #1731