### PR TITLE
PHP 8.3 | Keywords/ForbiddenNames: add support for detecting forbidden names in combination with typed constants

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -16,6 +16,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
+use PHPCSUtils\Utils\Constants;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Namespaces;
@@ -128,6 +129,9 @@ class ForbiddenNamesSniff extends Sniff
 
     /**
      * T_STRING keywords to recognize as forbidden names.
+     *
+     * These keywords cannot be used to name a class, interface or trait.
+     * Prior to PHP 8.0, they were also prohibited from being used in namespaces.
      *
      * @since 7.0.8
      * @since 10.0.0 Moved from the ForbiddenNamesAsDeclared sniff to this sniff.
@@ -622,17 +626,31 @@ class ForbiddenNamesSniff extends Sniff
      */
     protected function processConstDeclaration(File $phpcsFile, $stackPtr)
     {
-        $namePtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($namePtr === false) {
-            // Live coding or parse error.
-            return;
-        }
+        $tokens       = $phpcsFile->getTokens();
+        $isOOConstant = Scopes::isOOConstant($phpcsFile, $stackPtr);
 
-        $tokens = $phpcsFile->getTokens();
-        $name   = $tokens[$namePtr]['content'];
-        $nameLc = \strtolower($name);
-        if (isset($this->invalidNames[$nameLc]) === false) {
-            return;
+        if ($isOOConstant === false) {
+            // Non-class constant declared using the "const" keyword.
+            $namePtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($namePtr === false) {
+                // Live coding or parse error.
+                return;
+            }
+
+            $name   = $tokens[$namePtr]['content'];
+            $nameLc = \strtolower($name);
+            if (isset($this->invalidNames[$nameLc]) === false) {
+                return;
+            }
+        } else {
+            // Class constants can be typed since PHP 8.3, so handle these separately.
+            $properties = Constants::getProperties($phpcsFile, $stackPtr);
+            $namePtr    = $properties['name_token'];
+            $name       = $tokens[$namePtr]['content'];
+            $nameLc     = \strtolower($name);
+            if (isset($this->invalidNames[$nameLc]) === false) {
+                return;
+            }
         }
 
         /*
@@ -644,7 +662,7 @@ class ForbiddenNamesSniff extends Sniff
          * when used as OO constant names, as they are not problematic in PHP < 7.0.
          */
         if ($nameLc !== 'class'
-            && Scopes::isOOConstant($phpcsFile, $stackPtr) === true
+            && $isOOConstant === true
             && (ScannedCode::shouldRunOnOrBelow('5.6') === false
                 || ($this->invalidNames[$nameLc] !== 'all'
                 && \version_compare($this->invalidNames[$nameLc], '7.0', '>=')))

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
@@ -414,3 +414,19 @@ namespace Foo\Enum\Bar;
 class enum implements Foo {}
 interface Enum extends Foo {}
 // phpcs:enable
+
+// Ensure that PHP 8.3+ typed constants do not lead to false positives for the types.
+class TypedConstants {
+    const null CONST_A = null;
+    public const true CONST_B = true;
+    protected const false CONST_C = false;
+    private const bool CONST_D = false;
+    final const int CONST_E = 10;
+    final protected const float CONST_F = 10.2;
+    public final const string CONST_G = 'foo';
+    final private const iterable CONST_H = [];
+    const object CONST_I = new stdClass;
+    const mixed CONST_J = 10;
+    const resource CONST_K = null;
+    const \numeric CONST_L = 10;
+}

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.3.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.3.inc
@@ -86,3 +86,11 @@ define(value: 'class', constant_name: 'class'); // Error.
 // Ensure that "mixed" when used in a namespace name gets flagged when PHP 7 needs to be supported, as it was already soft reserved.
 namespace mixed;
 namespace Foo\Mixed\Baz;
+
+// Ensure that keyword used as the constant name for a PHP 8.3+ typed constant are picked up correctly.
+class TypedConstants {
+    const \A FINAL = new A;
+    public const A|B FOR = new B;
+    protected const A&B EMPTY = new A;
+    private const (A&B)|C PUBLIC = new C;
+}

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -336,6 +336,10 @@ class ForbiddenNamesUnitTest extends BaseSniffTestCase
             [79, 'namespace'],
             [81, 'namespace'],
             [84, 'class'],
+            [92, 'final'],
+            [93, 'for'],
+            [94, 'empty'],
+            [95, 'public'],
         ];
     }
 


### PR DESCRIPTION
PHP 8.3 introduced typed constants.

While the types themselves should not lead to false positives as the PHP native types are considered "other reserved keywords" and can be used as (class) constant names, so wouldn't be flagged, the sniff as-was would not find the _actual_ name of the constant for typed constants, which could result in false negatives.

Fixed now.

Includes tests.

Ref:
* https://www.php.net/manual/en/reserved.other-reserved-words.php