### PR TITLE
Classes/NewTypedProperties: start using PHPCSUtils 1.1.0 getDeclared*()

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -14,8 +14,11 @@ use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Exceptions\ValueError;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
-use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\ObjectDeclarations;
+use PHPCSUtils\Utils\Parentheses;
 use PHPCSUtils\Utils\TypeString;
 use PHPCSUtils\Utils\Variables;
 
@@ -140,10 +143,7 @@ class NewTypedPropertiesSniff extends Sniff
      */
     public function register()
     {
-        return [
-            \T_VARIABLE,
-            \T_FUNCTION,
-        ];
+        return Collections::ooPropertyScopes();
     }
 
     /**
@@ -161,46 +161,56 @@ class NewTypedPropertiesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
+        $tokens         = $phpcsFile->getTokens();
+        $ooProperties   = ObjectDeclarations::getDeclaredProperties($phpcsFile, $stackPtr);
+        $endOfStatement = false;
 
-        if ($tokens[$stackPtr]['code'] === \T_VARIABLE) {
-            if (Scopes::isOOProperty($phpcsFile, $stackPtr) === false) {
-                // Not a class property.
-                return;
+        foreach ($ooProperties as $varToken) {
+            if ($endOfStatement !== false && $varToken < $endOfStatement) {
+                // Don't throw the same error multiple times for multi-property declarations.
+                // Also skip over any other constructor promoted properties.
+                continue;
             }
 
-            $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
+            try {
+                $properties = Variables::getMemberProperties($phpcsFile, $varToken);
+            } catch (ValueError $e) {
+                // This must be constructor property promotion.
+                // Ignore for now and skip over any other promoted properties, these will be handled via the constructor.
+                $deepestOpen = Parentheses::getLastOpener($phpcsFile, $varToken);
+                if ($deepestOpen !== false
+                    && $stackPtr < $deepestOpen
+                    && Parentheses::isOwnerIn($phpcsFile, $deepestOpen, \T_FUNCTION)
+                    && isset($tokens[$deepestOpen]['parenthesis_closer'])
+                ) {
+                    $endOfStatement = $tokens[$deepestOpen]['parenthesis_closer'];
+                }
+
+                continue;
+            }
+
             if ($properties['type'] === '') {
                 // Not a typed property.
-                return;
+                continue;
             }
 
             $this->checkType($phpcsFile, $properties['type_token'], $properties);
 
-            $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
-            if ($endOfStatement !== false) {
-                // Don't throw the same error multiple times for multi-property declarations.
-                return ($endOfStatement + 1);
-            }
-
-            return;
+            $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($varToken + 1));
         }
 
         /*
-         * This must be a function declaration. Let's check for constructor property promotion.
+         * Now, let's check for typed properties in constructor property promotion.
          */
-        if (Scopes::isOOMethod($phpcsFile, $stackPtr) === false) {
-            // Global function.
+        $ooMethods   = ObjectDeclarations::getDeclaredMethods($phpcsFile, $stackPtr);
+        $ooMethodsLC = \array_change_key_case($ooMethods, \CASE_LOWER);
+
+        if (isset($ooMethodsLC['__construct']) === false) {
+            // OO construct doesn't declare a `__construct()` method.
             return;
         }
 
-        $functionName = FunctionDeclarations::getName($phpcsFile, $stackPtr);
-        if (\strtolower($functionName) !== '__construct') {
-            // Not a class constructor.
-            return;
-        }
-
-        $parameters = FunctionDeclarations::getParameters($phpcsFile, $stackPtr);
+        $parameters = FunctionDeclarations::getParameters($phpcsFile, $ooMethodsLC['__construct']);
         foreach ($parameters as $param) {
             if (empty($param['property_visibility']) === true) {
                 // Not property promotion.
@@ -209,7 +219,7 @@ class NewTypedPropertiesSniff extends Sniff
 
             if ($param['type_hint'] === '') {
                 // Not a typed property.
-                return;
+                continue;
             }
 
             // Juggle some of the array entries to what it expected for properties.


### PR DESCRIPTION
A while ago, someone reported a performance issue with the `Generic.PHP.LowerCaseType` sniff, which was due to the sniff examining all variables, instead of only examining OO properties.

Along the same lines, a similar performance issue was previously reported in 1477 and an initial fix was put in place via 1577.

PHPCSUtils 1.1.0 now introduces the new `ObjectDeclarations::getDeclaredProperties` and `ObjectDeclarations::getDeclaredMethods()` methods which can retrieve a list of all properties/methods declared in an OO structure.

These PHPCSUtils methods are highly optimized and will cache the results, which means that if multiple sniffs use these methods, the results will be nearly instantaneously returned on subsequent uses.

This commits starts using these methods in this sniff, which should further improve performance.

---

Some non-scientific performance impact estimation:

Using the test file which was shared with me - https://github.com/Automattic/HyperDB/blob/trunk/db.php - and running the below on PHP 8.4:
```
phpcs -ps db.php --standard=PHPCompatibility --report=source -vvv --sniffs=PHPCompatibility.Classes.NewTypedProperties
```

... yielded the following difference in runtime:

Baseline - Timing when run without this commit:
```
        *** START SNIFF PROCESSING REPORT ***
        PHPCompatibility\Sniffs\Classes\NewTypedPropertiesSniff: 0.1963 secs
        *** END SNIFF PROCESSING REPORT ***
```

Timing when run with this commit:
```
        *** START SNIFF PROCESSING REPORT ***
        PHPCompatibility\Sniffs\Classes\NewTypedPropertiesSniff: 0.0119 secs
        *** END SNIFF PROCESSING REPORT ***
```

While it doesn't make that much difference on the total runtime with just one file, you can see the sniff runtime has gone down significantly - from 0.1963 secs to 0.0119 secs, which should have a significant positive impact when scanning complete codebases.