### PR TITLE
PHP 8.3 | Interfaces/NewInterfaces: add support for detecting new interfaces in typed constants

### DIFF
--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -16,6 +16,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Constants;
 use PHPCSUtils\Utils\ControlStructures;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
@@ -216,6 +217,7 @@ class NewInterfacesSniff extends Sniff
             \T_USE       => \T_USE,
             \T_INTERFACE => \T_INTERFACE,
             \T_CATCH     => \T_CATCH,
+            \T_CONST     => \T_CONST,
         ];
 
         $targets += Collections::ooCanImplement();
@@ -255,6 +257,10 @@ class NewInterfacesSniff extends Sniff
 
             case \T_INTERFACE:
                 $this->processInterfaceToken($phpcsFile, $stackPtr);
+                break;
+
+            case \T_CONST:
+                $this->processConstantToken($phpcsFile, $stackPtr);
                 break;
 
             case \T_CATCH:
@@ -382,6 +388,36 @@ class NewInterfacesSniff extends Sniff
                 }
             }
         }
+    }
+
+
+    /**
+     * Processes this test for when a constant token is encountered.
+     *
+     * - Detect new interfaces when used as a class constant type declaration.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    private function processConstantToken(File $phpcsFile, $stackPtr)
+    {
+        try {
+            $properties = Constants::getProperties($phpcsFile, $stackPtr);
+        } catch (ValueError $e) {
+            // Not an OO constant or parse error.
+            return;
+        }
+
+        if ($properties['type'] === '') {
+            return;
+        }
+
+        $this->checkTypeDeclaration($phpcsFile, $properties['type_token'], $properties['type']);
     }
 
 

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -215,6 +215,26 @@ class DNFTypes {
 // Safeguard correct handling of PHP 8.3 readonly anonymous class.
 $anon = new readonly class implements \Random\Engine {};
 
+// Global constants can't be typed. Ignore.
+const FOO = 10;
+
+// Test support for PHP 8.3 typed constants.
+class TypedConstants {
+    const UNTYPED = 10;
+    protected const UnitEnum CLASS_TYPE = new ClassName();
+    private const ?BackedEnum NULLABLE_CLASS_TYPE = null;
+    protected const \Random\CryptoSafeEngine FQN_INTERFACE = new ClassName;
+
+    // Union types are supported.
+    private final const RecursiveIterator|\SeekableIterator UNION_TWO_CLASSES = new MyClassA;
+
+    // Intersection types are supported.
+    public const JsonSerializable&\SessionHandlerInterface INTERSECTION_TYPE = new MyClassA;
+
+    // DNF types are supported.
+    public const (Random\Engine&\Random\CryptoSafeEngine)|null DNF_TYPE = new MyClassA;
+}
+
 // Test parse error/live coding.
 // This MUST be the last test in the file!
 try {

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -69,13 +69,13 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             ['Traversable', '4.4', [35, 50, 60, 71, 79, 164], '5.0'],
             ['Countable', '5.0', [3, 17, 41, 153], '5.1'],
             ['OuterIterator', '5.0', [4, 42, 65, 154], '5.1'],
-            ['RecursiveIterator', '5.0', [5, 43, 65, 154], '5.1'],
-            ['SeekableIterator', '5.0', [6, 17, 28, 44, 163], '5.1'],
+            ['RecursiveIterator', '5.0', [5, 43, 65, 154, 229], '5.1'],
+            ['SeekableIterator', '5.0', [6, 17, 28, 44, 163, 229], '5.1'],
             ['Serializable', '5.0', [7, 29, 45, 55, 70, 119, 125, 191], '5.1'],
             ['SplObserver', '5.0', [11, 46, 65, 153], '5.1'],
             ['SplSubject', '5.0', [12, 17, 47, 69, 163], '5.1'],
-            ['JsonSerializable', '5.3', [13, 48, 134, 135, 155, 190], '5.4'],
-            ['SessionHandlerInterface', '5.3', [14, 49, 147, 155], '5.4'],
+            ['JsonSerializable', '5.3', [13, 48, 134, 135, 155, 190, 232], '5.4'],
+            ['SessionHandlerInterface', '5.3', [14, 49, 147, 155, 232], '5.4'],
             ['DateTimeInterface', '5.4', [36, 51, 61, 80], '5.5'],
             ['SessionIdInterface', '5.5.0', [89, 117, 146], '5.6', '5.5'],
             ['Throwable', '5.6', [37, 52, 62, 93, 98, 103, 162, 186], '7.0'],
@@ -83,10 +83,10 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             ['Stringable', '7.4', [112, 179, 203, 212], '8.0'],
             ['DOMChildNode', '7.4', [196, 210, 212], '8.0'],
             ['DOMParentNode', '7.4', [196, 204, 210], '8.0'],
-            ['UnitEnum', '8.0', [198, 211], '8.1'],
-            ['BackedEnum', '8.0', [198, 211], '8.1'],
-            ['Random\Engine', '8.1', [200, 216], '8.2'],
-            ['Random\CryptoSafeEngine', '8.1', [200], '8.2'],
+            ['UnitEnum', '8.0', [198, 211, 224], '8.1'],
+            ['BackedEnum', '8.0', [198, 211, 225], '8.1'],
+            ['Random\Engine', '8.1', [200, 216, 235], '8.2'],
+            ['Random\CryptoSafeEngine', '8.1', [200, 226, 235], '8.2'],
         ];
     }
 
@@ -221,6 +221,8 @@ class NewInterfacesUnitTest extends BaseSniffTestCase
             [189],
             [208],
             [219],
+            [223],
+            [241],
         ];
     }
 


### PR DESCRIPTION
PHP 8.3 introduced typed constants and as `new` can be used in initializers since PHP 8.1, class/interface types are also supported.

This commit adds support for detecting the use of new PHP interfaces in typed constants to this sniff.

Includes tests.