### PR TITLE
PHP 8.3 | :sparkles: New `PHPCompatibility.Generators.NewYieldFromComment` sniff

### DIFF
--- a/PHPCompatibility/Docs/Generators/NewYieldFromCommentStandard.xml
+++ b/PHPCompatibility/Docs/Generators/NewYieldFromCommentStandard.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Yield From Comment"
+    >
+    <standard>
+    <![CDATA[
+    Having a comment between the "yield" and "from" keywords in a "yield from" expression is allowed since PHP 8.3.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: yield from without comment.">
+        <![CDATA[
+function myGenerator() {
+    <em>yield from</em> foo();
+}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.3: yield and from keywords separated by a comment.">
+        <![CDATA[
+function myGenerator() {
+    <em>yield /*comment*/ from</em> foo();
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Generators/NewYieldFromCommentSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewYieldFromCommentSniff.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Generators;
+
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * As of PHP 8.3, there can be a comment between the "yield" and "from" keywords.
+ *
+ * PHP version 8.3
+ *
+ * @link https://github.com/php/php-src/issues/14926
+ *
+ * @since 10.0.0
+ */
+class NewYieldFromCommentSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            \T_YIELD_FROM,
+            \T_YIELD, // Only needed for PHPCS < 3.11.0 on PHP < 8.3.
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void|int Void or a stack pointer to skip forward.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrBelow('8.2') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $content      = $tokens[$stackPtr]['content'];
+        $yieldFromEnd = $stackPtr;
+
+        if ($tokens[$stackPtr]['code'] === \T_YIELD) {
+            /*
+             * Only needed for PHPCS < 3.11.0 on PHP < 8.3.
+             * Once support for PHPCS < 3.11.0 has been dropped, this can be removed.
+             */
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($nextNonEmpty === false) {
+                // Live coding or parse error.
+                return;
+            }
+
+            if ($tokens[$nextNonEmpty]['code'] !== \T_STRING || \strtolower($tokens[$nextNonEmpty]['content']) !== 'from') {
+                // Not "yield from". This must be an ordinary "yield".
+                return;
+            }
+
+            $yieldFromEnd = $nextNonEmpty;
+
+        } else {
+            /*
+             * Handle potentially multi-token "yield from" expressions.
+             */
+            if (\strtolower(\trim($content)) === 'yield') {
+                for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
+                    if ($tokens[$i]['code'] === \T_YIELD_FROM && \strtolower(\trim($tokens[$i]['content'])) === 'from') {
+                        $content     .= $tokens[$i]['content'];
+                        $yieldFromEnd = $i;
+                        break;
+                    }
+
+                    if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false && $tokens[$i]['code'] !== \T_YIELD_FROM) {
+                        // Shouldn't be possible. Just to be on the safe side.
+                        return; // @codeCoverageIgnore
+                    }
+
+                    $content .= $tokens[$i]['content'];
+                }
+            }
+
+            $contentSansKeywords = \substr($content, 5, -4);
+
+            if (\trim($contentSansKeywords) === '') {
+                return ($yieldFromEnd + 1);
+            }
+        }
+
+        $phpcsFile->addError(
+            'Comment(s) between the "yield" and "from" keywords were not supported in PHP 8.2 or earlier',
+            $stackPtr,
+            'Found'
+        );
+
+        // No need to look at this expression again.
+        return ($yieldFromEnd + 1);
+    }
+}

--- a/PHPCompatibility/Tests/Generators/NewYieldFromCommentUnitTest.inc
+++ b/PHPCompatibility/Tests/Generators/NewYieldFromCommentUnitTest.inc
@@ -1,0 +1,41 @@
+<?php
+
+// OK.
+function YieldNotFrom() {
+    yield foo();
+}
+
+function YieldFromSingleSpace() {
+    yield from foo();
+}
+
+function YieldFromMultiSpace() {
+    Yield           from foo();
+}
+
+function YieldFromNewLine() {
+    yield
+        FROM foo();
+}
+
+// PHP 8.3+
+function YieldFromSingleLineWithComment() {
+    yield  /*comment */ from foo();
+}
+
+function YieldFromMultiLineWithComment() {
+    YIELD
+    // comment.
+    from foo();
+}
+
+function YieldFromMultiLineWithAnnotation() {
+    yield
+    // phpcs:ignore Stnd.Cat -- for reasons.
+    From foo();
+}
+
+// Intentional parse error.
+// Only needed for PHPCS < 3.11.0 with PHP < 8.3. This test can be removed once support for PHPCS < 3.11.0 has been dropped.
+function YieldLiveCoding() {
+    yield

--- a/PHPCompatibility/Tests/Generators/NewYieldFromCommentUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewYieldFromCommentUnitTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Generators;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewYieldFromComment sniff.
+ *
+ * @group newYieldFromComment
+ * @group generators
+ *
+ * @covers \PHPCompatibility\Sniffs\Generators\NewYieldFromCommentSniff
+ *
+ * @since 10.0.0
+ */
+class NewYieldFromCommentUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test detection of comments between "yield" and "from".
+     *
+     * @dataProvider dataNewYieldFromComment
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewYieldFromComment($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertError($file, $line, 'Comment(s) between the "yield" and "from" keywords were not supported in PHP 8.2 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewYieldFromComment()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNewYieldFromComment()
+    {
+        return [
+            [23],
+            [27],
+            [33],
+        ];
+    }
+
+
+    /**
+     * Test the sniff doesn't throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 20 lines.
+        for ($line = 1; $line <= 20; $line++) {
+            $data[] = [$line];
+        }
+
+        // Live coding test.
+        $data[] = [41];
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION

> . In addition to whitespace characters, now comments are allowed between
>   `yield` and `from`. The whole "construct" (e.g. `yield /* comment */ from`)
>   is reported as a single `T_YIELD_FROM` token by the tokenizer.

This commit adds a new sniff which detects this in a PHPCS cross-version compatible manner.

Once support for PHPCS < 3.11.0 has been dropped, this sniff can be simplified, but IMO, this sniff alone is not enough reason to raise the minimum supported PHPCS version, especially as working around the different tokenizations isn't that complicated.

Includes tests.
Includes documentation.

Refs:
* php/php-src#14926
* https://github.com/php/php-src/blob/e4010fcf957c62ddb70f8d3296d52c5486a84d4d/UPGRADING#L48-L50
* php/php-src#10125
* https://github.com/php/php-src/commit/f291d37a1a7d78e841f40a4410359548bc73de1b

Related to #1589
Fixes #1720