### PR TITLE
Generators/NewYieldFromComment: simplify the code

### DIFF
--- a/PHPCompatibility/Sniffs/Generators/NewYieldFromCommentSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewYieldFromCommentSniff.php
@@ -38,7 +38,6 @@ class NewYieldFromCommentSniff extends Sniff
     {
         return [
             \T_YIELD_FROM,
-            \T_YIELD, // Only needed for PHPCS < 3.11.0 on PHP < 8.3.
         ];
     }
 
@@ -64,50 +63,30 @@ class NewYieldFromCommentSniff extends Sniff
         $content      = $tokens[$stackPtr]['content'];
         $yieldFromEnd = $stackPtr;
 
-        if ($tokens[$stackPtr]['code'] === \T_YIELD) {
-            /*
-             * Only needed for PHPCS < 3.11.0 on PHP < 8.3.
-             * Once support for PHPCS < 3.11.0 has been dropped, this can be removed.
-             */
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-            if ($nextNonEmpty === false) {
-                // Live coding or parse error.
-                return;
-            }
-
-            if ($tokens[$nextNonEmpty]['code'] !== \T_STRING || \strtolower($tokens[$nextNonEmpty]['content']) !== 'from') {
-                // Not "yield from". This must be an ordinary "yield".
-                return;
-            }
-
-            $yieldFromEnd = $nextNonEmpty;
-
-        } else {
-            /*
-             * Handle potentially multi-token "yield from" expressions.
-             */
-            if (\strtolower(\trim($content)) === 'yield') {
-                for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
-                    if ($tokens[$i]['code'] === \T_YIELD_FROM && \strtolower(\trim($tokens[$i]['content'])) === 'from') {
-                        $content     .= $tokens[$i]['content'];
-                        $yieldFromEnd = $i;
-                        break;
-                    }
-
-                    if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false && $tokens[$i]['code'] !== \T_YIELD_FROM) {
-                        // Shouldn't be possible. Just to be on the safe side.
-                        return; // @codeCoverageIgnore
-                    }
-
-                    $content .= $tokens[$i]['content'];
+        /*
+         * Handle potentially multi-token "yield from" expressions.
+         */
+        if (\strtolower(\trim($content)) === 'yield') {
+            for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
+                if ($tokens[$i]['code'] === \T_YIELD_FROM && \strtolower(\trim($tokens[$i]['content'])) === 'from') {
+                    $content     .= $tokens[$i]['content'];
+                    $yieldFromEnd = $i;
+                    break;
                 }
-            }
 
-            $contentSansKeywords = \substr($content, 5, -4);
+                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false && $tokens[$i]['code'] !== \T_YIELD_FROM) {
+                    // Shouldn't be possible. Just to be on the safe side.
+                    return; // @codeCoverageIgnore
+                }
 
-            if (\trim($contentSansKeywords) === '') {
-                return ($yieldFromEnd + 1);
+                $content .= $tokens[$i]['content'];
             }
+        }
+
+        $contentSansKeywords = \substr($content, 5, -4);
+
+        if (\trim($contentSansKeywords) === '') {
+            return ($yieldFromEnd + 1);
         }
 
         $phpcsFile->addError(


### PR DESCRIPTION
~~⚠️ This PR needs for PR #1806 to be merged first to allow CI to pass. ⚠️~~ (PR #1806 has been merged)  

---


Follow up on #1792

Now support for PHPCS < 3.13.0 has been dropped, some cross-version compatibility code can be dropped from this sniff.