### PR TITLE
PHP 8.4 | :sparkles: New `PHPCompatibility.Interfaces.NewPropertiesInInterfaces` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/Interfaces/NewPropertiesInInterfacesStandard.xml
+++ b/PHPCompatibility/Docs/Interfaces/NewPropertiesInInterfacesStandard.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Properties in Interfaces"
+    >
+    <standard>
+    <![CDATA[
+    Declaring properties in interfaces is allowed since PHP 8.4.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: interface without properties.">
+        <![CDATA[
+interface Foo {
+    public MY_CONST = 10;
+
+    public method($a, $b);
+}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.4: interface declaring properties.">
+        <![CDATA[
+interface Foo {
+    <em>public string $readable { get; }</em>
+    <em>public string $writeable { set; }</em>
+    <em>public string $both { get; set; }</em>
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Interfaces/NewPropertiesInInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewPropertiesInInterfacesSniff.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Interfaces;
+
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Detect declaration of properties in interfaces, which is available since PHP 8.4.0.
+ *
+ * PHP version 8.4
+ *
+ * @link https://wiki.php.net/rfc/property-hooks#interfaces
+ *
+ * @since 10.0.0
+ */
+final class NewPropertiesInInterfacesSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_INTERFACE];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrBelow('8.3') === false) {
+            return;
+        }
+
+        $properties = ObjectDeclarations::getDeclaredProperties($phpcsFile, $stackPtr);
+        if (empty($properties)) {
+            // There are no declared properties.
+            return;
+        }
+
+        $skipTo = $stackPtr;
+        foreach ($properties as $name => $ptr) {
+            if ($skipTo > $ptr) {
+                // Don't throw the same error multiple times for multi-property declarations.
+                continue;
+            }
+
+            $phpcsFile->addError(
+                'Declaring properties in interfaces is not supported in PHP 8.3 or earlier.',
+                $ptr,
+                'Found'
+            );
+
+            $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG, \T_OPEN_CURLY_BRACKET], ($ptr + 1));
+            if ($endOfStatement !== false) {
+                // Don't throw the same error multiple times for multi-property declarations.
+                $skipTo = ($endOfStatement + 1);
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Interfaces/NewPropertiesInInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewPropertiesInInterfacesUnitTest.inc
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Valid cross-version/not our targets.
+ */
+$variableOutsideOoScope = 'foo';
+
+class ClassNotInterface
+{
+    public $prop = 1;
+}
+
+trait TraitNotInterface
+{
+    public $prop = 1;
+}
+
+$a = new class
+{
+    public $prop = 1;
+};
+
+enum EnumNotInterface
+{
+    public $prop = 1;
+}
+
+interface InterfaceDemo
+{
+    public function __construct($parameterNotProperty);
+    public function method($parameterNotProperty);
+}
+
+
+/**
+ * PHP 8.4+: (hooked) properties in interfaces.
+ */
+interface PropertiesInInterface
+{
+    // Only public properties are supported in interfaces. A type is not required.
+    public $noType { get; set; }
+
+    // The old-style "var" keyword (alias for "public") is also supported.
+    var $alsoNoType { get; set; }
+
+    public string $readable { get; }
+    public int $writeable { set; }
+    public ?bool $both { get; set; }
+}
+
+/*
+ * All of the following are not supported, but that's an implementation detail of PHP
+ * and not the concern of this sniff (unless any of this would change in the future).
+ * The sniff should still throw an error for these, as PHPCompatibility only concerns
+ * itself with cross-version compat issues, not incorrect use of PHP.
+ */
+interface UnsupportedPropertiesInInterface
+{
+    // Due to the nature of interfaces, all declared properties must be public.
+    // Fatal error: Property in interface cannot be protected or private.
+    protected $protected { get; set; }
+    private $private { get; set; }
+
+    // Non-hooked properties are not supported in interfaces.
+    // Fatal error: Interfaces may only include hooked properties.
+    public $notHooked;
+
+    // Constructor property promotion is not supported.
+    // Fatal error: Cannot declare promoted property in an abstract constructor.
+    public function __construct(
+        public string $promoted { set; }
+    );
+
+    // Readonly properties are not supported, as property hooks are not supported for readonly properties.
+    // Fatal error: Hooked properties cannot be readonly.
+    readonly $readonlyProp { get; }
+
+    // Static properties are not supported, as property hooks are not supported for static properties.
+    // Parse error: syntax error, unexpected token ";", expecting "function".
+    static $staticProp { get; }
+
+    // Multi-property declarations are not supported, as property hooks are not supported for multi-property declarations.
+    // Parse error: syntax error, unexpected token "{", expecting "," or ";".
+    public int $readableA, $readableB {get;}
+}

--- a/PHPCompatibility/Tests/Interfaces/NewPropertiesInInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewPropertiesInInterfacesUnitTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Interfaces;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewPropertiesInInterfaces sniff.
+ *
+ * @group newPropertiesInInterfaces
+ * @group interfaces
+ *
+ * @covers \PHPCompatibility\Sniffs\Interfaces\NewPropertiesInInterfacesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewPropertiesInInterfacesUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test that an error is thrown for properties declared in interfaces.
+     *
+     * @dataProvider dataPropertyInInterface
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testPropertyInInterface($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertError($file, $line, 'Declaring properties in interfaces is not supported in PHP 8.3 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public static function dataPropertyInInterface()
+    {
+        return [
+            [41],
+            [44],
+            [46],
+            [47],
+            [48],
+
+            // Invalid, still flagged.
+            [61],
+            [62],
+            [66],
+            [71],
+            [76],
+            [80],
+            [84],
+        ];
+    }
+
+
+    /**
+     * Verify that there are no false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+        for ($line = 1; $line <= 34; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
As of PHP 8.4, properties can be declared in interfaces.

This commit adds a new sniff to detect declaration of (hooked) properties in interfaces as supported in PHP 8.4.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/property-hooks#interfaces
* php/php-src#13455
* https://github.com/php/php-src/commit/780a8280d23453ebab5df0dbc35ac897c07c1f0d

Related to #1731