### PR TITLE
Various sniffs: reduce the use of the PHPCSUtils BCTokens class

### DIFF
--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\Numbers;
 
 /**
@@ -89,7 +88,7 @@ class DiscouragedSwitchContinueSniff extends Sniff
      */
     public function register()
     {
-        $this->acceptedLevelTokens += BCTokens::arithmeticTokens();
+        $this->acceptedLevelTokens += Tokens::$arithmeticTokens;
         $this->acceptedLevelTokens += Tokens::$emptyTokens;
 
         return [\T_SWITCH];

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
 
@@ -166,7 +165,7 @@ class NewClosureSniff extends Sniff
                 /*
                  * Closures only have access to $this if used within a class context.
                  */
-                elseif (Conditions::hasCondition($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) === false) {
+                elseif (Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens) === false) {
                     $phpcsFile->addWarning(
                         'Closures / anonymous functions only have access to $this if used within a class or when bound to an object using bindTo(). Please verify.',
                         $thisFound,

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
 
@@ -56,7 +55,7 @@ class NewExceptionsFromToStringSniff extends Sniff
     {
         // Enhance the array of tokens to ignore for finding the docblock.
         $this->docblockIgnoreTokens += Tokens::$methodPrefixes;
-        $this->docblockIgnoreTokens += BCTokens::phpcsCommentTokens();
+        $this->docblockIgnoreTokens += Tokens::$phpcsCommentTokens;
 
         return [\T_FUNCTION];
     }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -14,7 +14,7 @@ use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHPCSUtils\BackCompat\BCTokens;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -289,7 +289,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
                     // Only throw this error for PHP 5.2+ as before that the "type hint not supported" error
                     // will be thrown.
                     if (($type === 'self' || $type === 'parent')
-                        && (Conditions::hasCondition($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) === false
+                        && (Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens) === false
                             || ($tokens[$stackPtr]['code'] === \T_FUNCTION
                             && Scopes::isOOMethod($phpcsFile, $stackPtr) === false))
                         && ScannedCode::shouldRunOnOrBelow('5.1') === false

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -353,7 +352,7 @@ class ForbiddenNamesSniff extends Sniff
                  * and the 'conditions' aren't always correctly set, so we need to do an additional check for
                  * the last condition potentially being a previous trait T_USE.
                  */
-                $traitScopes = BCTokens::ooScopeTokens();
+                $traitScopes = Tokens::$ooScopeTokens;
                 unset($traitScopes[\T_INTERFACE]);
 
                 if (Conditions::hasCondition($phpcsFile, $stackPtr, $traitScopes) === false) {

--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -13,8 +13,8 @@ namespace PHPCompatibility\Sniffs\Operators;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Operators;
 
@@ -117,7 +117,7 @@ class RemovedTernaryAssociativitySniff extends Sniff
             }
 
             // Check for operators with lower operator precedence.
-            if (isset(BCTokens::assignmentTokens()[$tokens[$i]['code']])
+            if (isset(Tokens::$assignmentTokens[$tokens[$i]['code']])
                 || isset($this->tokensWithLowerPrecedence[$tokens[$i]['code']])
             ) {
                 break;

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
@@ -14,7 +14,6 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -88,7 +87,7 @@ class ChangedIntToBoolParamTypeSniff extends AbstractFunctionCallParameterSniff
                 \T_LNUMBER => \T_LNUMBER,
                 \T_DNUMBER => \T_DNUMBER,
             ];
-            $search += BCTokens::arithmeticTokens();
+            $search += Tokens::$arithmeticTokens;
             $search += Tokens::$emptyTokens;
         }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
-use PHPCSUtils\BackCompat\BCTokens;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -82,7 +82,7 @@ class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCallParame
                 return;
             }
 
-            if (isset(BCTokens::textStringTokens()[$tokens[$i]['code']]) === true
+            if (isset(Tokens::$textStringTokens[$tokens[$i]['code']]) === true
                 && \strpos($tokens[$i]['content'], '/>') !== false
             ) {
                 $phpcsFile->addError(

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -119,7 +118,7 @@ class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterS
                         break;
                     }
 
-                    if (isset(BCTokens::textStringTokens()[$tokens[$i]['code']]) === true
+                    if (isset(Tokens::$textStringTokens[$tokens[$i]['code']]) === true
                         && \strpos($tokens[$i]['content'], '>') !== false
                     ) {
                         $phpcsFile->addWarning(

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 
@@ -279,7 +278,7 @@ class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParamete
                 return;
             }
 
-            if (isset(BCTokens::textStringTokens()[$tokenCode]) === true) {
+            if (isset(Tokens::$textStringTokens[$tokenCode]) === true) {
                 $this->throwNotice($phpcsFile, $stackPtr, $functionName);
                 return;
             }

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
@@ -56,7 +55,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
      */
     public function register()
     {
-        $this->assignOrCompare = BCTokens::assignmentTokens() + BCTokens::equalityTokens();
+        $this->assignOrCompare = Tokens::$assignmentTokens + Tokens::$equalityTokens;
 
         return [
             \T_STRING,

--- a/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
@@ -14,7 +14,6 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
-use PHPCSUtils\BackCompat\BCTokens;
 
 /**
  * Detect dereferencing of magic constants as allowed per PHP 8.0.
@@ -96,7 +95,7 @@ class NewMagicConstantDereferencingSniff extends Sniff
             }
 
             // If the next token is an assignment, that's all we need to know.
-            if (isset(BCTokens::assignmentTokens()[$tokens[$nextNext]['code']]) === true) {
+            if (isset(Tokens::$assignmentTokens[$tokens[$nextNext]['code']]) === true) {
                 return;
             }
 

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
@@ -88,7 +87,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
      */
     public function register()
     {
-        $this->skipOverScopes += BCTokens::ooScopeTokens();
+        $this->skipOverScopes += Tokens::$ooScopeTokens;
 
         return [
             \T_FUNCTION,
@@ -295,7 +294,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
      */
     protected function isThisUsedAsParameter(File $phpcsFile, $stackPtr)
     {
-        if (Scopes::validDirectScope($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) !== false) {
+        if (Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens) !== false) {
             return;
         }
 
@@ -353,7 +352,7 @@ class ForbiddenThisUseContextsSniff extends Sniff
             return;
         }
 
-        if (Scopes::validDirectScope($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) !== false) {
+        if (Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens) !== false) {
             $methodProps = $phpcsFile->getMethodProperties($stackPtr);
             if ($methodProps['is_static'] === false) {
                 return;

--- a/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\Operators;
@@ -199,7 +198,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
             }
         }
 
-        if (isset(BCTokens::assignmentTokens()[$tokens[$nextNonEmpty]['code']]) === true) {
+        if (isset(Tokens::$assignmentTokens[$tokens[$nextNonEmpty]['code']]) === true) {
             $phpcsFile->addError(
                 \sprintf(self::WRITE_ERROR, 'assignment to $GLOBALS'),
                 $stackPtr,


### PR DESCRIPTION
The PHPCS `Tokens` class provides a number of token arrays for use by sniffs. The PHPCSUtils `BCTokens` class mirrors that class and provides PHPCS cross-version compatible versions of the same with the latest version from PHPCS being leading in what needs to be supported.

Since both PHPCompatibility, as well as PHPCSUtils are no longer supporting a wide range of PHPCS versions, this has become largely irrelevant, with only some minimal relevance for token arrays which will change in the upcoming PHPCS 4.0 version.

At this time, there are only six token arrays in the `BCTokens` class to which the "PHPCS 4.0 compatility" argument can be applied:
1. `assignmentTokens` - but the cross-version compat is only relevant for libraries which includes sniffs scanning javascript files.
2. `blockOpeners` - but the cross-version compat is only relevant for libraries which includes sniffs scanning javascript files.
3. `functionNameTokens` - provides cross-version compat with the change in how namespaced names are tokenized in PHPCS 4.0.
4. `nameTokens` - new token array in PHPCS 4.0, but was already available in PHPCSUtils via the token arrays in `Collections`.
5. `parenthesisOpeners` - provides cross-version compat with the changes in what tokens will get `parenthesis_*` token array index keys in PHPCS 4.0.
6. `scopeOpeners` - but the cross-version compat is only relevant for libraries which includes sniffs scanning javascript files.

This means that the only two token arrays for which the use of the `BCTokens` variant is relevant for PHPCompatibility are the `functionNameTokens` and the `parenthesisOpeners` token arrays and neither of these are in use by PHPCompatibility.

So this commit does some clean-up, removing the no longer necessary usage of the `BCTokens` class.