### PR TITLE
PHP 8.3 | Classes/RemovedClasses: add support for detecting removed classes in typed constants

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -17,6 +17,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Constants;
 use PHPCSUtils\Utils\ControlStructures;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
@@ -259,6 +260,7 @@ class RemovedClassesSniff extends Sniff
             \T_ANON_CLASS   => \T_ANON_CLASS,
             \T_DOUBLE_COLON => \T_DOUBLE_COLON,
             \T_CATCH        => \T_CATCH,
+            \T_CONST        => \T_CONST,
         ];
 
         $targets += Collections::functionDeclarationTokens();
@@ -284,6 +286,10 @@ class RemovedClassesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         switch ($tokens[$stackPtr]['code']) {
+            case \T_CONST:
+                $this->processConstantToken($phpcsFile, $stackPtr);
+                break;
+
             case \T_CATCH:
                 $this->processCatchToken($phpcsFile, $stackPtr);
                 break;
@@ -390,6 +396,36 @@ class RemovedClassesSniff extends Sniff
         }
 
         $this->checkTypeDeclaration($phpcsFile, $properties['return_type_token'], $properties['return_type']);
+    }
+
+
+    /**
+     * Processes this test for when a constant token is encountered.
+     *
+     * - Detect removed classes when used as a class constant type declaration.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    private function processConstantToken(File $phpcsFile, $stackPtr)
+    {
+        try {
+            $properties = Constants::getProperties($phpcsFile, $stackPtr);
+        } catch (ValueError $e) {
+            // Not an OO constant or parse error.
+            return;
+        }
+
+        if ($properties['type'] === '') {
+            return;
+        }
+
+        $this->checkTypeDeclaration($phpcsFile, $properties['type_token'], $properties['type']);
     }
 
 

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.inc
@@ -141,3 +141,23 @@ class ConstructorPropertyPromotionWithTypes {
         SWFVideoStream $normalParamClassType,
     ) {}
 }
+
+// Global constants can't be typed. Ignore.
+const FOO = 10;
+
+// Test support for PHP 8.3 typed constants.
+class TypedConstants {
+    const UNTYPED = 10;
+    protected const HW_API_Error CLASS_TYPE = new HW_API_Error();
+    private const ?OCICollection NULLABLE_CLASS_TYPE = null;
+    protected const \IMAP\Connection FQN_INTERFACE = new ClassName;
+
+    // Union types are supported.
+    private final const SWFFontChar|\SWFGradient UNION_TWO_CLASSES = new MyClassA;
+
+    // Intersection types are supported.
+    public const SWFShape&\SWFSound INTERSECTION_TYPE = new MyClassA;
+
+    // DNF types are supported.
+    public const (PSpell\Config&\PSpell\Dictionary)|null DNF_TYPE = new MyClassA;
+}

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
@@ -67,7 +67,7 @@ class RemovedClassesUnitTest extends BaseSniffTestCase
             ['HW_API', '5.2', [59], '5.1'],
             ['HW_API_Object', '5.2', [60, 102, 115], '5.1'],
             ['HW_API_Attribute', '5.2', [61, 102, 115], '5.1'],
-            ['HW_API_Error', '5.2', [62], '5.1'],
+            ['HW_API_Error', '5.2', [62, 151], '5.1'],
             ['HW_API_Content', '5.2', [63, 91], '5.1'],
             ['HW_API_Reason', '5.2', [64, 91], '5.1'],
 
@@ -77,13 +77,13 @@ class RemovedClassesUnitTest extends BaseSniffTestCase
             ['SWFDisplayItem', '5.3', [39, 84], '5.2'],
             ['SWFFill', '5.3', [40, 92], '5.2'],
             ['SWFFont', '5.3', [41, 92], '5.2'],
-            ['SWFFontChar', '5.3', [44], '5.2'],
-            ['SWFGradient', '5.3', [45], '5.2'],
+            ['SWFFontChar', '5.3', [44, 156], '5.2'],
+            ['SWFGradient', '5.3', [45, 156], '5.2'],
             ['SWFMorph', '5.3', [46, 100, 113], '5.2'],
             ['SWFMovie', '5.3', [47, 100, 113], '5.2'],
             ['SWFPrebuiltClip', '5.3', [48], '5.2'],
-            ['SWFShape', '5.3', [49, 138], '5.2'],
-            ['SWFSound', '5.3', [50, 138], '5.2'],
+            ['SWFShape', '5.3', [49, 138, 159], '5.2'],
+            ['SWFSound', '5.3', [50, 138, 159], '5.2'],
             ['SWFSoundInstance', '5.3', [51], '5.2'],
             ['SWFSprite', '5.3', [52, 101, 114], '5.2'],
             ['SWFText', '5.3', [55, 101, 114], '5.2'],
@@ -97,11 +97,11 @@ class RemovedClassesUnitTest extends BaseSniffTestCase
 
             ['XmlRpcServer', '8.0', [71, 74], '7.4'],
 
-            ['IMAP\Connection', '8.4', [118, 135], '8.3'],
-            ['OCICollection', '8.4', [120, 136], '8.3'],
+            ['IMAP\Connection', '8.4', [118, 153], '8.3'],
+            ['OCICollection', '8.4', [120, 136, 152], '8.3'],
             ['OCILob', '8.4', [121, 129], '8.3'],
-            ['PSpell\Config', '8.4', [124, 137], '8.3'],
-            ['PSpell\Dictionary', '8.4', [125, 137], '8.3'],
+            ['PSpell\Config', '8.4', [124, 137, 162], '8.3'],
+            ['PSpell\Dictionary', '8.4', [125, 137, 162], '8.3'],
         ];
     }
 
@@ -140,6 +140,8 @@ class RemovedClassesUnitTest extends BaseSniffTestCase
         $data[] = [89];
         $data[] = [98];
         $data[] = [111];
+        $data[] = [146];
+        $data[] = [150];
 
         return $data;
     }


### PR DESCRIPTION
PHP 8.3 introduced typed constants and as `new` can be used in initializers since PHP 8.1, class/interface types are also supported.

This commit adds support for detecting the use of removed PHP classes in typed constants to this sniff.

Includes tests.