### PR TITLE
GH Actions: use the xmllint-validate action runner and enhance checks

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -49,29 +49,17 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
-      # This should not be blocking for this job, so ignore any errors from this step.
-      # Ref: https://github.com/dotnet/core/issues/4167
-      - name: Update the available packages list
-        continue-on-error: true
-        run: sudo apt-get update
+      - name: Validate ruleset XML file against schema
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "PHPCompatibility/ruleset.xml"
+          xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
 
-      - name: Install xmllint
-        run: sudo apt-get install --no-install-recommends -y libxml2-utils
-
-      # Show XML violations inline in the file diff.
-      # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - name: Enable showing XML issues inline
-        uses: korelstar/xmllint-problem-matcher@v1
-
-      # Validate the Ruleset XML file.
-      # @link http://xmlsoft.org/xmllint.html
-      - name: Validate ruleset against schema
-        run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd PHPCompatibility/ruleset.xml
-
-      # Validate the Documentation XML files.
-      - name: Validate documentation against schema
-        run: xmllint --noout --schema vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd ./PHPCompatibility/Docs/*/*Standard.xml
+      - name: Validate documentation XML files against schema
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "./PHPCompatibility/Docs/*/*Standard.xml"
+          xsd-file: "vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd"
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -61,6 +61,30 @@ jobs:
           pattern: "./PHPCompatibility/Docs/*/*Standard.xml"
           xsd-file: "vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd"
 
+      - name: Validate Project PHPCS ruleset against schema
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpcs.xml.dist"
+          xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
+
+      - name: "Validate PHPUnit < 10 config for use with PHPUnit 8"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunit.xml.dist"
+          xsd-file: "vendor/phpunit/phpunit/schema/8.5.xsd"
+
+      - name: "Validate PHPUnit < 10 config for use with PHPUnit 9"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunit.xml.dist"
+          xsd-file: "vendor/phpunit/phpunit/schema/9.2.xsd"
+
+      - name: "Validate PHPUnit 10+ config for use with PHPUnit 10"
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "phpunit10.xml.dist"
+          xsd-file: "vendor/phpunit/phpunit/phpunit.xsd"
+
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
         id: phpcs

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      XMLLINT_INDENT: '    '
       # - COMPOSER_ROOT_VERSION is needed to get round the recursive dependency when using CI.
       COMPOSER_ROOT_VERSION: '10.99.99'
 
@@ -70,10 +69,6 @@ jobs:
       - name: Validate ruleset against schema
         run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd PHPCompatibility/ruleset.xml
 
-      # Check the code-style consistency of the XML file.
-      - name: Check XML code style
-        run: diff -B ./PHPCompatibility/ruleset.xml <(xmllint --format "./PHPCompatibility/ruleset.xml")
-
       # Validate the Documentation XML files.
       - name: Validate documentation against schema
         run: xmllint --noout --schema vendor/phpcsstandards/phpcsdevtools/DocsXsd/phpcsdocs.xsd ./PHPCompatibility/Docs/*/*Standard.xml
@@ -92,6 +87,34 @@ jobs:
       # At a later stage the documentation check can be activated.
       - name: Check sniff feature completeness
         run: composer check-complete
+
+  xml-cs:
+    name: 'XML Code style'
+    runs-on: ubuntu-latest
+
+    env:
+      XMLLINT_INDENT: '    '
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
+      # This should not be blocking for this job, so ignore any errors from this step.
+      # Ref: https://github.com/dotnet/core/issues/4167
+      - name: Update the available packages list
+        continue-on-error: true
+        run: sudo apt-get update
+
+      - name: Install xmllint
+        run: sudo apt-get install --no-install-recommends -y libxml2-utils
+
+      # Show XML violations inline in the file diff.
+      - name: Enable showing XML issues inline
+        uses: korelstar/xmllint-problem-matcher@v1
+
+      - name: Check XML code style
+        run: diff -B ./PHPCompatibility/ruleset.xml <(xmllint --format "./PHPCompatibility/ruleset.xml")
 
   verify-tests:
     name: 'Check test files are up to date'


### PR DESCRIPTION
### GH Actions: split XML code style check off from "Basic QA"check 

The intention is for there to be a dedicated action runner available at some point for XML code style checking, so let's move this to a separate job.

Also see: PHPCSStandards/PHPCSDevTools#145

### GH Actions: use the xmllint-validate action runner 

Instead of doing all the installation steps for xmllint validation in the workflow, use the ✨ new dedicated `phpcsstandards/xmllint-validate` action runner instead.

Ref: https://github.com/marketplace/actions/xmllint-validate

### GH Actions: add some additional XML validation checks 

... for dev tool files.