### PR TITLE
ParameterValue sniffs: add slew of extra tests

### DIFF
--- a/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.inc
@@ -3,15 +3,15 @@
 // OK.
 sem_get( $key, $max_acquire, $perm, );
 sem_get($SHM_KEY, 1024, 0644 | IPC_CREAT);
-sem_get( $SEMKey, 2, 0666, true);
+\sem_get( $SEMKey, 2, 0666, true);
 sem_get( $SEMKey, 2, 0666, false);
 ob_implicit_flush();
 ob_implicit_flush(true);
 
 // Ignore as undetermined.
 sem_get( $key, $max_acquire, $perm, $auto_release );
-sem_get( $key, $max_acquire, $perm, SEMVER_RELEASE );
-sem_get( $key, $max_acquire, $perm, self::RELEASE_TOGGLE );
+\sem_get( $key, $max_acquire, $perm, SEMVER_RELEASE );
+SEM_get( $key, $max_acquire, $perm, self::RELEASE_TOGGLE );
 ob_implicit_flush($flag);
 
 // Ignore for complexity + could be valid cross-version toggle.
@@ -20,9 +20,17 @@ sem_get( $key, $max_acquire, $perm, $test ? 1 : true );
 // Error.
 sem_get( $key, $max_acquire, $perm, 0 );
 sem_get( $key, $max_acquire, $perm, 1 );
-sem_get( $key, $max_acquire, $perm, -1 );
+\sem_get( $key, $max_acquire, $perm, -1 );
 Sem_Get( $key, $max_acquire, $perm, 0 );
 sem_get( $key, $max_acquire, $perm, 1.0 );
 sem_get( $key, auto_release: 1 * 1);
 ob_implicit_flush(0);
-ob_implicit_flush(enable: 1);
+\ob_implicit_flush(enable: 1);
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::sem_get( $key, $max_acquire, $perm, 0 );
+$obj->ob_implicit_flush(0);
+$obj?->sem_get( $key, $max_acquire, $perm, 0 );
+namespace\ob_implicit_flush(0);
+\Fully\Qualified\sem_get( $key, $max_acquire, $perm, 0 );
+Partially\Qualified\ob_implicit_flush(0);

--- a/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
@@ -98,6 +98,10 @@ class ChangedIntToBoolParamTypeUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        for ($line = 30; $line <= 36; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.1.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.1.inc
@@ -6,16 +6,16 @@
 // OK.
 session_module_name(module: $module);
 session_module_name();
-session_module_name('user' . $something);
+\session_module_name('user' . $something);
 session_module_name(<<<EOD
 user-nonsense
 EOD
 );
 
 // Not OK.
-session_module_name('user',);
+\session_module_name('user',);
 session_module_name(module: "USER");
-session_module_name(<<<'EOD'
+Session_Module_name(<<<'EOD'
 user
 EOD
 );
@@ -34,3 +34,8 @@ session_module_name(name: 'user'); // Wrong param name.
 // Safeguard against false positives when this name is used as an attribute class.
 #[Session_Module_Name('user')]
 function do_something() {}
+
+// Safeguard against false positives on namespaced function calls.
+namespace\session_module_name('user');
+\Fully\Qualified\session_module_name('user');
+Partially\Qualified\session_module_name('user');

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
@@ -102,12 +102,9 @@ class ForbiddenSessionModuleNameUserUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [24];
-        $cases[] = [25];
-        $cases[] = [26];
-        $cases[] = [29];
-        $cases[] = [32];
-        $cases[] = [35];
+        for ($line = 23; $line <= 41; $line++) {
+            $cases[] = [$line];
+        }
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.1.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.1.inc
@@ -3,7 +3,7 @@
 // OK.
 $str = strip_tags($str);
 $str = strip_tags($input, '<br>');
-$str = strip_tags($input, allowed_tags: '<img><br><meta><input>');
+$str = \strip_tags($input, allowed_tags: '<img><br><meta><input>');
 
 // Undetermined. Ignore.
 $str = strip_tags($str, $allowable_tags);
@@ -11,8 +11,8 @@ $str = strip_tags($str, self::ALLOWABLE_TAGS);
 $str = strip_tags($str, allowed_tags: MyClass::get_allowable_tags('<br/>'));
 
 // Not OK - warning.
-$str = strip_tags($input, '<br/>');
-$str = strip_tags(allowed_tags: '<img/><br/>' . '<meta/><input/>', string: $input);
+$str = \strip_tags($input, '<br/>');
+$str = Strip_Tags(allowed_tags: '<img/><br/>' . '<meta/><input/>', string: $input);
 
 // Safeguard handling heredocs/nowdocs, including PHP 7.3 indented variants.
 // Okay.
@@ -28,7 +28,15 @@ strip_tags($input,
 EOD
 );
 
-// Safeguard against false positives on method calls.
+// Safeguard against false positives on method calls and namespaced function calls.
 ClassName::strip_tags($input, '<br/>');
 $obj->strip_tags($input, '<br/>');
 $obj?->strip_tags($input, '<br/>'); // PHP 8.0+.
+namespace\strip_tags($input, '<br/>');
+\Fully\Qualified\strip_tags($input, '<br/>');
+Partially\Qualified\strip_tags($input, '<br/>');
+
+// More undetermined. Ignore.
+$str = strip_tags($str, namespace\get_allowed_tags('<br/>'));
+$str = strip_tags($str, \Fully\Qualified\get_allowed_tags('<br/>'));
+$str = strip_tags($str, Partially\Qualified\get_allowed_tags('<br/>'));

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
@@ -113,6 +113,13 @@ class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTestCase
         $cases[] = [32];
         $cases[] = [33];
         $cases[] = [34];
+        $cases[] = [35];
+        $cases[] = [36];
+        $cases[] = [37];
+
+        $cases[] = [40];
+        $cases[] = [41];
+        $cases[] = [42];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarUnitTest.inc
@@ -14,10 +14,10 @@ register_callback(array_merge_recursive(...));
  * Valid cross-version: not passing $GLOBALS twice to array_merge_recursive().
  */
 array_merge_recursive();
-array_merge_recursive($GLOBALS);
+\array_merge_recursive($GLOBALS);
 array_merge_recursive(my_get_array(), $GLOBALS, $someOtherArray);
 array_merge_recursive($GLOBALS, $someOtherArray);
-array_merge_recursive($GLOBALS, $GLOBALS['_GET']);
+ARRAY_MERGE_RECURSIVE($GLOBALS, $GLOBALS['_GET']);
 array_merge_recursive($GLOBALS['_POST'], $GLOBALS);
 
 /*
@@ -26,4 +26,8 @@ array_merge_recursive($GLOBALS['_POST'], $GLOBALS);
  * PHP < 7.0: would exhaust memory to the limit.
  */
 array_merge_recursive($GLOBALS, $GLOBALS);
-array_merge_recursive($GLOBALS, $someOtherArray, $GLOBALS, my_get_array(),);
+\Array_Merge_Recursive($GLOBALS, $someOtherArray, $GLOBALS, my_get_array(),);
+
+// More safeguards against false positives on namespaced function calls.
+namespace\array_merge_recursive($GLOBALS, $GLOBALS);
+\Fully\Qualified\array_merge_recursive($GLOBALS, $GLOBALS);

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarUnitTest.php
@@ -88,6 +88,9 @@ final class NewArrayMergeRecursiveWithGlobalsVarUnitTest extends BaseSniffTestCa
             $cases[] = [$line];
         }
 
+        $cases[] = [32];
+        $cases[] = [33];
+
         return $cases;
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.inc
@@ -7,7 +7,7 @@ array_reduce( $array, $callback, 15 );
 array_reduce( $array, $callback, 15 * 3 );
 array_reduce( $array, $callback, 24 * 60 * 60 );
 array_reduce( $array, $callback, /*initial*/ -100 /*initial*/ );
-array_reduce( $array, $callback, 'string' ); // Will be typecast by PHP.
+\array_reduce( $array, $callback, 'string' ); // Will be typecast by PHP.
 array_reduce( $array, $callback, 20.5 ); // Will be typecast by PHP.
 array_reduce( $array, $callback, false ); // Will be typecast by PHP.
 array_reduce( $array, $callback, initial: null ); // Will be typecast by PHP.
@@ -17,10 +17,23 @@ array_reduce( $array, $callback, array() );
 
 // Not OK - warning.
 array_reduce( $array, $callback, $initial /*initial*/ );
-array_reduce( $array, $callback, $this->initial );
-array_reduce( $array, $callback, self::INITIAL );
+\array_reduce( $array, $callback, $this->initial );
+Array_REDUCE( $array, $callback, self::INITIAL );
 array_reduce( $array, $callback, 15 * $initial );
 array_reduce( $array, $callback, new stdClass );
 
 // Safeguard support for PHP 8 named parameters.
 array_reduce( $array, initial: array(), callback: $callback ); // Error.
+
+// Safeguard against false positives. Not our target.
+$obj->array_reduce( $array, $callback, array() );
+$obj?->array_reduce( $array, $callback, [] );
+MyClass::array_reduce( $array, $callback, self::INITIAL );
+\Fully\Qualified\array_reduce( $array, $callback, $this->initial );
+Partially\Qualified\array_reduce( $array, $callback, $initial );
+namespace\array_reduce( $array, $callback, $initial );
+
+// Not OK - warning.
+array_reduce( $array, $callback, \get_initial() );
+\array_reduce( $array, $callback, Partially\Qualified\get_initial() );
+Array_REDUCE( $array, $callback, namespace\get_initial() );

--- a/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewArrayReduceInitialTypeUnitTest.php
@@ -67,23 +67,50 @@ class NewArrayReduceInitialTypeUnitTest extends BaseSniffTestCase
             [23, false],
 
             [26],
+
+            [37, false],
+            [38, false],
+            [39, false],
         ];
     }
 
 
     /**
-     * testNoFalsePositives
+     * Test the sniff doesn't throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 14 lines.
         for ($line = 1; $line <= 14; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 29; $line <= 34; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.inc
@@ -5,7 +5,7 @@ assert('mysql_query("")');
 
 // OK, second param string.
 assert("2 < 1", 'Two is less than one');
-assert(false, 'Unexpected condition');
+\assert(false, 'Unexpected condition');
 
 // Undetermined. Ignore.
 assert($assertion, $errorMsg);
@@ -15,5 +15,14 @@ assert(false, (string) new CustomError('True is not false!'));
 
 // PHP 7.0+ custom exception.
 class CustomError extends AssertionError {}
-assert(false, new CustomError('True is not false!'));
-assert(false, new CustomError((string) $otherObj));
+\assert(false, new CustomError('True is not false!'));
+Assert(false, new CustomError((string) $otherObj));
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::assert(false, new CustomError('True is not false!'));
+$obj->assert(false, new CustomError('True is not false!'));
+$obj?->assert(false, new CustomError('True is not false!'));
+// (Re)defining a custom assert function is not allowed in PHP, but that's not the concern of this sniff.
+namespace\assert(false, new CustomError('True is not false!'));
+\Fully\Qualified\assert(false, new CustomError('True is not false!'));
+Partially\Qualified\assert(false, new CustomError('True is not false!'));

--- a/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewAssertCustomExceptionUnitTest.php
@@ -61,16 +61,39 @@ class NewAssertCustomExceptionUnitTest extends BaseSniffTestCase
     /**
      * Verify there are no false positives on code this sniff should ignore.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        $cases = [];
 
         // No errors expected on the first 15 lines.
         for ($line = 1; $line <= 15; $line++) {
-            $this->assertNoViolation($file, $line);
+            $cases[] = [$line];
         }
+
+        for ($line = 21; $line <= 28; $line++) {
+            $cases[] = [$line];
+        }
+
+        return $cases;
     }
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.inc
@@ -2,15 +2,26 @@
 
 // OK.
 $handle = fopen("/home/rasmus/file.txt", "r");
-$handle = fopen("/home/rasmus/file.gif", mode: 'wb');
+$handle = \fopen("/home/rasmus/file.gif", mode: 'wb');
 $handle = fopen("/home/rasmus/file.gif", 'a' . $additional_modes);
 
 // Not OK.
 $handle = fopen("/home/rasmus/file.txt", "re"); // PHP 7.0.16+
-$handle = fopen("/home/rasmus/file.gif", 'c+'); // PHP 5.2.6+
+$handle = \fopen("/home/rasmus/file.gif", 'c+'); // PHP 5.2.6+
 $handle = fopen(mode: 'c', filename: "/home/rasmus/file.gif"); // PHP 5.2.6+
-$handle = fopen("/home/rasmus/file.gif", 'c'./*comment*/'e'); // PHP 5.2.6+ and PHP 7.0.16+
+$handle = FOpen("/home/rasmus/file.gif", 'c'./*comment*/'e'); // PHP 5.2.6+ and PHP 7.0.16+
 
 // Issue #1043 - ignore function calls, constants etc.
 $handle = fopen("/home/rasmus/file.gif", setFormat('c+'));
 $handle = fopen("/home/rasmus/file.txt", $array["re"]);
+$handle = fopen("/home/rasmus/file.gif", namespace\setFormat('c+'));
+$handle = \fopen("/home/rasmus/file.gif", \Fully\Qualified\setFormat('c+'));
+$handle = fopen("/home/rasmus/file.gif", Partially\Qualified\setFormat('c+'));
+
+// Safeguard against false positives. Not our target.
+$obj->fopen("/home/rasmus/file.txt", "re");
+$obj?->fopen("/home/rasmus/file.txt", "re");
+MyClass::fopen("/home/rasmus/file.txt", "re");
+\Fully\Qualified\fopen("/home/rasmus/file.txt", "re");
+Partially\Qualified\fopen("/home/rasmus/file.txt", "re");
+namespace\fopen("/home/rasmus/file.txt", "re");

--- a/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewFopenModesUnitTest.php
@@ -103,8 +103,9 @@ class NewFopenModesUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
-        $data[] = [15];
-        $data[] = [16];
+        for ($line = 15; $line <= 27; $line++) {
+            $data[] = [$line];
+        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.inc
@@ -2,12 +2,20 @@
 
 // OK.
 echo htmlentities( $string, ENT_QUOTES, 'UTF-8' );
-echo htmlspecialchars( $string, encoding: $encoding, flags: ENT_COMPAT, double_encode: false );
+echo \htmlspecialchars( $string, encoding: $encoding, flags: ENT_COMPAT, double_encode: false );
 echo html_entity_decode( $string, ENT_COMPAT, $encoding );
 echo get_html_translation_table( $table, ENT_COMPAT, $encoding );
 
 // Not OK - error.
 echo htmlentities( string: $string, flags: $flags, double_encode: false );
 echo htmlspecialchars($string);
-echo HTML_entity_decode( $string, ENT_COMPAT );
+echo \HTML_entity_decode( $string, ENT_COMPAT );
 echo get_html_translation_table( $table );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::htmlspecialchars($string);
+$obj->get_html_translation_table( $table );
+$obj?->htmlspecialchars($string);
+namespace\get_html_translation_table( $table );
+\Fully\Qualified\htmlspecialchars($string);
+Partially\Qualified\get_html_translation_table( $table );

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesEncodingDefaultUnitTest.php
@@ -64,16 +64,39 @@ class NewHTMLEntitiesEncodingDefaultUnitTest extends BaseSniffTestCase
     /**
      * Test that there are no false positives.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.3-5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 8 lines.
         for ($line = 1; $line <= 8; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 15; $line <= 21; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.inc
@@ -3,7 +3,7 @@
 // OK cross-version.
 echo htmlentities( $string, ENT_QUOTES, 'UTF-8' );
 echo htmlspecialchars( $string, $flags);
-echo html_entity_decode( string: $string, encoding: 'ISO-8859-1', flags: ENT_COMPAT );
+echo \html_entity_decode( string: $string, encoding: 'ISO-8859-1', flags: ENT_COMPAT );
 echo htmlspecialchars_decode($string, ENT_COMPAT | ENT_XHTML);
 echo get_html_translation_table( $table, ENT_NOQUOTES, $encoding );
 
@@ -11,5 +11,13 @@ echo get_html_translation_table( $table, ENT_NOQUOTES, $encoding );
 echo htmlentities( $string );
 echo htmlspecialchars($string);
 echo HTML_entity_decode( string: $string, encoding: $encoding );
-echo htmlspecialchars_decode($string);
+echo \htmlspecialchars_decode($string);
 echo get_html_translation_table( $table );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::htmlentities( $string );
+$obj->htmlspecialchars_decode($string);
+$obj?->htmlentities( $string );
+namespace\htmlspecialchars_decode($string);
+\Fully\Qualified\htmlentities( $string );
+Partially\Qualified\htmlspecialchars_decode($string);

--- a/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHTMLEntitiesFlagsDefaultUnitTest.php
@@ -66,16 +66,39 @@ class NewHTMLEntitiesFlagsDefaultUnitTest extends BaseSniffTestCase
     /**
      * Verify there are no false positives on code this sniff should ignore.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '8.0-8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 9 lines.
         for ($line = 1; $line <= 9; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 17; $line <= 23; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.inc
@@ -4,7 +4,7 @@
  * These should all be fine.
  */
 hash_file(algo: "something"); // Not one of the targetted algorithms.
-hash("1st param", "md2"); // Not the right parameter.
+\hash("1st param", "md2"); // Not the right parameter.
 hash_init; // Not a function call.
 
 /**
@@ -12,15 +12,15 @@ hash_init; // Not a function call.
  */
 hash_file('md2');
 hash_file('ripemd256');
-hash_file("ripemd320");
+\hash_file("ripemd320");
 hash_file( "salsa10" );
 
 hash_hmac(     "salsa20"      );
 hash_hmac_file("snefru256" /*comment*/);
-hash_init(   'sha224'  );
+Hash_Init(   'sha224'  );
 
 hash(/*comment*/ "joaat");
-hash("fnv132", "2nd param", 3, false);
+Hash("fnv132", "2nd param", 3, false);
 hash("fnv164");
 
 hash_pbkdf2(algo: 'gost-crypto');
@@ -29,12 +29,12 @@ hash_file('sha512/224');
 hash_hmac_file('sha512/256');
 hash_hmac('sha3-224');
 hash_init('sha3-256');
-hash_pbkdf2('sha3-384');
+\hash_pbkdf2('sha3-384');
 hash('sha3-512');
 hash('crc32c');
 
 hash_file('murmur3a');
-hash('murmur3c');
+HASH('murmur3c');
 hash_init('murmur3f');
 hash('xxh32');
 hash_init('xxh64');
@@ -45,3 +45,11 @@ hash('xxh128');
 hash_init();
 hash_hmac( data: 'salsa20', key: $key ); // Missing $algo param.
 hash_pbkdf2(algorithm: 'salsa20'); // Incorrect param name.
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::hash_file('md2');
+$obj->hash("fnv164");
+$obj?->hash_hmac_file('sha512/256');
+namespace\hash('sha3-512');
+\Fully\Qualified\hash_init('xxh64');
+Partially\Qualified\hash('xxh128');

--- a/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewHashAlgorithmsUnitTest.php
@@ -120,6 +120,13 @@ class NewHashAlgorithmsUnitTest extends BaseSniffTestCase
             [45],
             [46],
             [47],
+
+            [50],
+            [51],
+            [52],
+            [53],
+            [54],
+            [55],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.inc
@@ -2,7 +2,7 @@
 
 // OK.
 echo idn_to_ascii('täst.de', idna_info: $idna_info, variant: $variant);
-echo idn_to_ascii( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
+echo idn_to_ascii( $domain, IDNA_DEFAULT, \INTL_IDNA_VARIANT_UTS46);
 echo idn_to_utf8('xn--tst-qla.de', $options, $variant, $idna_info);
 echo idn_to_utf8( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003 );
 
@@ -12,4 +12,12 @@ echo idn_to_ascii( $domain, IDNA_DEFAULT);
 echo IDN_to_utf8('xn--tst-qla.de');
 echo idn_to_utf8( $domain, IDNA_DEFAULT);
 echo idn_to_ascii(idna_info: $idna_info, domain: 'täst.de');
-echo idn_to_utf8( flags: IDNA_DEFAULT, domain: $domain);
+echo idn_to_utf8( flags: \IDNA_DEFAULT, domain: $domain);
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::idn_to_ascii( $domain, IDNA_DEFAULT);
+$obj->idn_to_ascii( $domain, IDNA_DEFAULT);
+$obj?->idn_to_ascii( $domain, IDNA_DEFAULT);
+namespace\idn_to_ascii( $domain, IDNA_DEFAULT);
+\Fully\Qualified\idn_to_ascii( $domain, IDNA_DEFAULT);
+Partially\Qualified\idn_to_ascii( $domain, IDNA_DEFAULT);

--- a/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIDNVariantDefaultUnitTest.php
@@ -64,18 +64,41 @@ class NewIDNVariantDefaultUnitTest extends BaseSniffTestCase
 
 
     /**
-     * testNoFalsePositives
+     * Test that there are no false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
      *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '7.3-');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 8 lines.
         for ($line = 1; $line <= 8; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 17; $line <= 23; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.inc
@@ -11,7 +11,7 @@ $a = iconv_mime_decode( $encoded_header, $mode, $charset );
 $a = iconv_strlen($str, $charset);
 $a = iconv_strpos ( $haystack, $needle, 0, 'UTF-8' );
 $a = iconv_strrpos($haystack, $needle, $charset );
-$a = iconv_substr($str, $offset, $length, ini_get("iconv.internal_encoding"));
+$a = \iconv_substr($str, $offset, $length, ini_get("iconv.internal_encoding"));
 
 $a = mb_check_encoding($var, $encoding);
 
@@ -26,7 +26,7 @@ $a = mb_strcut($str, $start, $length, $encoding);
 $a = mb_stripos( $haystack, $needle, $offset, $encoding );
 $a = mb_stristr( $haystack, $needle, true, $encoding );
 $a = mb_strlen($str, $encoding);
-$a = mb_strpos( $haystack, $needle, $offset, $encoding );
+$a = \mb_strpos( $haystack, $needle, $offset, $encoding );
 $a = mb_strrchr( $haystack, $needle, $part, $encoding );
 $a = mb_strrichr( $haystack, $needle, $part, $encoding );
 $a = mb_strripos( $haystack, $needle, $offset, $encoding );
@@ -34,7 +34,7 @@ $a = mb_strrpos( $haystack, $needle, $offset, $encoding );
 $a = mb_strstr( $haystack, $needle, true, $encoding );
 $a = mb_strtolower( $str, $encoding );
 $a = mb_strtoupper( $str, $encoding );
-$a = mb_strwidth( $str, $encoding );
+$a = \mb_strwidth( $str, $encoding );
 $a = mb_substr_count( $haystack, $needle, $encoding );
 $a = mb_substr(string: $str, start: $start, encoding: $encoding);
 
@@ -44,7 +44,7 @@ $a = mb_substr(string: $str, start: $start, encoding: $encoding);
 $a = iconv_mime_decode_headers( $encoded_headers, $mode );
 $a = iconv_mime_decode( $encoded_header, $mode );
 $a = Iconv_Strlen($str);
-$a = iconv_strpos ( $haystack, $needle );
+$a = \iconv_strpos ( $haystack, $needle );
 $a = iconv_strrpos($haystack, $needle );
 $a = iconv_substr($str, $offset);
 
@@ -62,7 +62,7 @@ $a = mb_stripos( $haystack, $needle );
 $a = mb_stristr( $haystack, $needle );
 $a = mb_strlen($str);
 $a = mb_strpos( $haystack, $needle );
-$a = mb_strrchr( $haystack, $needle, $part );
+$a = \mb_strrchr( $haystack, $needle, $part );
 $a = mb_strrichr( $haystack, $needle );
 $a = mb_strripos( $haystack, $needle, $offset );
 $a = mb_strrpos( $haystack, $needle );
@@ -71,7 +71,7 @@ $a = mb_strtolower($str);
 $a = mb_strtoupper( $str );
 $a = mb_strwidth( $str );
 $a = mb_substr_count( $haystack, $needle );
-$a = mb_substr(string: $str, start: $start, length: 10);
+$a = \mb_substr(string: $str, start: $start, length: 10);
 
 /*
  * iconv_mime_encode() specific tests.
@@ -90,7 +90,7 @@ $a = iconv_mime_encode(
 
 $a = Iconv_Mime_Encode( $field_name, $field_value ); // Error: $preferences not set.
 $a = ICONV_mime_encode( $field_name, $field_value, $preferences ); // Warning: unclear whether array keys are set or not.
-$a = iconv_mime_encode(
+$a = \iconv_mime_encode(
     $field_name,
     $field_value,
     array(
@@ -109,7 +109,7 @@ $a = iconv_mime_encode(
     ]
 ); // Error: 'input-charset' not set.
 
-$a = iconv_mime_encode(
+$a = \iconv_mime_encode(
     $field_name,
     $field_value,
     [
@@ -204,3 +204,11 @@ $a = iconv_mime_encode(
         'output-charset' => 'UTF-8',
     ]
 ); // Warning: 'input-charset' potentially not set.
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::iconv_substr($str, $offset);
+$obj->mb_convert_kana( $str, $option );
+$obj?->mb_strwidth( $str );
+namespace\iconv_substr($str, $offset);
+\Fully\Qualified\mb_convert_kana( $str, $option );
+Partially\Qualified\mb_strwidth( $str );

--- a/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewIconvMbstringCharsetDefaultUnitTest.php
@@ -90,16 +90,39 @@ class NewIconvMbstringCharsetDefaultUnitTest extends BaseSniffTestCase
     /**
      * Test that there are no false positives.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.4-7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 40 lines.
         for ($line = 1; $line <= 40; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 208; $line <= 214; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.inc
@@ -13,14 +13,14 @@ mb_ereg_search_setpos(
     // phpcs:ignore Standard.Category.Sniff -- for reasons.
 );
 mb_ereg_search_setpos($position);
-mb_ereg_search_setpos( -1 + 10 );
+\mb_ereg_search_setpos( -1 + 10 );
 mb_ereg_search_setpos( 100 - 10 );
 mb_ereg_search_setpos( 100- );
 
 $content = file_get_contents( $filename, false, $context, 0, 100 );
 $content = file_get_contents( $filename, false, $context, 100 );
 
-$content = file_get_contents( $filename, false, $context, $offset ); // Not necessarily OK, but we can't determine it.
+$content = \file_get_contents( $filename, false, $context, $offset ); // Not necessarily OK, but we can't determine it.
 
 $content = file_get_contents( $filename, false, $context, ($previous_offset + $chunk_size) ); // Not necessarily OK, but we can't determine it.
 
@@ -35,7 +35,7 @@ MB_ereg_search_setpos( -     100);
 
 $a = file_get_contents($filename, true, $context, -1024, 1024 );
 $a = grapheme_extract($haystack, $size, $extract_type, -10 );
-$a = grapheme_stripos($haystack, $needle, -1000 );
+$a = \grapheme_stripos($haystack, $needle, -1000 );
 $a = grapheme_strpos($haystack, $needle, -3 );
 $a = iconv_strpos($haystack, $needle, -052 );
 $a = mb_strimwidth($str, -100, -10, '' );
@@ -43,10 +43,18 @@ $a = mb_stripos($haystack, $needle, -2 );
 $a = mb_strpos($haystack, $needle, -5 );
 $a = stripos($haystack, $needle, -42 );
 $a = strpos($haystack, $needle, -30 );
-$a = substr_count($haystack, $needle, -20, -10 );
+$a = \substr_count($haystack, $needle, -20, -10 );
 $a = Substr_Count($haystack, $needle, -20, 10 );
 $a = substr_count($haystack, $needle, 20, -+-+-10 );
 
 // Safeguard support for PHP 8 named parameters.
 $a = mb_strimwidth(trim_marker: '', width: 5, start: -2, string: $str, ); // Error x 1.
-$a = mb_strimwidth(start: -2, width: -10, string: $str, trim_marker: ''); // Error x 2.
+$a = \MB_Strimwidth(start: -2, width: -10, string: $str, trim_marker: ''); // Error x 2.
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::mb_strpos($haystack, $needle, -5 );
+$obj->file_get_contents($filename, true, $context, -1024, 1024 );
+$obj?->mb_ereg_search_setpos( -100);
+namespace\iconv_strpos($haystack, $needle, -052 );
+\Fully\Qualified\substr_count($haystack, $needle, 20, -+-+-10 );
+Partially\Qualified\stripos($haystack, $needle, -42 );

--- a/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNegativeStringOffsetUnitTest.php
@@ -75,25 +75,48 @@ class NewNegativeStringOffsetUnitTest extends BaseSniffTestCase
             [47, 'offset', 'Substr_Count'],
             [48, 'length', 'substr_count'],
             [51, 'start', 'mb_strimwidth'],
-            [52, 'start', 'mb_strimwidth'],
-            [52, 'width', 'mb_strimwidth'],
+            [52, 'start', 'MB_Strimwidth'],
+            [52, 'width', 'MB_Strimwidth'],
         ];
     }
 
 
     /**
-     * testNoFalsePositives
+     * Test that there are no false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
      *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 26 lines.
         for ($line = 1; $line <= 26; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 54; $line <= 60; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.inc
@@ -11,7 +11,7 @@ number_format($number);
 number_format($number, $decimals);
 number_format($number, decimal_separator: $dec_point, thousands_separator: $thousands_sep, decimals: $decimals); // Undetermined.
 // Variables passed in a double quoted string are presumed to be single-byte.
-number_format($number, $decimals, "$dec_point", "${thousands->{${'sep'}}}");
+\number_format($number, $decimals, "$dec_point", "${thousands->{${'sep'}}}");
 number_format($number, $decimals, '.', ','); // Single-byte.
 
 /*
@@ -23,7 +23,7 @@ number_format($number, $decimals, '.', '::'); // Thousand-sep multi-byte.
 // has to be passed too, but that's not the concern of this sniff.
 number_format(num: $number, decimal_separator: "-$a", decimals: $decimals,); // Dec point multi-byte (most probably, depends on contents of the variable).
 
-number_format(
+\Number_Format(
     $number,
     $decimals,
     <<<EOD
@@ -38,3 +38,11 @@ EOT
 // Bug #1679: empty string was incorrectly being flagged as multi-byte.
 number_format($number, $decimals, '', ''); // OK.
 number_format($number, $decimals, "", ""); // OK.
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::number_format($number, $decimals, '.', '::');
+$obj->number_format($number, $decimals, '.', '::');
+$obj?->number_format($number, $decimals, '.', '::');
+namespace\number_format($number, $decimals, '.', '::');
+\Fully\Qualified\number_format($number, $decimals, '.', '::');
+Partially\Qualified\number_format($number, $decimals, '.', '::');

--- a/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewNumberFormatMultibyteSeparatorsUnitTest.php
@@ -90,8 +90,9 @@ class NewNumberFormatMultibyteSeparatorsUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [39];
-        $cases[] = [40];
+        for ($line = 38; $line <= 48; $line++) {
+            $cases[] = [$line];
+        }
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.inc
@@ -12,7 +12,7 @@ $text = preg_match_all(
     $text
   );
 
-preg_split(
+preg_Split(
     [
         'be' => '/single-quoted/J',
         'ce' => '#hash-chars (common)#j',
@@ -20,7 +20,7 @@ preg_split(
     ], $subject, 2
 );
 
-preg_replace_callback_array(
+\preg_replace_callback_array(
     [
         '~[a]+~J' => function ($match) {
             echo strlen($match[0]), ' matches for "a" found', PHP_EOL;
@@ -47,12 +47,12 @@ EOD
 
 // Safeguard support for PHP 8 named parameters.
 preg_grep(array: $input, pattern: '#some text#i'); // OK.
-preg_grep(array: $input, pattern: '#some text#Ji', flags: $flags); // Error.
+PREG_grep(array: $input, pattern: '#some text#Ji', flags: $flags); // Error.
 
 // Recognize use of the PHP 8.2 "n" modifier.
 preg_match('/.(.)./n', 'abc', $m);
 preg_match('`.(?P<test>.).`n', 'abc', $m);
-preg_match('{.(?P<test>.).}n', 'abc', $m);
+\preg_match('{.(?P<test>.).}n', 'abc', $m);
 
 // Recognize use of the PHP 8.4 "r" modifier.
 preg_match('/.(.)./ri', 'abc', $m);
@@ -60,5 +60,15 @@ preg_match('`.(?P<test>.).`r', 'abc', $m);
 preg_match('{A\x{17f}\x{212a}Z}xr', 'abc', $m);
 
 // Issue #1764 - safeguard against false positives for text within brackets.
-preg_match_all( $my->get_regex('_regexp'), $text, $matches );
-preg_match_all( $regexes[ $type . '_regexp' ], $text, $matches );
+preg_match_all( $my->get_regex('#regexp#J'), $text, $matches );
+preg_match_all( $regexes[ $type . '#regexp#n' ], $text, $matches );
+\Preg_Match_ALL( namespace\get_regex('#regexp#r'), $text, $matches );
+preg_match_all( \get_regex('#regexp#J'), $text, $matches );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::preg_match_all('/some text/J', $subject);
+$obj->preg_match('/some text/n', $subject);
+$obj?->preg_replace_callback_array('/some text/r', $subject);
+namespace\preg_match_all('/some text/r', $subject);
+\Fully\Qualified\preg_match('/some text/n', $subject);
+Partially\Qualified\preg_split('/some text/J', $subject);

--- a/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPCREModifiersUnitTest.php
@@ -102,6 +102,14 @@ class NewPCREModifiersUnitTest extends BaseSniffTestCase
             [49],
             [63],
             [64],
+            [65],
+            [66],
+            [69],
+            [70],
+            [71],
+            [72],
+            [73],
+            [74],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
@@ -2,18 +2,18 @@
 
 // OK.
 $binarydata = pack("nvc*", 0x1234, 0x5678, 65, 66);
-$binarydata = pack("n{$e}vc*", 0x1234, 0x5678, 65, 66);
+$binarydata = \pack("n{$e}vc*", 0x1234, 0x5678, 65, 66);
 
 // Not OK.
 $binarydata = pack("nZc*", 0x1234, 0x5678, 65, 66);
 $binarydata = pack("nvq*", 0x1234, 0x5678, 65, 66);
-$binarydata = pack("Qnvc*", 0x1234, 0x5678, 65, 66);
+$binarydata = \pack("Qnvc*", 0x1234, 0x5678, 65, 66);
 $binarydata = pack("nJc*", 0x1234, 0x5678, 65, 66);
 $binarydata = pack('nvPc*', 0x1234, 0x5678, 65, 66);
 $binarydata = pack("nec*", 0x1234, 0x5678, 65, 66);
-$binarydata = pack("Envc*", 0x1234, 0x5678, 65, 66);
+$binarydata = PACK("Envc*", 0x1234, 0x5678, 65, 66);
 $binarydata = pack('nvcgG*', 0x1234, 0x5678, 65, 66);
-$binarydata = pack("n{$s}vGc*", 0x1234, 0x5678, 65, 66);
+$binarydata = \pack("n{$s}vGc*", 0x1234, 0x5678, 65, 66);
 
 $binarydata = pack("ZJE*", 0x1234, 0x5678, 65, 66); // Error x 3.
 
@@ -25,3 +25,16 @@ $binarydata = pack($obj->getModes('type'), 0x1234, 0x5678, 65, 66);
 
 // Test handling of more complex embedded variables and expressions.
 $binarydata = pack("n${(eq)}vc*", 0x1234, 0x5678, 65, 66); // OK.
+
+// More tests related to issue #1043 - all OK.
+pack(namespace\setFormat('type'));
+pack(\Fully\Qualified\setFormat('type'));
+\pack(Partially\Qualified\setFormat('type'));
+
+// Safeguard against false positives. Not our target.
+$obj->pack("nZc*", 0x1234, 0x5678, 65, 66);
+$obj?->pack("nZc*", 0x1234, 0x5678, 65, 66);
+MyClass::pack("nZc*", 0x1234, 0x5678, 65, 66);
+\Fully\Qualified\pack("nZc*", 0x1234, 0x5678, 65, 66);
+Partially\Qualified\pack("nZc*", 0x1234, 0x5678, 65, 66);
+namespace\pack("nZc*", 0x1234, 0x5678, 65, 66);

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -111,9 +111,9 @@ class NewPackFormatUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
-        $data[] = [23];
-        $data[] = [24];
-        $data[] = [27];
+        for ($line = 22; $line <= 40; $line++) {
+            $data[] = [$line];
+        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.inc
@@ -2,16 +2,16 @@
 
 // OK.
 $str = strip_tags($str);
-$str = strip_tags($input, allowed_tags: '<a><p>');
+$str = \strip_tags($input, allowed_tags: '<a><p>');
 
 // Undetermined. Ignore.
 $str = strip_tags($str, $allowable_tags);
-$str = strip_tags($str, self::ALLOWABLE_TAGS);
+$str = \strip_tags($str, self::ALLOWABLE_TAGS);
 $str = strip_tags($str, MyClass::get_allowable_tags(['a', 'p']));
 
 // PHP 7.4: passing $allowable_tags as an array.
 $str = strip_tags($input, ['a', 'p']);
-$str = strip_tags(
+$str = \strip_tags(
     $input,
     array(
         'a',
@@ -21,7 +21,7 @@ $str = strip_tags(
 
 // PHP 7.4: Warning. Incorrectly passing $allowable_tags as an array.
 $str = strip_tags(allowed_tags: ['<a>', '<p>'], string: $input);
-$str = strip_tags(
+$str = Strip_TAGS(
     $input,
     array(
         '<a>',
@@ -29,7 +29,7 @@ $str = strip_tags(
     ),
 );
 
-// Prevent false positive.
+// Prevent false positives.
 $str = strip_tags($input, ['br', ...function_call('<a>,<p>')]); // PHP 7.4 syntax: unpacking within an array.
 $str = strip_tags($input, []);
 
@@ -40,3 +40,16 @@ $str = strip_tags(
         'p', // <p> 
     ),
 );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::strip_tags($input, ['a', 'p']);
+$obj->strip_tags($input, ['a', 'p']);
+$obj?->strip_tags($input, ['a', 'p']);
+namespace\strip_tags($input, ['<a>', '<p>']);
+\Fully\Qualified\strip_tags($input, ['a', 'p']);
+Partially\Qualified\strip_tags($input, ['<a>', '<p>']);
+
+// More prevent false positives for incorrect format. Ignore.
+$str = strip_tags($str, [...namespace\get_allowed_tags(['<a>', '<p>'])]);
+$str = \strip_tags($str, [...\Fully\Qualified\get_allowed_tags(['<a>', '<p>'])]);
+$str = strip_tags($str, [...Partially\Qualified\get_allowed_tags(['<a>', '<p>'])]);

--- a/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewStripTagsAllowableTagsArrayUnitTest.php
@@ -58,6 +58,10 @@ class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTestCase
             [26],
             [33],
             [34],
+            [38],
+            [53],
+            [54],
+            [55],
         ];
     }
 
@@ -130,6 +134,9 @@ class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTestCase
             [39],
             [40],
             [41],
+            [53],
+            [54],
+            [55],
         ];
     }
 
@@ -148,6 +155,10 @@ class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTestCase
 
         // No errors expected on the first 11 lines.
         for ($line = 1; $line <= 11; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        for ($line = 44; $line <= 50; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }
@@ -170,6 +181,6 @@ class NewStripTagsAllowableTagsArrayUnitTest extends BaseSniffTestCase
 
     /*
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors
-     * about independently of the testVersion.
+     * independently of the testVersion.
      */
 }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.inc
@@ -5,7 +5,7 @@ assert();
 
 // OK in all versions.
 assert(false);
-assert(true);
+\assert(true);
 
 // Undetermined. Ignore.
 assert($assertion);
@@ -16,13 +16,22 @@ assert((bool) ($input));
 
 // Deprecated as of PHP 7.2.
 assert('mysql_query("")');
-assert("2 < 1" /* just a demo */, 'Two is less than one');
+\assert("2 < 1" /* just a demo */, 'Two is less than one');
 assert(<<<'EOT'
     is_string($result) &&
     (strlen($result) > 0);
 EOT
 );
-assert(
+Assert(
     'is_int($int)'
     . '&& $int > 10'
 );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::assert('mysql_query("")');
+$obj->assert('mysql_query("")');
+$obj?->assert('mysql_query("")');
+// (Re)defining a custom assert function is not allowed in PHP, but that's not the concern of this sniff.
+namespace\assert('mysql_query("")');
+\Fully\Qualified\assert('mysql_query("")');
+Partially\Qualified\assert('mysql_query("")');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedAssertStringAssertionUnitTest.php
@@ -66,16 +66,39 @@ class RemovedAssertStringAssertionUnitTest extends BaseSniffTestCase
     /**
      * Verify there are no false positives on code this sniff should ignore.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '7.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 16 lines.
         for ($line = 1; $line <= 16; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 30; $line <= 37; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
     /**

--- a/PHPCompatibility/Tests/ParameterValues/RemovedGetClassNoArgsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedGetClassNoArgsUnitTest.inc
@@ -37,3 +37,7 @@ get_parent_class(
 // Also not OK: wrong parameter name used.
 \get_class(something_else: $object);
 get_parent_class(something_else: $object_or_class);
+
+// Safeguard against false positives on namespaced function calls.
+namespace\get_parent_class()
+\Fully\Qualified\get_class();

--- a/PHPCompatibility/Tests/ParameterValues/RemovedGetClassNoArgsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedGetClassNoArgsUnitTest.php
@@ -94,6 +94,9 @@ final class RemovedGetClassNoArgsUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        $data[] = [42];
+        $data[] = [43];
+
         return $data;
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.inc
@@ -4,7 +4,7 @@
  * These should all be fine.
  */
 hash_file("something"); // Not one of the targetted algorithms.
-hash(algo: "1st param", "salsa10"); // Not the right parameter.
+\hash(algo: "1st param", "salsa10"); // Not the right parameter.
 hash_hmac; // Not a function call.
 
 /**
@@ -12,12 +12,12 @@ hash_hmac; // Not a function call.
  */
 hash_file("salsa10");
 hash_file("salsa20");
-hash_file('salsa10');
+Hash_File('salsa10');
 hash_file('salsa20');
 
 hash_hmac_file(algo: "salsa10");
 hash_hmac( "salsa20" /*comment*/ );
-hash_init(   'salsa10'  );
+\hash_init(   'salsa10'  );
 
 hash(/*comment*/ "salsa10");
 hash("salsa10", "2nd param", 3, false);
@@ -28,3 +28,11 @@ hash_pbkdf2('salsa20');
 hash_init();
 hash_hmac( data: 'salsa20', key: $key ); // Missing $algo param.
 hash_pbkdf2(algorithm: 'salsa20'); // Incorrect param name.
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::hash_file("salsa20");
+$obj->hash_init("salsa20");
+$obj?->hash_pbkdf2('salsa10');
+namespace\hash("salsa10");
+\Fully\Qualified\hash_init('salsa10');
+Partially\Qualified\hash_pbkdf2('salsa20');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedHashAlgorithmsUnitTest.php
@@ -103,6 +103,12 @@ class RemovedHashAlgorithmsUnitTest extends BaseSniffTestCase
             [28],
             [29],
             [30],
+            [33],
+            [34],
+            [35],
+            [36],
+            [37],
+            [38],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.inc
@@ -15,4 +15,11 @@ iconv_set_encoding('internal_encoding', 'UTF-8');
 \iconv_set_encoding( 'input_encoding', 'ISO-8859-1' );
 iconv_set_encoding("output_encoding", "ISO-8859-1");
 iconv_set_encoding( encoding: "ISO-8859-1", type: $type );
-iconv_set_encoding('all', 'UTF-8'); // Not a valid $type value.
+ICONV_Set_Encoding('all', 'UTF-8'); // Not a valid $type value.
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::iconv_set_encoding('internal_encoding', 'UTF-8');
+$obj->iconv_set_encoding('internal_encoding', 'UTF-8');
+$obj?->iconv_set_encoding('internal_encoding', 'UTF-8');
+namespace\iconv_set_encoding('internal_encoding', 'UTF-8');
+\Fully\Qualified\iconv_set_encoding('internal_encoding', 'UTF-8');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedIconvEncodingUnitTest.php
@@ -60,18 +60,41 @@ class RemovedIconvEncodingUnitTest extends BaseSniffTestCase
 
 
     /**
-     * testNoFalsePositives
+     * Test that there are no false positives.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
      *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 10 lines.
         for ($line = 1; $line <= 10; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 20; $line <= 25; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.inc
@@ -4,24 +4,24 @@
 implode();
 implode($pieces);
 implode(', ', $pieces);
-implode( "$glue", $pieces );
+\implode( "$glue", $pieces );
 implode(PHP_EOL, $pieces);
 
 join();
 join( $pieces );
 join(', ' /*comment*/, $pieces);
-join("$glue", $pieces);
+\join("$glue", $pieces);
 join(DIRECTORY_SEPARATOR, $pieces);
 
 // Undetermined, sniff stays silent.
 implode($glue, $pieces);
 implode( $settings['glue'], $pieces );
 implode( $pieces, $settings['glue'] );
-implode( $pieces, get_glue( 'type' ) );
+Implode( $pieces, get_glue( 'type' ) );
 implode( $pieces, $obj->get_glue() );
 implode( $pieces, MY_GLUE );
 implode( Custom\array_map( 'strtolower', $pieces ), $glue );
-implode( $obj->array_map( 'strtolower', $pieces ), $glue );
+\implode( $obj->array_map( 'strtolower', $pieces ), $glue );
 implode( My_Class::array_map( 'strtolower', $pieces ), $glue );
 implode( array_search( $glue_needle, $haystack ), $pieces );
 
@@ -30,11 +30,11 @@ implode( $pieces, ', ' );
 join($pieces, ' ');
 
 implode(array('a', 'b'), $glue);
-join( [1, 2] /*comment*/, $glue);
+\join( [1, 2] /*comment*/, $glue);
 
 implode(array('a', 'b'), '-' . '|');
 join([1, 2], "$glue");
-implode($pieces, ('-' . '|'));
+\implode($pieces, ('-' . '|'));
 implode( $pieces, ( $type === 'a' ? '-' : '|') );
 
 join ($pieces, <<<EOD
@@ -44,7 +44,7 @@ EOD
 
 // Special cased functions.
 implode( array_map( 'strtolower', $pieces ), $glue );
-implode( array_value( $pieces ), $glue );
+IMPLODE( array_value( $pieces ), $glue );
 implode( explode( ',', $text ), $glue );
 implode( compact( $piece1, $piece2, $piece3 ), $glue );
 
@@ -70,3 +70,23 @@ implode( (array) $object, $glue ); // Error.
 // Prevent false positives on PHP 8.0+ nullsafe method calls.
 $obj?->implode( $pieces, ', ' );
 implode( $obj?->array_map( 'strtolower', $pieces ), $glue ); // Undetermined, same as other params with unrecognized function calls.
+
+// More safeguard against false positives on method calls and namespaced function calls.
+ClassName::implode(array('a', 'b'), $glue);
+$obj->join($pieces, ' ');
+namespace\implode(array('a', 'b'), $glue);
+\Fully\Qualified\join($pieces, ' ');
+Partially\Qualified\implode(array('a', 'b'), $glue);
+
+// Safeguard for fully qualified and uppercase special cased functions.
+implode( \array_map( 'strtolower', $pieces ), $glue );
+\join( ARRAY_VALUE( $pieces ), $glue );
+implode( \Explode( ',', $text ), $glue );
+\implode( \compact( $piece1, $piece2, $piece3 ), $glue );
+implode( \array_pop( $array ), $pieces ); // OK.
+
+// Safeguard for fully qualified special cased PHP native constants.
+implode( \PHP_EOL, $pieces, ); // OK.
+implode( \DIRECTORY_SEPARATOR, $pieces, ); // OK.
+implode( $pieces, \PHP_EOL );
+implode( $pieces, \DIRECTORY_SEPARATOR );

--- a/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedImplodeFlexibleParamOrderUnitTest.php
@@ -64,12 +64,19 @@ class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTestCase
             [38, 'implode'],
             [40, 'join'],
             [46, 'implode'],
-            [47, 'implode'],
+            [47, 'IMPLODE'],
             [48, 'implode'],
             [49, 'implode'],
             [52, 'implode'],
             [53, 'implode'],
             [68, 'implode'],
+
+            [82, 'implode'],
+            [83, 'join'],
+            [84, 'implode'],
+            [85, 'implode'],
+            [91, 'implode'],
+            [92, 'implode'],
         ];
     }
 
@@ -108,8 +115,10 @@ class RemovedImplodeFlexibleParamOrderUnitTest extends BaseSniffTestCase
         $data[] = [57];
         $data[] = [64];
         $data[] = [67];
-        $data[] = [71];
-        $data[] = [72];
+
+        for ($line = 70; $line <= 79; $line++) {
+            $data[] = [$line];
+        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.inc
@@ -6,8 +6,16 @@
 //OK.
 mb_check_encoding($value, $encoding);
 mb_check_encoding($value);
-mb_check_encoding(encoding: $encoding);
+\mb_check_encoding(encoding: $encoding);
 
 // Not OK.
 mb_check_encoding();
-Mb_Check_Encoding( /* comment */ );
+\Mb_Check_Encoding( /* comment */ );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::mb_check_encoding();
+$obj->mb_check_encoding();
+$obj?->mb_check_encoding();
+namespace\mb_check_encoding();
+\Fully\Qualified\mb_check_encoding();
+Partially\Qualified\mb_check_encoding();

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbCheckEncodingNoArgsUnitTest.php
@@ -59,16 +59,39 @@ class RemovedMbCheckEncodingNoArgsUnitTest extends BaseSniffTestCase
     /**
      * Test that there are no false positives for valid code.
      *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 11 lines.
         for ($line = 1; $line <= 11; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        for ($line = 15; $line <= 21; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrimWidthNegativeWidthUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrimWidthNegativeWidthUnitTest.inc
@@ -41,3 +41,7 @@ $a = mb_strimwidth($str, -100, -10, '' );
 
 // Safeguard support for PHP 8 named parameters.
 $a = \MB_StrimWidth(start: -2, width: -10, string: $str, trim_marker: '');
+
+// Safeguard against false positives on namespaced function calls.
+namespace\mb_strimwidth($str, -100, -10, '' );
+\Fully\Qualified\mb_strimwidth($str, -100, -10, '' );

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrimWidthNegativeWidthUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrimWidthNegativeWidthUnitTest.php
@@ -87,6 +87,10 @@ final class RemovedMbStrimWidthNegativeWidthUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        for ($line = 45; $line <= 47; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.inc
@@ -11,7 +11,7 @@ mb_strrpos(
 );
 mb_strrpos('abc abc abc', 'abc', $offset, $encoding);
 mb_strrpos('abc abc abc', 'abc', -5);
-mb_strrpos('abc abc abc', 'abc', +1.2); // Float will be cast to int, so this is fine.
+\mb_strrpos('abc abc abc', 'abc', +1.2); // Float will be cast to int, so this is fine.
 mb_strrpos('abc abc abc', 'abc', 'UTF-' + 8);
 
 // Ignoring. Can not be reliably determined:
@@ -21,11 +21,11 @@ mb_strrpos('abc abc abc', 'abc', $encoding);
 // PHP 5.2/7.4: deprecated encoding as third param.
 mb_strrpos('abc abc abc', 'abc', 'UTF-8');
 mb_strrpos('abc abc abc', 'abc', "utf-$utfType");
-mb_strrpos('abc abc abc', 'abc', 'utf-' . $utfType);
+\mb_strrpos('abc abc abc', 'abc', 'utf-' . $utfType);
 
 // Safeguard support for PHP 8 named parameters.
 mb_strrpos(haystack: 'abc abc abc', needle: 'abc', encoding: 'UTF-8'); // OK.
-mb_strrpos(offset: 'UTF-8', haystack: 'abc abc abc', needle: 'abc',); // Error, not that it would make sense to pass this.
+MB_Strrpos(offset: 'UTF-8', haystack: 'abc abc abc', needle: 'abc',); // Error, not that it would make sense to pass this.
 
 // Issue #1721: ignore as undetermined.
 mb_strrpos('abc abc abc', 'abc', $pos['offset']);
@@ -35,7 +35,7 @@ mb_strrpos('abc abc abc', 'abc', function ($a = 'default') { return get_offset_o
 
 // ... but still flag this as we can be sure that the resulting param value is a string.
 mb_strrpos('abc abc abc', 'abc', (string) $encoding);
-mb_strrpos('abc abc abc', 'abc', $utf . $nr);
+\mb_strrpos('abc abc abc', 'abc', $utf . $nr);
 mb_strrpos(
     'abc abc abc',
     'abc',
@@ -43,3 +43,11 @@ mb_strrpos(
 $utf
 EOD
 );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::mb_strrpos('abc abc abc', 'abc', 'UTF-8');
+$obj->mb_strrpos('abc abc abc', 'abc', 'UTF-8');
+$obj?->mb_strrpos('abc abc abc', 'abc', 'UTF-8');
+namespace\mb_strrpos('abc abc abc', 'abc', 'UTF-8');
+\Fully\Qualified\mb_strrpos('abc abc abc', 'abc', 'UTF-8');
+Partially\Qualified\mb_strrpos('abc abc abc', 'abc', 'UTF-8');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbStrrposEncodingThirdParamUnitTest.php
@@ -102,10 +102,14 @@ class RemovedMbStrrposEncodingThirdParamUnitTest extends BaseSniffTestCase
         }
 
         $data[] = [27];
-        $data[] = [31];
-        $data[] = [32];
-        $data[] = [33];
-        $data[] = [34];
+
+        for ($line = 30; $line <= 34; $line++) {
+            $data[] = [$line];
+        }
+
+        for ($line = 47; $line <= 53; $line++) {
+            $data[] = [$line];
+        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.inc
@@ -3,7 +3,7 @@
 // These should all be ignored as we're passing in a variable.
 mb_ereg_replace( $pattern, $replace, $subject, $options );
 mb_eregi_replace( $pattern, $replace, $subject, $options );
-mb_regex_set_options( $options );
+\mb_regex_set_options( $options );
 
 // These should be ignored as they contain valid options.
 mb_ereg_replace( $pattern, $replace, $subject, 'msi' );
@@ -13,7 +13,7 @@ mb_regex_set_options( 'ims' );
 // These should all be flagged.
 mb_ereg_replace( $pattern, $replace, $subject, 'e' );
 MB_eregi_replace( $pattern, $replace, $subject, "seim" );
-mb_regex_set_options( 'im' . 'se' );
+\mb_regex_set_options( 'im' . 'se' );
 
 // Interpolated strings: These should NOT be flagged.
 mb_ereg_replace( $pattern, $replace, $subject, "${se->{$b}}" );
@@ -22,7 +22,7 @@ mb_regex_set_options( 'im' . "$se" );
 
 // Interpolated strings: These should all be flagged.
 mb_ereg_replace( $pattern, $replace, $subject, "e$m" );
-mb_eregi_replace( $pattern, $replace, $subject, "me$i" );
+\mb_eregi_replace( $pattern, $replace, $subject, "me$i" );
 Mb_Regex_Set_Options( 'im' . "{$se}e" );
 
 // Verify the sniff also picks up on the function aliases.
@@ -32,3 +32,16 @@ mberegi_replace( $pattern, $replace, $subject, "me$i" );
 // Issue #1043 - ignore function calls, constants etc.
 mb_ereg_replace( $pattern, $replace, $subject, getOptions('type'));
 mb_eregi_replace( $pattern, $replace, $subject, CONSTANT_NAME['array_access'] );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::mb_ereg_replace( $pattern, $replace, $subject, 'e' );
+$obj->mb_ereg_replace( $pattern, $replace, $subject, 'e' );
+$obj?->mb_ereg_replace( $pattern, $replace, $subject, 'e' );
+namespace\mb_ereg_replace( $pattern, $replace, $subject, 'e' );
+\Fully\Qualified\mb_ereg_replace( $pattern, $replace, $subject, 'e' );
+Partially\Qualified\mb_ereg_replace( $pattern, $replace, $subject, 'e' );
+
+// More issue #1043, undetermined. Ignore.
+mb_ereg_replace( $pattern, $replace, $subject, namespace\getOptions('type'));
+\mb_ereg_replace( $pattern, $replace, $subject, \Fully\Qualified\getOptions('type'));
+mb_ereg_replace( $pattern, $replace, $subject, Partially\Qualified\getOptions('type'));

--- a/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedMbstringModifiersUnitTest.php
@@ -105,6 +105,15 @@ class RemovedMbstringModifiersUnitTest extends BaseSniffTestCase
             [21],
             [33],
             [34],
+            [37],
+            [38],
+            [39],
+            [40],
+            [41],
+            [42],
+            [45],
+            [46],
+            [47],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.inc
@@ -10,17 +10,17 @@ hash_init( algo: 'gost-crypto', 1);
 
 // Not OK.
 hash_hmac('adler32');
-hash_hmac_file("crc32");
+\hash_hmac_file("crc32");
 hash_pbkdf2('crc32b');
 hash_init( flags: HASH_HMAC, algo: 'fnv132', key: $key );
 hash_hmac('fnv1a32');
 hash_hmac_file("fnv164",);
 hash_pbkdf2('fnv1a64');
-hash_init( 'joaat', 1);
+\hash_init( 'joaat', 1);
 hash_pbkdf2(
     'adler32' // Comment.
 );
-hash_init( 'crc32b', HASH_HMAC /*comment*/);
+HASH_INIT( 'crc32b', HASH_HMAC /*comment*/);
 
 // Safeguard against false positives when target param not found.
 hash_init( algorithm: 'gost-crypto', flags: 1); // OK, well not really, but incorrect algo param name used.
@@ -32,3 +32,11 @@ hash_init( 'joaat', \  HASH_HMAC, $key); // No longer valid since PHP 8.0, but t
 // Safeguard against false positives when $flag for hash_init is not HASH_HMAC.
 hash_init( 'joaat', 0, $key);
 hash_init( 'joaat', $unknownValue, $key);
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::hash_file('fnv164');
+$obj->hash("crc32");
+$obj?->hash_hmac_file('joaat');
+namespace\hash('adler32');
+\Fully\Qualified\hash_init('crc32b');
+Partially\Qualified\hash('fnv132');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedNonCryptoHashUnitTest.php
@@ -61,7 +61,7 @@ class RemovedNonCryptoHashUnitTest extends BaseSniffTestCase
             [18, 'hash_pbkdf2'],
             [19, 'hash_init'],
             [20, 'hash_pbkdf2'],
-            [23, 'hash_init'],
+            [23, 'HASH_INIT'],
             [29, 'hash_init'],
             [30, 'hash_init'],
         ];
@@ -100,8 +100,10 @@ class RemovedNonCryptoHashUnitTest extends BaseSniffTestCase
         }
 
         $data[] = [26];
-        $data[] = [33];
-        $data[] = [34];
+
+        for ($line = 32; $line <= 42; $line++) {
+            $data[] = [$line];
+        }
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.inc
@@ -56,7 +56,7 @@ preg_replace('!exclamations (why not?!e', $Replace, $Source);
 
 // Other modifiers with /e
 preg_replace('/some text/emS', $Replace, $Source);
-preg_replace('/some text/meS', $Replace, $Source);
+\Preg_Replace('/some text/meS', $Replace, $Source);
 preg_replace('/some text/mSe', $Replace, $Source);
 
 // Multi-line example (issue #83)
@@ -103,7 +103,7 @@ preg_replace('`\d{2}e`', $Replace, $Source); // good
 preg_replace('{^fopen(.*?): }', $Replace, $Source); //good - monolog example
 preg_replace('[\d{2}]e', $Replace, $Source); //bad
 preg_replace('[\d{2}e]', $Replace, $Source); //good
-preg_replace('(\d{2})e', $Replace, $Source); //bad
+\preg_replace('(\d{2})e', $Replace, $Source); //bad
 preg_replace('(\d{2}e)', $Replace, $Source); //good
 preg_replace('<\d{2}>e', $Replace, $Source); //bad
 preg_replace('<\d{2}e>', $Replace, $Source); //good
@@ -150,7 +150,7 @@ preg_filter('/\/e/e', $Replace, $Source);
 ///////////// More warning generated:
 
 // Regex build up of strings combined with variables/function calls.
-preg_replace('/something' . $variable . 'something else/e', $Replace, $Source);
+\preg_replace('/something' . $variable . 'something else/e', $Replace, $Source);
 preg_replace('/something' . preg_quote($variable) . 'something else/e', $Replace, $Source);
 
 // Issue 265 - build up string with varying quotes - this should be ok.
@@ -237,3 +237,13 @@ preg_replace("/double-quoted/${e->{$z}}", $Replace, $Source); // Ok.
 // Safeguard against false positives for text within brackets.
 preg_replace( $my->get_regex('_regexp'), $replace, $subject );
 preg_replace( $regexes[ $type . '_regexp' ], $replace, $subject );
+\PREG_Filter( namespace\get_regex('#regexp#e'), $text, $matches );
+preg_filter( \get_regex('#regexp#e'), $text, $matches );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::preg_replace('/some text/e', $subject);
+$obj->preg_filter('/some text/e', $subject);
+$obj?->preg_replace('/some text/e', $subject);
+namespace\preg_filter('/some text/e', $subject);
+\Fully\Qualified\preg_replace('/some text/e', $subject);
+Partially\Qualified\preg_filter('/some text/e', $subject);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedPCREModifiersUnitTest.php
@@ -62,7 +62,7 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTestCase
             [54],
             [55],
             [58],
-            [59],
+            [59, 'Preg_Replace'],
             [60],
             [72],
             [80],
@@ -197,6 +197,15 @@ class RemovedPCREModifiersUnitTest extends BaseSniffTestCase
             // Issue #1764 - text within brackets should be ignored.
             [238],
             [239],
+            [240],
+            [241],
+
+            [244],
+            [245],
+            [246],
+            [247],
+            [248],
+            [249],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedProprietaryCSVEscapingUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedProprietaryCSVEscapingUnitTest.inc
@@ -24,7 +24,7 @@ str_getcsv($string, $separator, $enclosure, " ");
 fputcsv();
 \fgetcsv();
 str_getcsv();
-fputcsv($stream, $fields);
+FPUTCSV($stream, $fields);
 \fgetcsv($stream);
 str_getcsv($string);
 fputcsv($stream, $fields, $separator $enclosure, eol: "\r\n");
@@ -35,10 +35,14 @@ fgetcsv($stream, $length, $separator, $enclosure, /* comment */);
 // PHP 7.4+: passing an empty string as the $escape parameter will disable escaping.
 fputcsv($stream, $fields, /*comment*/ escape: /*comment*/ ''/*comment*/ );
 \fgetcsv($stream, $length, $separator, $enclosure, '');
-str_getcsv(
+Str_Getcsv(
     $string,
     $separator,
     $enclosure,
     // phpcs:ignore Stnd.Cat.Sniff -- for (testing) reasons.
     "",
 );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+namespace\fputcsv($stream, $fields);
+\Fully\Qualified\fgetcsv($stream, $length, $separator, $enclosure, '');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedProprietaryCSVEscapingUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedProprietaryCSVEscapingUnitTest.php
@@ -130,6 +130,9 @@ final class RemovedProprietaryCSVEscapingUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        $data[] = [47];
+        $data[] = [48];
+
         return $data;
     }
 
@@ -215,6 +218,9 @@ final class RemovedProprietaryCSVEscapingUnitTest extends BaseSniffTestCase
         for ($line = 35; $line <= 44; $line++) {
             $data[] = [$line];
         }
+
+        $data[] = [47];
+        $data[] = [48];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.inc
@@ -3,11 +3,11 @@
 // OK.
 setlocale();
 setlocale(LC_ALL, 'nl_NL');
-setlocale($category, $lang); // Can't be determined.
+\setlocale($category, $lang); // Can't be determined.
 
 // Not OK.
 setlocale('LC_ALL', 'nl_NL');
-setlocale('LC_'.$category, $lang);
+\setlocale('LC_'.$category, $lang);
 
 // Issue #1043 - ignore function calls, constants etc.
 setlocale(getMyLocale('text'), 'nl_NL');
@@ -15,7 +15,20 @@ setlocale($array['LC_ALL'], 'nl_NL');
 
 // Safeguard support for PHP 8 named parameters.
 setlocale(locales: 'nl_NL', category: $category); // Can't be determined.
-setlocale(category: 'LC_ALL', locales: 'nl_NL'); // Error.
+SETLOCALE(category: 'LC_ALL', locales: 'nl_NL'); // Error.
 
 // Safeguard against false positives when target param not found.
 setlocale(locales: 'nl_NL', cat: LC_ALL,); // OK, well not really, but using incorrect parameter name.
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::setlocale('LC_'.$category, $lang);
+$obj->setlocale('LC_'.$category, $lang);
+$obj?->setlocale('LC_'.$category, $lang);
+namespace\setlocale('LC_'.$category, $lang);
+\Fully\Qualified\setlocale('LC_'.$category, $lang);
+Partially\Qualified\setlocale('LC_'.$category, $lang);
+
+// More issue #1043, undetermined. Ignore.
+setlocale(namespace\getMyLocale('text'), 'nl_NL');
+\SetLocale(\Fully\Qualified\getMyLocale('text'), 'nl_NL');
+setlocale(Partially\Qualified\getMyLocale('text'), 'nl_NL');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedSetlocaleStringUnitTest.php
@@ -96,6 +96,10 @@ class RemovedSetlocaleStringUnitTest extends BaseSniffTestCase
         $data[] = [17];
         $data[] = [21];
 
+        for ($line = 23; $line <= 34; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedTriggerErrorLevelUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedTriggerErrorLevelUnitTest.inc
@@ -13,7 +13,7 @@ trigger_error($message, level: false); // Typo in param name.
 // OK.
 trigger_error($message, E_USER_WARNING);
 trigger_error($message, /*comment*/ E_USER_NOTICE /*comment*/);
-trigger_error($message, \E_USER_DEPRECATED);
+\trigger_error($message, \E_USER_DEPRECATED);
 trigger_error($message, 1024);
 
 // Invalid, but not our concern.
@@ -27,10 +27,15 @@ trigger_error($message, \get_error_level());
 
 // Not OK - deprecated in PHP >= 8.4.
 trigger_error($message, E_USER_ERROR);
-trigger_error($message, 256);
+\trigger_error($message, 256);
 trigger_error(
     $message,
     // Comment.
     \E_USER_ERROR // phpcs:ignore Stnd.Cat.Sniff -- for (testing) reasons.
 );
-trigger_error(error_level: E_USER_ERROR, message: $message);
+Trigger_Error(error_level: E_USER_ERROR, message: $message);
+trigger_error($message, \E_USER_ERROR);
+
+// Safeguard against false positives on namespaced function calls.
+namespace\trigger_error($message, E_USER_ERROR);
+\Fully\Qualified\trigger_error($message, E_USER_ERROR);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedTriggerErrorLevelUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedTriggerErrorLevelUnitTest.php
@@ -59,6 +59,7 @@ final class RemovedTriggerErrorLevelUnitTest extends BaseSniffTestCase
             [30],
             [34],
             [36],
+            [37],
         ];
     }
 
@@ -92,6 +93,9 @@ final class RemovedTriggerErrorLevelUnitTest extends BaseSniffTestCase
         for ($line = 1; $line <= 27; $line++) {
             $data[] = [$line];
         }
+
+        $data[] = [40];
+        $data[] = [41];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.inc
@@ -3,7 +3,7 @@
 // OK cross-version.
 version_compare($version1, $version2);
 version_compare($version1, $version2, /*comment*/ );
-version_compare($version1, $version2, '<');
+version_Compare($version1, $version2, '<');
 version_compare($version1, $version2, 'lt');
 version_compare($version1, $version2, '<=');
 version_compare($version1, $version2, <<<'EOD'
@@ -13,7 +13,7 @@ EOD
 version_compare($version1, $version2, '>');
 version_compare($version1, $version2, 'gt');
 version_compare($version1, $version2, ">=");
-version_compare(operator: 'ge', version1: $version1, version2: $version2);
+\version_compare(operator: 'ge', version1: $version1, version2: $version2);
 version_compare($version1, $version2, '==');
 version_compare($version1, $version2, '=');
 version_compare($version1, $version2, 'eq' /*comment*/);
@@ -27,13 +27,13 @@ version_compare($version1, $version2, 'ne');
 // Ignore as undetermined.
 version_compare($version1, $version2, "$operator"); // Can't be determined.
 version_compare($version1, $version2, $operator); // Can't be determined.
-version_compare($version1, $version2, getOperator('e')); // Can't be determined.
+\version_compare($version1, $version2, getOperator('e')); // Can't be determined.
 version_compare($version1, $version2, $operators['e']); // Can't be determined.
 version_compare($version1, $version2, g); // Lowercase constant. Can't be determined.
 
 // Ignore as never supported.
 version_compare($version1, $version2, 'GE');
-version_compare($version1, $version2, 'E');
+VERSION_COMPARE($version1, $version2, 'E');
 version_compare($version1, $version2, <<<'EOD'
 g
 e
@@ -42,12 +42,20 @@ EOD
 
 // PHP 8.1: operators for which support has been removed.
 version_compare($version1, $version2, '');
-version_compare($version1, $version2, "");
+\version_compare($version1, $version2, "");
 version_compare(version1: $version1, operator: 'l', version2: $version2, );
 version_compare($version1, $version2, /*comment*/ 'g');
 version_compare($version1, $version2, <<<EOD
 e
 EOD
 );
-version_compare($version1, $version2, "!");
+Version_Compare($version1, $version2, "!");
 version_compare($version1, $version2, 'n');
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::version_compare($version1, $version2, '');
+$obj->version_compare($version1, $version2, /*comment*/ 'g');
+$obj?->version_compare($version1, $version2, "!");
+namespace\version_compare($version1, $version2, "");
+\Fully\Qualified\version_compare($version1, $version2, 'n');
+Partially\Qualified\version_compare($version1, $version2, 'n');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedVersionCompareOperatorsUnitTest.php
@@ -92,6 +92,10 @@ class RemovedVersionCompareOperatorsUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        for ($line = 55; $line <= 61; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/RemovedXmlSetHandlerCallbackUnsetUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedXmlSetHandlerCallbackUnsetUnitTest.inc
@@ -73,3 +73,7 @@ xml_set_start_namespace_decl_handler($parser, <<<'EOD'
 
 EOD
 );
+
+// Safeguard against false positives on namespaced function calls.
+namespace\xml_set_character_data_handler($parser, '');
+\Fully\Qualified\xml_set_character_data_handler($parser, '');

--- a/PHPCompatibility/Tests/ParameterValues/RemovedXmlSetHandlerCallbackUnsetUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedXmlSetHandlerCallbackUnsetUnitTest.php
@@ -107,6 +107,9 @@ final class RemovedXmlSetHandlerCallbackUnsetUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        $data[] = [78];
+        $data[] = [79];
+
         return $data;
     }
 


### PR DESCRIPTION
PHPCS 4.0 will change the tokenization of namespaced names.

To be able to properly assess PHPCompatibility's readiness for PHPCS 4.0, we need to make sure there are sufficient tests with all variants of the namespaced names:
* Unqualified: `callMe()`
* Partially qualified: `Partial\callMe()`
* Fully qualified: `\Full\callMe()`
* Namespace relative: `namespace\callMe()`

The commits in this PR are the result of a review of the tests for the ParameterValue sniffs and add any of the above syntaxes if these were not previously tested for that sniff.

If a sniff also looks for namespaced names within a function call parameter, additional tests for that situation may also have been added.

Lastly, a check has been done to make sure that all test case files include fully qualified function calls for the function the sniff is looking for, as well as non-lowercase function calls.

Note: there will be more sniffs which will need additional tests, so this is only one of the first of a range of PRs adding more tests to help get ready for PHPCS 4.0.