### PR TITLE
PHP 8.4 | RemovedFunctions: detect use of lcg_value (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5684,6 +5684,11 @@ class RemovedFunctionsSniff extends Sniff
             '8.4'       => true,
             'extension' => 'pspell',
         ],
+        'lcg_value' => [
+            '8.4'         => false,
+            'alternative' => 'Random\Randomizer::getFloat()',
+            'extension'   => 'random',
+        ],
         'xml_set_object' => [
             '8.4'         => false,
             'alternative' => 'a fully formed callback in a xml_set_*_handler() function',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1392,3 +1392,4 @@ xml_set_object();
 mysqli_ping();
 mysqli_refresh();
 mysqli_kill();
+lcg_value();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -168,6 +168,7 @@ class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['mysqli_ping', '8.4', 'exception catching on normal queries or, for long running processes, sending a "DO 1" query', 1392, '8.3'],
             ['mysqli_refresh', '8.4', 'a FLUSH SQL statement', 1393, '8.3'],
             ['mysqli_kill', '8.4', 'a KILL CONNECTION/QUERY SQL statement', 1394, '8.3'],
+            ['lcg_value', '8.4', 'Random\Randomizer::getFloat()', 1395, '8.3'],
         ];
     }
 


### PR DESCRIPTION
> . lcg_value() is deprecated, as the function is broken in multiple ways.
>   Use \Random\Randomizer::getFloat() instead.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4

This commit accounts for the deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_lcg_value
* https://github.com/php/php-src/blob/634708a14f9546cc81bc5f9bf269ec0c46743a0f/UPGRADING#L480-L482
* php/php-src#15211
* https://github.com/php/php-src/commit/f5f92941537993d871888608dae224d1c0474786

Related to #1731