### PR TITLE
Allow for running the tests on PHPUnit 11

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -87,10 +87,16 @@ jobs:
         id: phpunit_version
         run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
-      - name: Run the unit tests (PHPUnit < 10)
-        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
-        run: vendor/bin/phpunit --no-coverage
+      - name: Determine PHPUnit config file to use
+        id: phpunit_config
+        run: |
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
+          elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
+          else
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Run the unit tests (PHPUnit 10+)
-        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
-        run: vendor/bin/phpunit -c phpunit10.xml.dist --no-coverage
+      - name: Run the unit tests
+        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,13 +281,10 @@ jobs:
         run: |
           if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
             echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
-            echo 'EXTRA_ARGS="--coverage-cache ./build/phpunit-cache"' >> $GITHUB_OUTPUT
           elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
             echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
-            echo 'EXTRA_ARGS="--coverage-cache ./build/phpunit-cache"' >> $GITHUB_OUTPUT
           else
             echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
-            echo 'EXTRA_ARGS=""' >> $GITHUB_OUTPUT
           fi
 
       # PHPUnit 9.3 started using PHP-Parser for code coverage causing some of our coverage builds to fail.
@@ -297,10 +294,10 @@ jobs:
       # As coverage is only run on high/low PHP, the high PHP version will use PHPUnit 11, so just check for that.
       - name: "Warm the PHPUnit cache (PHPUnit 9.3+)"
         if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}
-        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} ${{ steps.phpunit_config.outputs.EXTRA_ARGS }} --warm-coverage-cache
+        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --warm-coverage-cache
 
       - name: Run the unit tests with code coverage
-        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} ${{ steps.phpunit_config.outputs.EXTRA_ARGS }}
+        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }}
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,13 +174,19 @@ jobs:
         id: phpunit_version
         run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
-      - name: Run the unit tests (PHPUnit < 10)
-        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
-        run: vendor/bin/phpunit --no-coverage
+      - name: Determine PHPUnit config file to use
+        id: phpunit_config
+        run: |
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
+          elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
+          else
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Run the unit tests (PHPUnit 10+)
-        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
-        run: vendor/bin/phpunit -c phpunit10.xml.dist --no-coverage
+      - name: Run the unit tests
+        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage
 
 
   #### CODE COVERAGE STAGE ####
@@ -270,22 +276,31 @@ jobs:
       - name: "DEBUG: Show grabbed version"
         run: echo ${{ steps.phpunit_version.outputs.VERSION }}
 
+      - name: Determine PHPUnit config file to use
+        id: phpunit_config
+        run: |
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
+            echo 'EXTRA_ARGS="--coverage-cache ./build/phpunit-cache"' >> $GITHUB_OUTPUT
+          elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
+            echo 'EXTRA_ARGS="--coverage-cache ./build/phpunit-cache"' >> $GITHUB_OUTPUT
+          else
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+            echo 'EXTRA_ARGS=""' >> $GITHUB_OUTPUT
+          fi
+
       # PHPUnit 9.3 started using PHP-Parser for code coverage causing some of our coverage builds to fail.
       # As of PHPUnit 9.3.4, a cache warming option is available.
       # Using that option prevents issues with PHP-Parser backfilling PHP tokens when PHPCS does not (yet),
       # which would otherwise cause tests to fail on tokens being available when they shouldn't be.
-      # As coverage is only run on high/low PHP, the high PHP version will use PHPUnit 10, so just check for that.
+      # As coverage is only run on high/low PHP, the high PHP version will use PHPUnit 11, so just check for that.
       - name: "Warm the PHPUnit cache (PHPUnit 9.3+)"
-        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
-        run: vendor/bin/phpunit -c phpunit10.xml.dist --coverage-cache ./build/phpunit-cache --warm-coverage-cache
+        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}
+        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} ${{ steps.phpunit_config.outputs.EXTRA_ARGS }} --warm-coverage-cache
 
-      - name: "Run the unit tests with code coverage (PHPUnit < 10)"
-        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
-        run: vendor/bin/phpunit
-
-      - name: "Run the unit tests with code coverage (PHPUnit 10+)"
-        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
-        run: vendor/bin/phpunit -c phpunit10.xml.dist --coverage-cache ./build/phpunit-cache
+      - name: Run the unit tests with code coverage
+        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} ${{ steps.phpunit_config.outputs.EXTRA_ARGS }}
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}

--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -17,6 +17,9 @@ use PHP_CodeSniffer\Files\LocalFile;
 use PHP_CodeSniffer\Ruleset;
 use PHP_CodeSniffer\Util\Common;
 use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\AfterClass;
+use PHPUnit\Framework\Attributes\BeforeClass;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 
 /**
@@ -78,6 +81,8 @@ abstract class BaseSniffTestCase extends TestCase
      *
      * @return void
      */
+    #[BeforeClass]
+    #[AfterClass]
     public static function resetSniffFiles()
     {
         self::$sniffFiles = [];
@@ -94,6 +99,7 @@ abstract class BaseSniffTestCase extends TestCase
      *
      * @return void
      */
+    #[After]
     public function resetTestVersion()
     {
         // Reset the targetPhpVersion.

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,10 @@
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.4.0",
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
-    "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.1.0",
+    "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.5.32 || ^11.3.3",
     "phpcsstandards/phpcsdevcs": "^1.1.3",
     "phpcsstandards/phpcsdevtools": "^1.2.0",
-    "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+    "yoast/phpunit-polyfills": "^1.0.5 || ^2.0 || ^3.0"
   },
   "replace": {
     "wimg/php-compatibility": "*"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -84,4 +84,8 @@
         <exclude-pattern>*/PHPCompatibility/Util/Tests/*\.php</exclude-pattern>
     </rule>
 
+    <rule ref="PHPCompatibility.Attributes.NewAttributes.PHPUnitAttributeFound">
+        <exclude-pattern>*/PHPCompatibility/Tests/BaseSniffTestCase\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -8,6 +8,7 @@
         beStrictAboutChangesToGlobalState="true"
         beStrictAboutOutputDuringTests="true"
         beStrictAboutTestsThatDoNotTestAnything="true"
+        cacheDirectory="build/.phpunit-cache"
         displayDetailsOnTestsThatTriggerErrors="true"
         displayDetailsOnTestsThatTriggerWarnings="true"
         displayDetailsOnTestsThatTriggerNotices="true"

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/10.1/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/10.5/phpunit.xsd"
         bootstrap="./phpunit-bootstrap.php"
         backupGlobals="true"
         colors="true"
@@ -12,9 +12,11 @@
         displayDetailsOnTestsThatTriggerWarnings="true"
         displayDetailsOnTestsThatTriggerNotices="true"
         displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnPhpunitDeprecations="false"
         failOnWarning="true"
         failOnNotice="true"
         failOnDeprecation="true"
+        failOnPhpunitDeprecation="false"
         requireCoverageMetadata="true"
     >
     <testsuites>


### PR DESCRIPTION
### Composer: update the PHPUnit Polyfills to v 3.0 and allow for PHPUnit 11 

A PHPUnit 11 compatible version of the PHPUnit Polyfills has been released and the `UtilityMethodTestCase` from PHPCSUtils is also fully compatible with PHPUnit 11, so let's start using it.

Mind: PHPUnit 11 throws (~1000) deprecation notices about the use of annotations instead of attributes.
On PHPUnit < 10.5.32 and PHPUnit < 11.3.3, these deprecation notices would fail the test run.

PHPUnit 10.5.32 and 11.3.3 introduce two new options for both the configuration file and as CLI arguments: `displayDetailsOnPhpunitDeprecations` and `failOnPhpunitDeprecation`, both of which will now default to `false`, which means the test runs will no longer fail, making the update viable.

These options have been added to the PHPUnit configuration for PHPUnit 10/11 to safeguard them against changes in the default value.

Includes updating the GitHub Actions workflows to use the correct PHPUnit config file based on the PHPUnit version (and allowing for PHPUnit 11).

Ref:
* https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/3.0.0
* https://phpunit.de/announcements/phpunit-11.html
* sebastianbergmann/phpunit#5937

### GH Actions/PHPUnit config: deal with removed --coverage-cache CLI option

The `--coverage-cache` flag was silently deprecated in PHPUnit 10 and has been removed in PHPUnit 11.

The `--cache-directory` flag replaces it and can also be set in the XML file.

This commit removes the outdated flag from the commands used in GH Actions and adds the attribute to the PHPUnit config file.

Ref:
* sebastianbergmann/phpunit#4599

### BaseSniffTestCase: add Before/After[Class] attributes 

PHPUnit 10 introduced attributes as replacements for docblock annotations.
PHPUnit 11 deprecates the use of docblock annotations in favour of attributes.

If both an attribute as well as an annotation are found, no PHPUnit deprecation warning will be thrown.

While not strictly necessary yet, this commit adds the `Before/After*` attributes in the `BaseSniffTestCase` class to reduce the amount of deprecation notices somewhat (Before: > 1050, after: ~694).

_The rest of the "annotations to attributes" conversion for the test suite is left for the update to PHPUnit 12 (if and when)._

Note: The `@before/after*` annotations remain as the tests also still need to run on PHP 5.4 - 8.0 using PHPUnit 4.x - 9.x.
These can be removed once the codebase has a PHP 8.1/PHPUnit 10 minimum requirement.
Alternatively, once support for PHP < 7.2 / PHPUnit < 8.0 is dropped, the fixture methods can be reverted to use the canonical `setUp/tearDown[BeforeClass|AfterClass]` names again.

Note: due to the syntax for attributes, these can be safely added as they are ignored as comments on PHP < 8.0.
Along the same line, if there is no "listener" for the attributes (PHP 8.0/PHPUnit 9.x), they are ignored by PHP as well.