### PR TITLE
ParameterValues/RemovedLdapConnectSignatures: allow for fully qualified and uppercase null

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedLdapConnectSignaturesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedLdapConnectSignaturesSniff.php
@@ -123,14 +123,15 @@ final class RemovedLdapConnectSignaturesSniff extends AbstractFunctionCallParame
 
         // Check for the, still supported, 3+ param signature and if found, check the second param is `null`.
         if (\count($parameters) > 2) {
-            $hasVariableContent = $phpcsFile->findNext([\T_VARIABLE, \T_STRING], $portParam['start'], ($portParam['end'] + 1));
-            if ($hasVariableContent !== false) {
-                // We don't have access to the contents of the parameter. Bow out.
+            $cleanPort = \strtolower($portParam['clean']);
+            if ($cleanPort === 'null' || $cleanPort === '\null') {
+                // This is the correct value to still use the 3+ param signature. Bow out.
                 return;
             }
 
-            if ($portParam['clean'] === 'null') {
-                // This is the correct value to still use the 3+ param signature. Bow out.
+            $hasVariableContent = $phpcsFile->findNext([\T_VARIABLE, \T_STRING], $portParam['start'], ($portParam['end'] + 1));
+            if ($hasVariableContent !== false) {
+                // We don't have access to the contents of the parameter. Bow out.
                 return;
             }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.inc
@@ -74,3 +74,7 @@ namespace\ldap_connect($host, $port);
 ldap_connect($uri, namespace\get_port(), $wallet, $password, $auth_mode); // Port value undetermined, so ignore for PHP 8.3 deprecation check.
 ldap_connect($uri, \Fully\Qualified\get_port(), $wallet, $password, $auth_mode); // Port value undetermined, so ignore for PHP 8.3 deprecation check.
 ldap_connect($uri, \Partially\Qualified\get_port(), $wallet, $password, $auth_mode); // Port value undetermined, so ignore for PHP 8.3 deprecation check.
+
+// Safeguard handling of uppercase and fully qualified null.
+ldap_connect($uri, NULL, $wallet, $password, $auth_mode);
+ldap_connect($uri, \null, $wallet, $password, $auth_mode);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.inc
@@ -65,3 +65,12 @@ ldap_connect($uri, 369 + $offset, $wallet, $password, $auth_mode); // Port value
 \ldap_connect(uri: $uri, wallet: $wallet);
 \ldap_connect(auth_mode: $auth_mode, wallet: $wallet);
 \ldap_connect(auth_mode: $auth_mode, wallet: $wallet, password: $password);
+
+// Safeguard against false positives on namespaced function calls.
+namespace\ldap_connect($host, $port);
+\Fully\Qualified\ldap_connect($host, $port);
+
+// Safeguard handling where port value cannot be determined.
+ldap_connect($uri, namespace\get_port(), $wallet, $password, $auth_mode); // Port value undetermined, so ignore for PHP 8.3 deprecation check.
+ldap_connect($uri, \Fully\Qualified\get_port(), $wallet, $password, $auth_mode); // Port value undetermined, so ignore for PHP 8.3 deprecation check.
+ldap_connect($uri, \Partially\Qualified\get_port(), $wallet, $password, $auth_mode); // Port value undetermined, so ignore for PHP 8.3 deprecation check.

--- a/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.php
@@ -153,6 +153,10 @@ final class RemovedLdapConnectSignaturesUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        for ($line = 70; $line <= 76; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 
@@ -192,6 +196,9 @@ final class RemovedLdapConnectSignaturesUnitTest extends BaseSniffTestCase
             [65],
             [66],
             [67],
+            [74],
+            [75],
+            [76],
         ];
     }
 
@@ -226,6 +233,9 @@ final class RemovedLdapConnectSignaturesUnitTest extends BaseSniffTestCase
         for ($line = 1; $line <= 31; $line++) {
             $data[] = [$line];
         }
+
+        $data[] = [70];
+        $data[] = [71];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedLdapConnectSignaturesUnitTest.php
@@ -153,7 +153,7 @@ final class RemovedLdapConnectSignaturesUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
-        for ($line = 70; $line <= 76; $line++) {
+        for ($line = 70; $line <= 80; $line++) {
             $data[] = [$line];
         }
 
@@ -199,6 +199,8 @@ final class RemovedLdapConnectSignaturesUnitTest extends BaseSniffTestCase
             [74],
             [75],
             [76],
+            [79],
+            [80],
         ];
     }
 


### PR DESCRIPTION
### ParameterValues/RemovedLdapConnectSignatures: add extra tests

### ParameterValues/RemovedLdapConnectSignatures: allow for fully qualified and uppercase null

Includes tests.