### PR TITLE
Various sniffs: prefer using token constants instead of token names

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -139,7 +139,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
 
         $closer = \end($tokens[$stackPtr]['nested_parenthesis']);
         if (isset($tokens[$closer]['parenthesis_owner'])
-            && $tokens[$tokens[$closer]['parenthesis_owner']]['type'] === 'T_CLOSURE'
+            && $tokens[$tokens[$closer]['parenthesis_owner']]['code'] === \T_CLOSURE
         ) {
             $throwError = true;
         } else {

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -249,7 +249,7 @@ class NewKeywordsSniff extends Sniff
         $end = $stackPtr;
 
         // Translate T_STRING token if necessary.
-        if ($tokens[$stackPtr]['type'] === 'T_STRING') {
+        if ($tokens[$stackPtr]['code'] === \T_STRING) {
             $content = \strtolower($tokens[$stackPtr]['content']);
 
             if (isset($this->translateContentToToken[$content]) === false) {
@@ -262,7 +262,7 @@ class NewKeywordsSniff extends Sniff
 
         // Find the end of potentially multi-line/multi-token "yield from" expressions.
         if ($tokenType === 'T_YIELD_FROM'
-            && preg_match('`yield\s+from`i', $tokens[$stackPtr]['content']) !== 1
+            && \preg_match('`yield\s+from`i', $tokens[$stackPtr]['content']) !== 1
         ) {
             for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
                 if ($tokens[$i]['code'] === \T_YIELD_FROM && \strtolower(\trim($tokens[$i]['content'])) === 'from') {
@@ -301,10 +301,10 @@ class NewKeywordsSniff extends Sniff
         if (($nextToken === false
                 || $tokenType === 'T_FN' // Open parenthesis is expected after "fn" keyword.
                 || $tokenType === 'T_MATCH' // ... and after the "match" keyword.
-                || $tokens[$nextToken]['type'] !== 'T_OPEN_PARENTHESIS')
+                || $tokens[$nextToken]['code'] !== \T_OPEN_PARENTHESIS)
             && ($prevToken === false
-                || $tokens[$prevToken]['type'] !== 'T_CLASS'
-                || $tokens[$prevToken]['type'] !== 'T_INTERFACE')
+                || $tokens[$prevToken]['code'] !== \T_CLASS
+                || $tokens[$prevToken]['code'] !== \T_INTERFACE)
         ) {
             // Skip based on the output of a specific callback.
             if (isset($this->newKeywords[$tokenType]['callback'])

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -176,7 +176,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
             }
 
             // Ignore anything within long array definition brackets.
-            if ($tokens[$nextVariable]['type'] === 'T_ARRAY'
+            if ($tokens[$nextVariable]['code'] === \T_ARRAY
                 && isset($tokens[$nextVariable]['parenthesis_closer'])
             ) {
                 // Skip forward to the end of the short array definition.
@@ -185,7 +185,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
             }
 
             // Ignore anything within short array definition brackets.
-            if ($tokens[$nextVariable]['type'] === 'T_OPEN_SHORT_ARRAY'
+            if ($tokens[$nextVariable]['code'] === \T_OPEN_SHORT_ARRAY
                 && isset($tokens[$nextVariable]['bracket_closer'])
             ) {
                 // Skip forward to the end of the short array definition.
@@ -194,8 +194,8 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
             }
 
             // Skip past closures and arrow functions passed as function parameters.
-            if (($tokens[$nextVariable]['type'] === 'T_CLOSURE'
-                || $tokens[$nextVariable]['type'] === 'T_FN')
+            if (($tokens[$nextVariable]['code'] === \T_CLOSURE
+                || $tokens[$nextVariable]['code'] === \T_FN)
                 && isset($tokens[$nextVariable]['scope_closer'])
             ) {
                 // Skip forward to the end of the closure/arrow function declaration.

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -80,7 +80,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
 
         foreach ($dereferencing as $openBrace => $closeBrace) {
             if ($supports53 === true
-                && $tokens[$openBrace]['type'] === 'T_OPEN_SQUARE_BRACKET'
+                && $tokens[$openBrace]['code'] === \T_OPEN_SQUARE_BRACKET
             ) {
                 $phpcsFile->addError(
                     'Function array dereferencing is not present in PHP version 5.3 or earlier',
@@ -92,7 +92,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
             }
 
             // PHP 7.0 function array dereferencing using curly braces.
-            if ($tokens[$openBrace]['type'] === 'T_OPEN_CURLY_BRACKET') {
+            if ($tokens[$openBrace]['code'] === \T_OPEN_CURLY_BRACKET) {
                 $phpcsFile->addError(
                     'Function array dereferencing using curly braces is not present in PHP version 5.6 or earlier',
                     $openBrace,
@@ -165,8 +165,8 @@ class NewFunctionArrayDereferencingSniff extends Sniff
                 break;
             }
 
-            if ($tokens[$nextNonEmpty]['type'] === 'T_OPEN_SQUARE_BRACKET'
-                || $tokens[$nextNonEmpty]['type'] === 'T_OPEN_CURLY_BRACKET' // PHP 7.0+.
+            if ($tokens[$nextNonEmpty]['code'] === \T_OPEN_SQUARE_BRACKET
+                || $tokens[$nextNonEmpty]['code'] === \T_OPEN_CURLY_BRACKET // PHP 7.0+.
             ) {
                 if (isset($tokens[$nextNonEmpty]['bracket_closer']) === false) {
                     // Live coding or parse error.

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -63,7 +63,7 @@ class RemovedNewReferenceSniff extends Sniff
 
         $tokens       = $phpcsFile->getTokens();
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['type'] !== 'T_BITWISE_AND') {
+        if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== \T_BITWISE_AND) {
             return;
         }
 


### PR DESCRIPTION
These are remnants of the past when a wider range of PHPCS versions was supported, which meant that some token constants may not exist in all supported PHPCS versions, but this is no longer needed.

Note: this doesn't "fix" this completely. I am aware there are some more places in the codebase where `'type'` is used. These will be reviewed at a later point in time.