### PR TITLE
Classes/NewReadonlyProperties: start using PHPCSUtils 1.1.0 getDeclared*()

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
@@ -13,8 +13,11 @@ namespace PHPCompatibility\Sniffs\Classes;
 use PHP_CodeSniffer\Files\File;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
+use PHPCSUtils\Exceptions\ValueError;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
-use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\ObjectDeclarations;
+use PHPCSUtils\Utils\Parentheses;
 use PHPCSUtils\Utils\Variables;
 
 /**
@@ -39,10 +42,7 @@ final class NewReadonlyPropertiesSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_VARIABLE,
-            \T_FUNCTION,
-        ];
+        return Collections::ooPropertyScopes();
     }
 
     /**
@@ -66,44 +66,54 @@ final class NewReadonlyPropertiesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
         $error  = 'Readonly properties are not supported in PHP 8.0 or earlier. Property %s was declared as readonly.';
 
-        if ($tokens[$stackPtr]['code'] === \T_VARIABLE) {
-            if (Scopes::isOOProperty($phpcsFile, $stackPtr) === false) {
-                // Not a class property.
-                return;
+        $ooProperties   = ObjectDeclarations::getDeclaredProperties($phpcsFile, $stackPtr);
+        $endOfStatement = false;
+        foreach ($ooProperties as $varToken) {
+            if ($endOfStatement !== false && $varToken < $endOfStatement) {
+                // Don't throw the same error multiple times for multi-property declarations.
+                // Also skip over any other constructor promoted properties.
+                continue;
             }
 
-            $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
+            try {
+                $properties = Variables::getMemberProperties($phpcsFile, $varToken);
+            } catch (ValueError $e) {
+                // This must be constructor property promotion.
+                // Ignore for now and skip over any other promoted properties, these will be handled via the constructor.
+                $deepestOpen = Parentheses::getLastOpener($phpcsFile, $varToken);
+                if ($deepestOpen !== false
+                    && $stackPtr < $deepestOpen
+                    && Parentheses::isOwnerIn($phpcsFile, $deepestOpen, \T_FUNCTION)
+                    && isset($tokens[$deepestOpen]['parenthesis_closer'])
+                ) {
+                    $endOfStatement = $tokens[$deepestOpen]['parenthesis_closer'];
+                }
+
+                continue;
+            }
+
             if ($properties['is_readonly'] === false) {
                 // Not a readonly property.
-                return;
+                continue;
             }
 
-            $phpcsFile->addError($error, $stackPtr, 'Found', [$tokens[$stackPtr]['content']]);
+            $phpcsFile->addError($error, $varToken, 'Found', [$tokens[$varToken]['content']]);
 
-            $endOfStatement = $phpcsFile->findNext(\T_SEMICOLON, ($stackPtr + 1));
-            if ($endOfStatement !== false) {
-                // Don't throw the same error multiple times for multi-property declarations.
-                return ($endOfStatement + 1);
-            }
-
-            return;
+            $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($varToken + 1));
         }
 
         /*
-         * This must be a function declaration. Let's check for constructor property promotion.
+         * Now, let's check for readonly properties in constructor property promotion.
          */
-        if (Scopes::isOOMethod($phpcsFile, $stackPtr) === false) {
-            // Global function.
+        $ooMethods   = ObjectDeclarations::getDeclaredMethods($phpcsFile, $stackPtr);
+        $ooMethodsLC = \array_change_key_case($ooMethods, \CASE_LOWER);
+
+        if (isset($ooMethodsLC['__construct']) === false) {
+            // OO construct doesn't declare a `__construct()` method.
             return;
         }
 
-        $functionName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
-        if (\strtolower($functionName) !== '__construct') {
-            // Not a class constructor.
-            return;
-        }
-
-        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $ooMethodsLC['__construct']);
         foreach ($parameters as $param) {
             if (empty($param['readonly_token']) === true) {
                 // Not property promotion with readonly.

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.inc
@@ -64,19 +64,19 @@ class PHP81Example {
     private readonly ?ClassName $nullableClassType;
 
     // Readonly properties do not need to explicitly declare their visibility.
-    readonly bool $flag;
+    readonly bool $noVisibility;
 
 	// Readonly properties cannot have a default value, but that's not the concern of this sniff.
     public readonly int $scalarType = 0;
 
     // Readonly can only be applied to typed properties, but that's not the concern of this sniff.
-    public readonly $prop;
+    public readonly $unTyped;
 
     // Readonly is not allowed on static properties, but that's not the concern of this sniff.
     public static readonly Iterable $staticProp;
 
     // Readonly can not be applied to old-style "var" properties, but that's not the concern of this sniff.
-    var readonly bool $flag;
+    var readonly bool $declaredUsingVar;
 
 	// Multi-property declarations.
     public readonly float $a, $b;


### PR DESCRIPTION
A while ago, someone reported a performance issue with the `Generic.PHP.LowerCaseType` sniff, which was due to the sniff examining all variables, instead of only examining OO properties.

Along the same lines, a similar performance issue was previously reported in #1477 and an initial fix was put in place via #1577.

PHPCSUtils 1.1.0 now introduces the new `ObjectDeclarations::getDeclaredProperties` and `ObjectDeclarations::getDeclaredMethods()` methods which can retrieve a list of all properties/methods declared in an OO structure.

These PHPCSUtils methods are highly optimized and will cache the results, which means that if multiple sniffs use these methods, the results will be nearly instantaneously returned on subsequent uses.

This commits starts using these methods in this sniff, which should further improve performance.

Note: the one downside of using the new methods, is that the names of the declared properties and methods in an OO construct have to be unique. As that's already a requirement in PHP anyway, I'm not concerned about the "real world" impact of this, though it does mean we need to be careful with this when creating test case files for sniffs which use these methods.

For that reason, there are some minor adjustments in the test case file for this sniff.

---

Some non-scientific performance impact estimation:

Using the test file which was shared with me - https://github.com/Automattic/HyperDB/blob/trunk/db.php - and running the below on PHP 8.4:
```
phpcs -ps db.php --standard=PHPCompatibility --report=source -vvv --sniffs=PHPCompatibility.Classes.NewReadonlyProperties
```

... yielded the following difference in runtime:

Baseline - Timing when run without this commit:
```
        *** START SNIFF PROCESSING REPORT ***
        PHPCompatibility\Sniffs\Classes\NewReadonlyProperties: 0.1542 secs
        *** END SNIFF PROCESSING REPORT ***
```

Timing when run with this commit:
```
        *** START SNIFF PROCESSING REPORT ***
        PHPCompatibility\Sniffs\Classes\NewReadonlyProperties: 0.002 secs
        *** END SNIFF PROCESSING REPORT ***
```

While it doesn't make that much difference on the total runtime with just one file, you can see the sniff runtime has gone down significantly - from 0.1542 secs to 0.002 secs, which should have a significant positive impact when scanning complete codebases.