### PR TITLE
GH Actions: always quote variables

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -47,9 +47,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install PHP
@@ -85,7 +85,7 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
-        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: Run the unit tests (PHPUnit < 10)
         if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,15 +122,15 @@ jobs:
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
           if [ ${{ matrix.custom_ini }} == "true" ]; then
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1, short_open_tag=On' >> $GITHUB_OUTPUT
+              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1, short_open_tag=On' >> "$GITHUB_OUTPUT"
             else
-              echo 'PHP_INI=error_reporting=-1, display_errors=On, short_open_tag=On, zend.assertions=1' >> $GITHUB_OUTPUT
+              echo 'PHP_INI=error_reporting=-1, display_errors=On, short_open_tag=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             fi
           else
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
+              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             else
-              echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
+              echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             fi
           fi
 
@@ -172,7 +172,7 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
-        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: Run the unit tests (PHPUnit < 10)
         if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
@@ -226,15 +226,15 @@ jobs:
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
           if [ ${{ matrix.custom_ini }} == "true" ]; then
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1, short_open_tag=On' >> $GITHUB_OUTPUT
+              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1, short_open_tag=On' >> "$GITHUB_OUTPUT"
             else
-              echo 'PHP_INI=error_reporting=-1, display_errors=On, short_open_tag=On, zend.assertions=1' >> $GITHUB_OUTPUT
+              echo 'PHP_INI=error_reporting=-1, display_errors=On, short_open_tag=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             fi
           else
             if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
+              echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             else
-              echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> $GITHUB_OUTPUT
+              echo 'PHP_INI=error_reporting=-1, display_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             fi
           fi
 
@@ -265,7 +265,7 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
-        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: "DEBUG: Show grabbed version"
         run: echo ${{ steps.phpunit_version.outputs.VERSION }}


### PR DESCRIPTION
... to satisfy shellcheck rule SC2086: "Double quote to prevent globbing and word splitting".

Ref: https://www.shellcheck.net/wiki/SC2086