### PR TITLE
PHP 7.4/8.4 | :sparkles: New `PHPCompatibility.ParameterValues.RemovedProprietaryCSVEscaping` sniff

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedProprietaryCSVEscapingStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedProprietaryCSVEscapingStandard.xml
@@ -10,9 +10,8 @@
     ]]>
     </standard>
     <code_comparison>
-        <code title="Cross-version compatible: not passing the $escape parameter or passing a non-empty string.">
+        <code title="Cross-version compatible: passing a non-empty string as the $escape parameter.">
         <![CDATA[
-fgetcsv($stream);
 fputcsv($stream, $fields, ',', '"', <em>'\\'</em>);
         ]]>
         </code>
@@ -29,15 +28,37 @@ fgetcsv($stream, null, ',', '"', <em>''</em>);
     ]]>
     </standard>
     <code_comparison>
-        <code title="Cross-version compatible: not passing the $escape parameter or passing a non-empty string.">
+        <code title="Cross-version compatible: passing a non-empty string as the $escape parameter.">
         <![CDATA[
-str_getcsv($string_to_parse);
 str_getcsv($string_to_parse, ',', '"', <em>'\\'</em>);
         ]]>
         </code>
         <code title="Not cross-version compatible: passing an empty string will fall through to the default value in PHP &lt;= 7.3 and will disable the proprietary escaping mechanism in PHP &gt;= 7.4.">
         <![CDATA[
 str_getcsv($string_to_parse, ',', '"', <em>''</em>);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    As of PHP 8.4, a deprecation notice will be thrown when the `$escape` parameter is not passed when calling fputcsv(), fgetcsv() or str_getcsv().
+
+    The default value of the $escape parameter - "\\" - will change in a future version of PHP and passing the parameter should prevent problems such as data exported as escaped, but imported as not escaped.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: passing the $escape parameter.">
+        <![CDATA[
+fputcsv($stream, $fields, ',', '"', <em>'\\'</em>);
+fgetcsv($stream, null, ',', '"', <em>''</em>);
+str_getcsv($string_to_parse, escape: <em>'~'</em>);
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: not passing the $escape parameter, thereby relying on the default value for the parameter.">
+        <![CDATA[
+fputcsv($stream, $fields);
+fgetcsv($stream);
+str_getcsv($string_to_parse);
         ]]>
         </code>
     </code_comparison>

--- a/PHPCompatibility/Docs/ParameterValues/RemovedProprietaryCSVEscapingStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedProprietaryCSVEscapingStandard.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed Proprietary CSV Escaping"
+    >
+    <standard>
+    <![CDATA[
+    As of PHP 7.4, fputcsv() and fgetcsv() accept an empty string for the `$escape` parameter.
+    This effectively disables the proprietary PHP escaping mechanism for CSV.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: not passing the $escape parameter or passing a non-empty string.">
+        <![CDATA[
+fgetcsv($stream);
+fputcsv($stream, $fields, ',', '"', <em>'\\'</em>);
+        ]]>
+        </code>
+        <code title="PHP &gt;= 7.4: passing an empty string to disable the proprietary escaping mechanism.">
+        <![CDATA[
+fgetcsv($stream, null, ',', '"', <em>''</em>);
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    For str_getcsv(), the behaviour when passing an empty string has changed accordingly in PHP 7.4. Previously, an empty string would fall through to the default parameter value.
+    Now it will disable the proprietary PHP escaping mechanism.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: not passing the $escape parameter or passing a non-empty string.">
+        <![CDATA[
+str_getcsv($string_to_parse);
+str_getcsv($string_to_parse, ',', '"', <em>'\\'</em>);
+        ]]>
+        </code>
+        <code title="Not cross-version compatible: passing an empty string will fall through to the default value in PHP &lt;= 7.3 and will disable the proprietary escaping mechanism in PHP &gt;= 7.4.">
+        <![CDATA[
+str_getcsv($string_to_parse, ',', '"', <em>''</em>);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedProprietaryCSVEscapingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedProprietaryCSVEscapingSniff.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Detect code affected by the various steps taken to deprecate (and eventually remove) the proprietary CSV escaping mechanism.
+ *
+ * PHP 7.4: Passing an empty string for the `$escape` parameter is allowed and will effectively deactivate the escaping.
+ *          For the fputcsv() and the fgetcsv() functions, passing an empty string was previously not allowed.
+ *          For the str_getcsv() function, this constitutes a behavioural change as an empty string would previously fall through
+ *          to the default value.
+ *
+ * PHP version 7.4
+ *
+ * @link https://wiki.php.net/rfc/kill-csv-escaping
+ *
+ * @since 10.0.0
+ */
+final class RemovedProprietaryCSVEscapingSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, array<string, int|string>>
+     */
+    protected $targetFunctions = [
+        'fputcsv' => [
+            'position' => 5,
+            'name'     => 'escape',
+        ],
+        'fgetcsv' => [
+            'position' => 5,
+            'name'     => 'escape',
+        ],
+        'str_getcsv' => [
+            'position' => 4,
+            'name'     => 'escape',
+        ],
+    ];
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrBelow('7.3') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File                  $phpcsFile    The file being scanned.
+     * @param int                                          $stackPtr     The position of the current token in the stack.
+     * @param string                                       $functionName The token content (function name) which was matched.
+     * @param array<int|string, array<string, int|string>> $parameters   Array with information about the parameters.
+     *
+     * @return void
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $functionLC  = \strtolower($functionName);
+        $paramInfo   = $this->targetFunctions[$functionLC];
+        $targetParam = PassedParameters::getParameterFromStack($parameters, $paramInfo['position'], $paramInfo['name']);
+        if ($targetParam === false) {
+            return;
+        }
+
+        if ($targetParam['clean'] !== '""' && $targetParam['clean'] !== "''") {
+            // Not a hard-coded empty string. Bow out, either valid non-empty string or undetermined.
+            return;
+        }
+
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+
+        // Special case the changed behaviour for str_getcsv().
+        if ($functionLC === 'str_getcsv') {
+            if (ScannedCode::shouldRunOnOrAbove('7.4') === false) {
+                // Only report the error when the code needs to run on both PHP <= 7.3 as well as PHP >= 7.4.
+                return;
+            }
+
+            $msg  = 'Passing an empty string as the $%s parameter to %s() would fall through to the default value ("\\") in PHP 7.3 and earlier, while in PHP 7.4+ it will disable the proprietary CSV escaping mechanism.';
+            $code = 'ChangedBehaviour';
+            $data = [
+                $paramInfo['name'],
+                $functionLC,
+            ];
+
+            $phpcsFile->addError($msg, $firstNonEmpty, $code, $data);
+            return;
+        }
+
+        $msg  = 'Passing an empty string as the $%s parameter to %s() to disable the proprietary CSV escaping mechanism was not supported in PHP 7.3 or earlier.';
+        $code = 'EmptyStringNotAllowed';
+        $data = [
+            $paramInfo['name'],
+            $functionLC,
+        ];
+
+        $phpcsFile->addError($msg, $firstNonEmpty, $code, $data);
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedProprietaryCSVEscapingUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedProprietaryCSVEscapingUnitTest.inc
@@ -6,7 +6,7 @@ MyClass::fgetcsv($stream, $length, $separator, $enclosure, '');
 My\Ns\str_getcsv($string, $separator, $enclosure, '');
 $class = new fputcsv($stream, $fields, $separator, $enclosure, '');
 
-// Undetermined. Ignore.
+// Undetermined value. Ignore for the PHP 7.4 change as undetermined. OK for PHP 8.4 as param was passed.
 fputcsv($stream, $fields, $separator, $enclosure, $escape);
 fgetcsv($stream, $length, $separator, $enclosure, $escape);
 \str_getcsv($string, $separator, $enclosure, $escape);
@@ -15,12 +15,12 @@ fgetcsv($stream, $length, $separator, $enclosure, MyClass::ESCAPE_CHAR);
 \str_getcsv($string, $separator, $enclosure, $obj->escape_char);
 fgetcsv($stream, $length, $separator, $enclosure, $obj?->get(['escape', '']));
 
-// OK, target param is a non-empty string.
+// OK in all versions, target param is a non-empty string.
 \fputcsv($stream, $fields, $separator, $enclosure, '\\');
 fgetcsv($stream, escape: '$');
 str_getcsv($string, $separator, $enclosure, " ");
 
-// OK, target param not provided, nothing to do.
+// OK for PHP < 8.4. Flag for PHP 8.4+. Target param not provided.
 fputcsv();
 \fgetcsv();
 str_getcsv();

--- a/PHPCompatibility/Tests/ParameterValues/RemovedProprietaryCSVEscapingUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedProprietaryCSVEscapingUnitTest.inc
@@ -1,0 +1,44 @@
+<?php
+
+// Not our target.
+$obj?->fputcsv($stream, $fields, $separator, $enclosure, '');
+MyClass::fgetcsv($stream, $length, $separator, $enclosure, '');
+My\Ns\str_getcsv($string, $separator, $enclosure, '');
+$class = new fputcsv($stream, $fields, $separator, $enclosure, '');
+
+// Undetermined. Ignore.
+fputcsv($stream, $fields, $separator, $enclosure, $escape);
+fgetcsv($stream, $length, $separator, $enclosure, $escape);
+\str_getcsv($string, $separator, $enclosure, $escape);
+fputcsv($stream, $fields, $separator, $enclosure, get_escape(''));
+fgetcsv($stream, $length, $separator, $enclosure, MyClass::ESCAPE_CHAR);
+\str_getcsv($string, $separator, $enclosure, $obj->escape_char);
+fgetcsv($stream, $length, $separator, $enclosure, $obj?->get(['escape', '']));
+
+// OK, target param is a non-empty string.
+\fputcsv($stream, $fields, $separator, $enclosure, '\\');
+fgetcsv($stream, escape: '$');
+str_getcsv($string, $separator, $enclosure, " ");
+
+// OK, target param not provided, nothing to do.
+fputcsv();
+\fgetcsv();
+str_getcsv();
+fputcsv($stream, $fields);
+\fgetcsv($stream);
+str_getcsv($string);
+fputcsv($stream, $fields, $separator $enclosure, eol: "\r\n");
+fgetcsv($stream, $length, $separator, $enclosure, /* comment */);
+\str_getcsv($string, escape_char: ''); // Typo in param name.
+\fgetcsv($string, escape: /*comment*/, length: 10); // Parse error, empty param value, but not our concern.
+
+// PHP 7.4+: passing an empty string as the $escape parameter will disable escaping.
+fputcsv($stream, $fields, /*comment*/ escape: /*comment*/ ''/*comment*/ );
+\fgetcsv($stream, $length, $separator, $enclosure, '');
+str_getcsv(
+    $string,
+    $separator,
+    $enclosure,
+    // phpcs:ignore Stnd.Cat.Sniff -- for (testing) reasons.
+    "",
+);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedProprietaryCSVEscapingUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedProprietaryCSVEscapingUnitTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedProprietaryCSVEscaping sniff.
+ *
+ * @group removedProprietaryCSVEscaping
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedProprietaryCSVEscapingSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedProprietaryCSVEscapingUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test the sniff correctly detects an empty string being passed as the $escape parameter.
+     *
+     * @dataProvider dataNewEmptyStringDisablesEscaping
+     *
+     * @param int    $line   Line number where the error should occur.
+     * @param string $fnName Expected function name.
+     *
+     * @return void
+     */
+    public function testNewEmptyStringDisablesEscaping($line, $fnName)
+    {
+        $file  = $this->sniffFile(__FILE__, '7.3');
+        $error = \sprintf('Passing an empty string as the $escape parameter to %s() to disable the proprietary CSV escaping mechanism was not supported in PHP 7.3 or earlier.', $fnName);
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewEmptyStringDisablesEscaping()
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataNewEmptyStringDisablesEscaping()
+    {
+        return [
+            [36, 'fputcsv'],
+            [37, 'fgetcsv'],
+        ];
+    }
+
+    /**
+     * Test the sniff correctly detects an empty string being passed as the $escape parameter.
+     *
+     * @dataProvider dataChangedBehaviourStrGetCsvWithEmptyString
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testChangedBehaviourStrGetCsvWithEmptyString($line)
+    {
+        $file  = $this->sniffFile(__FILE__, '7.3-');
+        $error = 'Passing an empty string as the $escape parameter to str_getcsv() would fall through to the default value ("\\") in PHP 7.3 and earlier, while in PHP 7.4+ it will disable the proprietary CSV escaping mechanism.';
+
+        $this->assertError($file, $line, $error);
+
+        // This error should only show if `testVersion` includes both PHP <= 7.3 as well as PHP >= 7.4.
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewChangedBehaviourStrGetCsvWithEmptyString()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataChangedBehaviourStrGetCsvWithEmptyString()
+    {
+        return [
+            [43],
+        ];
+    }
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 34 lines.
+        for ($line = 1; $line <= 34; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
### PHP 7.4 | New `PHPCompatibility.ParameterValues.RemovedProprietaryCSVEscaping` sniff

> - Standard:
>  . fputcsv() and fgetcsv() now accept an empty string as $escape argument,
>    which disables the proprietary PHP escaping mechanism. The behavior of
>    str_getcsv() has been adjusted accordingly (formerly, an empty string was
>    identical to using the default).

This adds a new sniff to detect code subject to this change.

The one thing I'm not 100% sure about, is whether this should be an `error` or a `warning`.

In PHP 7.3 and lower, passing an empty string as `$escape` to `fputcsv()` and `fgetcsv()` would result in a PHP warning: "Warning: fputcsv(): escape must be a character", not in a fatal error, but as the resulting CSV data can be significantly different - which could break imports/exports, I've elected to make it an error for PHPCompatibility anyway.

Refs:
* https://wiki.php.net/rfc/kill-csv-escaping (step 1)
* https://github.com/php/php-src/blob/004cb827501d1ddaf98daacb185a53e0816f78a7/UPGRADING#L489-L493
* php/php-src#3515
* php/php-src@3b0f051

### PHP 8.4 | ParameterValues/RemovedProprietaryCSVEscaping: detect new deprecation

> - Standard:
>  . Using the default value for $escape parameter of:
>   - fputcsv()
>   - fgetcsv()
>   - str_getcsv()
>   is now deprecated. It must be passed explicitly either positionally or via named arguments.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism

This commit updates the `PHPCompatibility.ParameterValues.RemovedProprietaryCSVEscaping` sniff to start flagging code affected by this next step in the plan to "kill csv escaping".

Note: the changelog entry isn't very clear and the implementation is different from the implementation proposed via the RFC.

In practice, it now comes down to: passing _any_ value to the `$escape` parameter is okay.
Not passing the parameter, i.e. relying on the default value for the `$escape` parameter will now trigger a deprecation notice.
Also see: https://3v4l.org/lsjvA/rfc#vgit.master

Refs:
* https://wiki.php.net/rfc/kill-csv-escaping (step 2)
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_proprietary_csv_escaping_mechanism
* https://github.com/php/php-src/blob/ee7e21020e74f02ca1d0ebee462ef9878fe9d55a/UPGRADING#L612-L617
* php/php-src#15362
* php/php-src@c818d94
* php/php-src#15569
* php/php-src@f756b96

Related to #1731