### PR TITLE
PHP 8.4 | :sparkles: New `PHPCompatibility.Classes.NewFinalProperties` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/Classes/NewFinalPropertiesStandard.xml
+++ b/PHPCompatibility/Docs/Classes/NewFinalPropertiesStandard.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Final Properties"
+    >
+    <standard>
+    <![CDATA[
+    OO properties can be declared as final since PHP 8.4.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: not using the final modifier.">
+        <![CDATA[
+class Foo {
+    public string $name;
+}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.4: using the final modifier.">
+        <![CDATA[
+class Foo {
+    <em>final</em> public string $name;
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Classes/NewFinalPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewFinalPropertiesSniff.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\ObjectDeclarations;
+use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\Variables;
+
+/**
+ * Using the "final" modifier for properties is available since PHP 8.4.
+ *
+ * Note: the "final" modifier is not supported (yet) in constructor property promotion.
+ *
+ * PHP version 8.4
+ *
+ * @link https://wiki.php.net/rfc/property-hooks#final_hooks
+ *
+ * @since 10.0.0
+ */
+final class NewFinalPropertiesSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return Collections::ooPropertyScopes();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrBelow('8.3') === false) {
+            return;
+        }
+
+        $properties = ObjectDeclarations::getDeclaredProperties($phpcsFile, $stackPtr);
+        if (empty($properties)) {
+            // There are no declared properties.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $skipTo = $stackPtr;
+        foreach ($properties as $name => $ptr) {
+            if ($skipTo > $ptr) {
+                // Don't throw the same error multiple times for multi-property declarations.
+                continue;
+            }
+
+            if (Scopes::isOOProperty($phpcsFile, $ptr) === false) {
+                // This must be a constructor promoted property. Final is not (yet) supported.
+                continue;
+            }
+
+            $propertyInfo = Variables::getMemberProperties($phpcsFile, $ptr);
+            if ($propertyInfo['is_final'] === false) {
+                // Not a final property.
+                continue;
+            }
+
+            $finalPtr = $phpcsFile->findPrevious([\T_SEMICOLON, \T_FINAL], ($ptr - 1));
+            if ($finalPtr === false || $tokens[$finalPtr]['code'] !== \T_FINAL) {
+                // Shouldn't be possible, but just in case.
+                $finalPtr = $ptr; // @codeCoverageIgnore
+            }
+
+            $phpcsFile->addError(
+                'The final modifier for OO properties is not supported in PHP 8.3 or earlier.',
+                $finalPtr,
+                'Found'
+            );
+
+            $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($ptr + 1));
+            if ($endOfStatement !== false) {
+                // Don't throw the same error multiple times for multi-property declarations.
+                $skipTo = ($endOfStatement + 1);
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewFinalPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewFinalPropertiesUnitTest.inc
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Valid cross-version/not our targets.
+ */
+
+// Variables defined in the global namespace can not have the final modifier,
+// but this is outside the scope of this library. Would cause a parse error anyway.
+final $finalOutsideOOScope = 'not valid';
+
+// The sniff should not trigger on uses of the "final" keyword other than for properties.
+// The sniff should also not trigger on non-final properties or on variables which are not properties.
+final class ClassWithoutFinalProperties
+{
+    final const MY_CONST = 10;
+
+    protected $notFinal;
+
+    final function bar($notFinal) {}
+}
+
+interface InterfaceWithoutFinalProperties
+{
+    final public const MY_CONST = 10;
+
+    public $notFinal { get; }
+
+    public function bar($notFinal);
+}
+
+trait TraitWithoutFinalProperties
+{
+    final const MY_CONST = 10;
+
+    private $notFinal;
+
+    final protected function bar($notFinal) {}
+}
+
+$anonClass = new class
+{
+    final const MY_CONST = 10;
+
+    readonly int $notFinal;
+
+    protected final static function bar($notFinal) {}
+};
+
+enum EnumWithFinalProperties
+{
+    final public const MY_CONST = 10;
+
+    // Properties are not allowed in enums. Ignore.
+    // Fatal error: Enum EnumWithFinalProperties cannot include properties.
+    final $illegal = 10;
+
+    final public function bar($notFinal) {}
+}
+
+
+/*
+ * PHP 8.4: Detect final properties.
+ */
+class ClassWithFinalProperties
+{
+    final $onlyFinal = 1;
+    final public $finalPublic = 2;
+    public /*comment*/ final int $publicFinalTyped = 3;
+    final protected /*comment*/ MyType|false $protectedFinalTyped = false;
+    static final $finalStatic = 5;
+    final
+     readonly
+      ?int
+       $finalReadonlyErrorLineCheck;
+
+    final $multiPropA, $multiPropB, $multiPropC;
+
+    // Fatal error as final with private is an oxymoron, but that's the concern of this sniff.
+    final private $finalPrivate = 7;
+    private final $privateFinal = 8;
+}
+
+trait TraitWithFinalProperties
+{
+    protected static final $protectedStaticFinal;
+}
+
+$anonClass = new class
+{
+    readonly final string|false $readonlyFinalTyped;
+};
+
+interface InterfaceWithFinalProperties
+{
+    // Illegal, but that's not the concern of this sniff.
+    // Fatal error: Property in interface cannot be final.
+    final public $finalPublic { get; }
+}

--- a/PHPCompatibility/Tests/Classes/NewFinalPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewFinalPropertiesUnitTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewFinalProperties sniff.
+ *
+ * @group newFinalProperties
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewFinalPropertiesSniff
+ *
+ * @since 10.0.0
+ */
+class NewFinalPropertiesUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test that an error is thrown for OO properties declared as final.
+     *
+     * @dataProvider dataFinalProperties
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testFinalProperties($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertError($file, $line, 'The final modifier for OO properties is not supported in PHP 8.3 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataFinalProperties()
+    {
+        return [
+            [66],
+            [67],
+            [68],
+            [69],
+            [70],
+            [71],
+            [76],
+            [79],
+            [80],
+            [85],
+            [90],
+            [97],
+        ];
+    }
+
+
+    /**
+     * Verify that there are no false positives for valid code/code errors outside the scope of this sniff.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+        for ($line = 1; $line <= 60; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
As of PHP 8.4, properties can be declared as `final`.

Note: the `final` keyword is not (yet) supported for constructor promoted properties. Support for this will be added in PHP 8.5 (and the sniff will need to be updated once PHPCS/PHPCSUtils supports this).

This commit adds a new sniff to detect final properties as supported in PHP 8.4.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/property-hooks#final_hooks
* php/php-src#13455
* https://github.com/php/php-src/commit/780a8280d23453ebab5df0dbc35ac897c07c1f0d

Related to #1731