### PR TITLE
ParameterValues/RemovedSplAutoloadRegisterThrowFalse: allow for uppercase and fully qualified false

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSplAutoloadRegisterThrowFalseSniff.php
@@ -74,7 +74,8 @@ class RemovedSplAutoloadRegisterThrowFalseSniff extends AbstractFunctionCallPara
             return;
         }
 
-        if ($targetParam['clean'] !== 'false') {
+        $cleanValueLc = \strtolower($targetParam['clean']);
+        if ($cleanValueLc !== 'false' && $cleanValueLc !== '\false') {
             return;
         }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.inc
@@ -6,10 +6,18 @@
 // OK.
 spl_autoload_register();
 spl_autoload_register($autoload_function);
-spl_autoload_register($autoload_function, true, false);
+\spl_autoload_register($autoload_function, true, false);
 spl_autoload_register($autoload_function, $throw, $prepend);
 spl_autoload_register(callback: $autoload_function, prepend: false);
 
 // Not OK.
 spl_autoload_register($autoload_function, false);
-spl_autoload_register(prepend: false, callback: $autoload_function, throw: false);
+\SPL_Autoload_Register(prepend: false, callback: $autoload_function, throw: false);
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::spl_autoload_register($autoload_function, false);
+$obj->spl_autoload_register($autoload_function, false);
+$obj?->spl_autoload_register($autoload_function, false);
+namespace\spl_autoload_register($autoload_function, false);
+\Fully\Qualified\spl_autoload_register($autoload_function, false);
+Partially\Qualified\spl_autoload_register($autoload_function, false);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.inc
@@ -21,3 +21,7 @@ $obj?->spl_autoload_register($autoload_function, false);
 namespace\spl_autoload_register($autoload_function, false);
 \Fully\Qualified\spl_autoload_register($autoload_function, false);
 Partially\Qualified\spl_autoload_register($autoload_function, false);
+
+// Handle fully qualified and uppercase false, not OK.
+spl_autoload_register($autoload_function, FALSE);
+\spl_autoload_register($autoload_function, \false);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
@@ -52,6 +52,8 @@ class RemovedSplAutoloadRegisterThrowFalseUnitTest extends BaseSniffTestCase
         return [
             [14],
             [15],
+            [26],
+            [27],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSplAutoloadRegisterThrowFalseUnitTest.php
@@ -59,16 +59,39 @@ class RemovedSplAutoloadRegisterThrowFalseUnitTest extends BaseSniffTestCase
     /**
      * Verify the sniff does not throw false positives for valid code.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 12 lines.
         for ($line = 1; $line <= 12; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 17; $line <= 23; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 


### PR DESCRIPTION
### ParameterValues/RemovedSplAutoloadRegisterThrowFalse: add extra tests

### ParameterValues/RemovedSplAutoloadRegisterThrowFalse: allow for uppercase and fully qualified false

Includes tests.