### PR TITLE
ParameterValues/ForbiddenGetClassNull: allow for uppercase and fully qualified null

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -74,7 +74,8 @@ class ForbiddenGetClassNullSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        if ($target['clean'] !== 'null') {
+        $cleanValueLc = \strtolower($target['clean']);
+        if ($cleanValueLc !== 'null' && $cleanValueLc !== '\null') {
             return;
         }
 

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.inc
@@ -24,3 +24,7 @@ $obj?->get_class(null);
 namespace\get_class(null);
 \Fully\Qualified\get_class(null);
 Partially\Qualified\get_class(null);
+
+// Handle fully qualified and uppercase null, not OK.
+get_class(NULL);
+\get_class(\null);

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.inc
@@ -5,14 +5,22 @@
 
 //OK.
 get_class($object);
-get_class();
+\get_class();
 
 // Not OK.
-get_class(null);
-get_class(
+\get_class(null);
+Get_class(
     null // Comment.
 );
 get_class(object:null);
 
 // Safeguard against false positives when target param not found.
 get_class(instance: null); // Wrong param name.
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::get_class(null);
+$obj->get_class(null);
+$obj?->get_class(null);
+namespace\get_class(null);
+\Fully\Qualified\get_class(null);
+Partially\Qualified\get_class(null);

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
@@ -58,18 +58,41 @@ class ForbiddenGetClassNullUnitTest extends BaseSniffTestCase
 
 
     /**
-     * testNoFalsePositives
+     * Verify there are no false positives on valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '7.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        $cases = [];
 
         // No errors expected on the first 9 lines.
         for ($line = 1; $line <= 9; $line++) {
-            $this->assertNoViolation($file, $line);
+            $cases[] = [$line];
         }
+
+        for ($line = 20; $line <= 26; $line++) {
+            $cases[] = [$line];
+        }
+
+        return $cases;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenGetClassNullUnitTest.php
@@ -53,6 +53,8 @@ class ForbiddenGetClassNullUnitTest extends BaseSniffTestCase
             [11],
             [12],
             [15],
+            [29],
+            [30],
         ];
     }
 


### PR DESCRIPTION
### ParameterValues/ForbiddenGetClassNull: add extra tests

### ParameterValues/ForbiddenGetClassNull: allow for uppercase and fully qualified null

Includes tests.