### PR TITLE
Classes/NewConstVisibility + NewFinalConstants: use new PHPCSUtils 1.1.0 Constants class 

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -13,8 +13,8 @@ namespace PHPCompatibility\Sniffs\Classes;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Exceptions\ValueError;
+use PHPCSUtils\Utils\Constants;
 
 /**
  * Visibility for class constants is available since PHP 7.1.
@@ -58,29 +58,23 @@ class NewConstVisibilitySniff extends Sniff
             return;
         }
 
-        $tokens = $phpcsFile->getTokens();
-        $skip   = Tokens::$emptyTokens;
-        $skip[] = \T_FINAL;
-
-        $prevToken = $phpcsFile->findPrevious($skip, ($stackPtr - 1), null, true, null, true);
-
-        // Is the previous token a visibility indicator ?
-        if ($prevToken === false || isset(Tokens::$scopeModifiers[$tokens[$prevToken]['code']]) === false) {
+        try {
+            $properties = Constants::getProperties($phpcsFile, $stackPtr);
+        } catch (ValueError $e) {
+            // Not an OO constant or parse error.
             return;
         }
 
-        // Is this a class constant ?
-        if (Scopes::isOOConstant($phpcsFile, $stackPtr) === false) {
-            // This may be a constant declaration in the global namespace with visibility,
-            // but that would throw a parse error, i.e. not our concern.
+        if ($properties['scope_token'] === false) {
+            // Not a constant with visibility explicitly set.
             return;
         }
 
         $phpcsFile->addError(
             'Visibility indicators for OO constants are not supported in PHP 7.0 or earlier. Found "%s const"',
-            $prevToken,
+            $properties['scope_token'],
             'Found',
-            [$tokens[$prevToken]['content']]
+            [$properties['scope']]
         );
     }
 }

--- a/PHPCompatibility/Sniffs/Classes/NewFinalConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewFinalConstantsSniff.php
@@ -13,8 +13,8 @@ namespace PHPCompatibility\Sniffs\Classes;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Exceptions\ValueError;
+use PHPCSUtils\Utils\Constants;
 
 /**
  * Using the "final" modifier for class constants is available since PHP 8.1.
@@ -58,23 +58,21 @@ class NewFinalConstantsSniff extends Sniff
             return;
         }
 
-        // Is this a class constant ?
-        if (Scopes::isOOConstant($phpcsFile, $stackPtr) === false) {
+        try {
+            $properties = Constants::getProperties($phpcsFile, $stackPtr);
+        } catch (ValueError $e) {
+            // Not an OO constant or parse error.
             return;
         }
 
-        $tokens    = $phpcsFile->getTokens();
-        $skip      = Tokens::$emptyTokens + Tokens::$scopeModifiers;
-        $prevToken = $phpcsFile->findPrevious($skip, ($stackPtr - 1), null, true, null, true);
-
-        // Is the previous token the final keyword ?
-        if ($prevToken === false || $tokens[$prevToken]['code'] !== \T_FINAL) {
+        if ($properties['final_token'] === false) {
+            // Not a final constant.
             return;
         }
 
         $phpcsFile->addError(
             'The final modifier for OO constants is not supported in PHP 8.0 or earlier.',
-            $prevToken,
+            $properties['final_token'],
             'Found'
         );
     }


### PR DESCRIPTION
### Classes/NewConstVisibility: use new PHPCSUtils 1.1.0 Constants class 

As the features supported for class constant declarations in PHP in recent years have become more complex, PHPCSUtils 1.1.0 introduces a new `PHPCSUtils\Utils\Constants::getProperties()` method to retrieve the relevant information about a class constant declaration based on a `T_CONST` token.

Advantages of using the new method:
* Instead of having to update individual sniffs for new `const` related PHP features, updates now only have to be made in one place (PHPCSUtils).
* The results of the method are cached, so using the method should have a small, positive impact on performance if multiple sniffs each examine the same `T_CONST` token.

This commit starts using this new function in the `PHPCompatibility.Classes.NewConstVisibility` sniff.

### Classes/NewFinalConstants: use new PHPCSUtils 1.1.0 Constants class 

As the features supported for class constant declarations in PHP in recent years have become more complex, PHPCSUtils 1.1.0 introduces a new `PHPCSUtils\Utils\Constants::getProperties()` method to retrieve the relevant information about a class constant declaration based on a `T_CONST` token.

Advantages of using the new method:
* Instead of having to update individual sniffs for new `const` related PHP features, updates now only have to be made in one place (PHPCSUtils).
* The results of the method are cached, so using the method should have a small, positive impact on performance if multiple sniffs each examine the same `T_CONST` token.

This commit starts using this new function in the `PHPCompatibility.Classes.NewFinalConstants` sniff.