### PR TITLE
README/docs: update code sample for setting property

### DIFF
--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -52,7 +52,10 @@ class RemovedExtensionsSniff extends Sniff
      * This property can be set from the ruleset, like so:
      * <rule ref="PHPCompatibility.Extensions.RemovedExtensions">
      *   <properties>
-     *     <property name="functionWhitelist" type="array" value="mysql_to_rfc3339,mysql_another_function" />
+     *     <property name="functionWhitelist" type="array">
+     *       <element value="mysql_to_rfc3339"/>
+     *       <element value="mysql_another_function"/>
+     *     </property>
      *   </properties>
      * </rule>
      *

--- a/README.md
+++ b/README.md
@@ -212,7 +212,10 @@ To whitelist userland functions, you can pass a comma-delimited list of function
     <!-- Whitelist the mysql_to_rfc3339() and mysql_another_function() functions. -->
     <rule ref="PHPCompatibility.Extensions.RemovedExtensions">
         <properties>
-            <property name="functionWhitelist" type="array" value="mysql_to_rfc3339,mysql_another_function"/>
+            <property name="functionWhitelist" type="array">
+                <element value="mysql_to_rfc3339"/>
+                <element value="mysql_another_function"/>
+            </property>
         </properties>
     </rule>
 ```


### PR DESCRIPTION
PHPCS 3.3.0 introduced a new format for array properties. As support for PHPCS < 3.3.0 has been dropped a while ago, the code sample for how to exclude functions for the `PHPCompatibility.Extensions.RemovedExtensions` sniff can be updated to use the new format.

All the more relevant now as support for the old comma-separated string format will be dropped in PHPCS 4.0.