### PR TITLE
ParameterValues/NewProcOpenCmdArray: bug fix - check for escapeshellarg case-insensitively

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -101,7 +101,7 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
         }
 
         if (ScannedCode::shouldRunOnOrAbove('7.4') === true) {
-            if (\strpos($targetParam['clean'], 'escapeshellarg(') === false) {
+            if (\strpos(\strtolower($targetParam['clean']), 'escapeshellarg(') === false) {
                 // Efficiency: prevent needlessly walking the array.
                 return;
             }
@@ -115,7 +115,7 @@ class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
             foreach ($items as $item) {
                 for ($i = $item['start']; $i <= $item['end']; $i++) {
                     if ($tokens[$i]['code'] !== \T_STRING
-                        || $tokens[$i]['content'] !== 'escapeshellarg'
+                        || \strtolower($tokens[$i]['content']) !== 'escapeshellarg'
                     ) {
                         continue;
                     }

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.inc
@@ -16,7 +16,7 @@ $proc = proc_open(self::COMMAND, $descriptorSpec, $pipes);
 
 // PHP 7.4: passing $cmd as an array.
 $proc = proc_open(['php', '-r', 'echo "Hello World\n";'], $descriptors, $pipes);
-$proc = proc_open(
+$proc = \Proc_Open(
     array(
         'php',
         '-r',
@@ -31,7 +31,7 @@ $proc = proc_open(['php', '-r', escapeshellarg($echo)], $descriptors, $pipes);
 $proc = proc_open(
     array(
         'phpcs',
-        '--standard=' . escapeshellarg($standard), // Escaping.
+        '--standard=' . \escapeshellarg($standard), // Escaping.
         './path/to/' . escapeshellarg($file),
     ),
     $descriptors,
@@ -39,7 +39,7 @@ $proc = proc_open(
 );
 
 // Safeguard support for PHP 8 named parameters.
-$proc = proc_open(
+$proc = proc_Open(
     descriptor_spec: array(
         0 => array("pipe", "r"),
         1 => array("pipe", "w"),
@@ -50,7 +50,7 @@ $proc = proc_open(
     env_vars: $env_vars
 ); // OK.
 
-$proc = proc_open(
+$proc = \proc_open(
     pipes: $pipes,
     env_vars: $env_vars,
     descriptor_spec: array(
@@ -58,5 +58,13 @@ $proc = proc_open(
         1 => array("pipe", "w"),
         2 => array("file", "/tmp/error-output.txt", "a"),
     ),
-    command: array('php', '-r', escapeshellarg($echo)),
+    command: array('php', '-r', \escapeshellarg($echo)),
 ); // Error + Warning.
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::proc_open(['php', '-r', 'echo "Hello World\n";'], $descriptors, $pipes);
+$obj->proc_open(['php', '-r', 'echo "Hello World\n";'], $descriptors, $pipes);
+$obj?->proc_open(['php', '-r', 'echo "Hello World\n";'], $descriptors, $pipes);
+namespace\proc_open(['php', '-r', 'echo "Hello World\n";'], $descriptors, $pipes);
+\Fully\Qualified\proc_open(['php', '-r', 'echo "Hello World\n";'], $descriptors, $pipes);
+Partially\Qualified\proc_open(['php', '-r', 'echo "Hello World\n";'], $descriptors, $pipes);

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.inc
@@ -32,7 +32,7 @@ $proc = proc_open(
     array(
         'phpcs',
         '--standard=' . \escapeshellarg($standard), // Escaping.
-        './path/to/' . escapeshellarg($file),
+        './path/to/' . EscapeShellArg($file),
     ),
     $descriptors,
     $pipes

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
@@ -91,7 +91,7 @@ class NewProcOpenCmdArrayUnitTest extends BaseSniffTestCase
         return [
             [30, 'escapeshellarg($echo)'],
             [34, '\'--standard=\' . \escapeshellarg($standard)'],
-            [35, '\'./path/to/\' . escapeshellarg($file)'],
+            [35, '\'./path/to/\' . EscapeShellArg($file)'],
             [61, '\escapeshellarg($echo)'],
         ];
     }

--- a/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewProcOpenCmdArrayUnitTest.php
@@ -90,9 +90,9 @@ class NewProcOpenCmdArrayUnitTest extends BaseSniffTestCase
     {
         return [
             [30, 'escapeshellarg($echo)'],
-            [34, '\'--standard=\' . escapeshellarg($standard)'],
+            [34, '\'--standard=\' . \escapeshellarg($standard)'],
             [35, '\'./path/to/\' . escapeshellarg($file)'],
-            [61, 'escapeshellarg($echo)'],
+            [61, '\escapeshellarg($echo)'],
         ];
     }
 
@@ -117,6 +117,10 @@ class NewProcOpenCmdArrayUnitTest extends BaseSniffTestCase
 
         // Nor on line 41 to 51.
         for ($line = 41; $line <= 51; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        for ($line = 64; $line <= 70; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }


### PR DESCRIPTION
### ParameterValues/NewProcOpenCmdArray: add extra tests

### ParameterValues/NewProcOpenCmdArray: bug fix - check for escapeshellarg case-insensitively

Includes test.