### PR TITLE
Syntax/RemovedCurlyBraceArrayAccess: bug fix - detect curly brace access on namespaced constants

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -10,7 +10,6 @@
 
 namespace PHPCompatibility\Sniffs\Syntax;
 
-use PHPCompatibility\Helpers\MiscHelper;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCompatibility\Sniffs\Syntax\NewArrayStringDereferencingSniff;
@@ -319,12 +318,6 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
         $tokens       = $phpcsFile->getTokens();
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
-        if (MiscHelper::isUseOfGlobalConstant($phpcsFile, $stackPtr) === false
-            && $tokens[$prevNonEmpty]['code'] !== \T_DOUBLE_COLON // Class constant access.
-        ) {
-            return [];
-        }
-
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             return [];
@@ -363,7 +356,7 @@ class RemovedCurlyBraceArrayAccessSniff extends Sniff
 
                 $braces[$current] = $tokens[$current]['bracket_closer'];
 
-                // Continue, just in case there is nested access using curly braces, i.e. `$a{$i}{$j};`.
+                // Continue, just in case there is nested access using curly braces, i.e. `FOO[$a]{$i}{$j};`.
                 $current = $tokens[$current]['bracket_closer'];
                 continue;
             }

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc
@@ -135,5 +135,18 @@ echo $foo->bar()->baz(){0}[2];
 // No false negative with PHP 8.0 nullsafe object operator and curlies.
 echo $obj?->array_num{1}, PHP_EOL;
 
+// Safeguard against false negatives on dereferencing namespaced constants and function calls.
+namespace\FOO[1]{0};
+\Fully\Qualified\FOO[1]{0};
+Partially\Qualified\FOO[1]{0};
+
+namespace\ClassName::FOO[1]{0};
+\Fully\Qualified\ClassName::FOO[1]{0};
+Partially\Qualified\ClassName::FOO[1]{0};
+
+namespace\callMe(){0};
+\Fully\Qualified\callMe($input){0};
+Partially\Qualified\callMe($a, $b){0};
+
 /* Live coding. Intentional parse error. This has to be the last test in the file. */
 $a = $b[0] + $c['something']{

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
@@ -135,5 +135,18 @@ echo $foo->bar()->baz()[0][2];
 // No false positive with PHP 8.0 nullsafe object operator and curlies.
 echo $obj?->array_num[1], PHP_EOL;
 
+// Safeguard against false negatives on dereferencing namespaced constants and function calls.
+namespace\FOO[1][0];
+\Fully\Qualified\FOO[1][0];
+Partially\Qualified\FOO[1][0];
+
+namespace\ClassName::FOO[1][0];
+\Fully\Qualified\ClassName::FOO[1][0];
+Partially\Qualified\ClassName::FOO[1][0];
+
+namespace\callMe()[0];
+\Fully\Qualified\callMe($input)[0];
+Partially\Qualified\callMe($a, $b)[0];
+
 /* Live coding. Intentional parse error. This has to be the last test in the file. */
 $a = $b[0] + $c['something']{

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
@@ -97,6 +97,15 @@ class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTestCase
             [132],
             [133],
             [136],
+            [139],
+            [140],
+            [141],
+            [143],
+            [144],
+            [145],
+            [147],
+            [148],
+            [149],
         ];
     }
 
@@ -116,7 +125,7 @@ class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTestCase
         }
 
         // ...and on the last few lines.
-        for ($line = 137; $line <= 140; $line++) {
+        for ($line = 150; $line <= 153; $line++) {
             $this->assertNoViolation($file, $line);
         }
     }


### PR DESCRIPTION
Most "namespaced name" syntaxes this sniff is listening for were correctly handled already, but curly brace array access on a namespaced constant was not.

Fixed now.

Includes tests for this specific issue and additional tests to safeguard the other "namespaced name" syntaxes.