### PR TITLE
CS/QA: make all classes final

### DIFF
--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -45,7 +45,7 @@ use PHPCSUtils\Tokens\Collections;
  *
  * @since 10.0.0
  */
-class NewAttributesSniff extends Sniff
+final class NewAttributesSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenExtendingFinalPHPClassSniff.php
@@ -26,7 +26,7 @@ use PHP_CodeSniffer\Files\File;
  *
  * @since 10.0.0
  */
-class ForbiddenExtendingFinalPHPClassSniff extends Sniff
+final class ForbiddenExtendingFinalPHPClassSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -23,8 +23,9 @@ use PHP_CodeSniffer\Files\File;
  * @link https://wiki.php.net/rfc/anonymous_classes
  *
  * @since 7.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewAnonymousClassesSniff extends Sniff
+final class NewAnonymousClassesSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -42,9 +42,10 @@ use PHPCSUtils\Utils\Variables;
  * @since 5.5
  * @since 5.6    Now extends the base `Sniff` class.
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` class.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewClassesSniff extends Sniff
+final class NewClassesSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -25,8 +25,9 @@ use PHPCSUtils\Utils\Constants;
  * @link https://www.php.net/manual/en/language.oop5.constants.php#language.oop5.basic.class.this
  *
  * @since 7.0.7
+ * @since 10.0.0 This class is now `final`.
  */
-class NewConstVisibilitySniff extends Sniff
+final class NewConstVisibilitySniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/NewFinalConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewFinalConstantsSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\Constants;
  *
  * @since 10.0.0
  */
-class NewFinalConstantsSniff extends Sniff
+final class NewFinalConstantsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -29,9 +29,10 @@ use PHPCSUtils\Utils\Conditions;
  * @link https://wiki.php.net/rfc/lsb_parentself_forwarding
  *
  * @since 7.0.3
- * @since 9.0.0 Renamed from `LateStaticBindingSniff` to `NewLateStaticBindingSniff`.
+ * @since 9.0.0  Renamed from `LateStaticBindingSniff` to `NewLateStaticBindingSniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewLateStaticBindingSniff extends Sniff
+final class NewLateStaticBindingSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -45,8 +45,9 @@ use PHPCSUtils\Utils\Variables;
  * @link https://wiki.php.net/rfc/dnf_types
  *
  * @since 9.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewTypedPropertiesSniff extends Sniff
+final class NewTypedPropertiesSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -41,7 +41,7 @@ use PHPCSUtils\Utils\Variables;
  *
  * @since 10.0.0
  */
-class RemovedClassesSniff extends Sniff
+final class RemovedClassesSniff extends Sniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -29,8 +29,9 @@ use PHPCSUtils\Utils\MessageHelper;
  * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.parent
  *
  * @since 9.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedOrphanedParentSniff extends Sniff
+final class RemovedOrphanedParentSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -22,9 +22,10 @@ use PHP_CodeSniffer\Files\File;
  * PHP version All
  *
  * @since 8.1.0
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewConstantsSniff extends Sniff
+final class NewConstantsSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -34,9 +34,10 @@ use PHPCSUtils\Utils\Context;
  *
  * @since 7.1.4
  * @since 7.1.5  Removed the incorrect checks against invalid usage of the constant.
- * @since 10.0.0 Now differentiates between Name::class (PHP 5.5+) and $obj::class (PHP 8.0+).
+ * @since 10.0.0 - Now differentiates between Name::class (PHP 5.5+) and $obj::class (PHP 8.0+).
+ *               - This class is now `final`.
  */
-class NewMagicClassConstantSniff extends Sniff
+final class NewMagicClassConstantSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -23,9 +23,10 @@ use PHPCSUtils\Utils\MessageHelper;
  * PHP version All
  *
  * @since 8.1.0
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ *               - This class is now `final`.
  */
-class RemovedConstantsSniff extends Sniff
+final class RemovedConstantsSniff extends Sniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -32,8 +32,9 @@ use PHPCSUtils\Utils\Numbers;
  * @link https://www.php.net/manual/en/control-structures.switch.php
  *
  * @since 8.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class DiscouragedSwitchContinueSniff extends Sniff
+final class DiscouragedSwitchContinueSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -26,8 +26,9 @@ use PHPCSUtils\Utils\MessageHelper;
  * @link https://www.php.net/manual/en/control-structures.continue.php
  *
  * @since 7.0.7
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
+final class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -30,9 +30,10 @@ use PHPCSUtils\Utils\Numbers;
  * @link https://www.php.net/manual/en/control-structures.continue.php
  *
  * @since 5.5
- * @since 5.6 Now extends the base `Sniff` class.
+ * @since 5.6    Now extends the base `Sniff` class.
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
+final class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -23,8 +23,9 @@ use PHP_CodeSniffer\Files\File;
  * @link https://www.php.net/manual/en/control-structures.switch.php
  *
  * @since 7.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
+final class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -37,9 +37,10 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @since 7.0.3
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewExecutionDirectivesSniff extends Sniff
+final class NewExecutionDirectivesSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -26,8 +26,9 @@ use PHP_CodeSniffer\Files\File;
  * @link https://www.php.net/manual/en/control-structures.foreach.php
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewForeachExpressionReferencingSniff extends Sniff
+final class NewForeachExpressionReferencingSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -24,8 +24,9 @@ use PHP_CodeSniffer\Files\File;
  * @link https://www.php.net/manual/en/control-structures.foreach.php#control-structures.foreach.list
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewListInForeachSniff extends Sniff
+final class NewListInForeachSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -24,8 +24,9 @@ use PHP_CodeSniffer\Files\File;
  * @link https://www.php.net/manual/en/language.exceptions.php#language.exceptions.catch
  *
  * @since 7.0.7
+ * @since 10.0.0 This class is now `final`.
  */
-class NewMultiCatchSniff extends Sniff
+final class NewMultiCatchSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ControlStructures/NewNonCapturingCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewNonCapturingCatchSniff.php
@@ -25,7 +25,7 @@ use PHPCompatibility\Sniff;
  *
  * @since 10.0.0
  */
-class NewNonCapturingCatchSniff extends Sniff
+final class NewNonCapturingCatchSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -37,9 +37,10 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * @since 5.5
  * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ *               - This class is now `final`.
  */
-class RemovedExtensionsSniff extends Sniff
+final class RemovedExtensionsSniff extends Sniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
@@ -33,11 +33,12 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * @link https://wiki.php.net/rfc/abstract_trait_method_validation
  *
  * @since 9.2.0
- * @since 10.0.0 The sniff has been renamed from `PHPCompatibility.Classes.ForbiddenAbstractPrivateMethods`
- *               to `PHPCompatibility.FunctionDeclarations.AbstractPrivateMethods` and now
- *               includes detection of the PHP 8.0 change.
+ * @since 10.0.0 - The sniff has been renamed from `PHPCompatibility.Classes.ForbiddenAbstractPrivateMethods`
+ *                 to `PHPCompatibility.FunctionDeclarations.AbstractPrivateMethods` and now
+ *                 includes detection of the PHP 8.0 change.
+ *               - This class is now `final`.
  */
-class AbstractPrivateMethodsSniff extends Sniff
+final class AbstractPrivateMethodsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
@@ -35,7 +35,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 10.0.0
  */
-class ForbiddenFinalPrivateMethodsSniff extends Sniff
+final class ForbiddenFinalPrivateMethodsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsSniff.php
@@ -26,8 +26,9 @@ use PHPCSUtils\Utils\Variables;
  * @link https://php-legacy-docs.zend.com/manual/php5/en/migration54.incompatible
  *
  * @since 7.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
+final class ForbiddenParameterShadowSuperGlobalsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -24,8 +24,9 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.func-parameters
  *
  * @since 7.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenParametersWithSameNameSniff extends Sniff
+final class ForbiddenParametersWithSameNameSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -28,8 +28,9 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * @link https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
  *
  * @since 9.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenToStringParametersSniff extends Sniff
+final class ForbiddenToStringParametersSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -31,8 +31,9 @@ use PHPCSUtils\Utils\Variables;
  * @link https://www.php.net/manual/en/functions.anonymous.php
  *
  * @since 7.1.4
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenVariableNamesInClosureUseSniff extends Sniff
+final class ForbiddenVariableNamesInClosureUseSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -39,8 +39,9 @@ use PHPCSUtils\Utils\Conditions;
  * @link https://wiki.php.net/rfc/closures/object-extension
  *
  * @since 7.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewClosureSniff extends Sniff
+final class NewClosureSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -25,8 +25,9 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * @link https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
  *
  * @since 9.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewExceptionsFromToStringSniff extends Sniff
+final class NewExceptionsFromToStringSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -27,8 +27,9 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * @link https://www.php.net/manual/en/functions.arguments.php#example-146
  *
  * @since 7.0.7
+ * @since 10.0.0 This class is now `final`.
  */
-class NewNullableTypesSniff extends Sniff
+final class NewNullableTypesSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -62,9 +62,10 @@ use PHPCSUtils\Utils\TypeString;
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
  * @since 9.0.0  Renamed from `NewScalarTypeDeclarationsSniff` to `NewParamTypeDeclarationsSniff`.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewParamTypeDeclarationsSniff extends Sniff
+final class NewParamTypeDeclarationsSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -53,9 +53,10 @@ use PHPCSUtils\Utils\TypeString;
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
  * @since 7.1.2  Renamed from `NewScalarReturnTypeDeclarationsSniff` to `NewReturnTypeDeclarationsSniff`.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewReturnTypeDeclarationsSniff extends Sniff
+final class NewReturnTypeDeclarationsSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Tokens\Collections;
  *
  * @since 10.0.0
  */
-class NewTrailingCommaSniff extends Sniff
+final class NewTrailingCommaSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -32,9 +32,10 @@ use PHPCSUtils\Utils\MessageHelper;
  * @link https://www.php.net/manual/en/language.oop5.magic.php
  *
  * @since 5.5
- * @since 5.6 Now extends the base `Sniff` class.
+ * @since 5.6    Now extends the base `Sniff` class.
+ * @since 10.0.0 This class is now `final`.
  */
-class NonStaticMagicMethodsSniff extends Sniff
+final class NonStaticMagicMethodsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -30,7 +30,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 10.0.0
  */
-class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
+final class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -46,7 +46,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 10.0.0
  */
-class RemovedOptionalBeforeRequiredParamSniff extends Sniff
+final class RemovedOptionalBeforeRequiredParamSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 10.0.0
  */
-class RemovedReturnByReferenceFromVoidSniff extends Sniff
+final class RemovedReturnByReferenceFromVoidSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -32,9 +32,10 @@ use PHPCSUtils\Utils\Scopes;
  *
  * @since 7.0.4
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewMagicMethodsSniff extends Sniff
+final class NewMagicMethodsSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -32,9 +32,10 @@ use PHPCSUtils\Utils\Scopes;
  * @link https://www.php.net/manual/en/function.autoload.php
  *
  * @since 8.1.0
- * @since 9.0.0 Renamed from `DeprecatedMagicAutoloadSniff` to `RemovedMagicAutoloadSniff`.
+ * @since 9.0.0  Renamed from `DeprecatedMagicAutoloadSniff` to `RemovedMagicAutoloadSniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedMagicAutoloadSniff extends Sniff
+final class RemovedMagicAutoloadSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -36,8 +36,9 @@ use PHPCSUtils\Utils\Scopes;
  * @link https://www.php.net/manual/en/function.assert.php
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedNamespacedAssertSniff extends Sniff
+final class RemovedNamespacedAssertSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -38,11 +38,12 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * @link https://www.php.net/manual/en/language.oop5.decon.php
  *
  * @since 7.0.0
- * @since 7.0.8 This sniff now throws a warning instead of an error as the functionality is
- *              only deprecated (for now).
- * @since 9.0.0 Renamed from `DeprecatedPHP4StyleConstructorsSniff` to `RemovedPHP4StyleConstructorsSniff`.
+ * @since 7.0.8  This sniff now throws a warning instead of an error as the functionality is
+ *               only deprecated (for now).
+ * @since 9.0.0  Renamed from `DeprecatedPHP4StyleConstructorsSniff` to `RemovedPHP4StyleConstructorsSniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedPHP4StyleConstructorsSniff extends Sniff
+final class RemovedPHP4StyleConstructorsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -26,10 +26,11 @@ use PHPCSUtils\Utils\Scopes;
  *
  * @since 8.2.0  This was previously, since 7.0.3, checked by the upstream sniff.
  * @since 9.3.2  The sniff will now ignore functions marked as `@deprecated` by design.
- * @since 10.0.0 The sniff no longer extends the upstream `Generic.NamingConventions.CamelCapsFunctionName`
- *               sniff and has been completely rewritten using PHPCSUtils.
+ * @since 10.0.0 - The sniff no longer extends the upstream `Generic.NamingConventions.CamelCapsFunctionName`
+ *                 sniff and has been completely rewritten using PHPCSUtils.
+ *               - This class is now `final`.
  */
-class ReservedFunctionNamesSniff implements Sniff
+final class ReservedFunctionNamesSniff implements Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -34,8 +34,9 @@ use PHPCSUtils\Utils\TextStrings;
  * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.func-parameter-modified
  *
  * @since 9.1.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ArgumentFunctionsReportCurrentValueSniff extends Sniff
+final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -33,8 +33,9 @@ use PHPCSUtils\Utils\MessageHelper;
  * @link https://www.php.net/manual/en/migration53.incompatible.php
  *
  * @since 8.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ArgumentFunctionsUsageSniff extends Sniff
+final class ArgumentFunctionsUsageSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -26,10 +26,11 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
- * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
- *               and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `AbstractFunctionCallParameterSniff` class
+ *                 and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewFunctionParametersSniff extends AbstractFunctionCallParameterSniff
+final class NewFunctionParametersSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -26,9 +26,10 @@ use PHPCSUtils\Tokens\Collections;
  * @since 5.6    Now extends the base `Sniff` class instead of the upstream
  *               `Generic.PHP.ForbiddenFunctions` sniff.
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewFunctionsSniff extends Sniff
+final class NewFunctionsSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
@@ -30,7 +30,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 10.0.0
  */
-class NewNamedParametersSniff extends Sniff
+final class NewNamedParametersSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -27,12 +27,13 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * @since 8.1.0
  * @since 9.0.0  Renamed from `OptionalRequiredFunctionParametersSniff` to `OptionalToRequiredFunctionParametersSniff`.
- * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class.
- *               Previously the sniff extended the sister-sniff `RequiredToOptionalFunctionParametersSniff`.
- *               Methods which were previously required due to the extending of the (grand-parent)
- *               `AbstractComplexVersionSniff` have been removed.
+ * @since 10.0.0 - Now extends the base `AbstractFunctionCallParameterSniff` class.
+ *                 Previously the sniff extended the sister-sniff `RequiredToOptionalFunctionParametersSniff`.
+ *                 Methods which were previously required due to the extending of the (grand-parent)
+ *                 `AbstractComplexVersionSniff` have been removed.
+ *               - This class is now `final`.
  */
-class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallParameterSniff
+final class OptionalToRequiredFunctionParametersSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -27,10 +27,11 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
- * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
- *               and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `AbstractFunctionCallParameterSniff` class
+ *                 and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
+final class RemovedFunctionParametersSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -30,9 +30,10 @@ use PHPCSUtils\Utils\MessageHelper;
  *               `Generic.PHP.ForbiddenFunctions` sniff.
  * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
  * @since 9.0.0  Renamed from `DeprecatedFunctionsSniff` to `RemovedFunctionsSniff`.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ *               - This class is now `final`.
  */
-class RemovedFunctionsSniff extends Sniff
+final class RemovedFunctionsSniff extends Sniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -28,11 +28,12 @@ use PHPCSUtils\Utils\PassedParameters;
  * @since 7.0.3
  * @since 7.1.0  Now extends the `AbstractComplexVersionSniff` instead of the base `Sniff` class.
  * @since 9.0.0  Renamed from `RequiredOptionalFunctionParametersSniff` to `RequiredToOptionalFunctionParametersSniff`.
- * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class.
- *               Methods which were previously required due to the extending of the `AbstractComplexVersionSniff`
- *               have been removed.
+ * @since 10.0.0 - Now extends the base `AbstractFunctionCallParameterSniff` class.
+ *                 Methods which were previously required due to the extending of the `AbstractComplexVersionSniff`
+ *                 have been removed.
+ *               - This class is now `final`.
  */
-class RequiredToOptionalFunctionParametersSniff extends AbstractFunctionCallParameterSniff
+final class RequiredToOptionalFunctionParametersSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -26,8 +26,9 @@ use PHPCSUtils\Utils\Conditions;
  * @link https://www.php.net/manual/en/language.generators.syntax.php
  *
  * @since 8.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewGeneratorReturnSniff extends Sniff
+final class NewGeneratorReturnSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Generators/NewYieldFromCommentSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewYieldFromCommentSniff.php
@@ -24,7 +24,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since 10.0.0
  */
-class NewYieldFromCommentSniff extends Sniff
+final class NewYieldFromCommentSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -30,10 +30,11 @@ use PHPCSUtils\Utils\TextStrings;
  * @since 7.0.7  When a new directive is used with `ini_set()`, the sniff will now throw an error
  *               instead of a warning.
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
- * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
- *               and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `AbstractFunctionCallParameterSniff` class
+ *                 and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
+final class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -32,10 +32,11 @@ use PHPCSUtils\Utils\TextStrings;
  * @since 7.0.1  The sniff will now only throw warnings for `ini_get()`.
  * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
  * @since 9.0.0  Renamed from `DeprecatedIniDirectivesSniff` to `RemovedIniDirectivesSniff`.
- * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
- *               and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `AbstractFunctionCallParameterSniff` class
+ *                 and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ *               - This class is now `final`.
  */
-class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
+final class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -26,9 +26,10 @@ use PHPCSUtils\Utils\Arrays;
  * @link https://www.php.net/manual/en/language.constants.syntax.php
  *
  * @since 7.1.4
- * @since 9.0.0 Renamed from `ConstantArraysUsingConstSniff` to `NewConstantArraysUsingConstSniff`.
+ * @since 9.0.0  Renamed from `ConstantArraysUsingConstSniff` to `NewConstantArraysUsingConstSniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewConstantArraysUsingConstSniff extends Sniff
+final class NewConstantArraysUsingConstSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -27,10 +27,11 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/language.constants.syntax.php
  *
  * @since 7.0.0
- * @since 9.0.0 Renamed from `ConstantArraysUsingDefineSniff` to `NewConstantArraysUsingDefineSniff`.
- * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class instead of `Sniff`.
+ * @since 9.0.0  Renamed from `ConstantArraysUsingDefineSniff` to `NewConstantArraysUsingDefineSniff`.
+ * @since 10.0.0 - Now extends the base `AbstractFunctionCallParameterSniff` class instead of `Sniff`.
+ *               - This class is now `final`.
  */
-class NewConstantArraysUsingDefineSniff extends AbstractFunctionCallParameterSniff
+final class NewConstantArraysUsingDefineSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -34,10 +34,11 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://wiki.php.net/rfc/const_scalar_exprs
  *
  * @since 8.2.0
- * @since 10.0.0 This sniff now extends the `AbstractInitialValueSniff` class instead of the
- *               base `Sniff` class.
+ * @since 10.0.0 - This sniff now extends the `AbstractInitialValueSniff` class instead of the
+ *                 base `Sniff` class.
+ *               - This class is now `final`.
  */
-class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
+final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
 {
 
     /**
@@ -297,7 +298,7 @@ class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
      */
     protected function throwError(File $phpcsFile, $stackPtr, $end, $type)
     {
-        $error     = static::ERROR_PHRASE;
+        $error     = self::ERROR_PHRASE;
         $errorCode = 'Found';
         $phrase    = '';
 

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -35,10 +35,11 @@ use PHPCSUtils\Utils\MessageHelper;
  * @since 7.1.4
  * @since 8.2.0  Now extends the NewConstantScalarExpressionsSniff instead of the base Sniff class.
  * @since 9.0.0  Renamed from `NewHeredocInitializeSniff` to `NewHeredocSniff`.
- * @since 10.0.0 This sniff now extends the `AbstractInitialValueSniff` class instead of the
- *               `NewConstantScalarExpressionsSniff` class.
+ * @since 10.0.0 - This sniff now extends the `AbstractInitialValueSniff` class instead of the
+ *                 `NewConstantScalarExpressionsSniff` class.
+ *               - This class is now `final`.
  */
-class NewHeredocSniff extends AbstractInitialValueSniff
+final class NewHeredocSniff extends AbstractInitialValueSniff
 {
 
     /**
@@ -102,7 +103,7 @@ class NewHeredocSniff extends AbstractInitialValueSniff
             return;
         }
 
-        $error       = static::ERROR_PHRASE;
+        $error       = self::ERROR_PHRASE;
         $errorCode   = 'Found';
         $phrase      = '';
         $codeSnippet = \trim(GetTokensAsString::noComments($phpcsFile, $stackPtr, $hasHeredoc));

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -27,8 +27,9 @@ use PHPCSUtils\Utils\UseStatements;
  * @link https://www.php.net/manual/en/class.datetimeinterface.php
  *
  * @since 7.0.3
+ * @since 10.0.0 This class is now `final`.
  */
-class InternalInterfacesSniff extends Sniff
+final class InternalInterfacesSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -34,9 +34,10 @@ use PHPCSUtils\Utils\Variables;
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
  * @since 7.1.4  Now also detects new interfaces when used as parameter type declarations.
  * @since 8.2.0  Now also detects new interfaces when used as return type declarations.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewInterfacesSniff extends Sniff
+final class NewInterfacesSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
@@ -42,7 +42,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 10.0.0
  */
-class RemovedSerializableSniff extends Sniff
+final class RemovedSerializableSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/CaseSensitiveKeywordsSniff.php
@@ -26,8 +26,9 @@ use PHPCSUtils\Tokens\Collections;
  * @link https://php-legacy-docs.zend.com/manual/php5/en/migration55.incompatible#migration55.incompatible.self-parent-static
  *
  * @since 7.1.4
+ * @since 10.0.0 This class is now `final`.
  */
-class CaseSensitiveKeywordsSniff extends Sniff
+final class CaseSensitiveKeywordsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -34,9 +34,10 @@ use PHPCSUtils\Utils\UseStatements;
  * @link https://www.php.net/manual/en/reserved.keywords.php
  *
  * @since 5.5
- * @since 10.0.0 Strictly checks declarations and aliases only.
+ * @since 10.0.0 - Strictly checks declarations and aliases only.
+ *               - This class is now `final`.
  */
-class ForbiddenNamesSniff extends Sniff
+final class ForbiddenNamesSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -34,9 +34,10 @@ use PHPCSUtils\Tokens\Collections;
  *
  * @since 5.5
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewKeywordsSniff extends Sniff
+final class NewKeywordsSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -27,11 +27,12 @@ use PHP_CodeSniffer\Util\Tokens;
  * @link https://www.php.net/manual/en/function.empty.php
  *
  * @since 7.0.4
- * @since 9.0.0 The "is the parameter a variable" determination has been abstracted out
- *              and moved to a separate method `Sniff::isVariable()`.
- * @since 9.0.0 Renamed from `EmptyNonVariableSniff` to `NewEmptyNonVariableSniff`.
+ * @since 9.0.0  The "is the parameter a variable" determination has been abstracted out
+ *               and moved to a separate method `Sniff::isVariable()`.
+ * @since 9.0.0  Renamed from `EmptyNonVariableSniff` to `NewEmptyNonVariableSniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewEmptyNonVariableSniff extends Sniff
+final class NewEmptyNonVariableSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -27,9 +27,10 @@ use PHP_CodeSniffer\Files\File;
  * @since 5.6
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
  * @since 9.0.0  Detection for new operator tokens has been moved to the `NewOperators` sniff.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewLanguageConstructsSniff extends Sniff
+final class NewLanguageConstructsSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -30,8 +30,9 @@ use PHPCSUtils\Utils\Lists;
  * @link https://www.php.net/manual/en/function.list.php
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class AssignmentOrderSniff extends Sniff
+final class AssignmentOrderSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -27,8 +27,9 @@ use PHPCSUtils\Utils\Lists;
  * @link https://www.php.net/manual/en/function.list.php
  *
  * @since 7.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenEmptyListAssignmentSniff extends Sniff
+final class ForbiddenEmptyListAssignmentSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -26,9 +26,10 @@ use PHPCSUtils\Utils\Lists;
  * @link https://www.php.net/manual/en/function.list.php
  *
  * @since 9.0.0
- * @since 10.0.0 Complete rewrite.
+ * @since 10.0.0 - Complete rewrite.
+ *               - This class is now `final`.
  */
-class NewKeyedListSniff extends Sniff
+final class NewKeyedListSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -27,10 +27,11 @@ use PHPCSUtils\Utils\Lists;
  * @link https://www.php.net/manual/en/function.list.php
  *
  * @since 9.0.0
- * @since 10.0.0 Complete rewrite. No longer extends the `NewKeyedListSniff`.
- *               Now extends the base `Sniff` class.
+ * @since 10.0.0 - Complete rewrite. No longer extends the `NewKeyedListSniff`.
+ *                 Now extends the base `Sniff` class.
+ *               - This class is now `final`.
  */
-class NewListReferenceAssignmentSniff extends Sniff
+final class NewListReferenceAssignmentSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -29,8 +29,9 @@ use PHPCSUtils\Utils\Lists;
  * @link https://wiki.php.net/rfc/short_list_syntax
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewShortListSniff extends Sniff
+final class NewShortListSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
@@ -28,8 +28,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
  *
  * @since 9.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenToStringParametersSniff extends Sniff
+final class ForbiddenToStringParametersSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -29,8 +29,9 @@ use PHPCSUtils\Tokens\Collections;
  * @link https://www.php.net/manual/en/language.oop5.cloning.php
  *
  * @since 9.1.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewDirectCallsToCloneSniff extends Sniff
+final class NewDirectCallsToCloneSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -28,8 +28,9 @@ use PHP_CodeSniffer\Files\File;
  * @link https://github.com/php/php-src/blob/30de357fa14480468132bbc22a272aeb91789ba8/UPGRADING#L37-L40
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewPHPOpenTagEOFSniff extends Sniff
+final class NewPHPOpenTagEOFSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -27,8 +27,9 @@ use PHPCSUtils\Tokens\Collections;
  * @link https://www.php.net/manual/en/language.basic-syntax.phptags.php
  *
  * @since 7.0.4
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedAlternativePHPTagsSniff extends Sniff
+final class RemovedAlternativePHPTagsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -32,7 +32,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since 10.0.0
  */
-class ReservedNamesSniff extends Sniff
+final class ReservedNamesSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Numbers;
  *
  * @since 10.0.0
  */
-class NewExplicitOctalNotationSniff extends Sniff
+final class NewExplicitOctalNotationSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Numbers/NewNumericLiteralSeparatorSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/NewNumericLiteralSeparatorSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\Numbers;
  *
  * @since 10.0.0
  */
-class NewNumericLiteralSeparatorSniff extends Sniff
+final class NewNumericLiteralSeparatorSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
@@ -35,7 +35,7 @@ use PHPCSUtils\Utils\TextStrings;
  * @since 10.0.0 The check in this sniff was previously contained in the ValidIntegers
  *               sniff and has now been split off to a separate sniff.
  */
-class RemovedHexadecimalNumericStringsSniff extends Sniff
+final class RemovedHexadecimalNumericStringsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
@@ -34,8 +34,9 @@ use PHPCSUtils\Utils\Numbers;
  * @since 7.0.8  This sniff now throws a warning instead of an error for invalid binary integers.
  * @since 10.0.0 - The sniff has been moved from the `Miscellaneous` category to `Numbers`.
  *               - The check for hexadecimal numeric strings has been split off to its own sniff.
+ *               - This class is now `final`.
  */
-class ValidIntegersSniff extends Sniff
+final class ValidIntegersSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
@@ -35,8 +35,9 @@ use PHPCSUtils\Utils\Operators;
  * @link https://www.php.net/manual/en/language.operators.precedence.php
  *
  * @since 9.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ChangedConcatOperatorPrecedenceSniff extends Sniff
+final class ChangedConcatOperatorPrecedenceSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -27,8 +27,9 @@ use PHPCSUtils\Utils\GetTokensAsString;
  * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.integers.negative-bitshift
  *
  * @since 7.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenNegativeBitshiftSniff extends Sniff
+final class ForbiddenNegativeBitshiftSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewOperatorsSniff.php
@@ -28,9 +28,10 @@ use PHP_CodeSniffer\Files\File;
  *
  * @since 9.0.0  Detection of new operators was originally included in the
  *               `NewLanguageConstruct` sniff (since 5.6).
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewOperatorsSniff extends Sniff
+final class NewOperatorsSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -27,10 +27,11 @@ use PHPCSUtils\Utils\Operators;
  * @link https://www.php.net/manual/en/language.operators.comparison.php#language.operators.comparison.ternary
  *
  * @since 7.0.0
- * @since 7.0.8 This sniff now throws an error instead of a warning.
- * @since 9.0.0 Renamed from `TernaryOperatorsSniff` to `NewShortTernarySniff`.
+ * @since 7.0.8  This sniff now throws an error instead of a warning.
+ * @since 9.0.0  Renamed from `TernaryOperatorsSniff` to `NewShortTernarySniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewShortTernarySniff extends Sniff
+final class NewShortTernarySniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -30,8 +30,9 @@ use PHPCSUtils\Utils\Operators;
  * @link https://github.com/php/php-src/pull/4017
  *
  * @since 9.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedTernaryAssociativitySniff extends Sniff
+final class RemovedTernaryAssociativitySniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 10.0.0
  */
-class ChangedIntToBoolParamTypeSniff extends AbstractFunctionCallParameterSniff
+final class ChangedIntToBoolParamTypeSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
@@ -31,7 +31,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 10.0.0
  */
-class ChangedObStartEraseFlagsSniff extends AbstractFunctionCallParameterSniff
+final class ChangedObStartEraseFlagsSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -25,8 +25,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/function.get-class.php#refsect1-function.get-class-changelog
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
+final class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
@@ -29,7 +29,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @since 10.0.0
  */
-class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallParameterSniff
+final class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -24,8 +24,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://php-legacy-docs.zend.com/manual/php5/en/function.strip-tags#refsect1-function.strip-tags-changelog
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCallParameterSniff
+final class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -25,8 +25,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/function.array-reduce.php#refsect1-function.array-reduce-changelog
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
+final class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewAssertCustomExceptionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewAssertCustomExceptionSniff.php
@@ -28,7 +28,7 @@ use PHPCompatibility\Helpers\ScannedCode;
  *
  * @since 10.0.0
  */
-class NewAssertCustomExceptionSniff extends AbstractFunctionCallParameterSniff
+final class NewAssertCustomExceptionSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -23,8 +23,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/function.fopen.php#refsect1-function.fopen-changelog
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
+final class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
@@ -27,8 +27,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/function.htmlspecialchars.php#refsect1-function.htmlspecialchars-changelog
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewHTMLEntitiesEncodingDefaultSniff extends AbstractFunctionCallParameterSniff
+final class NewHTMLEntitiesEncodingDefaultSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesFlagsDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesFlagsDefaultSniff.php
@@ -28,7 +28,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 10.0.0
  */
-class NewHTMLEntitiesFlagsDefaultSniff extends AbstractFunctionCallParameterSniff
+final class NewHTMLEntitiesFlagsDefaultSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -25,10 +25,11 @@ use PHP_CodeSniffer\Files\File;
  *
  * @since 7.0.7
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..
- * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
- *               and uses the `ComplexVersionNewFeatureTrait` and the `HashAlgorithmsTrait`.
+ * @since 10.0.0 - Now extends the base `AbstractFunctionCallParameterSniff` class
+ *                 and uses the `ComplexVersionNewFeatureTrait` and the `HashAlgorithmsTrait`.
+ *               - This class is now `final`.
  */
-class NewHashAlgorithmsSniff extends AbstractFunctionCallParameterSniff
+final class NewHashAlgorithmsSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionNewFeatureTrait;
     use HashAlgorithmsTrait;

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
@@ -27,8 +27,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/function.idn-to-utf8.php
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewIDNVariantDefaultSniff extends AbstractFunctionCallParameterSniff
+final class NewIDNVariantDefaultSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -36,8 +36,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://wiki.php.net/rfc/default_encoding
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterSniff
+final class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNegativeStringOffsetSniff.php
@@ -25,8 +25,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://wiki.php.net/rfc/negative-string-offsets
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
+final class NewNegativeStringOffsetSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
@@ -29,7 +29,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @since 10.0.0
  */
-class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCallParameterSniff
+final class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -29,9 +29,10 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 8.2.0
  * @since 9.0.0  Renamed from `PCRENewModifiersSniff` to `NewPCREModifiersSniff`.
- * @since 10.0.0 Now uses the new `PCRERegexTrait` and extends the `AbstractFunctionCallParameterSniff`.
+ * @since 10.0.0 - Now uses the new `PCRERegexTrait` and extends the `AbstractFunctionCallParameterSniff`.
+ *               - This class is now `final`.
  */
-class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
+final class NewPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 {
     use PCRERegexTrait;
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -25,8 +25,9 @@ use PHPCSUtils\Utils\TextStrings;
  * @link https://www.php.net/manual/en/function.pack.php#refsect1-function.pack-changelog
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
+final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -29,8 +29,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://wiki.php.net/rfc/password_registry
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParameterSniff
+final class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -28,8 +28,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/function.proc-open.php
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
+final class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -25,8 +25,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/function.strip-tags.php
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterSniff
+final class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
@@ -36,7 +36,7 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * @since 10.0.0
  */
-class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSniff
+final class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 10.0.0
  */
-class RemovedGetDefinedFunctionsExcludeDisabledFalseSniff extends AbstractFunctionCallParameterSniff
+final class RemovedGetDefinedFunctionsExcludeDisabledFalseSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -26,10 +26,11 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * @since 5.5
  * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.
- * @since 10.0.0 Now extends the base `AbstractFunctionCallParameterSniff` class
- *               and uses the `ComplexVersionNewFeatureTrait` and the `HashAlgorithmsTrait`.
+ * @since 10.0.0 - Now extends the base `AbstractFunctionCallParameterSniff` class
+ *                 and uses the `ComplexVersionNewFeatureTrait` and the `HashAlgorithmsTrait`.
+ *               - This class is now `final`.
  */
-class RemovedHashAlgorithmsSniff extends AbstractFunctionCallParameterSniff
+final class RemovedHashAlgorithmsSniff extends AbstractFunctionCallParameterSniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
     use HashAlgorithmsTrait;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -30,8 +30,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://wiki.php.net/rfc/default_encoding
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
+final class RemovedIconvEncodingSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -29,8 +29,9 @@ use PHPCSUtils\Utils\MessageHelper;
  * @link https://php.net/manual/en/function.implode.php
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParameterSniff
+final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbCheckEncodingNoArgsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbCheckEncodingNoArgsSniff.php
@@ -27,7 +27,7 @@ use PHP_CodeSniffer\Files\File;
  *
  * @since 10.0.0
  */
-class RemovedMbCheckEncodingNoArgsSniff extends AbstractFunctionCallParameterSniff
+final class RemovedMbCheckEncodingNoArgsSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -39,8 +39,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/function.mb-strrpos.php
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParameterSniff
+final class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -28,12 +28,13 @@ use PHPCSUtils\Utils\TextStrings;
  * @link https://www.php.net/manual/en/function.mb-regex-set-options.php
  *
  * @since 7.0.5
- * @since 7.0.8 This sniff now throws a warning instead of an error as the functionality is
- *              only deprecated (for now).
- * @since 8.2.0 Now extends the `AbstractFunctionCallParameterSniff` instead of the base `Sniff` class.
- * @since 9.0.0 Renamed from `MbstringReplaceEModifierSniff` to `RemovedMbstringModifiersSniff`.
+ * @since 7.0.8  This sniff now throws a warning instead of an error as the functionality is
+ *               only deprecated (for now).
+ * @since 8.2.0  Now extends the `AbstractFunctionCallParameterSniff` instead of the base `Sniff` class.
+ * @since 9.0.0  Renamed from `MbstringReplaceEModifierSniff` to `RemovedMbstringModifiersSniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
+final class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -28,8 +28,9 @@ use PHPCSUtils\Utils\TextStrings;
  * @link https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.hash-functions
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
+final class RemovedNonCryptoHashSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -39,9 +39,10 @@ use PHPCSUtils\Utils\PassedParameters;
  *               on the `testVersion` set. Previously it would always throw an error.
  * @since 8.2.0  Now extends the `AbstractFunctionCallParameterSniff` instead of the base `Sniff` class.
  * @since 9.0.0  Renamed from `PregReplaceEModifierSniff` to `RemovedPCREModifiersSniff`.
- * @since 10.0.0 Now uses the new `PCRERegexTrait`.
+ * @since 10.0.0 - Now uses the new `PCRERegexTrait`.
+ *               - This class is now `final`.
  */
-class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
+final class RemovedPCREModifiersSniff extends AbstractFunctionCallParameterSniff
 {
     use PCRERegexTrait;
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -30,8 +30,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/function.setlocale.php#refsect1-function.setlocale-changelog
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
+final class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
@@ -28,7 +28,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 10.0.0
  */
-class RemovedSplAutoloadRegisterThrowFalseSniff extends AbstractFunctionCallParameterSniff
+final class RemovedSplAutoloadRegisterThrowFalseSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedVersionCompareOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedVersionCompareOperatorsSniff.php
@@ -29,7 +29,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @since 10.0.0
  */
-class RemovedVersionCompareOperatorsSniff extends AbstractFunctionCallParameterSniff
+final class RemovedVersionCompareOperatorsSniff extends AbstractFunctionCallParameterSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -29,10 +29,11 @@ use PHPCSUtils\Utils\PassedParameters;
  * @link https://www.php.net/manual/en/language.references.pass.php
  *
  * @since 5.5
- * @since 7.0.8 This sniff now throws a warning (deprecated) or an error (removed) depending
- *              on the `testVersion` set. Previously it would always throw an error.
+ * @since 7.0.8  This sniff now throws a warning (deprecated) or an error (removed) depending
+ *               on the `testVersion` set. Previously it would always throw an error.
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenCallTimePassByReferenceSniff extends Sniff
+final class ForbiddenCallTimePassByReferenceSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -36,9 +36,10 @@ use PHP_CodeSniffer\Util\Tokens;
  *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}
  *
  * @since 7.1.4
- * @since 9.3.0 Now also detects dereferencing using curly braces.
+ * @since 9.3.0  Now also detects dereferencing using curly braces.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewArrayStringDereferencingSniff extends Sniff
+final class NewArrayStringDereferencingSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -28,8 +28,9 @@ use PHPCSUtils\Utils\GetTokensAsString;
  * @link https://wiki.php.net/rfc/spread_operator_for_array
  *
  * @since 9.2.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewArrayUnpackingSniff extends Sniff
+final class NewArrayUnpackingSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -37,9 +37,10 @@ use PHP_CodeSniffer\Util\Tokens;
  *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}
  *
  * @since 8.2.0
- * @since 9.3.0 Now also detects class member access on instantiation using curly braces.
+ * @since 9.3.0  Now also detects class member access on instantiation using curly braces.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewClassMemberAccessSniff extends Sniff
+final class NewClassMemberAccessSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -26,9 +26,10 @@ use PHP_CodeSniffer\Util\Tokens;
  * @link https://www.php.net/manual/en/migration53.new-features.php
  *
  * @since 8.1.0
- * @since 9.0.0 Renamed from `DynamicAccessToStaticSniff` to `NewDynamicAccessToStaticSniff`.
+ * @since 9.0.0  Renamed from `DynamicAccessToStaticSniff` to `NewDynamicAccessToStaticSniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewDynamicAccessToStaticSniff extends Sniff
+final class NewDynamicAccessToStaticSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -29,8 +29,9 @@ use PHP_CodeSniffer\Files\File;
  * @link https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes
  *
  * @since 9.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewFlexibleHeredocNowdocSniff extends Sniff
+final class NewFlexibleHeredocNowdocSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -36,9 +36,10 @@ use PHPCSUtils\Tokens\Collections;
  *            to allow re-use of the logic by the PHP 7.4 RemovedCurlyBraceArrayAccess sniff.}
  *
  * @since 7.0.0
- * @since 9.3.0 Now also detects dereferencing using curly braces.
+ * @since 9.3.0  Now also detects dereferencing using curly braces.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewFunctionArrayDereferencingSniff extends Sniff
+final class NewFunctionArrayDereferencingSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -25,9 +25,10 @@ use PHPCSUtils\Tokens\Collections;
  * @link https://wiki.php.net/rfc/trailing-comma-function-calls
  *
  * @since 8.2.0
- * @since 9.0.0 Renamed from `NewTrailingCommaSniff` to `NewFunctionCallTrailingCommaSniff`.
+ * @since 9.0.0  Renamed from `NewTrailingCommaSniff` to `NewFunctionCallTrailingCommaSniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewFunctionCallTrailingCommaSniff extends Sniff
+final class NewFunctionCallTrailingCommaSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
@@ -27,7 +27,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * @since 10.0.0
  */
-class NewInterpolatedStringDereferencingSniff extends Sniff
+final class NewInterpolatedStringDereferencingSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
@@ -24,7 +24,7 @@ use PHPCompatibility\Sniff;
  *
  * @since 10.0.0
  */
-class NewMagicConstantDereferencingSniff extends Sniff
+final class NewMagicConstantDereferencingSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
@@ -30,7 +30,7 @@ use PHPCSUtils\Tokens\Collections;
  *
  * @since 10.0.0
  */
-class NewNestedStaticAccessSniff extends Sniff
+final class NewNestedStaticAccessSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -25,9 +25,10 @@ use PHPCSUtils\Utils\Arrays;
  * @link https://www.php.net/manual/en/language.types.array.php#language.types.array.syntax
  *
  * @since 7.0.0
- * @since 9.0.0 Renamed from `ShortArraySniff` to `NewShortArraySniff`.
+ * @since 9.0.0  Renamed from `ShortArraySniff` to `NewShortArraySniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewShortArraySniff extends Sniff
+final class NewShortArraySniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -30,8 +30,9 @@ use PHP_CodeSniffer\Util\Tokens;
  * @link https://wiki.php.net/rfc/deprecate_curly_braces_array_access
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedCurlyBraceArrayAccessSniff extends Sniff
+final class RemovedCurlyBraceArrayAccessSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -27,9 +27,10 @@ use PHPCSUtils\Utils\MessageHelper;
  * @link https://wiki.php.net/rfc/remove_deprecated_functionality_in_php7
  *
  * @since 5.5
- * @since 9.0.0 Renamed from `DeprecatedNewReferenceSniff` to `RemovedNewReferenceSniff`.
+ * @since 9.0.0  Renamed from `DeprecatedNewReferenceSniff` to `RemovedNewReferenceSniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class RemovedNewReferenceSniff extends Sniff
+final class RemovedNewReferenceSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
@@ -30,8 +30,9 @@ use PHPCSUtils\Utils\TextStrings;
  * @link https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.double
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class NewUnicodeEscapeSequenceSniff extends Sniff
+final class NewUnicodeEscapeSequenceSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/TextStrings/RemovedDollarBraceStringEmbedsSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/RemovedDollarBraceStringEmbedsSniff.php
@@ -34,7 +34,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @since 10.0.0
  */
-class RemovedDollarBraceStringEmbedsSniff extends Sniff
+final class RemovedDollarBraceStringEmbedsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -23,9 +23,10 @@ use PHP_CodeSniffer\Files\File;
  * @link https://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting
  *
  * @since 8.0.1
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.
+ *               - This class is now `final`.
  */
-class NewTypeCastsSniff extends Sniff
+final class NewTypeCastsSniff extends Sniff
 {
     use ComplexVersionNewFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -27,9 +27,10 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * @since 8.0.1
  * @since 9.0.0  Renamed from `DeprecatedTypeCastsSniff` to `RemovedTypeCastsSniff`.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ *               - This class is now `final`.
  */
-class RemovedTypeCastsSniff extends Sniff
+final class RemovedTypeCastsSniff extends Sniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 

--- a/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
+++ b/PHPCompatibility/Sniffs/Upgrade/LowPHPSniff.php
@@ -29,8 +29,9 @@ use PHPCSUtils\Utils\MessageHelper;
  * @link https://github.com/PHPCompatibility/PHPCompatibility/issues/835
  *
  * @since 9.3.0
+ * @since 10.0.0 This class is now `final`.
  */
-class LowPHPSniff extends Sniff
+final class LowPHPSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -32,9 +32,10 @@ use PHP_CodeSniffer\Util\Tokens;
  * @link https://www.php.net/manual/en/language.namespaces.importing.php#language.namespaces.importing.group
  *
  * @since 7.0.0
- * @since 8.0.1 Now also checks for trailing commas in group `use` declarations.
+ * @since 8.0.1  Now also checks for trailing commas in group `use` declarations.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewGroupUseDeclarationsSniff extends Sniff
+final class NewGroupUseDeclarationsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -30,8 +30,9 @@ use PHPCSUtils\Utils\UseStatements;
  * @link https://www.php.net/manual/en/language.namespaces.importing.php
  *
  * @since 7.1.4
+ * @since 10.0.0 This class is now `final`.
  */
-class NewUseConstFunctionSniff extends Sniff
+final class NewUseConstFunctionSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -25,8 +25,9 @@ use PHPCSUtils\Utils\GetTokensAsString;
  * @link https://wiki.php.net/rfc/uniform_variable_syntax#global_keyword_takes_only_simple_variables
  *
  * @since 7.0.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenGlobalVariableVariableSniff extends Sniff
+final class ForbiddenGlobalVariableVariableSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -50,8 +50,9 @@ use PHPCSUtils\Utils\Scopes;
  * @link https://wiki.php.net/rfc/this_var
  *
  * @since 9.1.0
+ * @since 10.0.0 This class is now `final`.
  */
-class ForbiddenThisUseContextsSniff extends Sniff
+final class ForbiddenThisUseContextsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -25,9 +25,10 @@ use PHPCSUtils\Tokens\Collections;
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *
  * @since 7.1.2
- * @since 9.0.0 Renamed from `VariableVariablesSniff` to `NewUniformVariableSyntaxSniff`.
+ * @since 9.0.0  Renamed from `VariableVariablesSniff` to `NewUniformVariableSyntaxSniff`.
+ * @since 10.0.0 This class is now `final`.
  */
-class NewUniformVariableSyntaxSniff extends Sniff
+final class NewUniformVariableSyntaxSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -36,9 +36,10 @@ use PHPCSUtils\Utils\Scopes;
  *               instead of the base `Sniff` class.
  * @since 7.1.3  Merged the `LongArrays` sniff into the `RemovedGlobalVariables` sniff.
  * @since 9.0.0  Renamed from `RemovedGlobalVariablesSniff` to `RemovedPredefinedGlobalVariablesSniff`.
- * @since 10.0.0 Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionDeprecatedRemovedFeatureTrait`.
+ *               - This class is now `final`.
  */
-class RemovedPredefinedGlobalVariablesSniff extends Sniff
+final class RemovedPredefinedGlobalVariablesSniff extends Sniff
 {
     use ComplexVersionDeprecatedRemovedFeatureTrait;
 

--- a/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
+++ b/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewAttributesUnitTest extends BaseSniffTestCase
+final class NewAttributesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenExtendingFinalPHPClassUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class ForbiddenExtendingFinalPHPClassUnitTest extends BaseSniffTestCase
+final class ForbiddenExtendingFinalPHPClassUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewAnonymousClassesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class NewAnonymousClassesUnitTest extends BaseSniffTestCase
+final class NewAnonymousClassesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class NewClassesUnitTest extends BaseSniffTestCase
+final class NewClassesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewConstVisibilityUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.7
  */
-class NewConstVisibilityUnitTest extends BaseSniffTestCase
+final class NewConstVisibilityUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewFinalConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewFinalConstantsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewFinalConstantsUnitTest extends BaseSniffTestCase
+final class NewFinalConstantsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewFinalPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewFinalPropertiesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewFinalPropertiesUnitTest extends BaseSniffTestCase
+final class NewFinalPropertiesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.3
  */
-class NewLateStaticBindingUnitTest extends BaseSniffTestCase
+final class NewLateStaticBindingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.2.0
  */
-class NewTypedPropertiesUnitTest extends BaseSniffTestCase
+final class NewTypedPropertiesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedClassesUnitTest extends BaseSniffTestCase
+final class RemovedClassesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.2.0
  */
-class RemovedOrphanedParentUnitTest extends BaseSniffTestCase
+final class RemovedOrphanedParentUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.1.0
  */
-class NewConstantsUnitTest extends BaseSniffTestCase
+final class NewConstantsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewMagicClassConstantUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.1.4
  */
-class NewMagicClassConstantUnitTest extends BaseSniffTestCase
+final class NewMagicClassConstantUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.1.0
  */
-class RemovedConstantsUnitTest extends BaseSniffTestCase
+final class RemovedConstantsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/DiscouragedSwitchContinueUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.2.0
  */
-class DiscouragedSwitchContinueUnitTest extends BaseSniffTestCase
+final class DiscouragedSwitchContinueUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueOutsideLoopUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.7
  */
-class ForbiddenBreakContinueOutsideLoopUnitTest extends BaseSniffTestCase
+final class ForbiddenBreakContinueOutsideLoopUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTestCase
+final class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTestCase
+final class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.3
  */
-class NewExecutionDirectivesUnitTest extends BaseSniffTestCase
+final class NewExecutionDirectivesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/NewForeachExpressionReferencingUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewForeachExpressionReferencingUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class NewForeachExpressionReferencingUnitTest extends BaseSniffTestCase
+final class NewForeachExpressionReferencingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class NewListInForeachUnitTest extends BaseSniffTestCase
+final class NewListInForeachUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.7
  */
-class NewMultiCatchUnitTest extends BaseSniffTestCase
+final class NewMultiCatchUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewNonCapturingCatchUnitTest extends BaseSniffTestCase
+final class NewNonCapturingCatchUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
+++ b/PHPCompatibility/Tests/Extensions/RemovedExtensionsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class RemovedExtensionsUnitTest extends BaseSniffTestCase
+final class RemovedExtensionsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/AbstractPrivateMethodsUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  * @since 9.2.0
  * @since 10.0.0 Moved from `Classes` to `FunctionDeclarations`.
  */
-class AbstractPrivateMethodsUnitTest extends BaseSniffTestCase
+final class AbstractPrivateMethodsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenFinalPrivateMethodsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTestCase
+final class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParameterShadowSuperGlobalsUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.3
  */
-class ForbiddenParameterShadowSuperGlobalsUnitTest extends BaseSniffTestCase
+final class ForbiddenParameterShadowSuperGlobalsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTestCase
+final class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenToStringParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenToStringParametersUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.2.0
  */
-class ForbiddenToStringParametersUnitTest extends BaseSniffTestCase
+final class ForbiddenToStringParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.1.4
  */
-class ForbiddenVariableNamesInClosureUseUnitTest extends BaseSniffTestCase
+final class ForbiddenVariableNamesInClosureUseUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewClosureUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class NewClosureUnitTest extends BaseSniffTestCase
+final class NewClosureUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewExceptionsFromToStringUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.2.0
  */
-class NewExceptionsFromToStringUnitTest extends BaseSniffTestCase
+final class NewExceptionsFromToStringUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewNullableTypesUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.7
  */
-class NewNullableTypesUnitTest extends BaseSniffTestCase
+final class NewNullableTypesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewParamTypeDeclarationsUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
+final class NewParamTypeDeclarationsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewReturnTypeDeclarationsUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
+final class NewReturnTypeDeclarationsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewTrailingCommaUnitTest extends BaseSniffTestCase
+final class NewTrailingCommaUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class NonStaticMagicMethodsUnitTest extends BaseSniffTestCase
+final class NonStaticMagicMethodsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTestCase
+final class RemovedCallingDestructAfterConstructorExitUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
+final class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnByReferenceFromVoidUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedReturnByReferenceFromVoidUnitTest extends BaseSniffTestCase
+final class RemovedReturnByReferenceFromVoidUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewMagicMethodsUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.4
  */
-class NewMagicMethodsUnitTest extends BaseSniffTestCase
+final class NewMagicMethodsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.1.0
  */
-class RemovedMagicAutoloadUnitTest extends BaseSniffTestCase
+final class RemovedMagicAutoloadUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class RemovedNamespacedAssertUnitTest extends BaseSniffTestCase
+final class RemovedNamespacedAssertUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTestCase
+final class RemovedPHP4StyleConstructorsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.2.0
  */
-class ReservedFunctionNamesUnitTest extends BaseSniffTestCase
+final class ReservedFunctionNamesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.1.0
  */
-class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
+final class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.2.0
  */
-class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
+final class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class NewFunctionParametersUnitTest extends BaseSniffTestCase
+final class NewFunctionParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class NewFunctionsUnitTest extends BaseSniffTestCase
+final class NewFunctionsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewNamedParametersUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewNamedParametersUnitTest extends BaseSniffTestCase
+final class NewNamedParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/OptionalToRequiredFunctionParametersUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.1.0
  */
-class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTestCase
+final class OptionalToRequiredFunctionParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
+final class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class RemovedFunctionsUnitTest extends BaseSniffTestCase
+final class RemovedFunctionsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RequiredToOptionalFunctionParametersUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.3
  */
-class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTestCase
+final class RequiredToOptionalFunctionParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewGeneratorReturnUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.2.0
  */
-class NewGeneratorReturnUnitTest extends BaseSniffTestCase
+final class NewGeneratorReturnUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Generators/NewYieldFromCommentUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewYieldFromCommentUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewYieldFromCommentUnitTest extends BaseSniffTestCase
+final class NewYieldFromCommentUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class NewIniDirectivesUnitTest extends BaseSniffTestCase
+final class NewIniDirectivesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
+final class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingConstUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.1.4
  */
-class NewConstantArraysUsingConstUnitTest extends BaseSniffTestCase
+final class NewConstantArraysUsingConstUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantArraysUsingDefineUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class NewConstantArraysUsingDefineUnitTest extends BaseSniffTestCase
+final class NewConstantArraysUsingDefineUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.2.0
  */
-class NewConstantScalarExpressionsUnitTest extends BaseSniffTestCase
+final class NewConstantScalarExpressionsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewHeredocUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.1.4
  */
-class NewHeredocUnitTest extends BaseSniffTestCase
+final class NewHeredocUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/InternalInterfacesUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.3
  */
-class InternalInterfacesUnitTest extends BaseSniffTestCase
+final class InternalInterfacesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.3
  */
-class NewInterfacesUnitTest extends BaseSniffTestCase
+final class NewInterfacesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedSerializableUnitTest extends BaseSniffTestCase
+final class RemovedSerializableUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/CaseSensitiveKeywordsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.1.4
  */
-class CaseSensitiveKeywordsUnitTest extends BaseSniffTestCase
+final class CaseSensitiveKeywordsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class ForbiddenNamesUnitTest extends BaseSniffTestCase
+final class ForbiddenNamesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class NewKeywordsUnitTest extends BaseSniffTestCase
+final class NewKeywordsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.4
  */
-class NewEmptyNonVariableUnitTest extends BaseSniffTestCase
+final class NewEmptyNonVariableUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewLanguageConstructsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.6
  */
-class NewLanguageConstructsUnitTest extends BaseSniffTestCase
+final class NewLanguageConstructsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class AssignmentOrderUnitTest extends BaseSniffTestCase
+final class AssignmentOrderUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTestCase
+final class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class NewKeyedListUnitTest extends BaseSniffTestCase
+final class NewKeyedListUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class NewListReferenceAssignmentUnitTest extends BaseSniffTestCase
+final class NewListReferenceAssignmentUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewShortListUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class NewShortListUnitTest extends BaseSniffTestCase
+final class NewShortListUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/ForbiddenToStringParametersUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.2.0
  */
-class ForbiddenToStringParametersUnitTest extends BaseSniffTestCase
+final class ForbiddenToStringParametersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
+++ b/PHPCompatibility/Tests/MethodUse/NewDirectCallsToCloneUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.1.0
  */
-class NewDirectCallsToCloneUnitTest extends BaseSniffTestCase
+final class NewDirectCallsToCloneUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class NewPHPOpenTagEOFUnitTest extends BaseSniffTestCase
+final class NewPHPOpenTagEOFUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/RemovedAlternativePHPTagsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.4
  */
-class RemovedAlternativePHPTagsUnitTest extends BaseSniffTestCase
+final class RemovedAlternativePHPTagsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class ReservedNamesUnitTest extends BaseSniffTestCase
+final class ReservedNamesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewExplicitOctalNotationUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewExplicitOctalNotationUnitTest extends BaseSniffTestCase
+final class NewExplicitOctalNotationUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/NewNumericLiteralSeparatorUnitTest.php
@@ -23,7 +23,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @since 10.0.0
  */
-class NewNumericLiteralSeparatorUnitTest extends BaseSniffTestCase
+final class NewNumericLiteralSeparatorUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Numbers/RemovedHexadecimalNumericStringsUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/RemovedHexadecimalNumericStringsUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  * @since 7.0.3
  * @since 10.0.0 Split off from the ValidIntegers sniff.
  */
-class RemovedHexadecimalNumericStringsUnitTest extends BaseSniffTestCase
+final class RemovedHexadecimalNumericStringsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Numbers/ValidIntegersUnitTest.php
+++ b/PHPCompatibility/Tests/Numbers/ValidIntegersUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.3
  */
-class ValidIntegersUnitTest extends BaseSniffTestCase
+final class ValidIntegersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ChangedConcatOperatorPrecedenceUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.2.0
  */
-class ChangedConcatOperatorPrecedenceUnitTest extends BaseSniffTestCase
+final class ChangedConcatOperatorPrecedenceUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class ForbiddenNegativeBitshiftUnitTest extends BaseSniffTestCase
+final class ForbiddenNegativeBitshiftUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewOperatorsUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  * @since 9.0.0 Detection of new operators was originally included in the
  *              NewLanguageConstructSniff (since 5.6).
  */
-class NewOperatorsUnitTest extends BaseSniffTestCase
+final class NewOperatorsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/NewShortTernaryUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class NewShortTernaryUnitTest extends BaseSniffTestCase
+final class NewShortTernaryUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/RemovedTernaryAssociativityUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.2.0
  */
-class RemovedTernaryAssociativityUnitTest extends BaseSniffTestCase
+final class RemovedTernaryAssociativityUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class ChangedIntToBoolParamTypeUnitTest extends BaseSniffTestCase
+final class ChangedIntToBoolParamTypeUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class ChangedObStartEraseFlagsUnitTest extends BaseSniffTestCase
+final class ChangedObStartEraseFlagsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class ForbiddenGetClassNullUnitTest extends BaseSniffTestCase
+final class ForbiddenGetClassNullUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class ForbiddenSessionModuleNameUserUnitTest extends BaseSniffTestCase
+final class ForbiddenSessionModuleNameUserUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTestCase
+final class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class NewArrayReduceInitialTypeUnitTest extends BaseSniffTestCase
+final class NewArrayReduceInitialTypeUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewAssertCustomExceptionUnitTest extends BaseSniffTestCase
+final class NewAssertCustomExceptionUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class NewFopenModesUnitTest extends BaseSniffTestCase
+final class NewFopenModesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class NewHTMLEntitiesEncodingDefaultUnitTest extends BaseSniffTestCase
+final class NewHTMLEntitiesEncodingDefaultUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewHTMLEntitiesFlagsDefaultUnitTest extends BaseSniffTestCase
+final class NewHTMLEntitiesFlagsDefaultUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -24,7 +24,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.7
  */
-class NewHashAlgorithmsUnitTest extends BaseSniffTestCase
+final class NewHashAlgorithmsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class NewIDNVariantDefaultUnitTest extends BaseSniffTestCase
+final class NewIDNVariantDefaultUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTestCase
+final class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class NewNegativeStringOffsetUnitTest extends BaseSniffTestCase
+final class NewNegativeStringOffsetUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewNumberFormatMultibyteSeparatorsUnitTest extends BaseSniffTestCase
+final class NewNumberFormatMultibyteSeparatorsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -24,7 +24,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.2.0
  */
-class NewPCREModifiersUnitTest extends BaseSniffTestCase
+final class NewPCREModifiersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class NewPackFormatUnitTest extends BaseSniffTestCase
+final class NewPackFormatUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class NewPasswordAlgoConstantValuesUnitTest extends BaseSniffTestCase
+final class NewPasswordAlgoConstantValuesUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class NewProcOpenCmdArrayUnitTest extends BaseSniffTestCase
+final class NewProcOpenCmdArrayUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTestCase
+final class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedAssertStringAssertionUnitTest extends BaseSniffTestCase
+final class RemovedAssertStringAssertionUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest extends BaseSniffTestCase
+final class RemovedGetDefinedFunctionsExcludeDisabledFalseUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
@@ -24,7 +24,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class RemovedHashAlgorithmsUnitTest extends BaseSniffTestCase
+final class RemovedHashAlgorithmsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class RemovedIconvEncodingUnitTest extends BaseSniffTestCase
+final class RemovedIconvEncodingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTestCase
+final class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedMbCheckEncodingNoArgsUnitTest extends BaseSniffTestCase
+final class RemovedMbCheckEncodingNoArgsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTestCase
+final class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.5
  */
-class RemovedMbstringModifiersUnitTest extends BaseSniffTestCase
+final class RemovedMbstringModifiersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class RemovedNonCryptoHashUnitTest extends BaseSniffTestCase
+final class RemovedNonCryptoHashUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -24,7 +24,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.6
  */
-class RemovedPCREModifiersUnitTest extends BaseSniffTestCase
+final class RemovedPCREModifiersUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class RemovedSetlocaleStringUnitTest extends BaseSniffTestCase
+final class RemovedSetlocaleStringUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedSplAutoloadRegisterThrowFalseUnitTest extends BaseSniffTestCase
+final class RemovedSplAutoloadRegisterThrowFalseUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedVersionCompareOperatorsUnitTest extends BaseSniffTestCase
+final class RemovedVersionCompareOperatorsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class ForbiddenCallTimePassByReferenceUnitTest extends BaseSniffTestCase
+final class ForbiddenCallTimePassByReferenceUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayStringDereferencingUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.1.4
  */
-class NewArrayStringDereferencingUnitTest extends BaseSniffTestCase
+final class NewArrayStringDereferencingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.2.0
  */
-class NewArrayUnpackingUnitTest extends BaseSniffTestCase
+final class NewArrayUnpackingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.2.0
  */
-class NewClassMemberAccessUnitTest extends BaseSniffTestCase
+final class NewClassMemberAccessUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicAccessToStaticUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.1.0
  */
-class NewDynamicAccessToStaticUnitTest extends BaseSniffTestCase
+final class NewDynamicAccessToStaticUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.0.0
  */
-class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTestCase
+final class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class NewFunctionArrayDereferencingUnitTest extends BaseSniffTestCase
+final class NewFunctionArrayDereferencingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionCallTrailingCommaUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.2.0
  */
-class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTestCase
+final class NewFunctionCallTrailingCommaUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewInterpolatedStringDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewInterpolatedStringDereferencingUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewInterpolatedStringDereferencingUnitTest extends BaseSniffTestCase
+final class NewInterpolatedStringDereferencingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewMagicConstantDereferencingUnitTest extends BaseSniffTestCase
+final class NewMagicConstantDereferencingUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewNestedStaticAccessUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class NewNestedStaticAccessUnitTest extends BaseSniffTestCase
+final class NewNestedStaticAccessUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewShortArrayUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class NewShortArrayUnitTest extends BaseSniffTestCase
+final class NewShortArrayUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTestCase
+final class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedNewReferenceUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 5.5
  */
-class RemovedNewReferenceUnitTest extends BaseSniffTestCase
+final class RemovedNewReferenceUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/TextStrings/NewUnicodeEscapeSequenceUnitTest.php
+++ b/PHPCompatibility/Tests/TextStrings/NewUnicodeEscapeSequenceUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.3.0
  */
-class NewUnicodeEscapeSequenceUnitTest extends BaseSniffTestCase
+final class NewUnicodeEscapeSequenceUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.php
+++ b/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 10.0.0
  */
-class RemovedDollarBraceStringEmbedsUnitTest extends BaseSniffTestCase
+final class RemovedDollarBraceStringEmbedsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/NewTypeCastsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.0.1
  */
-class NewTypeCastsUnitTest extends BaseSniffTestCase
+final class NewTypeCastsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 8.0.1
  */
-class RemovedTypeCastsUnitTest extends BaseSniffTestCase
+final class RemovedTypeCastsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
+++ b/PHPCompatibility/Tests/Upgrade/LowPHPUnitTest.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Sniffs\Upgrade\LowPHPSniff;
  *
  * @since 9.3.0
  */
-class LowPHPUnitTest extends BaseSniffTestCase
+final class LowPHPUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewGroupUseDeclarationsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class NewGroupUseDeclarationsUnitTest extends BaseSniffTestCase
+final class NewGroupUseDeclarationsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.1.4
  */
-class NewUseConstFunctionUnitTest extends BaseSniffTestCase
+final class NewUseConstFunctionUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.0.0
  */
-class ForbiddenGlobalVariableVariableUnitTest extends BaseSniffTestCase
+final class ForbiddenGlobalVariableVariableUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenThisUseContextsUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 9.1.0
  */
-class ForbiddenThisUseContextsUnitTest extends BaseSniffTestCase
+final class ForbiddenThisUseContextsUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
@@ -22,7 +22,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  *
  * @since 7.1.2
  */
-class NewUniformVariableSyntaxUnitTest extends BaseSniffTestCase
+final class NewUniformVariableSyntaxUnitTest extends BaseSniffTestCase
 {
 
     /**

--- a/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedPredefinedGlobalVariablesUnitTest.php
@@ -24,7 +24,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  * @since 7.0   RemovedVariablesSniffTest.
  * @since 7.1.3 Merged to one sniff & test.
  */
-class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTestCase
+final class RemovedPredefinedGlobalVariablesUnitTest extends BaseSniffTestCase
 {
 
     /**


### PR DESCRIPTION
As the PHPCS native autoloader can run into trouble when one sniff extends another sniff and both sniffs are used within the same standard, all sniffs ought to be declared as `final`.

When inheritance or re-use of logic is needed for a sniff, use an abstract base class or a helper trait instead.

👉🏻 Note: this is a breaking change for any standard which would happen to be extending any of the PHPCompatibility sniffs and should be marked as such in the changelog.

Any "bug" reports regarding this change, should require users to detail the reason for extending the class and should advise users on what to do based on their usecase (send in PR to this repo to add a feature, instantiate the PHPCompatibility sniff within their own sniff, extend one of the abstract classes instead, use a helper trait etc).

The change to the PHPCompatibility classes, however, should not be undone.


### CS/QA: make all classes final [1] 

This commit adjusts all public facing classes which existed prior to PHPCompatibility 10.0 (as they need a changelog entry).

### CS/QA: make all classes final [2] 

This commit adjusts all public facing classes which are new in PHPCompatibility 10.0 (no changelog entry needed).

### CS/QA: make all classes final [3] 

This commit adjusts all test classes.