### PR TITLE
Sniff updates for upcoming "yield from" changes in PHPCS 3.11.0

### DIFF
--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.inc
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.inc
@@ -149,3 +149,12 @@ function nestedEnumReturn() {
 
     yield 20;
 }
+
+// Ensure no duplicate errors will be thrown when "yield from" is multiple tokens.
+$generator = function () {
+    yield
+        /*comment*/
+        from
+        bar();
+    return $foo;
+}

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -56,6 +56,7 @@ class NewGeneratorReturnUnitTest extends BaseSniffTestCase
             [64],
             [83],
             [101],
+            [159],
         ];
     }
 

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.inc
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.inc
@@ -254,6 +254,15 @@ enum SuitB: string implements Colorful {
   case Spades = 'S';
 }
 
+// Ensure the change in PHP 8.3 in regards to multi-line yield from with comment is handled in
+// a PHPCS cross-version compatible manner and doesn't yield duplicate messages.
+function testYieldFromMultilineWithComment() {
+    yield
+
+        // Comment
+        from [3, 4];
+}
+
 __halt_compiler();
 
 bla();

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -214,6 +214,39 @@ class NewKeywordsUnitTest extends BaseSniffTestCase
             [75],
             [76],
             [78],
+            [260],
+        ];
+    }
+
+    /**
+     * Test against false positives (duplicates) for a multi-token yield from keyword.
+     *
+     * @dataProvider dataYieldFromNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testYieldFromNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testYieldFrom()
+     *
+     * @return array
+     */
+    public static function dataYieldFromNoFalsePositives()
+    {
+        return [
+            [77],
+            [261],
+            [262],
+            [263],
         ];
     }
 
@@ -623,7 +656,7 @@ class NewKeywordsUnitTest extends BaseSniffTestCase
          * not be reported.
          */
         $file = $this->sniffFile(__FILE__, '5.2');
-        $this->assertNoViolation($file, 260);
+        $this->assertNoViolation($file, 269);
     }
 
 


### PR DESCRIPTION

### Generators/NewGeneratorReturn: add extra test

Since PHP 8.3 comments are allowed between the `yield` and `from` keywords in a `yield from` expression.
As of PHPCS 3.11.0, this will be properly supported by PHPCS itself (PR to add support is currently open).

This commit only adds an extra test to the `NewGeneratorReturn` sniff to safeguard that this will not cause the sniff to throw duplicate error messages.

Related to:
* php/php-src#14926
* PHPCSStandards/PHP_CodeSniffer#529
* PHPCSStandards/PHP_CodeSniffer#647

### Keywords/NewKeywords: handle "yield from" PHPCS cross-version

Follow up on #1478

The PHP 8.3 tokenization change for `yield from` with a comment between will be handled more consistently (and in the same way PHP cross-version) as of PHPCS 3.11.0.

This updates the sniff to handle this correctly for both "PHP 8.3+ with PHPCS < 3.11.0" as well as "PHPCS 3.11.0", while still preventing duplicate messages for multi-token `yield from` keywords.

Includes an additional test to safeguard this.

Related to:
* PHPCSStandards/PHP_CodeSniffer#529
* PHPCSStandards/PHP_CodeSniffer#647