### PR TITLE
Ruleset file: add schema tags to the ruleset

### DIFF
--- a/PHPCompatibility/ruleset.xml
+++ b/PHPCompatibility/ruleset.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibility">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibility" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>Coding Standard that checks for PHP version compatibility.</description>
 
     <autoload>./../PHPCSAliases.php</autoload>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCS Coding Standards for PHPCompatibility">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCS Coding Standards for PHPCompatibility" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
     <description>Check the code of the PHPCompatibility standard itself.</description>
 
     <!--


### PR DESCRIPTION
As of PHPCS 3.2.0, PHPCS offers an XSD schema for rulesets which defines what can be used in the XML ruleset file.

As of a couple of weeks ago, the XSD schema is now available via permalinks.

This commit adds the relevant schema tags to the PHPCS Ruleset file(s).

Refs:
* squizlabs/PHP_CodeSniffer#1433
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.2.0
* PHPCSStandards/PHP_CodeSniffer#1094
* https://github.com/PHPCSStandards/schema.phpcodesniffer.com