### PR TITLE
Tests: favour class level `@covers` tags over method level

### DIFF
--- a/PHPCompatibility/Util/Tests/Helpers/MiscHelper/IsUseOfGlobalConstantUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/MiscHelper/IsUseOfGlobalConstantUnitTest.php
@@ -20,6 +20,8 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  * @group utilityFunctions
  *
  * @since 8.1.0
+ *
+ * @covers \PHPCompatibility\Helpers\MiscHelper::isUseOfGlobalConstant
  */
 final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase
 {
@@ -28,8 +30,6 @@ final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase
      * Test whether detection of whether a T_STRING is a global constant works correctly.
      *
      * @dataProvider dataIsUseOfGlobalConstant
-     *
-     * @covers \PHPCompatibility\Helpers\MiscHelper::isUseOfGlobalConstant
      *
      * @param string $commentString The comment which prefaces the target token in the test file.
      * @param string $expected      The expected boolean return value.

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
@@ -20,6 +20,8 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  * @group utilityFunctions
  *
  * @since 7.0.5
+ *
+ * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQClassNameFromDoubleColonToken
  */
 final class GetFQClassNameFromDoubleColonTokenUnitTest extends UtilityMethodTestCase
 {
@@ -28,8 +30,6 @@ final class GetFQClassNameFromDoubleColonTokenUnitTest extends UtilityMethodTest
      * Test retrieving a fully qualified class name based on a T_DOUBLE_COLON token.
      *
      * @dataProvider dataGetFQClassNameFromDoubleColonToken
-     *
-     * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQClassNameFromDoubleColonToken
      *
      * @param string $commentString The comment which prefaces the T_DOUBLE_COLON token in the test file.
      * @param string $expected      The expected fully qualified class name.

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.php
@@ -20,6 +20,8 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  * @group utilityFunctions
  *
  * @since 7.0.3
+ *
+ * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQClassNameFromNewToken
  */
 final class GetFQClassNameFromNewTokenUnitTest extends UtilityMethodTestCase
 {
@@ -28,8 +30,6 @@ final class GetFQClassNameFromNewTokenUnitTest extends UtilityMethodTestCase
      * Test retrieving a fully qualified class name based on a T_NEW token.
      *
      * @dataProvider dataGetFQClassNameFromNewToken
-     *
-     * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQClassNameFromNewToken
      *
      * @param string $commentString The comment which prefaces the T_NEW token in the test file.
      * @param string $expected      The expected fully qualified class name.
@@ -75,8 +75,6 @@ final class GetFQClassNameFromNewTokenUnitTest extends UtilityMethodTestCase
 
     /**
      * Test an empty string is returned when an invalid token is passed.
-     *
-     * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQClassNameFromNewToken
      *
      * @return void
      */

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQExtendedClassNameUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQExtendedClassNameUnitTest.php
@@ -20,6 +20,8 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  * @group utilityFunctions
  *
  * @since 7.0.3
+ *
+ * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQExtendedClassName
  */
 final class GetFQExtendedClassNameUnitTest extends UtilityMethodTestCase
 {
@@ -28,8 +30,6 @@ final class GetFQExtendedClassNameUnitTest extends UtilityMethodTestCase
      * Test retrieving a fully qualified class name for the class being extended.
      *
      * @dataProvider dataGetFQExtendedClassName
-     *
-     * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQExtendedClassName
      *
      * @param string $commentString The comment which prefaces the T_CLASS token in the test file.
      * @param string $expected      The expected fully qualified class name.
@@ -77,8 +77,6 @@ final class GetFQExtendedClassNameUnitTest extends UtilityMethodTestCase
      * Test an empty string is returned when an invalid token is passed.
      *
      * @dataProvider dataGetFQExtendedClassNameInvalidToken
-     *
-     * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQExtendedClassName
      *
      * @param string     $commentString The comment which prefaces the T_CLASS token in the test file.
      * @param int|string $targetType    The token to pass to the method.


### PR DESCRIPTION
As of PHPUnit 12, coverage is handled via attributes and the coverage related attributes are only supported at class level, not method level.

While we don't support PHPUnit 12 yet, if all tests in a test class cover the same "code under test", we may as well switch to class level coverage annotations already.