### PR TITLE
PHP 8.3 | Various sniffs: add tests with typed constants 

### DIFF
--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.inc
@@ -85,3 +85,13 @@ trait ConstInTrait
     protected const PROTECTED_CONST = 4;
     private const PRIVATE_CONST = 5;
 }
+
+/*
+ * Make sure the sniff does not get confused by PHP 8.3 typed constants.
+ */
+class TypedConstants
+{
+    public const string PUBLIC_CONST_TYPED = 'string';
+    protected final const ?int PROTECTED_FINAL_CONST_TYPED = 6;
+    private const (A&B)|false PRIVATE_CONST_TYPED = false;
+}

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
@@ -73,6 +73,10 @@ class NewConstVisibilityUnitTest extends BaseSniffTestCase
             [84],
             [85],
             [86],
+
+            [94],
+            [95],
+            [96],
         ];
     }
 

--- a/PHPCompatibility/Tests/Classes/NewFinalConstantsUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewFinalConstantsUnitTest.inc
@@ -105,3 +105,13 @@ trait ConstInTrait
     final private const FINAL_PRIVATE_CONST_A = 8;
     private final const FINAL_PRIVATE_CONST_B = 9;
 }
+
+/*
+ * Make sure the sniff does not get confused by PHP 8.3 typed constants.
+ */
+class TypedConstants
+{
+    final public const string FINAL_PUBLIC_CONST_TYPED = 'string';
+    protected final const ?int PROTECTED_FINAL_CONST_TYPED = 6;
+    final private const (A&B)|false FINAL_PRIVATE_CONST_TYPED = false;
+}

--- a/PHPCompatibility/Tests/Classes/NewFinalConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewFinalConstantsUnitTest.php
@@ -89,6 +89,10 @@ class NewFinalConstantsUnitTest extends BaseSniffTestCase
             [102],
             [105],
             [106],
+
+            [114],
+            [115],
+            [116],
         ];
     }
 

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.inc
@@ -45,3 +45,17 @@ const MULTI_A = 1,
 // Constant array dereferencing.
 const DEREF = OTHER['key'];
 const DEREF = 'string'[2];
+
+// Safeguard handling of PHP 8.3 typed constants. The sniff should not trigger on the array type keyword.
+class TypedConstants {
+    protected const array ARRAY_TYPE = // OK.
+        [ 10, 20]; // Error.
+
+    private const ?array NULLABLE_ARRAY_TYPE_NULL = null; // OK.
+    private const ?array NULLABLE_ARRAY_TYPE_ARRAY = []; // Error.
+
+    private final const array|false UNION_TYPE = false; // OK.
+
+    public const (MyClass&\SomeInterface)|array DNF_TYPE = new MyClass; // OK.
+    public const (MyClass&\SomeInterface)|array DNF_TYPE = array(1, 2, 3); // Error.
+}

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
@@ -59,6 +59,9 @@ class NewConstantArraysUsingConstUnitTest extends BaseSniffTestCase
             [37],
             [39],
             [41],
+            [52],
+            [55],
+            [60],
         ];
     }
 
@@ -96,6 +99,10 @@ class NewConstantArraysUsingConstUnitTest extends BaseSniffTestCase
             [42],
             [46],
             [47],
+            [51],
+            [54],
+            [57],
+            [59],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.3 | Classes/NewConstVisibility: add tests with typed constants 

Already handled correctly by the sniff, just safeguarding this.

### PHP 8.3 | Classes/NewFinalConstants: add tests with typed constants 

Already handled correctly by the sniff, just safeguarding this.

### PHP 8.3 | InitialValue/NewConstantArraysUsingConst: add tests with typed constants

Already handled correctly by the sniff, just safeguarding this.