### PR TITLE
FunctionDeclarations/RemovedCallingDestructAfterConstructorExit: bug fix for abstract constructor

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -79,7 +79,13 @@ class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
             return;
         }
 
-        $tokens        = $phpcsFile->getTokens();
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$ooMethodsLC['__construct']]['scope_opener'], $tokens[$ooMethodsLC['__construct']]['scope_closer']) === false) {
+            // Abstract method. Bow out.
+            return;
+        }
+
         $constructPtr  = $ooMethodsLC['__construct'];
         $functionOpen  = $tokens[$constructPtr]['scope_opener'];
         $functionClose = $tokens[$constructPtr]['scope_closer'];

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
@@ -145,3 +145,19 @@ abstract class DoesntExtendAndDoesntHaveDestructMethodButMayUseTrait {
 
     abstract function skipOverParenthesis($a, $b);
 }
+
+// Issue #1873.
+abstract class BowOutWhenNoConstructorBody
+{
+    abstract public function __construct();
+}
+
+abstract class ReportEvenWhenDestructorIsAbstract
+{
+    public function __construct() {
+        exit(1); // Error.
+    }
+
+    abstract public function __destruct();
+}
+

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
@@ -64,6 +64,7 @@ class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTestCa
             [69, 'die'],
             [85, 'exit'],
             [97, 'die', false],
+            [158, 'exit'],
         ];
     }
 
@@ -102,7 +103,7 @@ class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTestCa
         $cases[] = [61];
         $cases[] = [66];
 
-        for ($line = 101; $line <= 147; $line++) {
+        for ($line = 101; $line <= 154; $line++) {
             $cases[] = [$line];
         }
 


### PR DESCRIPTION
Follow up on #1840

The sniff code no longer handled abstract constructors correctly (by ignoring them). Fixed now.

Includes tests.

Fixes #1873