### PR TITLE
FunctionDeclarations/ForbiddenFinalPrivateMethods: start using PHPCSUtils 1.1.0 getDeclaredMethods()

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
@@ -13,8 +13,9 @@ namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\FunctionDeclarations;
-use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
  * Applying the final modifier on a private method will produce a warning since PHP 8.0
@@ -46,7 +47,7 @@ class ForbiddenFinalPrivateMethodsSniff extends Sniff
      */
     public function register()
     {
-        return [\T_FUNCTION];
+        return Tokens::$ooScopeTokens;
     }
 
     /**
@@ -66,32 +67,31 @@ class ForbiddenFinalPrivateMethodsSniff extends Sniff
             return;
         }
 
-        if (Scopes::isOOMethod($phpcsFile, $stackPtr) === false) {
-            // Function, not method.
+        $ooMethods = ObjectDeclarations::getDeclaredMethods($phpcsFile, $stackPtr);
+        if (empty($ooMethods)) {
+            // No methods declared in the OO construct at all. Bow out.
             return;
         }
 
-        $name = FunctionDeclarations::getName($phpcsFile, $stackPtr);
-        if (empty($name) === true) {
-            // Parse error or live coding.
-            return;
-        }
+        $ooMethodsLC = \array_change_key_case($ooMethods, \CASE_LOWER);
 
-        if (\strtolower($name) === '__construct') {
-            // The rule does not apply to constructors. Bow out.
-            return;
-        }
+        foreach ($ooMethodsLC as $name => $functionPtr) {
+            if ($name === '__construct') {
+                // The rule does not apply to constructors. Bow out.
+                continue;
+            }
 
-        $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
-        if ($properties['scope'] !== 'private' || $properties['is_final'] === false) {
-            // Not an private final method.
-            return;
-        }
+            $properties = FunctionDeclarations::getProperties($phpcsFile, $functionPtr);
+            if ($properties['scope'] !== 'private' || $properties['is_final'] === false) {
+                // Not an private final method.
+                continue;
+            }
 
-        $phpcsFile->addWarning(
-            'Private methods should not be declared as final since PHP 8.0',
-            $stackPtr,
-            'Found'
-        );
+            $phpcsFile->addWarning(
+                'Private methods should not be declared as final since PHP 8.0',
+                $functionPtr,
+                'Found'
+            );
+        }
     }
 }

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.inc
@@ -59,3 +59,6 @@ enum MyEnum {
     final public static function publicFinal();
     final private function privateFinal() {}
 }
+
+// No methods, no problem.
+final class NoMethods {}

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
@@ -94,6 +94,7 @@ class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTestCase
 
         $cases[] = [50];
         $cases[] = [59];
+        $cases[] = [64];
 
         return $cases;
     }


### PR DESCRIPTION
PHPCSUtils 1.1.0 introduces a new `ObjectDeclarations::getDeclaredMethods()` method which can retrieve a list of all methods declared in an OO structure.

This method is highly optimized and will cache its results, which means that if multiple sniffs use the method, the results will be instantaneously returned on subsequent uses.