### PR TITLE
FunctionUse/ArgumentFunctionsUsage: various improvements

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -15,6 +15,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\MessageHelper;
 
 /**
@@ -112,7 +113,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
          * As PHPCS can not determine whether a file is included from within a function in
          * another file, so always throw a warning/error.
          */
-        if ($phpcsFile->hasCondition($stackPtr, [\T_FUNCTION, \T_CLOSURE]) === false) {
+        if (Conditions::hasCondition($phpcsFile, $stackPtr, Collections::functionDeclarationTokens()) === false) {
             $isError = false;
             $message = 'Use of %s() outside of a user-defined function is only supported if the file is included from within a user-defined function in another file prior to PHP 5.3.';
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -17,6 +17,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\MessageHelper;
+use PHPCSUtils\Utils\Parentheses;
 
 /**
  * Detect usage of `func_get_args()`, `func_get_arg()` and `func_num_args()` in invalid context.
@@ -132,14 +133,17 @@ class ArgumentFunctionsUsageSniff extends Sniff
             return;
         }
 
-        if (isset($tokens[$stackPtr]['nested_parenthesis']) === false) {
+        $opener = Parentheses::getLastOpener($phpcsFile, $stackPtr);
+        if ($opener === false
+            || isset($tokens[$opener]['parenthesis_owner']) === true
+        ) {
+            // Not nested in parentheses at all or nested in "owned" parentheses, which are never function calls.
             return;
         }
 
-        $closer       = \end($tokens[$stackPtr]['nested_parenthesis']);
-        $opener       = \key($tokens[$stackPtr]['nested_parenthesis']);
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
         if ($tokens[$prevNonEmpty]['code'] !== \T_STRING) {
+            // Not nested in a function call.
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -84,7 +84,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
         }
 
         // Next non-empty token should be the open parenthesis.
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -137,7 +137,7 @@ class ArgumentFunctionsUsageSniff extends Sniff
         /*
          * Check for use of the functions in the global scope.
          *
-         * As PHPCS can not determine whether a file is included from within a function in
+         * PHPCS can not determine whether a file is included from within a function in
          * another file, so always throw a warning/error.
          */
         if (Conditions::hasCondition($phpcsFile, $stackPtr, Collections::functionDeclarationTokens()) === false) {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -87,13 +87,15 @@ class ArgumentFunctionsUsageSniff extends Sniff
 
         // Next non-empty token should be the open parenthesis.
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
+        if ($nextNonEmpty === false
+            || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
+            || isset($tokens[$nextNonEmpty]['parenthesis_owner'])
+        ) {
             return;
         }
 
         $ignore  = [
-            \T_FUNCTION => true,
-            \T_NEW      => true,
+            \T_NEW => true,
         ];
         $ignore += Collections::objectOperators();
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -16,6 +16,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
+use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\Parentheses;
 
@@ -104,6 +105,11 @@ class ArgumentFunctionsUsageSniff extends Sniff
             || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
             || isset($tokens[$nextNonEmpty]['parenthesis_owner'])
         ) {
+            return;
+        }
+
+        if (Context::inAttribute($phpcsFile, $stackPtr) === true) {
+            // Class instantiation in attribute, not function call.
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -62,7 +62,11 @@ class ArgumentFunctionsUsageSniff extends Sniff
      */
     public function register()
     {
-        return [\T_STRING];
+        return [
+            \T_STRING,
+            // Only registering arrow functions to allow for skipping over them.
+            \T_FN,
+        ];
     }
 
 
@@ -75,11 +79,20 @@ class ArgumentFunctionsUsageSniff extends Sniff
      * @param int                         $stackPtr  The position of the current token in the
      *                                               stack passed in $tokens.
      *
-     * @return void
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens     = $phpcsFile->getTokens();
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === \T_FN
+            && isset($tokens[$stackPtr]['scope_closer'])
+        ) {
+            // Skip over everything within an arrow function.
+            return $tokens[$stackPtr]['scope_closer'];
+        }
+
         $functionLc = \strtolower($tokens[$stackPtr]['content']);
         if (isset($this->targetFunctions[$functionLc]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -135,29 +135,10 @@ class ArgumentFunctionsUsageSniff extends Sniff
             return;
         }
 
-        $throwError = false;
-
-        $closer = \end($tokens[$stackPtr]['nested_parenthesis']);
-        if (isset($tokens[$closer]['parenthesis_owner'])
-            && $tokens[$tokens[$closer]['parenthesis_owner']]['code'] === \T_CLOSURE
-        ) {
-            $throwError = true;
-        } else {
-            $opener       = \key($tokens[$stackPtr]['nested_parenthesis']);
-            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
-            if ($tokens[$prevNonEmpty]['code'] !== \T_STRING) {
-                return;
-            }
-
-            $prevPrevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
-            if ($tokens[$prevPrevNonEmpty]['code'] === \T_FUNCTION) {
-                return;
-            }
-
-            $throwError = true;
-        }
-
-        if ($throwError === false) {
+        $closer       = \end($tokens[$stackPtr]['nested_parenthesis']);
+        $opener       = \key($tokens[$stackPtr]['nested_parenthesis']);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
+        if ($tokens[$prevNonEmpty]['code'] !== \T_STRING) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -101,9 +101,14 @@ class ArgumentFunctionsUsageSniff extends Sniff
         if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
             // Not a call to a PHP function.
             return;
-        } elseif ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR && $tokens[$prevNonEmpty - 1]['code'] === \T_STRING) {
-            // Namespaced function.
-            return;
+        } elseif ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
+            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+            if ($tokens[$prevPrevToken]['code'] === \T_STRING
+                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
+            ) {
+                // Namespaced function.
+                return;
+            }
         }
 
         $data = [$tokens[$stackPtr]['content']];

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
@@ -28,7 +28,7 @@ function preventFalsePositivesForNonNestedAndNonGlobalFunctionCall($a, $b) {
 
     $d = Baz(Bar::func_get_args());
     $e = Baz($object->func_get_args());
-    $f = Baz(\Bar\func_get_args());
+    $f = Baz(\Fully\Qualified\func_get_args());
     $g = Baz( new Func_Get_Args());
     $h = Baz($obj?->func_num_args());
 
@@ -47,7 +47,7 @@ if ( \func_num_args() > 0 &&  baz( func_num_args() ) ) {} // x 2 (+ 1 x use in p
 // Test against false positives.
 $d = Baz(Bar::func_get_args());
 $e = Baz($object->func_get_args());
-$f = Baz(\Bar\func_get_args());
+$f = Baz(\Fully\Qualified\func_get_args());
 $g = Baz($obj?->func_num_args());
 $h = Baz($object->func_get_args); // Property access.
 $i = Baz(Bar::FUNC_NUM_ARGS); // Constant access
@@ -55,4 +55,13 @@ $i = Baz(Bar::FUNC_NUM_ARGS); // Constant access
 function codeInParenthesesButNotInFunctionCall($a, $b) {
     $arbitraryParentheses1 = (func_get_args());
     $arbitraryParentheses2 = ($array + \func_get_args());
+}
+
+// More tests against false positives for namespaced function calls.
+$j = Baz(Partially\Qualified\func_get_args());
+$k = Baz(namespace\Foo\func_get_arg(1));
+
+function namespacedFunctionCalls() {
+    $a = Baz(Partially\Qualified\func_get_args());
+    $b = Baz(namespace\Foo\func_get_args());
 }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
@@ -9,14 +9,14 @@ function detect($a, $b) {
 }
 
 $closure = function ( $param ) {
-    echo $this->Foo(FUNC_GET_ARGS());
+    echo $this->Foo(FUNC_GET_ARGS(),);
 };
 
 class ABC {
     public function foo($a, $b) {
         echo MyNS\Bar(func_get_arg(1));
         if ( Func_Num_Args() > 0 &&  self::baz( \func_num_args() ) ) {}
-        $b = new MyClass(func_get_args());
+        $b = new MyClass(func_get_args(),);
     }
 }
 
@@ -30,7 +30,7 @@ function preventFalsePositivesForNonNestedAndNonGlobalFunctionCall($a, $b) {
     $e = Baz($object->func_get_args());
     $f = Baz(\Fully\Qualified\func_get_args());
     $g = Baz( new Func_Get_Args());
-    $h = Baz($obj?->func_num_args());
+    $h = Baz($obj?->func_num_args(),);
 
     if ( !function_exists('func_get_args')) {
         function func_get_args() {}
@@ -42,7 +42,7 @@ function preventFalsePositivesForNonNestedAndNonGlobalFunctionCall($a, $b) {
  */
 $a = func_get_args();
 echo Bar(func_get_arg(1));
-if ( \func_num_args() > 0 &&  baz( func_num_args() ) ) {} // x 2 (+ 1 x use in param list) .
+if ( \func_num_args() > 0 &&  baz( func_num_args(), ) ) {} // x 2 (+ 1 x use in param list) .
 
 // Test against false positives.
 $d = Baz(Bar::func_get_args());
@@ -59,7 +59,7 @@ function codeInParenthesesButNotInFunctionCall($a, $b) {
 
 // More tests against false positives for namespaced function calls.
 $j = Baz(Partially\Qualified\func_get_args());
-$k = Baz(namespace\Foo\func_get_arg(1));
+$k = Baz(namespace\Foo\func_get_arg(1),);
 
 function namespacedFunctionCalls() {
     $a = Baz(Partially\Qualified\func_get_args());

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
@@ -3,27 +3,27 @@
 /*
  * Test pre-PHP 5.3: these functions could not be used in parameter lists.
  */
-function Foo() {
-    echo Foo(func_get_args());
+function detect($a, $b) {
+    echo array_map('trim', func_get_args());
     $closure = function( \func_get_args() ) {}; // Parse error, but not our concern.
 }
 
 $closure = function ( $param ) {
-    echo $this->Foo(func_get_args());
+    echo $this->Foo(FUNC_GET_ARGS());
 };
 
 class ABC {
-    public function foo() {
+    public function foo($a, $b) {
         echo MyNS\Bar(func_get_arg(1));
-        if ( func_num_args() > 0 &&  self::baz( \func_num_args() ) ) {}
+        if ( Func_Num_Args() > 0 &&  self::baz( \func_num_args() ) ) {}
         $b = new MyClass(func_get_args());
     }
 }
 
 // Test against false positives.
-function Foo() {
+function preventFalsePositivesForNonNestedAndNonGlobalFunctionCall($a, $b) {
     $a = func_get_args();
-    echo func_get_arg(1);
+    echo \func_get_arg(1);
     if ( func_num_args() > 0 ) {}
 
     $d = Baz(Bar::func_get_args());

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
@@ -73,3 +73,7 @@ class ReturnByRef {
 // Safeguard handling of PHP 7.4+ arrow functions.
 $arrow = fn($a, $b): array => func_get_args(); // OK, usage not in global scope.
 $arrow = fn($a, $b) => nested(\func_get_args()); // Even though nested, ignore as arrow functions can't be used with PHP < 5.3 anyway.
+
+// Ensure there are no false positives for PHP 8.0+ attributes with the same name.
+#[Func_get_args(), Func_Num_Args()]
+function hasAttribute() {}

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
@@ -5,7 +5,7 @@
  */
 function detect($a, $b) {
     echo array_map('trim', func_get_args());
-    $closure = function( \func_get_args() ) {}; // Parse error, but not our concern.
+    $closure = function($a, $b) { \nested(\func_get_args()) };
 }
 
 $closure = function ( $param ) {

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
@@ -65,3 +65,7 @@ function namespacedFunctionCalls() {
     $a = Baz(Partially\Qualified\func_get_args());
     $b = Baz(namespace\Foo\func_get_args());
 }
+
+class ReturnByRef {
+    public function &func_get_args() {}
+}

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
@@ -4,20 +4,20 @@
  * Test pre-PHP 5.3: these functions could not be used in parameter lists.
  */
 function Foo() {
-	echo Foo(func_get_args());
-	$closure = function( \func_get_args() ) {}; // Parse error, but not our concern.
+    echo Foo(func_get_args());
+    $closure = function( \func_get_args() ) {}; // Parse error, but not our concern.
 }
 
 $closure = function ( $param ) {
-	echo $this->Foo(func_get_args());
+    echo $this->Foo(func_get_args());
 };
 
 class ABC {
-	public function foo() {
-		echo MyNS\Bar(func_get_arg(1));
-		if ( func_num_args() > 0 &&  self::baz( \func_num_args() ) ) {}
-		$b = new MyClass(func_get_args());
-	}
+    public function foo() {
+        echo MyNS\Bar(func_get_arg(1));
+        if ( func_num_args() > 0 &&  self::baz( \func_num_args() ) ) {}
+        $b = new MyClass(func_get_args());
+    }
 }
 
 // Test against false positives.
@@ -26,15 +26,15 @@ function Foo() {
     echo func_get_arg(1);
     if ( func_num_args() > 0 ) {}
 
-	$d = Baz(Bar::func_get_args());
-	$e = Baz($object->func_get_args());
-	$f = Baz(\Bar\func_get_args());
-	$g = Baz( new Func_Get_Args());
-	$h = Baz($obj?->func_num_args());
+    $d = Baz(Bar::func_get_args());
+    $e = Baz($object->func_get_args());
+    $f = Baz(\Bar\func_get_args());
+    $g = Baz( new Func_Get_Args());
+    $h = Baz($obj?->func_num_args());
 
-	if ( !function_exists('func_get_args')) {
-		function func_get_args() {}
-	}
+    if ( !function_exists('func_get_args')) {
+        function func_get_args() {}
+    }
 }
 
 /*

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
@@ -69,3 +69,7 @@ function namespacedFunctionCalls() {
 class ReturnByRef {
     public function &func_get_args() {}
 }
+
+// Safeguard handling of PHP 7.4+ arrow functions.
+$arrow = fn($a, $b): array => func_get_args(); // OK, usage not in global scope.
+$arrow = fn($a, $b) => nested(\func_get_args()); // Even though nested, ignore as arrow functions can't be used with PHP < 5.3 anyway.

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.inc
@@ -49,3 +49,10 @@ $d = Baz(Bar::func_get_args());
 $e = Baz($object->func_get_args());
 $f = Baz(\Bar\func_get_args());
 $g = Baz($obj?->func_num_args());
+$h = Baz($object->func_get_args); // Property access.
+$i = Baz(Bar::FUNC_NUM_ARGS); // Constant access
+
+function codeInParenthesesButNotInFunctionCall($a, $b) {
+    $arbitraryParentheses1 = (func_get_args());
+    $arbitraryParentheses2 = ($array + \func_get_args());
+}

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -103,7 +103,7 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
 
         $data[] = [70];
 
-        for ($line = 73; $line <= 75; $line++) {
+        for ($line = 73; $line <= 79; $line++) {
             $data[] = [$line];
         }
 

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -101,6 +101,8 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        $data[] = [70];
+
         return $data;
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -103,6 +103,10 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
 
         $data[] = [70];
 
+        for ($line = 73; $line <= 75; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -26,7 +26,7 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
 {
 
     /**
-     * testArgumentFunctionsUseAsParameter
+     * Test that use of the functions nested within a function call is correctly detected.
      *
      * @dataProvider dataArgumentFunctionsUseAsParameter
      *
@@ -44,7 +44,7 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * Data provider dataArgumentFunctionsUseAsParameter.
+     * Data provider.
      *
      * @see testArgumentFunctionsUseAsParameter()
      *
@@ -64,7 +64,7 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
 
 
     /**
-     * testNoFalsePositivesUseAsParameter
+     * Test that there are no false positives for the "nested in function call" check.
      *
      * @dataProvider dataNoFalsePositivesUseAsParameter
      *
@@ -112,7 +112,7 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
 
 
     /**
-     * testArgumentFunctionsUseOutsideFunctionScope
+     * Test that use of the functions in the global scope is correctly detected.
      *
      * @dataProvider dataArgumentFunctionsUseOutsideFunctionScope
      *
@@ -130,7 +130,7 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * Data provider dataArgumentFunctionsUseOutsideFunctionScope.
+     * Data provider.
      *
      * @see testArgumentFunctionsUseOutsideFunctionScope()
      *
@@ -147,7 +147,7 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
 
 
     /**
-     * testNoFalsePositivesUseOutsideFunctionScope
+     * Test that there are no false positives for the "usage in global scope" check.
      *
      * @dataProvider dataNoFalsePositivesUseOutsideFunctionScope
      *

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -87,17 +87,17 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
      */
     public static function dataNoFalsePositivesUseAsParameter()
     {
-        return [
-            [25],
-            [26],
-            [27],
-            [29],
-            [30],
-            [31],
-            [32],
-            [33],
-            [36],
-        ];
+        $data = [];
+
+        for ($line = 24; $line <= 38; $line++) {
+            $data[] = [$line];
+        }
+
+        for ($line = 55; $line <= 58; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 
@@ -160,12 +160,14 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
      */
     public static function dataNoFalsePositivesUseOutsideFunctionScope()
     {
-        return [
-            [48],
-            [49],
-            [50],
-            [51],
-        ];
+        $data = self::dataNoFalsePositivesUseAsParameter();
+
+        // Tests specific for this error.
+        for ($line = 47; $line <= 53; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsUsageUnitTest.php
@@ -97,6 +97,10 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        for ($line = 64; $line <= 67; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 
@@ -164,6 +168,10 @@ class ArgumentFunctionsUsageUnitTest extends BaseSniffTestCase
 
         // Tests specific for this error.
         for ($line = 47; $line <= 53; $line++) {
+            $data[] = [$line];
+        }
+
+        for ($line = 60; $line <= 62; $line++) {
             $data[] = [$line];
         }
 


### PR DESCRIPTION
### FunctionUse/ArgumentFunctionsUsage: test case file - tabs vs spaces

### FunctionUse/ArgumentFunctionsUsage: minor improvements to the tests 

* Actually have parameters in the function signatures, so func_get_arg() et al would actually do something.
* Use unique function names and make these more descriptive for what is being tested by the code within.
* Have more variation in case for the function calls.
* Make sure the code actually triggers an error in PHP < 5.3 (for some cases).

### FunctionUse/ArgumentFunctionsUsage: add some extra tests 

... for code in the sniff previously uncovered.

Includes making the false positive data providers more robust.

### FunctionUse/ArgumentFunctionsUsage: remove silly parse error test 

... and some code in the sniff which was specifically related to that parse error and similar ones.

As a rule of thumb, we shouldn't concern ourselves with invalid code and a function call is not allowed within the signature of a function declaration.

### FunctionUse/ArgumentFunctionsUsage: remove unnecessary parameters 

No need to limit the `findNext()` to the current statement when checking for the next non-empty.

### FunctionUse/ArgumentFunctionsUsage: further implementation of PHPCSUtils [1]

### FunctionUse/ArgumentFunctionsUsage: further implementation of PHPCSUtils [2]

### FunctionUse/ArgumentFunctionsUsage: bug fix - false positives on namespace relative function calls

Includes tests.

### FunctionUse/ArgumentFunctionsUsage: bug fix - false positive for method declared to return by reference

Includes test.

### FunctionUse/ArgumentFunctionsUsage: update tests for PHP 7.3+ trailing commas in function calls

Already handled correctly, just safeguarding.

### FunctionUse/ArgumentFunctionsUsage: minor doc improvements

### FunctionUse/ArgumentFunctionsUsage: ignore contents of PHP 7.4+ arrow functions

Arrow functions scopes aren't added to the `conditions` array for tokens within the scope.

This would lead to false positives for this sniff as the "body" of an arrow function should not be regarded as _global_ scope, but was.

Fixed now by skipping over the complete arrow function.

While this means the "call to %s nested in function call" error will also not be thrown, I don't see this as problematic as that error is related to behaviour which is allowed since PHP 5.3 and arrow functions did not exist until PHP 7.4, so the "nested in function call" issue would never be a problem when found in the body of an arrow function anyway.

Includes tests.

### FunctionUse/ArgumentFunctionsUsage: prevent false positives on PHP 8.0+ attributes

`T_STRING` tokens in PHP 8.0+ attributes are either class names or possibly constant names (as a parameter for the class instantiation).
They are never function calls.

This commit ensures that `T_STRING` tokens in attributes are not confused with function calls.