### PR TITLE
:sparkles: PHP 8.3 | New `PHPCompatibility.Classes.NewTypedConstants` sniff

### DIFF
--- a/PHPCompatibility/Docs/Classes/NewTypedConstantsStandard.xml
+++ b/PHPCompatibility/Docs/Classes/NewTypedConstantsStandard.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Typed Constants"
+    >
+    <standard>
+    <![CDATA[
+    Declaring a type for OO constants is allowed since PHP 8.3.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: untyped OO constants.">
+        <![CDATA[
+class Foo {
+    const MULTIPLIER = 10;
+
+    const LOOKUP = ['a' => 1, 'b' => 2];
+}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.3: typed OO constants.">
+        <![CDATA[
+class Foo {
+    const <em>int</em> MULTIPLIER = 10;
+
+    const <em>array</em> LOOKUP = ['a' => 1, 'b' => 2];
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Classes/NewTypedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedConstantsSniff.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Exceptions\ValueError;
+use PHPCSUtils\Utils\Constants;
+use PHPCSUtils\Utils\TypeString;
+
+/**
+ * Detect and verify the use of typed OO constant declarations.
+ *
+ * Typed class, interface, trait and enum constant declarations are available since PHP 8.3.
+ *
+ * PHP version 8.3+
+ *
+ * @link https://www.php.net/manual/en/migration83.new-features.php#migration83.new-features.core.typed-class-constants
+ * @link https://wiki.php.net/rfc/typed_class_constants
+ *
+ * @since 10.0.0
+ */
+final class NewTypedConstantsSniff extends Sniff
+{
+
+    /**
+     * Invalid types. These will throw an error.
+     *
+     * The array lists : the invalid type => what was probably intended/alternative
+     * or false if no alternative available.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, string|false>
+     */
+    protected $invalidTypes = [
+        'callable' => false,
+        'void'     => false,
+        'never'    => false,
+    ];
+
+    /**
+     * Invalid "long" types which are likely typos. These will throw a warning.
+     *
+     * The array lists : the invalid type => what was probably intended/alternative
+     * or false if no alternative available.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, string|false>
+     */
+    protected $invalidLongTypes = [
+        'boolean' => 'bool',
+        'integer' => 'int',
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_CONST];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        try {
+            $properties = Constants::getProperties($phpcsFile, $stackPtr);
+        } catch (ValueError $e) {
+            // Not an OO constant or parse error.
+            return;
+        }
+
+        if ($properties['type'] === '') {
+            // Not a typed constant.
+            return;
+        }
+
+        $origType = $properties['type'];
+        $type     = \ltrim($origType, '?'); // Trim off potential nullability.
+
+        if (ScannedCode::shouldRunOnOrBelow('8.2') === true) {
+            $phpcsFile->addError(
+                'Typed constants are not supported in PHP 8.2 or earlier. Found: %s',
+                $properties['type_token'],
+                'Found',
+                [$origType]
+            );
+        } else {
+            $types = TypeString::toArray($type); // Returns all types and normalizes PHP native types.
+
+            foreach ($types as $type) {
+                if (isset($this->invalidTypes[$type])) {
+                    $error = '%s is not supported as a type declaration for constants';
+                    $data  = [$type];
+
+                    if ($this->invalidTypes[$type] !== false) {
+                        $error .= '. Did you mean %s ?';
+                        $data[] = $this->invalidTypes[$type];
+                    }
+
+                    $phpcsFile->addError($error, $properties['type_token'], 'InvalidType', $data);
+                    continue;
+                }
+
+                $type = \strtolower($type);
+                if (isset($this->invalidLongTypes[$type])) {
+                    $error = '%s is not supported as a type declaration for constants';
+                    $data  = [$type];
+
+                    if ($this->invalidLongTypes[$type] !== false) {
+                        $error .= '. Did you mean %s ?';
+                        $data[] = $this->invalidLongTypes[$type];
+                    }
+
+                    $phpcsFile->addWarning($error, $properties['type_token'], 'InvalidLongType', $data);
+                }
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedConstantsUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedConstantsUnitTest.inc
@@ -1,0 +1,76 @@
+<?php
+
+// OK: non-OO constants can still not be typed.
+const GLOBAL_CONSTANT = 10;
+
+// OK: Non-typed constants.
+class PHP82Example {
+    public const PUBLIC_CONST = 'public';
+    protected /* comment */ const PROTECTED_CONST = 'protected';
+    private final const PRIVATE_FINAL = 'private';
+    final public const FINAL_PUBLIC = 'final public';
+
+    // Intentional parse error.
+    const NAME_WITHOUT_VALUE;
+}
+
+// OK: constant names mirroring reserved keywords which can be used in types, but are not types.
+interface NotTypedConstants {
+    const TRUE = true;
+    const array = array();
+}
+
+// PHP 8.3 typed constants.
+class PHP83Example {
+    // All types with the exception of "void", "never" and "callable" are supported.
+    public const int SCALAR_TYPE = 10;
+    protected const ClassName CLASS_TYPE = new ClassName();
+    private const ?ClassName NULLABLE_CLASS_TYPE = null;
+    public const mixed MIXED_TYPE = true;
+    protected const \MyNamespace\InterfaceName FQN_INTERFACE = new ClassName;
+
+    // This also means that the below are all valid...
+    public const ?array ARRAY = array(1, 2, 3);
+    public const true TRUE = true;
+    public const false FALSE = false;
+    public const null NULL = null;
+
+    // Union types are supported.
+    final const int|float UNION_SIMPLE = 5;
+    private final const MyClassA|\Package\MyClassB UNION_TWO_CLASSES = new MyClassA;
+    protected const array|bool|int|float|NULL|object|string|iterable|parent UNION_ALL_BASE_TYPES = null;
+
+    // Intersection types are supported.
+    public const MyClassA&\Package\MyClassB INTERSECTION_TYPE = new MyClassA;
+    final const Traversable&\Countable COUNTABLE_ITERATOR = new MyCountableArray([1,2,3]);
+
+    // DNF types are supported.
+    public const (MyClassA&\Package\MyClassB)|null DNF_TYPE = new MyClassA;
+    final const array|(Traversable&\Countable) ARRAY_LIKE = new MyCountableArray([1,2,3]);
+
+    // The type applies to all constants in one declaration
+    public const float FIRST_CONST = 10.5, SECOND_CONST = 3.2;
+    public const bool FIRST = true,
+        /**
+         * Docblock
+         */
+        SECOND = false,
+        // comment.
+        THIRD = true;
+}
+
+enum PHP83Enum {
+    // The self and static types are only allowed in enums.
+    public const self MY_SELF = new self;
+    public const static MY_STATIC = new static;
+}
+
+// Invalid constant types.
+trait InvalidExample {
+    public const void INVALID_VOID = null;
+    public const never INVALID_NEVER = null;
+    protected const Callable INVALID_CALLABLE = 'strlen';
+    private const ?callable INVALID_NULLABLE_CALLABLE = null;
+    final const Boolean LONG_BOOL = false;
+    protected final const integer LONG_INT = 123;
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedConstantsUnitTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewTypedConstants sniff.
+ *
+ * @group newTypedConstants
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewTypedConstantsSniff
+ *
+ * @since 10.0.0
+ */
+final class NewTypedConstantsUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify that all type declarations are flagged when the minimum supported PHP version < 8.3.
+     *
+     * @dataProvider dataNewTypedConstants
+     *
+     * @param int  $line            The line number on which the error should occur.
+     * @param bool $testNoViolation Whether or not to test noViolation for PHP 8.3.
+     *
+     * @return void
+     */
+    public function testNewTypedConstants($line, $testNoViolation = true)
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertError($file, $line, 'Typed constants are not supported in PHP 8.2 or earlier');
+
+        if ($testNoViolation === true) {
+            $file = $this->sniffFile(__FILE__, '8.3');
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewTypedConstants()
+     *
+     * @return array<array<int|bool>>
+     */
+    public static function dataNewTypedConstants()
+    {
+        return [
+            [26],
+            [27],
+            [28],
+            [29],
+            [30],
+            [33],
+            [34],
+            [35],
+            [36],
+            [39],
+            [40],
+            [41],
+            [44],
+            [45],
+            [48],
+            [49],
+            [52],
+            [53],
+            [64],
+            [65],
+            [70, false],
+            [71, false],
+            [72, false],
+            [73, false],
+            [74, false],
+            [75, false],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff doesn't throw false positives for non-typed constants.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesNewTypedConstants($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $cases = [];
+        // No errors expected on the first 22 lines.
+        for ($line = 1; $line <= 22; $line++) {
+            $cases[] = [$line];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * Verify that invalid type declarations are flagged correctly.
+     *
+     * @dataProvider dataInvalidConstantType
+     *
+     * @param int    $line The line number on which the error should occur.
+     * @param string $type The invalid type which should be detected.
+     *
+     * @return void
+     */
+    public function testInvalidConstantType($line, $type)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertError($file, $line, "$type is not supported as a type declaration for constants");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidConstantType()
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataInvalidConstantType()
+    {
+        return [
+            [70, 'void'],
+            [71, 'never'],
+            [72, 'callable'],
+            [73, 'callable'],
+        ];
+    }
+
+    /**
+     * Verify that invalid "long" type declarations are flagged correctly.
+     *
+     * @dataProvider dataInvalidLongType
+     *
+     * @param int    $line The line number on which the error should occur.
+     * @param string $type The invalid type which should be detected.
+     *
+     * @return void
+     */
+    public function testInvalidLongType($line, $type)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertWarning($file, $line, "$type is not supported as a type declaration for constants");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidLongType()
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataInvalidLongType()
+    {
+        return [
+            [74, 'boolean'],
+            [75, 'integer'],
+        ];
+    }
+
+    /*
+     * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will also throw warnings/errors
+     * about invalid typed constants.
+     */
+}


### PR DESCRIPTION
~~⚠️ This PR needs for PR #1806 to be merged first. It relies on functionality from PHPCSUtils 1.1.0. ⚠️~~ (PR #1806 has been merged) 

---

PHP 8.3 introduced typed constants.

>   . Class, interface, trait, and enum constants now support type
>    declarations.

This commit adds a new sniff to detect these.

Includes unit tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/typed_class_constants
* php/php-src#10444
* https://github.com/php/php-src/commit/414f71a90254cc33896bb3ba953f979f743c198c

Related to #1589