### PR TITLE
Various sniffs: minor simplifications related to ControlStructures::getCaughtExceptions()

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHPCompatibility\Helpers\ResolveHelper;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ControlStructures;
@@ -1604,13 +1603,7 @@ class NewClassesSniff extends Sniff
      */
     private function processCatchToken(File $phpcsFile, $stackPtr)
     {
-        try {
-            $exceptions = ControlStructures::getCaughtExceptions($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
-            // Parse error or live coding.
-            return;
-        }
-
+        $exceptions = ControlStructures::getCaughtExceptions($phpcsFile, $stackPtr);
         if (empty($exceptions) === true) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
 use PHPCompatibility\Helpers\ResolveHelper;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ControlStructures;
@@ -476,13 +475,7 @@ class RemovedClassesSniff extends Sniff
      */
     private function processCatchToken(File $phpcsFile, $stackPtr)
     {
-        try {
-            $exceptions = ControlStructures::getCaughtExceptions($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
-            // Parse error or live coding.
-            return;
-        }
-
+        $exceptions = ControlStructures::getCaughtExceptions($phpcsFile, $stackPtr);
         if (empty($exceptions) === true) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ControlStructures;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -521,13 +520,7 @@ class NewInterfacesSniff extends Sniff
      */
     private function processCatchToken(File $phpcsFile, $stackPtr)
     {
-        try {
-            $exceptions = ControlStructures::getCaughtExceptions($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
-            // Parse error or live coding.
-            return;
-        }
-
+        $exceptions = ControlStructures::getCaughtExceptions($phpcsFile, $stackPtr);
         if (empty($exceptions) === true) {
             return;
         }


### PR DESCRIPTION
The `ControlStructures::getCaughtExceptions()` method will no longer throw an exception for live coding/parse errors, but will return an empty array instead since PHPCSUtils 1.0.12.

This means a `try/catch` around function calls to `ControlStructures::getCaughtExceptions()` is now redundant and can be removed.

Note: the `ControlStructures::getCaughtExceptions()` method will still throw exceptions for an invalid token pointer being passed to the method, but that's a situations which cannot occur for these three sniffs.