### PR TITLE
PHP 8.4 | Various sniffs: add tests with asymmetric visibility

### DIFF
--- a/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.inc
@@ -66,3 +66,13 @@ class ConstructorPropertyPromotionWithReadonlyProperties {
         private null $thisIsAlsoSilly,
     ) {}
 }
+
+// PHP 8.4: safeguard the sniff still functions correctly when asymmetric visibility is used.
+class AsymVisibility {
+    public function __construct(
+        protected(set) ?int $asymInConstructorImplicit,
+        protected private(set) string $asymInConstructorExplicit,
+        public(set) public (My&\DNF)|false $asymInConstructorImplicitOrderReversed,
+        string|false $normalParam,
+    ) {}
+}

--- a/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstructorPropertyPromotionUnitTest.php
@@ -62,6 +62,9 @@ final class NewConstructorPropertyPromotionUnitTest extends BaseSniffTestCase
             [64],
             [65],
             [66],
+            [73],
+            [74],
+            [75],
         ];
     }
 
@@ -97,6 +100,7 @@ final class NewConstructorPropertyPromotionUnitTest extends BaseSniffTestCase
         }
 
         $cases[] = [45];
+        $cases[] = [76];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/Classes/NewFinalPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewFinalPropertiesUnitTest.inc
@@ -96,3 +96,9 @@ interface InterfaceWithFinalProperties
     // Fatal error: Property in interface cannot be final.
     final public $finalPublic { get; }
 }
+
+// PHP 8.4: safeguard the sniff still functions correctly when asymmetric visibility is used.
+class AsymVisibility {
+    final public private(set) $asymExplicit;
+    protected(set) $asymImplicit;
+}

--- a/PHPCompatibility/Tests/Classes/NewFinalPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewFinalPropertiesUnitTest.php
@@ -60,6 +60,7 @@ class NewFinalPropertiesUnitTest extends BaseSniffTestCase
             [85],
             [90],
             [97],
+            [102],
         ];
     }
 
@@ -92,6 +93,8 @@ class NewFinalPropertiesUnitTest extends BaseSniffTestCase
         for ($line = 1; $line <= 60; $line++) {
             $data[] = [$line];
         }
+
+        $data[] = [103];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.inc
@@ -19,7 +19,7 @@ class NonReadonly {
     public string $str = "foo";
     public ?STRING $nullableStr = null;
 
-	// Multi-property declarations.
+    // Multi-property declarations.
     public float $a, $b;
     public int $x,
         /**
@@ -37,7 +37,7 @@ class NonReadonly {
     $invalidProperty;
 
 
-	// Constructor property promotion.
+    // Constructor property promotion.
     public function __construct(
         protected float|int $promotedProtected,
         public ?string &$promotedPublic = 'test',
@@ -66,7 +66,7 @@ class PHP81Example {
     // Readonly properties do not need to explicitly declare their visibility.
     readonly bool $noVisibility;
 
-	// Readonly properties cannot have a default value, but that's not the concern of this sniff.
+    // Readonly properties cannot have a default value, but that's not the concern of this sniff.
     public readonly int $scalarType = 0;
 
     // Readonly can only be applied to typed properties, but that's not the concern of this sniff.
@@ -78,7 +78,7 @@ class PHP81Example {
     // Readonly can not be applied to old-style "var" properties, but that's not the concern of this sniff.
     var readonly bool $declaredUsingVar;
 
-	// Multi-property declarations.
+    // Multi-property declarations.
     public readonly float $a, $b;
     readonly public int $x,
         /**
@@ -88,7 +88,7 @@ class PHP81Example {
         // comment.
         $z;
 
-	// Constructor property promotion.
+    // Constructor property promotion.
     public function __construct(
         protected readonly float|int $promotedProtected,
         // Default values are allowed when combined with constructor property promotion.
@@ -99,7 +99,18 @@ class PHP81Example {
     ) {}
 }
 
+// PHP 8.4: safeguard the sniff still functions correctly when asymmetric visibility is used.
+class AsymVisibility {
+    public protected(set) readonly string $ReadOnlyLast;
+    readonly private(set) string $ReadOnlyFirst;
+    protected(set) $notReadonly;
+
+    public function __construct(
+        readonly private(set) string $bar,
+    ) {}
+}
+
 // Parse error. This has to be the last test in the file.
 class ParseError {
-	public readonly $propertyWithoutSemiColon
+    public readonly $propertyWithoutSemiColon
 }

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.php
@@ -63,6 +63,10 @@ final class NewReadonlyPropertiesUnitTest extends BaseSniffTestCase
             [95],
             [96],
             [104],
+            [105],
+            [109],
+
+            [115],
         ];
     }
 
@@ -97,6 +101,8 @@ final class NewReadonlyPropertiesUnitTest extends BaseSniffTestCase
         for ($line = 1; $line <= 58; $line++) {
             $data[] = [$line];
         }
+
+        $data[] = [106];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -189,3 +189,12 @@ class DNFTypes {
         public (A&B)|(C&D) $y = new Something,
     ) {}
 }
+
+// PHP 8.4: safeguard the sniff still functions correctly when asymmetric visibility is used.
+class AsymVisibility {
+    protected(set) string $asym;
+
+    public function __construct(
+        protected private(set) (My&\DNF)|false $asymInConstructor,
+    ) {}
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -110,6 +110,8 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             [185],
             [188],
             [189],
+            [195, true],
+            [198],
         ];
     }
 
@@ -269,6 +271,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             ['mixed', '7.4', 116, '8.0', false],
             ['true', '8.1', 147, '8.2'],
             ['null', '7.4', 175, '8.2'],
+            ['false', '7.4', 198, '8.0', false],
         ];
     }
 
@@ -377,6 +380,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             [93, 'null'],
             [96, 'false'],
             [175, 'null'],
+            [198, 'false'],
         ];
     }
 
@@ -487,6 +491,7 @@ class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             ['(A&self)|A', 185],
             ['(Foo&Bar)|int', 188],
             ['(A&B)|(C&D)', 189],
+            ['(My&\DNF)|false', 198],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.inc
@@ -184,3 +184,13 @@ $arrow = fn((A&B)|(B&A) $a) => $a;
 // Intentional fatal error - segments which are strict subsets of others are disallowed, but that's not the concern of the sniff.
 // Intentional fatal error - using self type outside a class is invalid.
 $arrow = fn((A&self)|A $a) => $a;
+
+// PHP 8.4: safeguard the sniff still skips over constructor promoted properties.
+class AsymVisibility {
+    public function __construct(
+        protected(set) ?int $asymInConstructorImplicit,
+        protected private(set) string $asymInConstructorExplicit,
+        public(set) public (My&\DNF)|false $asymInConstructorImplicitOrderReversed,
+        string $normalParam,
+    ) {}
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -142,6 +142,8 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
             ['int', '5.6', 175, '8.2'],
             ['null', '7.4', 179, '8.2'],
             ['self', '5.1', 186, '8.2', false],
+
+            ['string', '5.6', 194, '7.0'],
         ];
     }
 
@@ -700,12 +702,13 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
             [179],
             [182],
             [186],
+            [194],
         ];
     }
 
 
     /**
-     * Verify that no false positives are thrown for function declarations without types.
+     * Verify that no false positives are thrown for function declarations without types or constructor property promotion.
      *
      * @dataProvider dataNoFalsePositives
      *
@@ -738,6 +741,9 @@ class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
             [129],
             [137],
             [173],
+            [191],
+            [192],
+            [193],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.inc
@@ -53,5 +53,14 @@ $closure = function (
 
 $arrow = fn(iterable $i = null): bool => doSomething($i);
 
+// PHP 8.4: safeguard the sniff still skips over constructor promoted properties.
+// Fatal error on all versions, but not the concern of this sniff.
+class AsymVisibility {
+    public function __construct(
+        protected(set) Foo $asymInConstructorImplicit = null,
+        protected private(set) string $asymInConstructorExplicit = null,
+    ) {}
+}
+
 // Intentional parse error. This has to be the last test in the file.
 $closure = function( Type $a = null, $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.php
@@ -93,9 +93,11 @@ final class RemovedImplicitlyNullableParamUnitTest extends BaseSniffTestCase
         }
 
         $cases[] = [51];
+        $cases[] = [60];
+        $cases[] = [61];
 
         // Parse error test case.
-        $cases[] = [57];
+        $cases[] = [66];
 
         return $cases;
     }


### PR DESCRIPTION
### PHP 8.4 | Classes/NewFinalProperties: add tests with asymmetric visibility

Already handled correctly by the sniff, just safeguarding this.

### PHP 8.4 | Classes/NewReadonlyProperties: add tests with asymmetric visibility

Already handled correctly by the sniff, just safeguarding this.

Includes some tabs vs spaces cleanup in the test case file.

### PHP 8.4 | Classes/NewTypedProperties: add tests with asymmetric visibility

Already handled correctly by the sniff, just safeguarding this.

### PHP 8.4 | Classes/NewConstructorPropertyPromotion: add tests with asymmetric visibility

Already handled correctly by the sniff, just safeguarding this.

### PHP 8.4 | FunctionDeclarations/NewParamTypeDeclarations: add tests with asymmetric visibility

Already handled correctly by the sniff, just safeguarding this.

### PHP 8.4 | FunctionDeclarations/RemovedImplicitlyNullableParam: add tests with asymmetric visibility

Already handled correctly by the sniff, just safeguarding this.