### PR TITLE
ParameterValues/ChangedObStartEraseFlags: allow for fully qualified true/false and flag constants

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedObStartEraseFlagsSniff.php
@@ -77,12 +77,13 @@ class ChangedObStartEraseFlagsSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        $cleanValueLc = \strtolower($targetParam['clean']);
-
         $error = 'The third parameter of ob_start() changed from the boolean $erase to the integer $flags in PHP 5.4. Found: %s';
         $data  = [$targetParam['clean']];
 
-        if ($cleanValueLc === 'true' || $cleanValueLc === 'false') {
+        $cleanValueLc = \strtolower($targetParam['clean']);
+        if ($cleanValueLc === 'true' || $cleanValueLc === 'false'
+            || $cleanValueLc === '\true' || $cleanValueLc === '\false'
+        ) {
             if (ScannedCode::shouldRunOnOrAbove('5.4') === true) {
                 $phpcsFile->addError($error, $targetParam['start'], 'BooleanFound', $data);
             }

--- a/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.inc
@@ -34,3 +34,17 @@ $obj?->ob_start($output_callback, $chunk_size, true);
 namespace\ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS);
 \Fully\Qualified\ob_start($output_callback, $chunk_size, true);
 Partially\Qualified\ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS);
+
+// Handle uppercase true/false.
+// Not OK - error PHP >= 5.4.
+ob_start($output_callback, $chunk_size, TRUE);
+ob_start($output_callback, $chunk_size, FALSE);
+
+// Handle fully qualified parameter contents.
+// Not OK - error PHP >= 5.4.
+\ob_start($output_callback, $chunk_size, \true);
+ob_start($output_callback, $chunk_size, \false);
+
+// Not OK - error PHP < 5.4.
+ob_start($output_callback, $chunk_size, \PHP_OUTPUT_HANDLER_STDFLAGS);
+\ob_start($output_callback, $chunk_size, \PHP_OUTPUT_HANDLER_STDFLAGS | \PHP_OUTPUT_HANDLER_FLUSHABLE);

--- a/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.inc
@@ -2,7 +2,7 @@
 
 // OK.
 ob_start($output_callback);
-ob_start($output_callback, $chunk_size);
+\ob_start($output_callback, $chunk_size);
 
 // Undetermined. Ignore.
 ob_start($output_callback, $chunk_size, $flags);
@@ -16,13 +16,21 @@ ob_start($output_callback, $chunk_size, false);
 // Not OK - error PHP < 5.4.
 ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_CLEANABLE);
 ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_FLUSHABLE);
-ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_REMOVABLE);
+\ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_REMOVABLE);
 ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS);
 ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS | PHP_OUTPUT_HANDLER_FLUSHABLE);
-ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS ^ PHP_OUTPUT_HANDLER_FLUSHABLE);
+OB_Start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS ^ PHP_OUTPUT_HANDLER_FLUSHABLE);
 ob_start($output_callback, $chunk_size, 10);
 
 // Safeguard support for PHP 8 named parameters.
 ob_start(flags: false);
 ob_start(flags: 20);
 ob_start(flags: $flags); // OK.
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::ob_start($output_callback, $chunk_size, true);
+$obj->ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS);
+$obj?->ob_start($output_callback, $chunk_size, true);
+namespace\ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS);
+\Fully\Qualified\ob_start($output_callback, $chunk_size, true);
+Partially\Qualified\ob_start($output_callback, $chunk_size, PHP_OUTPUT_HANDLER_STDFLAGS);

--- a/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
@@ -58,6 +58,10 @@ class ChangedObStartEraseFlagsUnitTest extends BaseSniffTestCase
             [13],
             [14],
             [26],
+            [40],
+            [41],
+            [45],
+            [46],
         ];
     }
 
@@ -100,6 +104,8 @@ class ChangedObStartEraseFlagsUnitTest extends BaseSniffTestCase
             [22],
             [23],
             [27],
+            [49],
+            [50],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedObStartEraseFlagsUnitTest.php
@@ -137,6 +137,10 @@ class ChangedObStartEraseFlagsUnitTest extends BaseSniffTestCase
 
         $data[] = [28];
 
+        for ($line = 30; $line <= 36; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 


### PR DESCRIPTION
### ParameterValues/ChangedObStartEraseFlags: add extra tests

### ParameterValues/ChangedObStartEraseFlags: allow for fully qualified true/false and flag constants

The flag constants were already handled correctly, uppercase `true`/`false` too, however, fully qualified `true`/`false` was not.

Includes tests.