### PR TITLE
Cast undefined testVersion to string to trigger "better" error

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -128,7 +128,7 @@ abstract class Sniff implements PHPCS_Sniff
         static $arrTestVersions = array();
 
         $default     = array(null, null);
-        $testVersion = trim(PHPCSHelper::getConfigData('testVersion'));
+        $testVersion = trim((string) PHPCSHelper::getConfigData('testVersion'));
 
         if (empty($testVersion) === false && isset($arrTestVersions[$testVersion]) === false) {
 


### PR DESCRIPTION
**Note:** This PR is against `master`, so for a potential version `9.3.6`.

👋 Hi there!

I understand that the most recent version, 9.3.5, is quite old, and I also know there have been a lot of changes made for the upcoming release. However, I don't know when that will land, so I wanted to fix a small issue I was encountering on an older project that does not specify a testVersion (range). In recent versions of PHP, `trim` expects a `string` value, so passing `null` to it will throw, depending on your PHP configuration.

![image](https://github.com/user-attachments/assets/3d1a9801-1cd8-4f5f-9986-7c452fb21e15)

To me, it makes sense to treat a missing `tesVersion` the same way than having an empty config value defined (via CLI or config), and prevent throwing the PHP-internal type mismatch error.

If you agree, this small fix could form a new patch version. But I understand if you want to address this in the upcoming big release only.

Either way, thanks!