### PR TITLE
Various sniffs: start using new PHPCSUtils 1.1.0 TypeString utility

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -20,6 +20,7 @@ use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ControlStructures;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\TypeString;
 use PHPCSUtils\Utils\UseStatements;
 use PHPCSUtils\Utils\Variables;
 
@@ -1559,9 +1560,7 @@ class NewClassesSniff extends Sniff
      */
     private function checkTypeDeclaration($phpcsFile, $stackPtr, $typeString)
     {
-        // Strip off potential nullable indication.
-        $typeString = \ltrim($typeString, '?');
-        $types      = \preg_split('`[|&()]`', $typeString, -1, \PREG_SPLIT_NO_EMPTY);
+        $types = TypeString::filterOOTypes(TypeString::toArray($typeString));
 
         if (empty($types) === true) {
             return;

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -16,6 +16,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\TypeString;
 use PHPCSUtils\Utils\Variables;
 
 /**
@@ -238,8 +239,6 @@ class NewTypedPropertiesSniff extends Sniff
     protected function checkType(File $phpcsFile, $typeToken, $typeInfo)
     {
         $origType = $typeInfo['type'];
-        $type     = \ltrim($origType, '?'); // Trim off potential nullability.
-        $type     = \strtolower($type);
 
         $errorSuffix = '';
         if (isset($typeInfo['param_name']) === true) {
@@ -254,10 +253,8 @@ class NewTypedPropertiesSniff extends Sniff
                 [$origType]
             );
         } else {
-            $types              = \preg_split('`[|&()]`', $type, -1, \PREG_SPLIT_NO_EMPTY);
-            $isUnionType        = (\strpos($type, '|') !== false && \strpos($type, '(') === false);
-            $isIntersectionType = (\strpos($type, '&') !== false && \strpos($type, '(') === false);
-            $isDNFType          = \strpos($type, '(') !== false;
+            $type        = \ltrim($origType, '?'); // Trim off potential nullability.
+            $isUnionType = TypeString::isUnion($type);
 
             if (ScannedCode::shouldRunOnOrBelow('7.4') === true && $isUnionType === true) {
                 $phpcsFile->addError(
@@ -268,7 +265,7 @@ class NewTypedPropertiesSniff extends Sniff
                 );
             }
 
-            if (ScannedCode::shouldRunOnOrBelow('8.0') === true && $isIntersectionType === true) {
+            if (ScannedCode::shouldRunOnOrBelow('8.0') === true && TypeString::isIntersection($type) === true) {
                 $phpcsFile->addError(
                     'Intersection types are not present in PHP version 8.0 or earlier. Found: %s',
                     $typeToken,
@@ -277,7 +274,7 @@ class NewTypedPropertiesSniff extends Sniff
                 );
             }
 
-            if (ScannedCode::shouldRunOnOrBelow('8.1') === true && $isDNFType === true) {
+            if (ScannedCode::shouldRunOnOrBelow('8.1') === true && TypeString::isDNF($type) === true) {
                 $phpcsFile->addError(
                     'Disjunctive Normal Form types are not present in PHP version 8.1 or earlier. Found: %s',
                     $typeToken,
@@ -285,6 +282,8 @@ class NewTypedPropertiesSniff extends Sniff
                     [$origType]
                 );
             }
+
+            $types = TypeString::toArray($type); // Returns all types and normalizes PHP native types.
 
             foreach ($types as $type) {
                 if (isset($this->newTypes[$type])) {
@@ -333,6 +332,7 @@ class NewTypedPropertiesSniff extends Sniff
                         continue;
                     }
 
+                    $type = \strtolower($type);
                     if (isset($this->invalidLongTypes[$type])) {
                         $error = '%s is not supported as a property type declaration' . $errorSuffix;
                         $data  = [$type];

--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -21,6 +21,7 @@ use PHPCSUtils\Utils\ControlStructures;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\TypeString;
 use PHPCSUtils\Utils\Variables;
 
 /**
@@ -431,9 +432,7 @@ class RemovedClassesSniff extends Sniff
      */
     private function checkTypeDeclaration($phpcsFile, $stackPtr, $typeString)
     {
-        // Strip off potential nullable indication.
-        $typeString = \ltrim($typeString, '?');
-        $types      = \preg_split('`[|&()]`', $typeString, -1, \PREG_SPLIT_NO_EMPTY);
+        $types = TypeString::filterOOTypes(TypeString::toArray($typeString));
 
         if (empty($types) === true) {
             return;

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -19,6 +19,7 @@ use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\TypeString;
 
 /**
  * Detect and verify the use of parameter type declarations in function declarations.
@@ -244,12 +245,8 @@ class NewParamTypeDeclarationsSniff extends Sniff
             }
 
             // Strip off potential nullable indication.
-            $typeHint           = \ltrim($param['type_hint'], '?');
-            $typeHint           = \strtolower($typeHint);
-            $types              = \preg_split('`[|&()]`', $typeHint, -1, \PREG_SPLIT_NO_EMPTY);
-            $isUnionType        = (\strpos($typeHint, '|') !== false && \strpos($typeHint, '(') === false);
-            $isIntersectionType = (\strpos($typeHint, '&') !== false && \strpos($typeHint, '(') === false);
-            $isDNFType          = \strpos($typeHint, '(') !== false;
+            $typeHint    = \ltrim($param['type_hint'], '?');
+            $isUnionType = TypeString::isUnion($typeHint);
 
             if ($supportsPHP7 === true && $isUnionType === true) {
                 $phpcsFile->addError(
@@ -260,7 +257,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
                 );
             }
 
-            if ($supportsPHP80 === true && $isIntersectionType === true) {
+            if ($supportsPHP80 === true && TypeString::isIntersection($typeHint) === true) {
                 $phpcsFile->addError(
                     'Intersection types are not present in PHP version 8.0 or earlier. Found: %s',
                     $param['token'],
@@ -269,7 +266,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
                 );
             }
 
-            if ($supportsPHP81 === true && $isDNFType === true) {
+            if ($supportsPHP81 === true && TypeString::isDNF($typeHint) === true) {
                 $phpcsFile->addError(
                     'Disjunctive Normal Form types are not present in PHP version 8.1 or earlier. Found: %s',
                     $param['token'],
@@ -277,6 +274,8 @@ class NewParamTypeDeclarationsSniff extends Sniff
                     [$param['type_hint']]
                 );
             }
+
+            $types = TypeString::toArray($typeHint); // Returns all types and normalizes PHP native types.
 
             foreach ($types as $type) {
                 if (isset($this->newTypes[$type])) {
@@ -343,6 +342,7 @@ class NewParamTypeDeclarationsSniff extends Sniff
                     continue;
                 }
 
+                $type = \strtolower($type);
                 if (isset($this->invalidLongTypes[$type])) {
                     $error = "'%s' is not a valid parameter type declaration. Did you mean %s ?";
                     $data  = [

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -16,6 +16,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\TypeString;
 
 /**
  * Detect and verify the use of return type declarations in function declarations.
@@ -209,13 +210,9 @@ class NewReturnTypeDeclarationsSniff extends Sniff
             return;
         }
 
-        $returnType         = \ltrim($properties['return_type'], '?'); // Trim off potential nullability.
-        $returnType         = \strtolower($returnType);
-        $returnTypeToken    = $properties['return_type_token'];
-        $types              = \preg_split('`[|&()]`', $returnType, -1, \PREG_SPLIT_NO_EMPTY);
-        $isUnionType        = (\strpos($returnType, '|') !== false && \strpos($returnType, '(') === false);
-        $isIntersectionType = (\strpos($returnType, '&') !== false && \strpos($returnType, '(') === false);
-        $isDNFType          = \strpos($returnType, '(') !== false;
+        $returnType      = \ltrim($properties['return_type'], '?'); // Trim off potential nullability.
+        $returnTypeToken = $properties['return_type_token'];
+        $isUnionType     = TypeString::isUnion($returnType);
 
         if (ScannedCode::shouldRunOnOrBelow('7.4') === true && $isUnionType === true) {
             $phpcsFile->addError(
@@ -226,7 +223,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
             );
         }
 
-        if (ScannedCode::shouldRunOnOrBelow('8.0') === true && $isIntersectionType === true) {
+        if (ScannedCode::shouldRunOnOrBelow('8.0') === true && TypeString::isIntersection($returnType) === true) {
             $phpcsFile->addError(
                 'Intersection types are not present in PHP version 8.0 or earlier. Found: %s',
                 $returnTypeToken,
@@ -235,7 +232,7 @@ class NewReturnTypeDeclarationsSniff extends Sniff
             );
         }
 
-        if (ScannedCode::shouldRunOnOrBelow('8.1') === true && $isDNFType === true) {
+        if (ScannedCode::shouldRunOnOrBelow('8.1') === true && TypeString::isDNF($returnType) === true) {
             $phpcsFile->addError(
                 'Disjunctive Normal Form types are not present in PHP version 8.1 or earlier. Found: %s',
                 $returnTypeToken,
@@ -243,6 +240,8 @@ class NewReturnTypeDeclarationsSniff extends Sniff
                 [$properties['return_type']]
             );
         }
+
+        $types = TypeString::toArray($returnType); // Returns all types and normalizes PHP native types.
 
         foreach ($types as $type) {
             if (isset($this->newTypes[$type]) === true) {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedImplicitlyNullableParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedImplicitlyNullableParamSniff.php
@@ -16,6 +16,7 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\TypeString;
 
 /**
  * Declaring an implicitly nullable parameter is deprecated since PHP 8.4.
@@ -108,10 +109,9 @@ final class RemovedImplicitlyNullableParamSniff extends Sniff
                 continue;
             }
 
-            if ($param['nullable_type'] === true
-                || $param['type_hint'] === 'null'
+            if ($param['type_hint'] === 'null'
                 || $param['type_hint'] === 'mixed'
-                || $phpcsFile->findNext(\T_NULL, $param['type_hint_token'], ($param['type_hint_end_token'] + 1)) !== false
+                || TypeString::isNullable($param['type_hint'])
             ) {
                 // Type is nullable, no issue.
                 continue;

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -21,6 +21,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\TypeString;
 use PHPCSUtils\Utils\UseStatements;
 use PHPCSUtils\Utils\Variables;
 
@@ -476,9 +477,7 @@ class NewInterfacesSniff extends Sniff
      */
     private function checkTypeDeclaration($phpcsFile, $stackPtr, $typeHint)
     {
-        // Strip off potential nullable indication.
-        $typeHint = \ltrim($typeHint, '?');
-        $types    = \preg_split('`[|&()]`', $typeHint, -1, \PREG_SPLIT_NO_EMPTY);
+        $types = TypeString::filterOOTypes(TypeString::toArray($typeHint));
 
         if (empty($types) === true) {
             return;

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -439,9 +439,9 @@ $file = new CURLStringFile($data, 'filename.txt', 'text/plain');
 
 // Test support for PHP 7.4 property types.
 public WeakMap $var; // Ignore, not a property, parse error.
-
 $anon = new class() {
-    public Attribute $property;
+    public $untyped;
+    public Attribute $Typed;
 };
 
 // Test support for PHP 7.4 arrow functions.
@@ -551,7 +551,7 @@ $db = new Pdo\DbLib();
 $anon = new class extends \Pdo\Firebird {
     public Pdo\Mysql $prop;
     public function ParamType(\Pdo\Odbc $param) {}
-    public function ReturnType( $a ) : Pdo\Pgsql {}
+    public function ReturnType( int $a ) : Pdo\Pgsql {}
 };
 \Pdo\Sqlite::CLASS_CONSTANT;
 

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -63,7 +63,7 @@ class InvalidExample {
     protected Callable $callable = 'strlen';
     private ?callable $nullableCallable = null;
     public boolean $booleanType;
-    protected integer $integerType = 123;
+    protected ?integer $integerType = 123;
 }
 
 // Mixed type declaration - PHP 8.0+.
@@ -175,7 +175,7 @@ class DNFTypes {
     public (Foo&Bar)|null $dnf1;
     public readonly (A&B)|(C&D) $dnf2;
 
-    // Intentional fatal error - &/| reversed, but that's not the concern of the sniff.
+    // Intentional fatal error - &/| reversed. This is not a valid type. Ignore.
     public B&(D|W) $illegalDnf;
 
     // Intentional fatal error - segments are not unique, but that's not the concern of the sniff.

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -481,9 +481,38 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
         return [
             ['(Foo&Bar)|null', 175],
             ['(A&B)|(C&D)', 176],
-            ['B&(D|W)', 179],
             ['(A&B)|(B&A)', 182],
             ['(A&self)|A', 185],
+        ];
+    }
+
+
+    /**
+     * Verify that no error is thrown when the type is not a (valid) DNF type.
+     *
+     * @dataProvider dataNewDNFTypesNoFalsePositives
+     *
+     * @param int $line Line number on which to expect an error.
+     *
+     * @return void
+     */
+    public function testNewDNFTypesNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewDNFTypesNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNewDNFTypesNoFalsePositives()
+    {
+        return [
+            [179],
         ];
     }
 

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
@@ -75,9 +75,9 @@ function XmlRpcServerTypeHintB(
 
 // Test support for PHP 7.4 property types.
 public SWFButton $var; // Ignore, not a property, parse error.
-
 $anon = new class() {
-    public SQLiteDatabase $property;
+    public $untyped;
+    public SQLiteDatabase $Typed;
 };
 
 // Test support for PHP 7.4 arrow functions.
@@ -99,7 +99,7 @@ class IntersectionTypes {
 
     public SWFMorph&SWFMovie $property;
     public function paramTypeB(SWFSprite&\SWFText $param) {}
-    public function returnType($param) : HW_API_Object&HW_API_Attribute {}
+    public function returnType(int $param) : HW_API_Object&HW_API_Attribute {}
 }
 
 function CheckAllTypeParts(

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -78,7 +78,7 @@ class Bar {
 $arrow = fn(int $a) => $a * 10;
 $arrow = fn(\FQN\ClassName $b) => $b::method();
 $arrow = fn(callable $a, string $b, mixed $c) => $a();
-$arrow = fn(integer $a) => $a . 'test';
+$arrow = fn(?integer $a) => $a . 'test';
 $arrow = fn($a) => $a * 10; // OK.
 
 // Mixed type declaration - PHP 8.0+.
@@ -175,7 +175,7 @@ function NOTDnfTypeParamDefault($param = (CONST_A & CONST_B) | CONST_C) {}
 function DNFTypes((Foo&Bar)|null $a, int|(\A&\B) $b) {}
 $closure = function($a, (A&B)|(C&D) $b) {};
 
-// Intentional fatal error - &/| reversed, but that's not the concern of the sniff.
+// Intentional fatal error - &/| reversed. This is not a valid type. Ignore.
 $arrow = fn(B&(D|W)|null $a) => $a;
 
 // Intentional fatal error - segments are not unique, but that's not the concern of the sniff.

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -565,7 +565,6 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
             ['(Foo&Bar)|null', 175],
             ['int|(\A&\B)', 175],
             ['(A&B)|(C&D)', 176],
-            ['B&(D|W)|null', 179],
             ['(A&B)|(B&A)', 182],
             ['(A&self)|A', 186, false],
         ];

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.inc
@@ -142,7 +142,7 @@ enum Suit implements Colorful
 function DNFTypes($var): (Foo&Bar)|null {}
 $closure = function($a) : (A&B)|(C&D) {};
 
-// Intentional fatal error - &/| reversed, but that's not the concern of the sniff.
+// Intentional fatal error - &/| reversed. This is not a valid type. Ignore.
 $arrow = fn($a):B&(D|W)|int => $a;
 
 // Intentional fatal error - segments are not unique, but that's not the concern of the sniff.

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -408,9 +408,38 @@ class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
         return [
             ['(Foo&Bar)|null', 142],
             ['(A&B)|(C&D)', 143],
-            ['B&(D|W)|int', 146],
             ['(A&B)|(B&A)', 149],
             ['(A&self)|A', 153],
+        ];
+    }
+
+
+    /**
+     * Verify that no error is thrown when the type is not a (valid) DNF type.
+     *
+     * @dataProvider dataNewDNFTypesNoFalsePositives
+     *
+     * @param int $line Line number on which to expect an error.
+     *
+     * @return void
+     */
+    public function testNewDNFTypesNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewDNFTypesNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNewDNFTypesNoFalsePositives()
+    {
+        return [
+            [146],
         ];
     }
 


### PR DESCRIPTION
PHPCSUtils introduces a new `PHPCSUtils\Utils\TypeString` utility class, which allows for consistent analysis of type strings.

---

### FunctionDeclarations/NewParamTypeDeclarations: start using new PHPCSUtils 1.1.0 TypeString utility

This commit starts using this new utility in the `NewParamTypeDeclarations` sniff.

Includes minor adjustments to the tests:
* One test will no longer be flagged as it is not a valid type in PHP. In my opinion, this is fine as PHPCompatibility is not about detecting invalid code.
    Note: this test has not been added to the `dataNewDNFTypesNoFalsePositives()` data provider, as the type includes `null` and that's flagged on PHP < 8.2 for other reasons and that aspect of the test is still valid.
* One test has been updated to safeguard that nullable "long form" types will still be flagged correctly.

### FunctionDeclarations/NewReturnTypeDeclarations: start using new PHPCSUtils 1.1.0 TypeString utility

This commit starts using this new utility in the `NewReturnTypeDeclarations` sniff.

Includes minor adjustments to the tests:
* One test will no longer be flagged as it is not a valid type in PHP. In my opinion, this is fine as PHPCompatibility is not about detecting invalid code.
    This test will now be checked via the "no false positives for DNF types" test.

### Classes/NewTypedProperties: start using new PHPCSUtils 1.1.0 TypeString utility

This commit starts using this new utility in the `NewTypedProperties` sniff.

Includes minor adjustments to the tests:
* One test will no longer be flagged as it is not a valid type in PHP. In my opinion, this is fine as PHPCompatibility is not about detecting invalid code.
    This test will now be checked via the "no false positives for DNF types" test.
* One test has been updated to safeguard that nullable "long form" types will still be flagged correctly.

### Classes/NewClasses: start using new PHPCSUtils 1.1.0 TypeString utility 

This commit starts using this new utility in the `NewClasses` sniff.

Includes minor improvements to the tests related to this.

### Classes/RemovedClasses: start using new PHPCSUtils 1.1.0 TypeString utility

This commit starts using this new utility in the `RemovedClasses` sniff.

Includes minor improvements to the tests related to this.

### Interfaces/NewInterfaces: start using new PHPCSUtils 1.1.0 TypeString utility

This commit starts using this new utility in the `NewInterfaces` sniff.

### FunctionDeclarations/RemovedImplicitlyNullableParam: minor simplification

... by using the PHPCSUtils 1.1.0 TypeString::isNullable()` method.