### PR TITLE
ScannedCodeUnitTest: use new ConfigDouble class

### DIFF
--- a/PHPCompatibility/Util/Tests/Helpers/ScannedCodeUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ScannedCodeUnitTest.php
@@ -10,9 +10,9 @@
 
 namespace PHPCompatibility\Util\Tests\Helpers;
 
-use PHP_CodeSniffer\Config;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\TestUtils\ConfigDouble;
 use ReflectionMethod;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
@@ -49,7 +49,7 @@ final class ScannedCodeUnitTest extends TestCase
      */
     public static function initializeConfig()
     {
-        self::$config = new Config();
+        self::$config = new ConfigDouble();
 
         self::$reflMethod = new ReflectionMethod('PHPCompatibility\Helpers\ScannedCode', 'getTestVersion');
         self::$reflMethod->setAccessible(true);
@@ -66,6 +66,24 @@ final class ScannedCodeUnitTest extends TestCase
     {
         Helper::setConfigData('testVersion', null, true, self::$config);
         Helper::setConfigData('testversion', null, true, self::$config);
+    }
+
+    /**
+     * Reset the static properties of the Config class after the tests.
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public function resetConfigClass()
+    {
+        /*
+         * Explicitly trigger __destruct() on the ConfigDouble to reset the Config statics.
+         * The explicit method call prevents potential stray test-local references to the $config object
+         * preventing the destructor from running the clean up (which without stray references would be
+         * automagically triggered when `self::$phpcsFile` is reset, but we can't definitively rely on that).
+         */
+        self::$config->__destruct();
     }
 
 


### PR DESCRIPTION
This should make the tests more stable as the `ConfigDouble` has handling for resetting the `static` properties on the PHPCS native `Config` class between tests.