### PR TITLE
GH Actions: apply temporary work-around for testing against PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ matrix.php == '8.5' && '8.4' || matrix.php }}
           ini-values: error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1
           coverage: none
           tools: cs2pr
@@ -58,6 +58,14 @@ jobs:
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: "Install PHP again (PHP 8.5)"
+        if: ${{ matrix.php == '8.5' }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+          coverage: none
 
       - name: Lint against parse errors
         if: ${{ matrix.php != '5.4' && matrix.php != '8.4' }}
@@ -137,7 +145,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ matrix.php == '8.5' && '8.4' || matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
@@ -169,6 +177,14 @@ jobs:
       - name: "Composer: set PHPCS version for tests (lowest)"
         if: ${{ matrix.phpcs_version == 'lowest' }}
         run: composer update squizlabs/php_codesniffer phpcsstandards/phpcsutils --prefer-lowest --no-scripts --no-interaction
+
+      - name: "Install PHP again (PHP 8.5)"
+        if: ${{ matrix.php == '8.5' }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+          coverage: none
 
       - name: Grab PHPUnit version
         id: phpunit_version


### PR DESCRIPTION
Currently every single `composer install` on PHP 8.5 fails due to a deprecation notice coming from a Composer dependency during the reading of the `composer.json` file.

While it is expected that this will be fixed soonish (fix is already available in the dependency, we're just waiting for a new release of both the dependency as well as of Composer), I rather not have the red crosses on every single PR.

So, this commit adds a temporary work-around which should allow the tests to run against PHP 8.5 again.

Once a new version of Composer has been released, we should be able to revert this commit.