### PR TITLE
PHP 8.0 | FunctionDeclarations/NonStaticMagicMethods: flag incorrect modifiers for __wakeup()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -23,7 +23,10 @@ use PHPCSUtils\Utils\Scopes;
  * The requirements have always existed, but as of PHP 5.3, a warning will be thrown
  * when magic methods have the wrong modifiers.
  *
+ * For unknown reasons, this check was not executed for the __wakeup() method until PHP 8.0.
+ *
  * PHP version 5.3
+ * PHP version 8.0
  *
  * @link https://www.php.net/manual/en/language.oop5.magic.php
  *
@@ -108,6 +111,11 @@ class NonStaticMagicMethodsSniff extends Sniff
             'visibility' => 'public',
             'static'     => false,
         ],
+        // Enforced since PHP 8.0.
+        '__wakeup' => [
+            'visibility' => 'public',
+            'static'     => false,
+        ],
     ];
 
 
@@ -160,17 +168,28 @@ class NonStaticMagicMethodsSniff extends Sniff
             return;
         }
 
+        // Special case __wakeup() for which the signature modifiers are only enforced since PHP 8.0.
+        $qualifyingPhrase = '';
+        if ($methodNameLc === '__wakeup') {
+            if (ScannedCode::shouldRunOnOrAbove('8.0') === false) {
+                return;
+            }
+
+            $qualifyingPhrase = ' since PHP 8.0';
+        }
+
         $methodProperties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
         $errorCodeBase    = MessageHelper::stringToErrorCode($methodNameLc);
 
         if (isset($this->magicMethods[$methodNameLc]['visibility'])
             && $this->magicMethods[$methodNameLc]['visibility'] !== $methodProperties['scope']
         ) {
-            $error     = 'Visibility for magic method %s must be %s. Found: %s';
+            $error     = 'Visibility for magic method %s must be %s%s. Found: %s';
             $errorCode = $errorCodeBase . 'MethodVisibility';
             $data      = [
                 $methodName,
                 $this->magicMethods[$methodNameLc]['visibility'],
+                $qualifyingPhrase,
                 $methodProperties['scope'],
             ];
 
@@ -180,9 +199,12 @@ class NonStaticMagicMethodsSniff extends Sniff
         if (isset($this->magicMethods[$methodNameLc]['static'])
             && $this->magicMethods[$methodNameLc]['static'] !== $methodProperties['is_static']
         ) {
-            $error     = 'Magic method %s cannot be defined as static.';
+            $error     = 'Magic method %s cannot be defined as static%s.';
             $errorCode = $errorCodeBase . 'MethodStatic';
-            $data      = [$methodName];
+            $data      = [
+                $methodName,
+                $qualifyingPhrase,
+            ];
 
             if ($this->magicMethods[$methodNameLc]['static'] === true) {
                 $error     = 'Magic method %s must be defined as static.';

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
@@ -352,3 +352,29 @@ enum WrongStaticEnum
     public static function __serialize() {}
     static public function __unserialize($data) {}
 }
+
+// PHP 8.0: __wakeup() modifiers are now checked too.
+class WakeUpPlain
+{
+    function __wakeup() {}
+}
+
+interface WakeUpCorrect
+{
+    public function __wakeup();
+}
+
+trait WakeUpVisibility
+{
+    private function __wakeup() {}
+}
+
+$wakeUp = new class()
+{
+    protected static function __wakeup() {} // Bad: static & protected.
+}
+
+enum WakeUpStatic
+{
+    static function __wakeup() {}
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -339,6 +339,100 @@ class NonStaticMagicMethodsUnitTest extends BaseSniffTestCase
 
 
     /**
+     * Verify an error is thrown for wrong visibility on the __wakeup() method when the code under scan needs to run on PHP 8.0 or higher.
+     *
+     * @dataProvider dataWrongMethodVisibilityWakeUp
+     *
+     * @param string $testVisibility The visibility the method actually has in the test.
+     * @param int    $line           The line number.
+     *
+     * @return void
+     */
+    public function testWrongMethodVisibilityWakeUp($testVisibility, $line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, "Visibility for magic method __wakeup must be public since PHP 8.0. Found: {$testVisibility}");
+
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<string|int>>
+     */
+    public static function dataWrongMethodVisibilityWakeUp()
+    {
+        return [
+            ['private', 369],
+            ['protected', 374],
+        ];
+    }
+
+
+    /**
+     * Verify an error is thrown for a statically declared __wakeup() method when the code under scan needs to run on PHP 8.0 or higher.
+     *
+     * @dataProvider dataWrongStaticMethodWakeUp
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testWrongStaticMethodWakeUp($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, $line, 'Magic method __wakeup cannot be defined as static since PHP 8.0.');
+
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataWrongStaticMethodWakeUp()
+    {
+        return [
+            [374],
+            [379],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid declarations of __wakeup().
+     *
+     * @dataProvider dataNoFalsePositivesWakeUp
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesWakeUp($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositivesWakeUp()
+    {
+        return [
+            [359],
+            [364],
+        ];
+    }
+
+
+    /**
      * Verify no notices are thrown at all.
      *
      * @return void


### PR DESCRIPTION
Came across this while testing something else. Apparently the modifier keywords check is now also executed for the `__wakeup()` magic method since PHP 8.0.

There is no information about this available in the PHP 8.0 changelog though, nor have I been able to pinpoint the commit in which this was changed.

Even so, this snippet clearly demonstrates the issue: https://3v4l.org/0Raok#veol

Related to #809