### PR TITLE
FunctionDeclarations/NewParamTypeDeclarations: minor test improvement

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -583,7 +583,7 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
      */
     public function testNewDNFTypesNoFalsePositives($line)
     {
-        $file = $this->sniffFile(__FILE__, '8.2');
+        $file = $this->sniffFile(__FILE__, '8.1');
         $this->assertNoViolation($file, $line);
     }
 


### PR DESCRIPTION
The `testNewDNFTypesNoFalsePositives()` test should test there are no false positives against a PHP version on which DNF types would be flagged, so PHP `8.2` was incorrect.