### PR TITLE
PHP 8.4 | NewFunctions: detect use of new bcdivmod() function (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5006,6 +5006,11 @@ class NewFunctionsSniff extends Sniff
             '8.4'       => true,
             'extension' => 'bcmath',
         ],
+        'bcdivmod' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'bcmath',
+        ],
         'bcfloor' => [
             '8.3'       => false,
             '8.4'       => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1090,3 +1090,4 @@ sodium_crypto_aead_aegis256_encrypt();
 sodium_crypto_aead_aegis256_keygen();
 openssl_password_hash();
 openssl_password_verify();
+bcdivmod();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1151,6 +1151,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['sodium_crypto_aead_aegis256_keygen', '8.3', 1090, '8.4'],
             ['openssl_password_hash', '8.3', 1091, '8.4'],
             ['openssl_password_verify', '8.3', 1092, '8.4'],
+            ['bcdivmod', '8.3', 1093, '8.4'],
         ];
     }
 


### PR DESCRIPTION
> - BCMath:
>  . Added bcdivmod().
>    RFC: https://wiki.php.net/rfc/add_bcdivmod_to_bcmath

Refs:
* https://wiki.php.net/rfc/add_bcdivmod_to_bcmath
* https://github.com/php/php-src/blob/612a6ad0af7150d27baa383bacbe5aad73441ba2/UPGRADING#L793-L794
* php/php-src#15740
* https://github.com/php/php-src/commit/f6db576c3162dfb3cd1fa5437c0eb70836d4c2ab

Related to #1731