### PR TITLE
FunctionDeclarations/RemovedOptionalBeforeRequiredParam: bug fix x 2

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -166,7 +166,8 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
             // Check for union types which include null, mixed types and stand-alone null types.
             $hasNullType = false;
             if ($param['type_hint_token'] !== false) {
-                if ($param['type_hint'] === 'mixed' || $param['type_hint'] === 'null') {
+                $typeHint = \strtolower($param['type_hint']);
+                if ($typeHint === 'mixed' || $typeHint === 'null') {
                     $hasNullType = $param['type_hint_token'];
                 } else {
                     $hasNullType = $phpcsFile->findNext(\T_NULL, $param['type_hint_token'], ($param['type_hint_end_token'] + 1));

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -11,11 +11,11 @@
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\GetTokensAsString;
 
 /**
  * Declaring an optional function parameter before a required parameter is deprecated since PHP 8.0.
@@ -85,19 +85,6 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
     const MSG_DETAILS = ' Parameter %1$s is optional, while parameter %2$s is required. The %1$s parameter is implicitly treated as a required parameter.';
 
     /**
-     * Tokens allowed in the default value (until PHP 8.4).
-     *
-     * This property will be enriched in the register() method.
-     *
-     * @since 10.0.0
-     *
-     * @var array<int|string, int|string>
-     */
-    private $allowedInDefault = [
-        \T_NULL => \T_NULL,
-    ];
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 10.0.0
@@ -106,8 +93,6 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
      */
     public function register()
     {
-        $this->allowedInDefault += Tokens::$emptyTokens;
-
         return Collections::functionDeclarationTokens();
     }
 
@@ -160,8 +145,9 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
 
             // Okay, so we have an optional parameter before a required one.
             // Note: as this will never be the _last_ parameter, we can be sure the 'comma_token' will be set to a token and not `false`.
-            $hasNull    = $phpcsFile->findNext(\T_NULL, $param['default_token'], $param['comma_token']);
-            $hasNonNull = $phpcsFile->findNext($this->allowedInDefault, $param['default_token'], $param['comma_token'], true);
+            $cleanDefaultValue  = GetTokensAsString::noEmpties($phpcsFile, $param['default_token'], ($param['comma_token'] - 1));
+            $cleanDefaultValue  = \strtolower($cleanDefaultValue);
+            $defaultValueIsNull = ($cleanDefaultValue === 'null' || $cleanDefaultValue === '\null');
 
             // Check for union types which include null, mixed types and stand-alone null types.
             $hasNullType = false;
@@ -182,7 +168,7 @@ class RemovedOptionalBeforeRequiredParamSniff extends Sniff
                 $requiredParam,
             ];
 
-            if ($hasNull !== false && $hasNonNull === false) {
+            if ($defaultValueIsNull === true) {
                 if ($param['nullable_type'] === true) {
                     // Skip flagging the issue if the codebase doesn't need to run on PHP 8.1+.
                     if (ScannedCode::shouldRunOnOrAbove('8.1') === false) {

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -127,5 +127,13 @@ function combinationOfAllDeprecations(
     Required $f,
 ) {}
 
+// Safeguard handling of uppercase null or mixed in type declarations.
+$uppercaseNullFirstUnionTypedWithNullDefaultValueBeforeOptional = fn(T1 $a, NULL|T2 $b = null, T3 $c = null) => dosomething(); // OK.
+function explicitlyUppercaseNullableUnionWithDefaultValue(T|NULL $var = null, int $var2 = 10) {} // OK.
+$uppercaseNullInDNFTypeWithNullDefaultValueBeforeRequired = function ( (Foo&NotOkay)|NULL $e = null, $f) {}; // Warning PHP 8.3.
+
+function uppercaseMixedTypedWithNullDefaultValueBeforeRequired(Okay $a, MIXED /*comment*/ $b = null, Required $c) {} // Warning PHP 8.3.
+function explicitNullableTypeUppercaseMixed(MIXED $var = null, callable $call = null) {} // OK.
+
 // Intentional parse error. This has to be the last test in the file.
 $closure = function( $a = [], $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -135,5 +135,10 @@ $uppercaseNullInDNFTypeWithNullDefaultValueBeforeRequired = function ( (Foo&NotO
 function uppercaseMixedTypedWithNullDefaultValueBeforeRequired(Okay $a, MIXED /*comment*/ $b = null, Required $c) {} // Warning PHP 8.3.
 function explicitNullableTypeUppercaseMixed(MIXED $var = null, callable $call = null) {} // OK.
 
+// Safeguard handling of FQN null as default value.
+$nullableTypedWithFqnNullDefaultValueBeforeOptional = function (T1 $a, ?T2 $b = \null, T3 $c = \NULL) {}; // This is fine, even on PHP 8.4.
+function fqnNullableTypedOptionalBeforeRequired(Okay $a, ?NotOkay $b = \NULL, Required $c) {} // PHP 8.1.
+function implicitNullableTypeClass(T $var = \null, $c) {} // Warning PHP 8.4.
+
 // Intentional parse error. This has to be the last test in the file.
 $closure = function( $a = [], $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -149,9 +149,10 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases['line 125 - deprecated in PHP 8.1'] = [125];
 
         // Not deprecated, false positive checks for PHP 8.3 deprecation.
-        $cases['line 81 - related to PHP 8.3 deprecation'] = [81];
-        $cases['line 82 - related to PHP 8.3 deprecation'] = [82];
-        $cases['line 83 - related to PHP 8.3 deprecation'] = [83];
+        $cases['line 81 - related to PHP 8.3 deprecation']  = [81];
+        $cases['line 82 - related to PHP 8.3 deprecation']  = [82];
+        $cases['line 83 - related to PHP 8.3 deprecation']  = [83];
+        $cases['line 131 - related to PHP 8.3 deprecation'] = [131];
 
         // Deprecated, but only flagged as of PHP 8.3.
         $cases['line 86 - deprecated in PHP 8.3']  = [86];
@@ -162,6 +163,8 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases['line 91 - deprecated in PHP 8.3']  = [91];
         $cases['line 95 - deprecated in PHP 8.3']  = [95];
         $cases['line 124 - deprecated in PHP 8.3'] = [124];
+        $cases['line 133 - deprecated in PHP 8.3'] = [133];
+        $cases['line 135 - deprecated in PHP 8.3'] = [135];
 
         // Not deprecated, false positive checks for PHP 8.4 deprecation.
         $cases['line 102 - related to PHP 8.4 deprecation'] = [102];
@@ -171,6 +174,8 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases['line 107 - related to PHP 8.4 deprecation'] = [107];
         $cases['line 113 - related to PHP 8.4 deprecation'] = [113];
         $cases['line 114 - related to PHP 8.4 deprecation'] = [114];
+        $cases['line 132 - related to PHP 8.4 deprecation'] = [132];
+        $cases['line 136 - related to PHP 8.4 deprecation'] = [136];
 
         // Deprecated as of PHP 8.4.
         $cases['line 111 - deprecated in PHP 8.4'] = [111];
@@ -181,7 +186,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases['line 123 - deprecated in PHP 8.4'] = [123];
 
         // Add parse error test case.
-        $cases['line 131 - parse error'] = [131];
+        $cases['line 139 - parse error'] = [139];
 
         return $cases;
     }
@@ -289,6 +294,8 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $data[] = [91, self::PHP83_MSG];
         $data[] = [95, self::PHP83_MSG];
         $data[] = [124, self::PHP83_MSG];
+        $data[] = [133, self::PHP83_MSG];
+        $data[] = [135, self::PHP83_MSG];
         return $data;
     }
 
@@ -326,7 +333,9 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
             $cases['line 90 - deprecated in PHP 8.3'],
             $cases['line 91 - deprecated in PHP 8.3'],
             $cases['line 95 - deprecated in PHP 8.3'],
-            $cases['line 124 - deprecated in PHP 8.3']
+            $cases['line 124 - deprecated in PHP 8.3'],
+            $cases['line 133 - deprecated in PHP 8.3'],
+            $cases['line 135 - deprecated in PHP 8.3']
         );
 
         return $cases;

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -140,13 +140,15 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases['line 61 - new in initializers'] = [61];
 
         // Not deprecated, false positive checks for PHP 8.1 deprecation.
-        $cases['line 67 - related to PHP 8.1 deprecation'] = [67];
-        $cases['line 68 - related to PHP 8.1 deprecation'] = [68];
+        $cases['line 67 - related to PHP 8.1 deprecation']  = [67];
+        $cases['line 68 - related to PHP 8.1 deprecation']  = [68];
+        $cases['line 139 - related to PHP 8.1 deprecation'] = [139];
 
         // Deprecated, but only flagged as of PHP 8.1.
         $cases['line 71 - deprecated in PHP 8.1']  = [71];
         $cases['line 75 - deprecated in PHP 8.1']  = [75];
         $cases['line 125 - deprecated in PHP 8.1'] = [125];
+        $cases['line 140 - deprecated in PHP 8.1'] = [140];
 
         // Not deprecated, false positive checks for PHP 8.3 deprecation.
         $cases['line 81 - related to PHP 8.3 deprecation']  = [81];
@@ -184,6 +186,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases['line 117 - deprecated in PHP 8.4'] = [117];
         $cases['line 118 - deprecated in PHP 8.4'] = [118];
         $cases['line 123 - deprecated in PHP 8.4'] = [123];
+        $cases['line 141 - deprecated in PHP 8.4'] = [141];
 
         // Add parse error test case.
         $cases['line 139 - parse error'] = [139];
@@ -221,6 +224,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $data[] = [71, self::PHP81_MSG];
         $data[] = [75, self::PHP81_MSG];
         $data[] = [125, self::PHP81_MSG];
+        $data[] = [140, self::PHP81_MSG];
         return $data;
     }
 
@@ -253,7 +257,8 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         unset(
             $cases['line 71 - deprecated in PHP 8.1'],
             $cases['line 75 - deprecated in PHP 8.1'],
-            $cases['line 125 - deprecated in PHP 8.1']
+            $cases['line 125 - deprecated in PHP 8.1'],
+            $cases['line 140 - deprecated in PHP 8.1']
         );
 
         return $cases;
@@ -376,6 +381,7 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $data[] = [117, self::PHP84_MSG];
         $data[] = [118, self::PHP84_MSG];
         $data[] = [123, self::PHP84_MSG];
+        $data[] = [141, self::PHP84_MSG];
         return $data;
     }
 
@@ -413,7 +419,8 @@ class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
             $cases['line 116 - deprecated in PHP 8.4'],
             $cases['line 117 - deprecated in PHP 8.4'],
             $cases['line 118 - deprecated in PHP 8.4'],
-            $cases['line 123 - deprecated in PHP 8.4']
+            $cases['line 123 - deprecated in PHP 8.4'],
+            $cases['line 141 - deprecated in PHP 8.4']
         );
 
         return $cases;


### PR DESCRIPTION
### FunctionDeclarations/RemovedOptionalBeforeRequiredParam: bug fix - allow for uppercase mixed in type

Uppercase `null` was already handled correctly, but uppercase `mixed` was not.

Fixed now.

Includes tests for both.

### FunctionDeclarations/RemovedOptionalBeforeRequiredParam: bug fix - allow for FQN `null` in default value

Not commonly used, but it is valid PHP.

Note: FQN `null` in a type declaration is not allowed and therefor not accounted for.

Includes tests.