### PR TITLE
PHP 8.4 | RemovedFunctions: detect use of mysqli_kill (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5385,6 +5385,11 @@ class RemovedFunctionsSniff extends Sniff
             'alternative' => 'IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime()',
             'extension'   => 'intl',
         ],
+        'mysqli_kill' => [
+            '8.4'         => false,
+            'alternative' => 'a KILL CONNECTION/QUERY SQL statement',
+            'extension'   => 'mysqli',
+        ],
         'mysqli_ping' => [
             '8.4'         => false,
             'alternative' => 'exception catching on normal queries or, for long running processes, sending a "DO 1" query',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1391,3 +1391,4 @@ pspell_suggest();
 xml_set_object();
 mysqli_ping();
 mysqli_refresh();
+mysqli_kill();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -167,6 +167,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['xml_set_object', '8.4', 'a fully formed callback in a xml_set_*_handler() function', 1391, '8.3'],
             ['mysqli_ping', '8.4', 'exception catching on normal queries or, for long running processes, sending a "DO 1" query', 1392, '8.3'],
             ['mysqli_refresh', '8.4', 'a FLUSH SQL statement', 1393, '8.3'],
+            ['mysqli_kill', '8.4', 'a KILL CONNECTION/QUERY SQL statement', 1394, '8.3'],
         ];
     }
 


### PR DESCRIPTION
> . The mysqli_kill() function and mysqli::kill() method are now deprecated.
>   If this functionality is needed a SQL "KILL" command can be used instead.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_mysqli_kill

This commit accounts for the deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_mysqli_kill
* https://github.com/php/php-src/blob/634708a14f9546cc81bc5f9bf269ec0c46743a0f/UPGRADING#L454-L456
* php/php-src#11926
* https://github.com/php/php-src/commit/7801f40449ba3b46d4cf6d5b8417b7c274c25f95

Related to #1731