### PR TITLE
PHP 8.4 | NewFunctions: detect use of new opcache_jit_blacklist() function

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5051,6 +5051,11 @@ class NewFunctionsSniff extends Sniff
             '8.4'       => true,
             'extension' => 'mbstring',
         ],
+        'opcache_jit_blacklist' => [
+            '8.3'       => false,
+            '8.4'       => true,
+            'extension' => 'opcache',
+        ],
         'openssl_password_hash' => [
             '8.3'       => false,
             '8.4'       => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1091,3 +1091,4 @@ sodium_crypto_aead_aegis256_keygen();
 openssl_password_hash();
 openssl_password_verify();
 bcdivmod();
+opcache_jit_blacklist();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1152,6 +1152,7 @@ class NewFunctionsUnitTest extends BaseSniffTestCase
             ['openssl_password_hash', '8.3', 1091, '8.4'],
             ['openssl_password_verify', '8.3', 1092, '8.4'],
             ['bcdivmod', '8.3', 1093, '8.4'],
+            ['opcache_jit_blacklist', '8.3', 1094, '8.4'],
         ];
     }
 


### PR DESCRIPTION
> - OPCache:
>  . Added opcache_jit_blacklist function. It allows skipping the tracing JIT
>   execution of select functions.

Refs:
* https://github.com/php/php-src/blob/612a6ad0af7150d27baa383bacbe5aad73441ba2/UPGRADING#L832-L834
* php/php-src#15559
* https://github.com/php/php-src/commit/654b787ee16ae6ebf9ee94507631da9251ff077b

Related to #1731