### PR TITLE
PHPCSUtils 1.1.0: only catch what should be caught

### DIFF
--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Helpers;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\GetTokensAsString;
@@ -192,7 +193,7 @@ trait PCRERegexTrait
                 }
 
                 $regex .= \trim($content);
-            } catch (RuntimeException $e) {
+            } catch (ValueError $e) {
                 // Ignore. Subsequent line of a multi-line double quoted text string.
             }
         }

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Sniffs\Lists;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
@@ -70,7 +70,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
 
         try {
             $assignments = Lists::getAssignments($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
+        } catch (UnexpectedTokenType $e) {
             // Parse error/live coding.
             return;
         }

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Sniffs\Lists;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
@@ -70,7 +70,7 @@ class NewKeyedListSniff extends Sniff
 
         try {
             $assignments = Lists::getAssignments($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
+        } catch (UnexpectedTokenType $e) {
             // Parse error/live coding.
             return;
         }

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Sniffs\Lists;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
@@ -72,7 +72,7 @@ class NewListReferenceAssignmentSniff extends Sniff
 
         try {
             $assignments = Lists::getAssignments($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
+        } catch (UnexpectedTokenType $e) {
             // Parse error/live coding.
             return;
         }


### PR DESCRIPTION
PHPCSUtils 1.1.0 introduces much more modular exceptions for a variety of errors the utility methods can throw.

This commit changes the exceptions being caught in various `catch` statements to more specific ones.

This means that exceptions which shouldn't be able to occur are no longer caught (passing incorrect data type and such) and only the potentially expected (and acceptable) exceptions will now be caught.