### PR TITLE
PHP 8.3 | Add tests with readonly anonymous classes to a few sniffs

### DIFF
--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -560,3 +560,6 @@ try {
 
 function mycalc( BcMath\Number $number) {}
 $c = new ReflectionConstant($name);
+
+// Safeguard correct handling of PHP 8.3 readonly anonymous class.
+$anon = new readonly class extends GdFont {};

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -241,7 +241,7 @@ class NewClassesUnitTest extends BaseSniffTestCase
             ['ReflectionIntersectionType', '8.0', [469], '8.1'],
             ['CURLStringFile', '8.0', [438], '8.1'],
             ['FTP\Connection', '8.0', [527], '8.1'],
-            ['GdFont', '8.0', [528], '8.1'],
+            ['GdFont', '8.0', [528, 565], '8.1'],
             ['IMAP\Connection', '8.0', [529], '8.1'],
             ['LDAP\Connection', '8.0', [531], '8.1'],
             ['LDAP\Result', '8.0', [532], '8.1'],

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
@@ -124,3 +124,6 @@ function my_pspell(
     PSpell\Config $config,
     PSpell\Dictionary $dictionary,
 ) {}
+
+// Safeguard correct handling of PHP 8.3 readonly anonymous class.
+$anon = new readonly class extends OCILob {};

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
@@ -99,7 +99,7 @@ class RemovedClassesUnitTest extends BaseSniffTestCase
 
             ['IMAP\Connection', '8.4', [118], '8.3'],
             ['OCICollection', '8.4', [120], '8.3'],
-            ['OCILob', '8.4', [121], '8.3'],
+            ['OCILob', '8.4', [121, 129], '8.3'],
             ['PSpell\Config', '8.4', [124], '8.3'],
             ['PSpell\Dictionary', '8.4', [125], '8.3'],
         ];

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -212,6 +212,9 @@ class DNFTypes {
     public function returnType($param) : (Stringable&DOMChildNode)|(A&B) {}
 }
 
+// Safeguard correct handling of PHP 8.3 readonly anonymous class.
+$anon = new readonly class implements \Random\Engine {};
+
 // Test parse error/live coding.
 // This MUST be the last test in the file!
 try {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -85,7 +85,7 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             ['DOMParentNode', '7.4', [196, 204, 210], '8.0'],
             ['UnitEnum', '8.0', [198, 211], '8.1'],
             ['BackedEnum', '8.0', [198, 211], '8.1'],
-            ['Random\Engine', '8.1', [200], '8.2'],
+            ['Random\Engine', '8.1', [200, 216], '8.2'],
             ['Random\CryptoSafeEngine', '8.1', [200], '8.2'],
         ];
     }


### PR DESCRIPTION
Not claiming completeness, just adding tests to some of the obvious sniffs which should have these tests.

---

### PHP 8.3 | Classes/NewClasses: add test with readonly anonymous class 

Already handled correctly by the sniff, just safeguarding this.

### PHP 8.3 | Classes/RemovedClasses: add test with readonly anonymous class 

Already handled correctly by the sniff, just safeguarding this.

### PHP 8.3 | Classes/NewInterfaces: add test with readonly anonymous class 

Already handled correctly by the sniff, just safeguarding this.


Related to #1589