### PR TITLE
Various sniffs: modernize inline phpcs annotations

### DIFF
--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -60,7 +60,7 @@ class RemovedExtensionsSniff extends Sniff
      *
      * @var string[]
      */
-    public $functionWhitelist;
+    public $functionWhitelist = [];
 
     /**
      * A list of removed extensions with their alternative, if any.
@@ -302,18 +302,6 @@ class RemovedExtensionsSniff extends Sniff
      */
     protected function isWhiteListed($content)
     {
-        if (isset($this->functionWhitelist) === false) {
-            return false;
-        }
-
-        if (\is_string($this->functionWhitelist) === true) {
-            if (\strpos($this->functionWhitelist, ',') !== false) {
-                $this->functionWhitelist = \explode(',', $this->functionWhitelist);
-            } else {
-                $this->functionWhitelist = (array) $this->functionWhitelist;
-            }
-        }
-
         if (\is_array($this->functionWhitelist) === true) {
             $this->functionWhitelist = \array_map('strtolower', $this->functionWhitelist);
             return \in_array($content, $this->functionWhitelist, true);

--- a/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
@@ -284,11 +284,6 @@ class RemovedSerializableSniff extends Sniff
      */
     private function updateInterfaceList()
     {
-        // Allow for resetting the property in test files.
-        if ($this->serializableInterfaces === null || $this->serializableInterfaces === '') {
-            $this->serializableInterfaces = [];
-        }
-
         if (isset($this->lastSeenSerializableInterfaces)
             && $this->lastSeenSerializableInterfaces === $this->serializableInterfaces
         ) {
@@ -320,14 +315,8 @@ class RemovedSerializableSniff extends Sniff
      */
     private function cleanInterfaceNames($interfaceNames)
     {
-        if (\is_string($interfaceNames) === true) {
-            // Probably received in old, pre-PHPCS 3.3.0 ruleset property syntax.
-            $interfaceNames = \explode(',', $interfaceNames);
-        }
-
         // Make double sure that this is an array.
         $interfaceNames = (array) $interfaceNames;
-
         $interfaceNames = \array_map('strtolower', $interfaceNames);
         $interfaceNames = \array_map('ltrim', $interfaceNames, \array_fill(0, \count($interfaceNames), '\\'));
 

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.inc
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.inc
@@ -64,16 +64,19 @@ mssql_bind();
 
 ereg();
 
-// @codingStandardsChangeSetting PHPCompatibility.Extensions.RemovedExtensions functionWhitelist mysql_to_rfc3339
+// phpcs:set PHPCompatibility.Extensions.RemovedExtensions functionWhitelist[] mysql_to_rfc3339
 mysql_to_rfc3339();
 
 // PHP 7.1 removed extensions:
 mcrypt_encrypt();
 
-// @codingStandardsChangeSetting PHPCompatibility.Extensions.RemovedExtensions functionWhitelist ereg_convert,ereg_translate_to_preg
+// phpcs:set PHPCompatibility.Extensions.RemovedExtensions functionWhitelist[] ereg_convert,ereg_translate_to_preg
 ereg_convert();
 ereg_translate_to_preg();
 ereg_replace(); // Non-whitelisted.
+
+// Reset property to its default value.
+// phpcs:set PHPCompatibility.Extensions.RemovedExtensions functionWhitelist[]
 
 ibase_trans();
 wddx_deserialize();

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -126,16 +126,16 @@ class RemovedExtensionsUnitTest extends BaseSniffTestCase
             ['dbx', '5.1', 'pecl/dbx', [12], '5.0'],
             ['dio', '5.1', 'pecl/dio', [14], '5.0'],
             ['fdf', '5.3', 'pecl/fdf', [20], '5.2'],
-            ['ibase', '7.4', 'pecl/ibase', [78], '7.3'],
+            ['ibase', '7.4', 'pecl/ibase', [81], '7.3'],
             ['ingres', '5.1', 'pecl/ingres', [26], '5.0'],
             ['mcve', '5.1', 'pecl/mcve', [30], '5.0'],
             ['ming', '5.3', 'pecl/ming', [32], '5.2'],
             ['ncurses', '5.3', 'pecl/ncurses', [40], '5.2'],
             ['oracle', '5.1', 'oci8 or pdo_oci', [42], '5.0'],
-            ['recode', '7.4', 'iconv or mbstring', [80], '7.3'],
+            ['recode', '7.4', 'iconv or mbstring', [83], '7.3'],
             ['sybase', '5.3', 'sybase_ct', [50], '5.2'],
             ['w32api', '5.1', 'pecl/ffi', [52], '5.0'],
-            ['wddx', '7.4', 'pecl/wddx', [79], '7.3'],
+            ['wddx', '7.4', 'pecl/wddx', [82], '7.3'],
         ];
     }
 
@@ -229,7 +229,7 @@ class RemovedExtensionsUnitTest extends BaseSniffTestCase
             [68], // Whitelisted function.
             [74], // Whitelisted function array.
             [75], // Whitelisted function array.
-            [82], // Live coding.
+            [86], // Live coding.
         ];
     }
 

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
@@ -137,7 +137,7 @@ class SkipOverDocblocks implements Serializable, ArrayAccess{ // Deprecation war
 
 
 // Test handling of property to search for additional interfaces.
-// @codingStandardsChangeSetting PHPCompatibility.Interfaces.RemovedSerializable serializableInterfaces SerializableInterface,ThisInterfaceIsInTheList
+// phpcs:set PHPCompatibility.Interfaces.RemovedSerializable serializableInterfaces[] SerializableInterface,ThisInterfaceIsInTheList
 interface ThisInterfaceisinTheList extends Serializable {}
 
 interface ThisInterfaceIsNOTInTheList extends ArrayAcces, \Serializable {} // Missing interface warning.
@@ -180,7 +180,7 @@ interface DoesNotExtend {}
 interface ThisInterfaceIsNOTInTheList extends ArrayAcces, \Serializable, ThisInterfaceisinTheList {} // Missing interface warning (plural found).
 
 // Reset property.
-// @codingStandardsChangeSetting PHPCompatibility.Interfaces.RemovedSerializable serializableInterfaces
+// phpcs:set PHPCompatibility.Interfaces.RemovedSerializable serializableInterfaces[]
 
 /*
  * Safeguard handling of enums implementing Serializable


### PR DESCRIPTION
### Extensions/RemovedExtensions: modernize inline phpcs annotations 

PHPCS 3.2.0 introduced the `phpcs:*` annotations to replace the `@codingStandards*` annotations and PHPCS 3.3.0 introduced a way to set array properties via these annotations.

As support for PHPCS < 3.3.0 has been dropped a while ago, the annotations used to test that the public properties are correctly supported can now be updated to use the new format.

All the more relevant now as support for the old annotations will be dropped in PHPCS 4.0.

Notes:
* If a property value was provided inline using the `@codingStandardsChangeSetting` format, a comma-separated string was not automatically parsed to the individual array values.
    For array property values provided using a `phpcs:set` annotation in combination with the `propertyName[]` format, PHPCS will handle the parsing of the comma-separated string to array, so we can now also remove the custom code for this from the sniff.
* The new annotation format also allows for resetting array properties. This is a good practice to prevent the test annotations from affecting more tests than intended.
    Adding the reset does mean that a few test line expectations needed to be renumbered.

### Interfaces/RemovedSerializable: modernize inline phpcs annotations 

PHPCS 3.2.0 introduced the `phpcs:*` annotations to replace the `@codingStandards*` annotations and PHPCS 3.3.0 introduced a way to set array properties via these annotations.

As support for PHPCS < 3.3.0 has been dropped a while ago, the annotations used to test that the public properties are correctly supported can now be updated to use the new format.

All the more relevant now as support for the old annotations will be dropped in PHPCS 4.0.

Notes:
* If a property value was provided inline using the `@codingStandardsChangeSetting` format, a comma-separated string was not automatically parsed to the individual array values.
    For array property values provided using a `phpcs:set` annotation in combination with the `propertyName[]` format, PHPCS will handle the parsing of the comma-separated string to array, so we can now also remove the custom code for this from the sniff.