### PR TITLE
Composer: raise the minimum supported PHPCS + PHPCSUtils versions + fix test failures

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\UseStatements;
 use PHPCSUtils\Utils\Variables;
@@ -68,7 +69,13 @@ class ForbiddenVariableNamesInClosureUseSniff extends Sniff
             return;
         }
 
-        $useParams = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        try {
+            $useParams = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        } catch (ValueError $e) {
+            // Live coding. Unfinished closure declaration.
+            return;
+        }
+
         if (empty($useParams)) {
             // No parameters imported. Parse error.
             return;

--- a/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
@@ -20,9 +20,13 @@ use PHPCSUtils\Utils\PassedParameters;
 /**
  * Detect the use of named function call parameters as supported since PHP 8.0.
  *
+ * As of PHP 8.4, named parameters can also be used for calls to exit/die.
+ *
  * PHP version 8.0
+ * PHP version 8.4
  *
  * @link https://wiki.php.net/rfc/named_params
+ * @link https://wiki.php.net/rfc/exit-as-function
  *
  * @since 10.0.0
  */
@@ -54,11 +58,18 @@ class NewNamedParametersSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if (ScannedCode::shouldRunOnOrBelow('7.4') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('8.3') === false) {
+            // Named params are supported in both function calls + exit on PHP 8.4 and higher.
             return;
         }
 
         $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['code'] !== \T_EXIT
+            && ScannedCode::shouldRunOnOrBelow('7.4') === false
+        ) {
+            // Not an exit expression and PHP < 8.0 does not need to be supported, so we're good. Bow out.
+            return;
+        }
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
@@ -87,18 +98,23 @@ class NewNamedParametersSniff extends Sniff
             return;
         }
 
+        $error    = 'Using named arguments %s is not supported in PHP 7.4 or earlier. Found: "%s"';
+        $code     = 'Found';
+        $inPhrase = 'in function calls';
+
+        if ($tokens[$stackPtr]['code'] === \T_EXIT) {
+            $error    = 'Using named arguments %s is not supported in PHP 8.3 or earlier. Found: "%s"';
+            $code     = 'FoundInExitDie';
+            $inPhrase = 'for calls to exit() or die()';
+        }
+
         foreach ($params as $param) {
             if (isset($param['name']) === false) {
                 continue;
             }
 
-            $phpcsFile->addError(
-                'Using named arguments in function calls is not supported in PHP 7.4 or earlier. Found: "%s"',
-                $param['name_token'],
-                'Found',
-                [$param['name'] . ': ' . $param['raw']]
-            );
-
+            $data = [$inPhrase, $param['name'] . ': ' . $param['raw']];
+            $phpcsFile->addError($error, $param['name_token'], $code, $data);
         }
     }
 }

--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -53,17 +53,12 @@ class NewPHPOpenTagEOFSniff extends Sniff
     {
         $targets = [
             \T_OPEN_TAG_WITH_ECHO,
+            \T_OPEN_TAG,
         ];
 
         $this->shortOpenTags = (bool) \ini_get('short_open_tag');
         if ($this->shortOpenTags === false) {
             $targets[] = \T_INLINE_HTML;
-        } else {
-            $targets[] = \T_STRING;
-        }
-
-        if (\PHP_VERSION_ID >= 70400) {
-            $targets[] = \T_OPEN_TAG;
         }
 
         return $targets;
@@ -104,16 +99,6 @@ class NewPHPOpenTagEOFSniff extends Sniff
                 }
                 break;
 
-            case \T_STRING:
-                // PHP < 7.4 with short open tags on.
-                if ($contents === 'php'
-                    && $tokens[($stackPtr - 1)]['code'] === \T_OPEN_TAG
-                    && $tokens[($stackPtr - 1)]['content'] === '<?'
-                ) {
-                    $error = true;
-                }
-                break;
-
             case \T_OPEN_TAG_WITH_ECHO:
                 // PHP 5.4+.
                 if (\rtrim($contents) === '<?=') {
@@ -122,7 +107,7 @@ class NewPHPOpenTagEOFSniff extends Sniff
                 break;
 
             case \T_OPEN_TAG:
-                // PHP 7.4+.
+                // PHP 5.4+ on PHPCS 3.12.2 or higher.
                 if ($contents === '<?php') {
                     $error = true;
                 }

--- a/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.inc
@@ -79,13 +79,20 @@ array_fill(start_index: 0, ...[100, 50]);
 test(...$values, param: $value); // Compile-time error
 
 /*
+ * PHP 8.4 named parameters in calls to exit/die.
+ */
+exit('message'); // OK.
+die( 128); // OK.
+
+// Parse error prior to PHP 8.4: exit is a language construct, not a function. Named params not supported until PHP 8.4.
+exit(status: $value);
+die(status: $value);
+
+/*
  * Still not allowed.
  */
 // Parse error: dynamic name. Ignore.
 function_name($variableStoringParamName: $value);
-
-// Parse error: exit is a language construct, not a function. Named params not supported.
-exit(status: $value);
 
 // Parse error: empty is a language construct, not a function. Named params not supported.
 empty(variable: $value);

--- a/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.php
@@ -39,6 +39,9 @@ class NewNamedParametersUnitTest extends BaseSniffTestCase
     {
         $file = $this->sniffFile(__FILE__, '7.4');
         $this->assertError($file, $line, "Using named arguments in function calls is not supported in PHP 7.4 or earlier. Found: \"$name");
+
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
     }
 
     /**
@@ -118,6 +121,38 @@ class NewNamedParametersUnitTest extends BaseSniffTestCase
 
 
     /**
+     * Verify that exit/die calls using named parameters are detected correctly.
+     *
+     * @dataProvider dataNewNamedParametersForExitDie
+     *
+     * @param int    $line The line number.
+     * @param string $name The parameter name detected.
+     *
+     * @return void
+     */
+    public function testNewNamedParametersForExitDie($line, $name)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertError($file, $line, "Using named arguments for calls to exit() or die() is not supported in PHP 8.3 or earlier. Found: \"$name");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewNamedParametersForExitDie()
+     *
+     * @return array
+     */
+    public static function dataNewNamedParametersForExitDie()
+    {
+        return [
+            [88, 'status'],
+            [89, 'status'],
+        ];
+    }
+
+
+    /**
      * Verify no false positives are thrown for valid code.
      *
      * @dataProvider dataNoFalsePositives
@@ -148,11 +183,13 @@ class NewNamedParametersUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        $data[] = [84];
         $data[] = [85];
-        $data[] = [88];
-        $data[] = [91];
-        $data[] = [94];
-        $data[] = [97];
+
+        // No errors expected on the lines after "Still not allowed".
+        for ($line = 91; $line <= 105; $line++) {
+            $data[] = [$line];
+        }
 
         return $data;
     }
@@ -165,7 +202,7 @@ class NewNamedParametersUnitTest extends BaseSniffTestCase
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '8.0');
+        $file = $this->sniffFile(__FILE__, '8.4');
         $this->assertNoViolation($file);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
   },
   "require": {
     "php": ">=5.4",
-    "squizlabs/php_codesniffer": "^3.10.0",
-    "phpcsstandards/phpcsutils": "^1.0.12"
+    "squizlabs/php_codesniffer": "^3.13.0",
+    "phpcsstandards/phpcsutils": "^1.1.0"
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.4.0",


### PR DESCRIPTION
Since the release of PHPCS 3.12.2, one test is failing on older PHP versions.
Since the release of PHPCSUtils 1.1.0, another two tests are failing.

This PR is intended to unblock contributors by fixing these CI failures.

Other updates which can/should be made for the more recent PHPCS versions and related to PHPCSUtils 1.1.0 will follow in separate PRs.


---

### Composer: raise the minimum supported PHPCSUtils version to 1.1.0 

... to benefit from new functionality related to PHP 8.3, 8.4 and PHPCS 4.0.

As the minimum supported PHPCS version for PHPCSUtils 1.1.0 is PHPCS 3.13.0, the minimum PHPCS version has also been raised.

Refs:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.1.0

### Miscellaneous/NewPHPOpenTagEOF: remove work-arounds which are no longer needed

PHPCS 3.12.2 fixed a PHP tokenization inconsistency directly related to what this sniff is detecting.

> - Tokenizer/PHP: a PHP open tag at the very end of a file will now always be tokenized as T_OPEN_TAG, independently of the PHP version.
>     Previously, a PHP open tag at the end of a file was not tokenized as an open tag on PHP < 7.4 and the tokenization would depend on the short_open_tag setting.

As the PHPCS tokenization will now be the same PHP cross-version, we can remove the work-arounds which were in place to accommodate the previous difference in tokenization.

Ref:
* PHPCSStandards/PHP_CodeSniffer#937


### FunctionDeclarations/ForbiddenVariableNamesInClosureUse: catch potential exception

The following PHPCSUtils 1.1.0 change was causing the tests to fail:

> `UseStatements::getType()` will now handle unfinished closure `use` statements (parse errors) more consistently and return `'closure'` for those cases.

This change means that during live coding, in specific cases where a closure declaration is incomplete, the `UseStatements::getType()` method will still correctly detect the `use` as a closure `use`.
However, the `FunctionDeclarations::getParameters()` method will not handle such incomplete code and will throw an exception as the parameters imported via the closure `use` cannot be reliably retrieved.

Fixed now by catching this potential exception.

### PHP 8.4 | NewNamedParameters: handle named params passed to exit/die 

> . The exit (and die) language constructs now behave more like a function.
>   They can be passed liked callables, are affected by the strict_types
>   declare statement, and now perform the usual type coercions instead of
>   casting any non-integer value to a string.
>   As such, passing invalid types to exit/die may now result in a TypeError
>   being thrown.
>   RFC: https://wiki.php.net/rfc/exit-as-function

This commit adds detection of the use of named arguments passed to `exit()`/`die()` to the `NewNamedParameters` sniff.

Includes tests.

Note: sniff updates for the other aspects of this PHP 8.4 feature will be pulled separately.

Refs:
* https://wiki.php.net/rfc/exit-as-function
* https://github.com/php/php-src/blob/8853cf3ae950a1658054f286117bc8f77f724f00/UPGRADING#L40-L46
* php/php-src#13486
* php/php-src@a79c70f
* php/php-src#15433
* php/php-src@4c5767f

Related to #1731