### PR TITLE
ParameterValues/RemovedDbaKeySplitNullFalse: allow for fully qualified false/null

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedDbaKeySplitNullFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedDbaKeySplitNullFalseSniff.php
@@ -106,7 +106,9 @@ final class RemovedDbaKeySplitNullFalseSniff extends AbstractFunctionCallParamet
              * Check if a hard-coded null or false was passed.
              */
             $contentLc = \strtolower($targetParam['clean']);
-            if ($contentLc !== 'null' && $contentLc !== 'false') {
+            if ($contentLc !== 'null' && $contentLc !== '\null'
+                && $contentLc !== 'false' && $contentLc !== '\false'
+            ) {
                 return;
             }
         }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.inc
@@ -45,3 +45,7 @@ dba_key_split(
 // Safeguard against false positives on namespaced function calls.
 namespace\dba_key_split(false);
 \Fully\Qualified\dba_key_split(false);
+
+// Handle fully qualified false and null, not OK.
+\dba_key_split(\false);
+dba_key_split(\null);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.inc
@@ -36,8 +36,12 @@ dba_key_split(
 // is queried).
 dba_key_split(dba_firstkey($dba));
 dba_key_split(key: dba_nextkey($obj->get_dba()));
-dba_key_split(\dba_firstkey($this->dba));
+\dba_key_split(\dba_firstkey($this->dba));
 dba_key_split(
     // Comment.
     \dba_NextKey($dba)
 );
+
+// Safeguard against false positives on namespaced function calls.
+namespace\dba_key_split(false);
+\Fully\Qualified\dba_key_split(false);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.php
@@ -97,6 +97,9 @@ final class RemovedDbaKeySplitNullFalseUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        $data[] = [46];
+        $data[] = [47];
+
         return $data;
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedDbaKeySplitNullFalseUnitTest.php
@@ -63,6 +63,8 @@ final class RemovedDbaKeySplitNullFalseUnitTest extends BaseSniffTestCase
             [38],
             [39],
             [42],
+            [50],
+            [51],
         ];
     }
 


### PR DESCRIPTION
### ParameterValues/RemovedDbaKeySplitNullFalse: add extra tests

### ParameterValues/RemovedDbaKeySplitNullFalse: allow for fully qualified false/null

Includes tests.