### PR TITLE
Upgrade/LowPHP: simplify skipping the rest of the file

### DIFF
--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -97,7 +97,7 @@ class LowPHPSniff extends Sniff
     {
         // Don't do anything if the warning has already been thrown or is not necessary.
         if ($this->examine === false) {
-            return ($phpcsFile->numTokens + 1);
+            return $phpcsFile->numTokens;
         }
 
         $phpVersion = \phpversion();
@@ -105,7 +105,7 @@ class LowPHPSniff extends Sniff
         // Don't do anything if the PHPCS version used is above the minimum recommended version.
         if (\version_compare($phpVersion, self::MIN_RECOMMENDED_VERSION, '>=')) {
             $this->examine = false;
-            return ($phpcsFile->numTokens + 1);
+            return $phpcsFile->numTokens;
         }
 
         if (\version_compare($phpVersion, self::MIN_SUPPORTED_VERSION, '<')) {
@@ -135,6 +135,6 @@ class LowPHPSniff extends Sniff
         $this->examine = false;
 
         // No need to look at this file again.
-        return ($phpcsFile->numTokens + 1);
+        return $phpcsFile->numTokens;
     }
 }


### PR DESCRIPTION
~~⚠️ This PR needs for PR #1806 to be merged first to allow CI to pass. ⚠️~~ (PR #1806 has been merged) 

---

This commit updates the sniff to use `return $phpcsFile->numTokens` instead of `return ($phpcsFile->numTokens + 1)`.

If a sniff file contains 50 tokens, the last `$stackPtr` will be 49, so returning `50` will already get us passed the end of the token stack and the `+ 1` is redundant.