### PR TITLE
PHP 8.3 | AbstractInitialValueSniff: add support for detection in combination with typed constants

### DIFF
--- a/PHPCompatibility/AbstractInitialValueSniff.php
+++ b/PHPCompatibility/AbstractInitialValueSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Constants;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;
@@ -167,17 +168,26 @@ abstract class AbstractInitialValueSniff extends Sniff
         /*
          * Handle default values for constants/static variables.
          */
-        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
+        $start          = ($stackPtr + 1);
+        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], $start);
         if ($endOfStatement === false) {
             // No semi-colon - live coding.
             return;
         }
 
-        $type = 'const';
+        // If this is a potentially typed class constant, we need to skip over the type.
+        if ($tokens[$stackPtr]['code'] === \T_CONST) {
+            $type = 'const';
+
+            if (Scopes::isOOConstant($phpcsFile, $stackPtr) === true) {
+                $constProperties = Constants::getProperties($phpcsFile, $stackPtr);
+                $start           = ($constProperties['name_token'] - 1);
+            }
+        }
 
         // Filter out late static binding, class properties, static closures and arrow function and static return types.
         if ($tokens[$stackPtr]['code'] === \T_STATIC) {
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::$emptyTokens, $start, null, true);
             if ($next === false || $tokens[$next]['code'] !== \T_VARIABLE) {
                 // Not a static variable declaration. Bow out.
                 return;
@@ -193,7 +203,6 @@ abstract class AbstractInitialValueSniff extends Sniff
         }
 
         // Examine each variable/constant in multi-declarations.
-        $start = ($stackPtr + 1);
         do {
             $end   = $this->findEndOfCurrentDeclaration($phpcsFile, $start, $endOfStatement);
             $start = $phpcsFile->findNext(Tokens::$emptyTokens, $start, $end, true);

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.inc
@@ -330,3 +330,13 @@ class ConstructorPromotedProperties {
         public string $promotedProp = 'hello' . ' world',
     ) {}
 }
+
+/*
+ * Test detecting constant scalar expressions in PHP 8.3+ typed constants.
+ */
+class TypedConstants {
+    public const int|false MY_TYPED_CONST_SINGLE = self::BAR ? 10 : false);
+
+    public const int MY_TYPED_CONST_MULTI_A = 1 + 1,
+        MY_TYPED_CONST_MULTI_B = (1 + 1);
+}

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -184,6 +184,9 @@ class NewConstantScalarExpressionsUnitTest extends BaseSniffTestCase
             [322, 'const'],
 
             [330, 'default'],
+            [338, 'const'],
+            [340, 'const'],
+            [341, 'const'],
         ];
     }
 

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
@@ -186,6 +186,22 @@ class c {
 }
 
 /*
+ * Test detecting heredoc initial values in PHP 8.3+ typed constants.
+ */
+class TypedConstants {
+    public const string MY_TYPED_CONST_SINGLE = <<<FOO
+Something
+FOO;
+
+    public const ?string MY_TYPED_CONST_MULTI_A = <<<FOO
+Something
+FOO
+        , MY_TYPED_CONST_MULTI_B = <<<FOO
+Something
+FOO;
+}
+
+/*
  * Safeguard that PHP 7.3+ flexible heredoc initial values are also detected correctly.
  * IMPORTANT: this must be the last test in the file!
  */

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.inc
@@ -84,10 +84,10 @@ FOOBAR;
 /*
  * Test handling of multi-declarations.
  */
-static $a = <<<EOD
+static $staticA = <<<EOD
 Multi-declaration in static variable.
 EOD
-    , $b = <<<"EOT"
+    , $staticB = <<<"EOT"
 Multi-declaration in static variable.
 EOT;
 
@@ -161,10 +161,10 @@ FOOBAR;
 /*
  * Test detection in multi-declarations where not all parts have an initial value.
  */
-static $a, $b, $c = <<<"EOT"
+static $multiA, $multib, $multic = <<<"EOT"
 Multi-declaration in static variable.
 EOT
-    $d;
+    , $multid;
 
 // Class properties.
 class foo

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -76,10 +76,13 @@ class NewHeredocUnitTest extends BaseSniffTestCase
             [156, 'constants'],
             [164, 'static variables'],
             [172, 'class properties'],
+            [192, 'constants'],
+            [196, 'constants'],
+            [199, 'constants'],
         ];
 
         if (\PHP_VERSION_ID >= 70300) {
-            $data[] = [192, 'static variables'];
+            $data[] = [208, 'static variables'];
         }
 
         return $data;


### PR DESCRIPTION
PHP 8.3 introduced typed constants.

The logic for the `AbstractInitialValueSniff` needs to find each constant name and then examine the value set for these. This was breaking on typed class constants.

Fixed now.

Includes tests via the sniffs using this abstract.