### PR TITLE
PHP 8.4 | Handle "Exit as function call" in various sniffs

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/NewExitAsFunctionCallStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/NewExitAsFunctionCallStandard.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Exit as Function Call"
+    >
+    <standard>
+    <![CDATA[
+    As of PHP 8.4, `exit()` and `die()` when called with a parameter, will behave like a function call, which means that the standard parameter type compliance rules will be applied.
+
+    For files not subject to `strict_types`, this leads to the following behavioural changes:
+    - Boolean parameter values were previously interpreted as a status message, but will now be juggled to an integer and handled as an exit code.
+    - Floating point parameter values were previously interpreted as a status message, but will now be juggled to an integer and handled as an exit code.
+    - A "null" parameter value was previously interpreted as a status message, but will now be juggled to the integer 0 and handled as an exit code.
+
+    For files which are subject to `strict_types`, passing anything but an integer, string or stringable object as the parameter, will now result in a TypeError.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: passing an integer or string $status to exit()/die().">
+        <![CDATA[
+exit(<em>12</em>);
+die(<em>'process killed for reasons'</em>);
+
+exit(<em>(string) $statusMessage</em>);
+die(<em>(int) $exitCode</em>);
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.4: passing a non-integer, non-string $status to exit()/die() was silently accepted as a status message.">
+        <![CDATA[
+exit(<em>null</em>);
+die(<em>12.0</em>);
+
+exit(<em>$array</em>);
+die(<em>$resource</em>);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Docs/Syntax/NewFirstClassCallablesStandard.xml
+++ b/PHPCompatibility/Docs/Syntax/NewFirstClassCallablesStandard.xml
@@ -24,4 +24,27 @@ $fn = <em>Foo::method(...)</em>;
         ]]>
         </code>
     </code_comparison>
+    <standard>
+    <![CDATA[
+    Since PHP 8.4, exit/die can also be used as a first class callable.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: not using first class callables.">
+        <![CDATA[
+$callback = <em>function() {
+    exit();
+}</em>;
+$callback = <em>function() {
+    die();
+}</em>;
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.4: using exit/die as a first class callable.">
+        <![CDATA[
+$callback = <em>exit(...)</em>;
+$callback = <em>die(...)</em>;
+        ]]>
+        </code>
+    </code_comparison>
 </documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/NewExitAsFunctionCallSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewExitAsFunctionCallSniff.php
@@ -1,0 +1,436 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\MiscHelper;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Detects the use of exit as a function call, as allowed since PHP 8.4.
+ *
+ * Prior to PHP 8.4, exit/die was a language construct.
+ * Since PHP 8.4, it is a proper function, with internal handling of its use as a constant
+ * (by changing this to a function call at compile time).
+ *
+ * As a consequence of this, exit/die can now:
+ * - be called with a named argument (handled in the `NewNamedParameters` sniff);
+ * - passed to functions as a callable (can't be reliably detected);
+ * - passed to functions as a first class callable (handled in the `NewFirstClassCallables` sniff);
+ * - have a trailing comma after its parameter (handled in the `NewFunctionCallTrailingComma` sniff);
+ * - respect strict_types and follow type juggling semantics (handled in this sniff).
+ *
+ * Passing as a callable can only reliable be detected when passed as a first class callable as
+ * when `exit`/`die` is passed as a text string, the chance of flagging a false positive is too high.
+ *
+ * As for the type juggling part: this can only be detected when the parameter is passed hard-coded, but
+ * in that case, this sniff can detect it with high precision.
+ *
+ * PHP version 8.4
+ *
+ * @link https://wiki.php.net/rfc/exit-as-function
+ *
+ * @since 10.0.0
+ */
+final class NewExitAsFunctionCallSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, true>
+     */
+    protected $targetFunctions = [
+        'exit' => true,
+        'die'  => true,
+    ];
+
+    /**
+     * All constants natively declared by PHP.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, mixed>
+     */
+    private $phpNativeConstants = [];
+
+    /**
+     * Current file being scanned.
+     *
+     * @since 10.0.0
+     *
+     * @var string
+     */
+    private $currentFile = '';
+
+    /**
+     * Whether strict types are in effect in the current file.
+     *
+     * @since 10.0.0
+     *
+     * @var bool
+     */
+    private $strictTypes = false;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        // Get the PHP natively defined constants only once.
+        $constants = \get_defined_constants(true);
+        unset($constants['user']);
+
+        $this->phpNativeConstants = [];
+        foreach ($constants as $group) {
+            $this->phpNativeConstants += $group;
+        }
+
+        // Call the parent method to set up some properties for the abstract.
+        parent::register();
+
+        // ... but register our own target tokens.
+        return [
+            \T_DECLARE,
+            \T_EXIT,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if ($this->bowOutEarly() === true) {
+            return;
+        }
+
+        $fileName = $phpcsFile->getFilename();
+        if ($this->currentFile !== $fileName) {
+            // Reset the declare statement related properties for each new file.
+            $this->currentFile = $fileName;
+            $this->strictTypes = false;
+        }
+
+        /*
+         * Check for strict types declarations.
+         *
+         * Ignore any invalid/incomplete declare statements.
+         */
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['code'] === \T_DECLARE) {
+            if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {
+                // Live coding or parse error.
+                return;
+            }
+
+            $declarations = GetTokensAsString::noEmpties(
+                $phpcsFile,
+                ($tokens[$stackPtr]['parenthesis_opener'] + 1),
+                ($tokens[$stackPtr]['parenthesis_closer'] - 1)
+            );
+
+            if (\preg_match('`\bstrict_types=([01])`i', $declarations, $matches) === 1) {
+                if ($matches[1] === '1') {
+                    $this->strictTypes = true;
+                } else {
+                    $this->strictTypes = false;
+                }
+            }
+
+            return;
+        }
+
+        // Check if this is exit/die used as a fully qualified function call.
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($tokens[$prev]['code'] === \T_NS_SEPARATOR) {
+            $phpcsFile->addError(
+                'Using "%s" as a fully qualified function call is not allowed in PHP 8.3 or earlier.',
+                $stackPtr,
+                'FullyQualified',
+                [$tokens[$stackPtr]['content']]
+            );
+        }
+
+        return parent::process($phpcsFile, $stackPtr);
+    }
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrAbove('8.4') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File                  $phpcsFile    The file being scanned.
+     * @param int                                          $stackPtr     The position of the current token in the stack.
+     * @param string                                       $functionName The token content (function name) which was matched.
+     * @param array<int|string, array<string, int|string>> $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $targetParam = PassedParameters::getParameterFromStack($parameters, 1, 'status');
+        if ($targetParam === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $data   = [$functionName, $targetParam['clean']];
+
+        $integer = 0;
+        $string  = 0;
+        $boolean = 0;
+        $float   = 0;
+        $null    = 0;
+        $concat  = 0;
+        $arithm  = 0;
+        $total   = 0;
+
+        for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) || $tokens[$i]['code'] === \T_NS_SEPARATOR) {
+                continue;
+            }
+
+            if (($tokens[$i]['code'] === \T_INT_CAST || $tokens[$i]['code'] === \T_STRING_CAST)
+                && $total === 0
+            ) {
+                // Assume the cast is for the whole parameter, in which case, we're good.
+                return;
+            }
+
+            if ($tokens[$i]['code'] === \T_NEW) {
+                // For objects, there is no change in behaviour. This was already a type error,
+                // or, in case of a stingable object, was okay and is still okay.
+                return;
+            }
+
+            // Check for use of PHP native global constants for which we know the type.
+            if ($tokens[$i]['code'] === \T_STRING
+                && isset($this->phpNativeConstants[$tokens[$i]['content']]) === true
+                && MiscHelper::isUseOfGlobalConstant($phpcsFile, $i) === true
+            ) {
+                $type = \gettype($this->phpNativeConstants[$tokens[$i]['content']]);
+                switch ($type) {
+                    case 'integer':
+                        ++$integer;
+                        break;
+
+                    case 'string':
+                        ++$string;
+                        break;
+
+                    case 'double':
+                        ++$float;
+                        break;
+
+                    case 'boolean':
+                        ++$boolean;
+                        break;
+
+                    // At this time, PHP doesn't have any native constants of type null.
+                    // @codeCoverageIgnoreStart
+                    case 'null':
+                        ++$null;
+                        break;
+                        // @codeCoverageIgnoreEnd
+
+                    default:
+                        $this->flagTypeError($phpcsFile, $i, $data, $type);
+                        return;
+                }
+
+                ++$total;
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_STRING
+                || $tokens[$i]['code'] === \T_VARIABLE
+            ) {
+                // Variable, non-PHP-native constant, function call. Ignore as undetermined.
+                return;
+            }
+
+            if (($tokens[$i]['code'] === \T_ARRAY
+                || $tokens[$i]['code'] === \T_LIST
+                || $tokens[$i]['code'] === \T_OPEN_SHORT_ARRAY)
+                && $total === 0 // Only flag when the parameter starts with one of these tokens.
+            ) {
+                $this->flagTypeError($phpcsFile, $i, $data, 'array');
+                return;
+            }
+
+            ++$total;
+
+            if ($tokens[$i]['code'] === \T_LNUMBER) {
+                ++$integer;
+                continue;
+            }
+
+            if (isset(Tokens::$arithmeticTokens[$tokens[$i]['code']])) {
+                ++$arithm;
+                continue;
+            }
+
+            if (isset(Tokens::$textStringTokens[$tokens[$i]['code']])
+                || isset(Tokens::$heredocTokens[$tokens[$i]['code']])
+            ) {
+                ++$string;
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_STRING_CONCAT) {
+                ++$concat;
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_DNUMBER) {
+                ++$float;
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_TRUE || $tokens[$i]['code'] === \T_FALSE) {
+                ++$boolean;
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_NULL) {
+                ++$null;
+                continue;
+            }
+        }
+
+        $unrecognized = ($total - $integer - $string - $boolean - $float - $null - $concat - $arithm);
+
+        if ($unrecognized > 0) {
+            // Ignore as undetermined.
+            return;
+        }
+
+        if (($integer > 0 && ($total - $integer - $arithm) === 0)
+            || ($string > 0 && ($total - $string - $concat - $integer) === 0)
+        ) {
+            // This is fine, either a purely integer value, a purely string value or a simple operation involving only strings/integers.
+            // No change in behaviour.
+            return;
+        }
+
+        if ($boolean > 0 && ($total - $boolean) === 0) {
+            if ($this->strictTypes === true) {
+                $this->flagTypeError($phpcsFile, $i, $data, 'boolean');
+                return;
+            }
+
+            $phpcsFile->addWarning(
+                'Passing a boolean value to %s() will be interpreted as an exit code instead of as a status message since PHP 8.4. Found: "%s"',
+                $i,
+                'BooleanParamFound',
+                $data
+            );
+            return;
+        }
+
+        if ($float > 0 && ($total - $float - $arithm - $integer) === 0) {
+            if ($this->strictTypes === true) {
+                $this->flagTypeError($phpcsFile, $i, $data, 'float');
+                return;
+            }
+
+            $phpcsFile->addWarning(
+                'Passing a floating point value to %s() will be interpreted as an exit code instead of as a status message since PHP 8.4. Found: "%s"',
+                $i,
+                'FloatParamFound',
+                $data
+            );
+            return;
+        }
+
+        if ($null > 0 && ($total - $null) === 0) {
+            if ($this->strictTypes === true) {
+                $this->flagTypeError($phpcsFile, $i, $data, 'null');
+                return;
+            }
+
+            $phpcsFile->addWarning(
+                'Passing null to %s() will be interpreted as an exit code instead of as a status message since PHP 8.4. Found: "%s"',
+                $i,
+                'NullParamFound',
+                $data
+            );
+            return;
+        }
+
+        // Ignore everything else as undetermined.
+    }
+
+    /**
+     * Throw an error about a received parameter type which will be a type error as of PHP 8.4.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The token position to throw the error on.
+     * @param array<string>               $data      The data for the error message.
+     * @param string                      $type      The inferred parameter type.
+     *
+     * @return void
+     */
+    private function flagTypeError(File $phpcsFile, $stackPtr, $data, $type)
+    {
+        $aOrAn = 'a ';
+        if ($type === 'null') {
+            $aOrAn = '';
+        } elseif ($type === 'array') {
+            $aOrAn = 'an ';
+        }
+
+        $data[] = $aOrAn;
+        $data[] = $type;
+
+        $phpcsFile->addError(
+            'Passing %3$s%4$s to %1$s() will result in a TypeError since PHP 8.4. Found: "%2$s"',
+            $stackPtr,
+            'TypeError',
+            $data
+        );
+    }
+}

--- a/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
@@ -18,10 +18,14 @@ use PHPCompatibility\Sniff;
 /**
  * Detects the use of the first class callable syntax, as introduced in PHP 8.1.
  *
+ * As of PHP 8.4, exit/die can also be used as a first class callable.
+ *
  * PHP version 8.1
+ * PHP version 8.4
  *
  * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.callable-syntax
  * @link https://wiki.php.net/rfc/first_class_callable_syntax
+ * @link https://wiki.php.net/rfc/exit-as-function
  *
  * @since 10.0.0
  */
@@ -53,7 +57,7 @@ final class NewFirstClassCallablesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if (ScannedCode::shouldRunOnOrBelow('8.0') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('8.3') === false) {
             return;
         }
 
@@ -66,6 +70,21 @@ final class NewFirstClassCallablesSniff extends Sniff
 
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($next === false || $tokens[$next]['code'] !== \T_CLOSE_PARENTHESIS) {
+            return;
+        }
+
+        $beforeParens = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+        if ($tokens[$beforeParens]['code'] === \T_EXIT) {
+            $phpcsFile->addError(
+                'Using exit/die as a first class callable is not supported in PHP 8.3 or earlier.',
+                $stackPtr,
+                'FoundExitDie'
+            );
+            return;
+        }
+
+        // "Normal" first class callables are supported since PHP 8.1.
+        if (ScannedCode::shouldRunOnOrBelow('8.0') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -19,10 +19,15 @@ use PHPCSUtils\Tokens\Collections;
 /**
  * Detect trailing commas in function calls, `isset()` and `unset()` as allowed since PHP 7.3.
  *
+ * As of PHP 8.4, exit/die are now treated as function calls, which means they now also support
+ * trailing commas.
+ *
  * PHP version 7.3
+ * PHP version 8.4
  *
  * @link https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.trailing-commas
  * @link https://wiki.php.net/rfc/trailing-comma-function-calls
+ * @link https://wiki.php.net/rfc/exit-as-function
  *
  * @since 8.2.0
  * @since 9.0.0  Renamed from `NewTrailingCommaSniff` to `NewFunctionCallTrailingCommaSniff`.
@@ -60,11 +65,18 @@ final class NewFunctionCallTrailingCommaSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if (ScannedCode::shouldRunOnOrBelow('7.2') === false) {
+        if (ScannedCode::shouldRunOnOrBelow('8.3') === false) {
+            // Trailing commas are supported in both function calls + exit on PHP 8.4 and higher.
             return;
         }
 
         $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['code'] !== \T_EXIT
+            && ScannedCode::shouldRunOnOrBelow('7.2') === false
+        ) {
+            // Not an exit expression, so we only need run for PHP 7.2 and lower.
+            return;
+        }
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
@@ -88,7 +100,8 @@ final class NewFunctionCallTrailingCommaSniff extends Sniff
             return;
         }
 
-        $data = [];
+        $message = 'Trailing commas are not allowed in %s in PHP 7.2 or earlier';
+        $data    = [];
         switch ($tokens[$stackPtr]['code']) {
             case \T_ISSET:
                 $data[]    = 'calls to isset()';
@@ -100,17 +113,18 @@ final class NewFunctionCallTrailingCommaSniff extends Sniff
                 $errorCode = 'FoundInUnset';
                 break;
 
+            case \T_EXIT:
+                $message   = 'Trailing commas are not allowed in %s in PHP 8.3 or earlier';
+                $data[]    = 'calls to exit() or die()';
+                $errorCode = 'FoundInExitDie';
+                break;
+
             default:
                 $data[]    = 'function calls';
                 $errorCode = 'FoundInFunctionCall';
                 break;
         }
 
-        $phpcsFile->addError(
-            'Trailing commas are not allowed in %s in PHP 7.2 or earlier',
-            $lastInParenthesis,
-            $errorCode,
-            $data
-        );
+        $phpcsFile->addError($message, $lastInParenthesis, $errorCode, $data);
     }
 }

--- a/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.inc
@@ -82,10 +82,10 @@ test(...$values, param: $value); // Compile-time error
  * PHP 8.4 named parameters in calls to exit/die.
  */
 exit('message'); // OK.
-die( 128); // OK.
+\die( 128); // OK.
 
 // Parse error prior to PHP 8.4: exit is a language construct, not a function. Named params not supported until PHP 8.4.
-exit(status: $value);
+\exit(status: $value);
 die(status: $value);
 
 /*

--- a/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallUnitTest.inc
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * Not our targets.
+ */
+$obj->exit();
+$obj?->die();
+
+class Foo {
+    const die = 5;
+    const exit = 10;
+
+    public function exit() {}
+    public function die() {}
+}
+
+Foo::exit();
+
+// Exit/die is still a reserved keyword and cannot be used to declare (global) constants/functions or goto labels.
+// The below statements are all parse errors, both in PHP 8.4 as well as PHP < 8.4.
+const exit = 10;
+function die() {}
+
+goto die;
+echo "In between\n";
+die:
+do_something();
+
+/*
+ * All okay (from a parameter type point of view).
+ */
+exit;
+die;
+exit();
+die();
+die(0);
+exit(1);
+exit(0b101);
+die(0xAF);
+die( /*comment*/ 0o53 /*comment*/ );
+exit(254);
+// Status code 255 is reserved by PHP itself, but PHP does not refuse it. Behaviour is unchanged, so not our concern.
+exit(255);
+// Status code 256 is invalid and is ignored, resulting in an actual status code of 0. Behaviour is unchanged, so not our concern.
+exit(256);
+
+die('status');
+exit('status' . 'type');
+exit( "status $message" );
+die( <<<'EOD'
+status
+EOD
+);
+exit( <<<EOD
+my $status message
+EOD
+);
+
+// Known PHP native constants which result in an integer or string.
+exit(PHP_INT_MIN);
+die(\PHP_VERSION);
+die(E_ERROR + \E_WARNING);
+
+// Assume the cast is for the whole parameter.
+exit((string) $status);
+die((int) STATUS);
+
+// Undetermined. Ignore.
+exit($variable);
+die(STATUS_CODE);
+exit(get_code([1,2]));
+die($obj->get());
+exit(\PHP_VERSION()); // Function name mirrors a PHP native constant, but should not be seen as integer.
+
+die(code: 10.5); // Incorrect parameter name.
+
+// Invalid as die only accepts one parameter, but that's not our concern.
+die(...$var);
+
+// Behaviour unchanged: Fatal error: Uncaught Error: Object of class stdClass could not be converted to string.
+// Mind: a class may implement Stringable or __toString(), so this _may_ work just fine, but in that case,
+// again, there is no change in behaviour.
+exit( new stdClass );
+
+// Simple operations involving only integers or strings are recognized and handled by the sniff.
+exit(10 + 2);
+die ('string' . 'string');
+die ('string' . 10);
+
+// Potential future scope: infer type of compound values based on operators.
+// Currently these are blindly ignored (though for the below examples the behaviour is unchanged anyway).
+exit(1 << 2);
+exit(10 + ['hello']); // TypeError: unsupported operand types.
+die(true + 10);
+
+
+/*
+ * PHP 8.4+: passing an array (or a non-stringable object or a resource, but we can rarely detect that) will now result in a TypeError.
+ */
+
+// Was array to string conversion warning + status message "Array", PHP 8.4: TypeError.
+exit([]);
+die( array(1, 2) );
+exit( list($a, $b) = $array);
+die( [$a, $b] = $array);
+
+// Was status message "Resource id #...", PHP 8.4: TypeError.
+die(STDERR); // PHP native resource.
+
+/*
+ * PHP 8.4+: passing a boolean, float or null will convert to an integer exit code instead of a string status message (warning).
+ *
+ * Note: the declare statements in the below tests would in real code result in a Fatal error for not being at the top
+ * of the file (or another error for being invalid/empty). That's not the concern of these tests though.
+ * The tests check that if a strict_types declaration is seen, the sniff behaviour changes, not whether the
+ * declare statements themselves are correct.
+ */
+exit(true); // Unless strict_types is used, will be juggled to 1.
+die( false ); // Unless strict_types is used, will be juggled to 0.
+exit(\PHP_ZTS); // PHP native constant of type boolean.
+exit ( 10.0 ); // Unless strict_types is used, will be juggled to integer 10.
+exit(status: 1.5); // Will also throw an "Implicit conversion from float to int loses precision" deprecation notice.
+die(1.5 + 1); // Will also throw an "Implicit conversion from float to int loses precision" deprecation notice.
+die(TRADER_REAL_MIN); // PHP native constant of type float (if available).
+die( null ); // Will also throw a "Passing null to parameter #1 ($status) of type string|int is deprecated" notice.
+
+// However, if strict_types is on, these will all result in a TypeError and should be flagged as an error.
+declare( strict_types = /*comment*/ 1);
+exit(status: \true);
+die( false );
+
+declare(); // Checking that invalid (empty) declare statement is ignored.
+exit ( 10.0 ); // Still error.
+exit(1.5); // Still error.
+
+declare(ticks=1); // Checking that non-strict_types declare statement is ignored.
+die(1.5 + 1); // Still error.
+die( null ); // Still error.
+
+// A strict_type reset/explicit non-strict types should be recognized though and result in a warning (again).
+declare(STRICT_TYPES=0, encoding='utf-8') {
+    die( \false ); // Warning.
+}
+
+/*
+ * PHP 8.4: exit can now be used as a fully qualified function call.
+ */
+\exit();
+\die(10);
+
+// Parse error/Live coding test.
+// This should be the last test in the file.
+declare(

--- a/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallUnitTest.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewExitAsFunctionCall sniff.
+ *
+ * @group newExitAsFunctionCall
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewExitAsFunctionCallSniff
+ *
+ * @since 10.0.0
+ */
+final class NewExitAsFunctionCallUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test an array parameter being passed to exit/die will be flagged with an error.
+     *
+     * @dataProvider dataTypeError
+     *
+     * @param int    $line Line number where the error should occur.
+     * @param string $name Function call name.
+     * @param string $type Parameter type expected to be mentioned in the message.
+     *
+     * @return void
+     */
+    public function testTypeError($line, $name, $type)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.4');
+        $error = " {$type} to {$name}() will result in a TypeError since PHP 8.4.";
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataTypeError()
+    {
+        return [
+            [102, 'exit', 'array'],
+            [103, 'die', 'array'],
+            [104, 'exit', 'array'],
+            [105, 'die', 'array'],
+            [108, 'die', 'resource'],
+
+            // Scalars and null with strict_types=1.
+            [129, 'exit', 'boolean'],
+            [130, 'die', 'boolean'],
+            [133, 'exit', 'float'],
+            [134, 'exit', 'float'],
+            [137, 'die', 'float'],
+            [138, 'die', 'null'],
+        ];
+    }
+
+
+    /**
+     * Test a boolean parameter being passed to exit/die will be flagged.
+     *
+     * @dataProvider dataBooleanParamFound
+     *
+     * @param int    $line Line number where the error should occur.
+     * @param string $name Function call name.
+     *
+     * @return void
+     */
+    public function testBooleanParamWarning($line, $name)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.4');
+        $error = "Passing a boolean value to {$name}() will be interpreted as an exit code instead of as a status message since PHP 8.4.";
+
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataBooleanParamFound()
+    {
+        $data = [
+            [118, 'exit'],
+            [119, 'die'],
+            [142, 'die'],
+        ];
+
+        // This constant _should_ be available since PHP 5.2.7, but wasn't always a boolean.
+        if (\defined('PHP_ZTS') && \is_bool(\PHP_ZTS)) {
+            $data[] = [120, 'exit'];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Test a float parameter being passed to exit/die will be flagged.
+     *
+     * @dataProvider dataFloatParamFound
+     *
+     * @param int    $line Line number where the error should occur.
+     * @param string $name Function call name.
+     *
+     * @return void
+     */
+    public function testFloatParamFound($line, $name)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.4');
+        $error = "Passing a floating point value to {$name}() will be interpreted as an exit code instead of as a status message since PHP 8.4.";
+
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataFloatParamFound()
+    {
+        $data = [
+            [121, 'exit'],
+            [122, 'exit'],
+            [123, 'die'],
+        ];
+
+        // PHP native constant from an optional extension used in the test. The constant may not exist in the test environment.
+        if (\defined('TRADER_REAL_MIN')) {
+            $data[] = [124, 'die'];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Test a null parameter being passed to exit/die will be flagged.
+     *
+     * @dataProvider dataNullParamFound
+     *
+     * @param int    $line Line number where the error should occur.
+     * @param string $name Function call name.
+     *
+     * @return void
+     */
+    public function testNullParamFound($line, $name)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.4');
+        $error = "Passing null to {$name}() will be interpreted as an exit code instead of as a status message since PHP 8.4.";
+
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataNullParamFound()
+    {
+        return [
+            [125, 'die'],
+        ];
+    }
+
+
+    /**
+     * Test that the use of fully qualified exit/die will be flagged with an error.
+     *
+     * @dataProvider dataFullyQualifiedError
+     *
+     * @param int    $line Line number where the error should occur.
+     * @param string $name Function call name.
+     *
+     * @return void
+     */
+    public function testFullyQualifiedError($line, $name)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.4');
+        $error = "Using \"{$name}\" as a fully qualified function call is not allowed in PHP 8.3 or earlier.";
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataFullyQualifiedError()
+    {
+        return [
+            [148, 'exit'],
+            [149, 'die'],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 96 lines.
+        for ($line = 1; $line <= 96; $line++) {
+            $data[] = [$line];
+        }
+
+        // PHP native constant (bool) which wasn't _always_ a boolean.
+        if (\defined('PHP_ZTS') === false || \is_bool(\PHP_ZTS) === false) {
+            $data[] = [120];
+        }
+
+        // PHP native constant (float) from an optional extension used in the test.
+        // The constant may not exist in the test environment.
+        // Note: unfortunately, this appears to be the only PHP extension which has float typed constants,
+        // so there is no alternative we could use for this test (at this time).
+        if (\defined('TRADER_REAL_MIN') === false) {
+            $data[] = [124];
+        }
+
+        // Parse error/live coding.
+        for ($line = 150; $line <= 153; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewFirstClassCallablesUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFirstClassCallablesUnitTest.inc
@@ -38,3 +38,9 @@ self::{$complex . $expression}(...);
 'strlen'(...);
 [$obj, 'method'](...);
 [Foo::class, 'method'](...);
+
+/*
+ * PHP 8.4: using exit/die as a first class callable is now allowed.
+ */
+$callable = exit(...);
+giveMeCallable(\die(...));

--- a/PHPCompatibility/Tests/Syntax/NewFirstClassCallablesUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFirstClassCallablesUnitTest.php
@@ -38,6 +38,9 @@ final class NewFirstClassCallablesUnitTest extends BaseSniffTestCase
     {
         $file = $this->sniffFile(__FILE__, '8.0');
         $this->assertError($file, $line, 'First class callables using the CallableExpr(...) syntax are not supported in PHP 8.0 or earlier.');
+
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
     }
 
     /**
@@ -62,6 +65,37 @@ final class NewFirstClassCallablesUnitTest extends BaseSniffTestCase
             [38],
             [39],
             [40],
+        ];
+    }
+
+
+    /**
+     * Verify that using exit/die as a first class callable is correctly detected.
+     *
+     * @dataProvider dataFirstClassCallableExit
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testFirstClassCallableExit($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertError($file, $line, 'Using exit/die as a first class callable is not supported in PHP 8.3 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testFirstClassCallableExit()
+     *
+     * @return array
+     */
+    public static function dataFirstClassCallableExit()
+    {
+        return [
+            [45],
+            [46],
         ];
     }
 
@@ -108,7 +142,7 @@ final class NewFirstClassCallablesUnitTest extends BaseSniffTestCase
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '8.1');
+        $file = $this->sniffFile(__FILE__, '8.4');
         $this->assertNoViolation($file);
     }
 }

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.inc
@@ -115,3 +115,13 @@ register_callback(strtolower(...,)); // Parse error, but throw an error anyway a
 namespace\callMe($a, $b,);
 \Fully\Qualified\callMe(1, 2, 3, 4, 5,);
 Partially\Qualified\callMe(1, 2, 3, 4, 5,);
+
+// OK cross-version.
+exit;
+die;
+exit($status);
+die($status);
+
+// Only allowed since PHP 8.4.
+exit($status,); // Error with PHP < 8.4.
+\die /*comment*/  ( 2, /*comment*/ ); // Error with PHP < 8.4.

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -26,7 +26,7 @@ final class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTestCase
 {
 
     /**
-     * testTrailingComma
+     * Verify that trailing commas in function calls, call to isset() and unset() are flagged correctly.
      *
      * @dataProvider dataTrailingComma
      *
@@ -39,6 +39,9 @@ final class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTestCase
     {
         $file = $this->sniffFile(__FILE__, '7.2');
         $this->assertError($file, $line, "Trailing commas are not allowed in {$type} in PHP 7.2 or earlier");
+
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file, $line);
     }
 
     /**
@@ -76,6 +79,37 @@ final class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTestCase
             [115],
             [116],
             [117],
+        ];
+    }
+
+
+    /**
+     * Verify that trailing commas in calls to exit() and die() are flagged correctly.
+     *
+     * @dataProvider dataTrailingCommaExit
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testTrailingCommaExit($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertError($file, $line, 'Trailing commas are not allowed in calls to exit() or die() in PHP 8.3 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testTrailingCommaExit()
+     *
+     * @return array
+     */
+    public static function dataTrailingCommaExit()
+    {
+        return [
+            [126, 'calls to exit() or die()'],
+            [127, 'calls to exit() or die()'],
         ];
     }
 
@@ -123,6 +157,10 @@ final class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        for ($line = 119; $line <= 124; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 
@@ -134,7 +172,7 @@ final class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTestCase
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '7.3');
+        $file = $this->sniffFile(__FILE__, '8.4');
         $this->assertNoViolation($file);
     }
 }


### PR DESCRIPTION
~~⚠️ This PR needs for PR #1806 to be merged first. It relies on functionality supported since PHPCSUtils 1.1.0. ⚠️~~

PR #1806 also contains one commit - https://github.com/PHPCompatibility/PHPCompatibility/pull/1806/commits/297d6b1ccceca6442c477159fd96c747bde6aad2 -  which, by rights, should be part of this PR.

---

### PHP 8.4 | NewFirstClassCallables: handle exit/die as first class callable

> . The exit (and die) language constructs now behave more like a function.
>   They can be passed liked callables, are affected by the strict_types
>   declare statement, and now perform the usual type coercions instead of
>   casting any non-integer value to a string.
>   As such, passing invalid types to exit/die may now result in a TypeError
>   being thrown.
>   RFC: https://wiki.php.net/rfc/exit-as-function

This commit adds detection of the use of `exit()`/`die()` as a first class callable to the `NewFirstClassCallables` sniff.

Includes tests.
Includes updated documentation.

Refs:
* https://wiki.php.net/rfc/exit-as-function
* https://github.com/php/php-src/blob/8853cf3ae950a1658054f286117bc8f77f724f00/UPGRADING#L40-L46
* php/php-src#13486
* php/php-src@a79c70f

Related to #1731

### PHP 8.4 | NewFunctionCallTrailingComma: handle trailing comma's for exit/die

> . The exit (and die) language constructs now behave more like a function.
>   They can be passed liked callables, are affected by the strict_types
>   declare statement, and now perform the usual type coercions instead of
>   casting any non-integer value to a string.
>   As such, passing invalid types to exit/die may now result in a TypeError
>   being thrown.
>   RFC: https://wiki.php.net/rfc/exit-as-function

This commit adds detection of the use of trailing comma's in `exit()`/`die()` to the `NewFunctionCallTrailingComma` sniff.

Includes tests.

Refs:
* https://wiki.php.net/rfc/exit-as-function
* https://github.com/php/php-src/blob/8853cf3ae950a1658054f286117bc8f77f724f00/UPGRADING#L40-L46
* php/php-src#13486
* php/php-src@a79c70f

Related to #1731

### PHP 8.4 | ✨ New `PHPCompatibility.ParameterValues.NewExitAsFunctionCall` sniff

> . The exit (and die) language constructs now behave more like a function.
>   They can be passed liked callables, are affected by the strict_types
>   declare statement, and now perform the usual type coercions instead of
>   casting any non-integer value to a string.
>   As such, passing invalid types to exit/die may now result in a TypeError
>   being thrown.
>   RFC: https://wiki.php.net/rfc/exit-as-function

This commit adds a new sniff which:
1. Will flag use of `exit`/`die` as fully qualified function calls, which is not allowed prior to PHP 8.4.
2. Tries to detect parameter values which will either be interpreted differently or will (likely) result in a TypeError on PHP 8.4.

Calls to `exit()`/`die()` for which the parameter type cannot be determined are silently ignored to prevent false positives.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/exit-as-function
* https://github.com/php/php-src/blob/8853cf3ae950a1658054f286117bc8f77f724f00/UPGRADING#L40-L46
* php/php-src#13486
* php/php-src@a79c70f
* php/php-src#15433
* php/php-src@4c5767f

Related to #1731

### PHP 8.4 | FunctionUse/NewNamedParameters: update tests to safeguard handling FQN exit/die

... which is allowed since PHP 8.4... _sigh_

Follow up to #1806 which already updated the sniff itself.