### PR TITLE
Classes/RemovedClasses: start using PHPCSUtils 1.1.0 getDeclaredProperties()

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -16,11 +16,13 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ControlStructures;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
-use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\ObjectDeclarations;
+use PHPCSUtils\Utils\Parentheses;
 use PHPCSUtils\Utils\TypeString;
 use PHPCSUtils\Utils\Variables;
 
@@ -253,15 +255,15 @@ class RemovedClassesSniff extends Sniff
         $this->removedClasses = \array_merge($this->removedClasses, $this->removedExceptions);
 
         $targets = [
-            \T_NEW,
-            \T_CLASS,
-            \T_ANON_CLASS,
-            \T_VARIABLE,
-            \T_DOUBLE_COLON,
-            \T_CATCH,
+            \T_NEW          => \T_NEW,
+            \T_CLASS        => \T_CLASS,
+            \T_ANON_CLASS   => \T_ANON_CLASS,
+            \T_DOUBLE_COLON => \T_DOUBLE_COLON,
+            \T_CATCH        => \T_CATCH,
         ];
 
         $targets += Collections::functionDeclarationTokens();
+        $targets += Collections::ooPropertyScopes();
 
         return $targets;
     }
@@ -283,17 +285,20 @@ class RemovedClassesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         switch ($tokens[$stackPtr]['code']) {
-            case \T_VARIABLE:
-                $this->processVariableToken($phpcsFile, $stackPtr);
-                break;
-
             case \T_CATCH:
                 $this->processCatchToken($phpcsFile, $stackPtr);
                 break;
 
-            default:
+            case \T_NEW:
+            case \T_CLASS:
+            case \T_ANON_CLASS:
+            case \T_DOUBLE_COLON:
                 $this->processSingularToken($phpcsFile, $stackPtr);
                 break;
+        }
+
+        if (isset(Collections::ooPropertyScopes()[$tokens[$stackPtr]['code']]) === true) {
+            $this->processOOProperties($phpcsFile, $stackPtr);
         }
 
         if (isset(Collections::functionDeclarationTokens()[$tokens[$stackPtr]['code']]) === true) {
@@ -390,9 +395,9 @@ class RemovedClassesSniff extends Sniff
 
 
     /**
-     * Processes this test for when a variable token is encountered.
+     * Processes an OO token for properties declared in the OO scope.
      *
-     * - Detect new classes when used as a property type declaration.
+     * - Detect removed classes when used as a property type declaration.
      *
      * @since 10.0.0
      *
@@ -402,19 +407,50 @@ class RemovedClassesSniff extends Sniff
      *
      * @return void
      */
-    private function processVariableToken(File $phpcsFile, $stackPtr)
+    private function processOOProperties(File $phpcsFile, $stackPtr)
     {
-        if (Scopes::isOOProperty($phpcsFile, $stackPtr) === false) {
-            // Not a class property.
+        $ooProperties = ObjectDeclarations::getDeclaredProperties($phpcsFile, $stackPtr);
+        if (empty($ooProperties)) {
             return;
         }
 
-        $properties = Variables::getMemberProperties($phpcsFile, $stackPtr);
-        if ($properties['type'] === '') {
-            return;
-        }
+        $tokens         = $phpcsFile->getTokens();
+        $endOfStatement = false;
+        foreach ($ooProperties as $variableToken) {
+            if ($endOfStatement !== false && $variableToken < $endOfStatement) {
+                // Don't throw the same error multiple times for multi-property declarations.
+                // Also skip over any other constructor promoted properties.
+                continue;
+            }
 
-        $this->checkTypeDeclaration($phpcsFile, $properties['type_token'], $properties['type']);
+            try {
+                $properties = Variables::getMemberProperties($phpcsFile, $variableToken);
+            } catch (ValueError $e) {
+                /*
+                 * This must be constructor property promotion.
+                 * Ignore for now and skip over any other promoted properties, these will be handled
+                 * via the function token for the constructor.
+                 */
+                $deepestOpen = Parentheses::getLastOpener($phpcsFile, $variableToken);
+                if ($deepestOpen !== false
+                    && $stackPtr < $deepestOpen
+                    && Parentheses::isOwnerIn($phpcsFile, $deepestOpen, \T_FUNCTION)
+                    && isset($tokens[$deepestOpen]['parenthesis_closer'])
+                ) {
+                    $endOfStatement = $tokens[$deepestOpen]['parenthesis_closer'];
+                }
+
+                continue;
+            }
+
+            if ($properties['type'] === '') {
+                continue;
+            }
+
+            $this->checkTypeDeclaration($phpcsFile, $properties['type_token'], $properties['type']);
+
+            $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($variableToken + 1));
+        }
     }
 
 

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
@@ -97,7 +97,7 @@ class UnionTypes {
 class IntersectionTypes {
     public function paramTypeA(NotATarget&AlsoNotATarget $okay) {}
 
-    public SWFMorph&SWFMovie $property;
+    public SWFMorph&SWFMovie $propertyA, $propertyB, $propertyC;
     public function paramTypeB(SWFSprite&\SWFText $param) {}
     public function returnType(int $param) : HW_API_Object&HW_API_Attribute {}
 }


### PR DESCRIPTION
PHPCSUtils 1.1.0 introduces a new `ObjectDeclarations::getDeclaredProperties()` method which can retrieve a list of all properties declared in an OO structure.

This method is highly optimized and will cache its results, which means that if multiple sniffs use the method, the results will be instantaneously returned on subsequent uses.

As `T_CLASS` tokens (and other OO tokens) occur much less often than `T_VARIABLE`, this change should lead to some small performance benefits.

Includes adding protection against throwing multiple errors for multi-property declarations and updating a test to test this.