### PR TITLE
Composer: bump minimum supported versions of various dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,15 +29,15 @@
   "require": {
     "php": ">=5.4",
     "squizlabs/php_codesniffer": "^3.13.0",
-    "phpcsstandards/phpcsutils": "^1.1.0"
+    "phpcsstandards/phpcsutils": "^1.1.1"
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.4.0",
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
     "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.5.32 || ^11.3.3",
-    "phpcsstandards/phpcsdevcs": "^1.1.3",
-    "phpcsstandards/phpcsdevtools": "^1.2.0",
-    "yoast/phpunit-polyfills": "^1.0.5 || ^2.0 || ^3.0"
+    "phpcsstandards/phpcsdevcs": "^1.1.6",
+    "phpcsstandards/phpcsdevtools": "^1.2.3",
+    "yoast/phpunit-polyfills": "^1.1.5 || ^2.0.5 || ^3.1.0"
   },
   "replace": {
     "wimg/php-compatibility": "*"


### PR DESCRIPTION
Mostly for initial runtime PHP 8.5 compatibility.