### PR TITLE
PHP 8.0 | AbstractInitialValueSniff: minor tweak for improved ignoring of `static` as return type

### DIFF
--- a/PHPCompatibility/AbstractInitialValueSniff.php
+++ b/PHPCompatibility/AbstractInitialValueSniff.php
@@ -133,6 +133,11 @@ abstract class AbstractInitialValueSniff extends Sniff
                 $this->processInitialValue($phpcsFile, $param['token'], $param['default_token'], $defaultEnd, $type);
             }
 
+            if (isset($tokens[$stackPtr]['scope_opener'])) {
+                // Skip over the declaration, no need to trigger the sniff for a "static" return type.
+                return $tokens[$stackPtr]['scope_opener'];
+            }
+
             /*
              * No need for the sniff to be triggered by the T_VARIABLEs in the function
              * definition as we've already examined them above, so let's skip over them.


### PR DESCRIPTION
There is already a test in the `NewConstantScalarExpressionsUnitTest` class covering this.