### PR TITLE
PHP 8.0/8.3 | ResolveHelper::getFQClassNameFromNewToken(): improve handling anon classes

### DIFF
--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -50,7 +50,7 @@ final class ResolveHelper
     {
         $tokens = $phpcsFile->getTokens();
 
-        // Check for the existence of the token and that an accepted token.
+        // Check for the existence of the token and that it's an accepted token.
         if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_NEW) {
             return '';
         }
@@ -59,6 +59,7 @@ final class ResolveHelper
         if ($start === false
             || $tokens[$start]['code'] === \T_VARIABLE
             || $tokens[$start]['code'] === \T_ANON_CLASS
+            || $tokens[$start]['code'] === \T_ATTRIBUTE // Only possible for anonymous classes.
         ) {
             // Parse error, name cannot be determined or not a named class.
             return '';

--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -60,6 +60,7 @@ final class ResolveHelper
             || $tokens[$start]['code'] === \T_VARIABLE
             || $tokens[$start]['code'] === \T_ANON_CLASS
             || $tokens[$start]['code'] === \T_ATTRIBUTE // Only possible for anonymous classes.
+            || $tokens[$start]['code'] === \T_READONLY // Only possible for anonymous classes.
         ) {
             // Parse error, name cannot be determined or not a named class.
             return '';

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.inc
@@ -50,6 +50,9 @@ $anon = new class() {};
 /* test 18 */
 $anon = new #[SomeAttribute] class() {};
 
+/* test 19 */
+$anon = new readonly class() {};
+
 // Issue #338 - no infinite loop on unfinished code.
 /* test 16 */
 $var = new

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.inc
@@ -47,6 +47,9 @@ new $className;
 /* test 17 */
 $anon = new class() {};
 
+/* test 18 */
+$anon = new #[SomeAttribute] class() {};
+
 // Issue #338 - no infinite loop on unfinished code.
 /* test 16 */
 $var = new

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.php
@@ -71,6 +71,7 @@ final class GetFQClassNameFromNewTokenUnitTest extends UtilityMethodTestCase
             ['/* test 16 */', ''],
             ['/* test 17 */', ''],
             ['/* test 18 */', ''],
+            ['/* test 19 */', ''],
         ];
     }
 

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.php
@@ -70,6 +70,7 @@ final class GetFQClassNameFromNewTokenUnitTest extends UtilityMethodTestCase
             ['/* test 15 */', ''],
             ['/* test 16 */', ''],
             ['/* test 17 */', ''],
+            ['/* test 18 */', ''],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.0 | ResolveHelper::getFQClassNameFromNewToken(): correctly handle anon classes with attributes

Includes test.

### PHP 8.3 | ResolveHelper::getFQClassNameFromNewToken(): correctly handle readonly anon classes

Includes test.