### PR TITLE
FunctionUse/ArgumentFunctionsReportCurrentValue: various improvements

### DIFF
--- a/PHPCompatibility/Helpers/TokenGroup.php
+++ b/PHPCompatibility/Helpers/TokenGroup.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Helpers;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\Numbers;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -175,7 +176,8 @@ final class TokenGroup
         if ($tokens[$nextNonEmpty]['code'] === \T_LNUMBER
             || $tokens[$nextNonEmpty]['code'] === \T_DNUMBER
         ) {
-            $content = (float) $tokens[$nextNonEmpty]['content'];
+            $numberInfo = Numbers::getCompleteNumber($phpcsFile, $nextNonEmpty);
+            $content    = (float) $numberInfo['decimal'];
         } elseif ($tokens[$nextNonEmpty]['code'] === \T_TRUE) {
             $content = 1.0;
         } elseif ($tokens[$nextNonEmpty]['code'] === \T_FALSE

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -55,18 +55,6 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
     ];
 
     /**
-     * The tokens for variable incrementing/decrementing.
-     *
-     * @since 9.1.0
-     *
-     * @var array<int|string, true>
-     */
-    private $plusPlusMinusMinus = [
-        \T_DEC => true,
-        \T_INC => true,
-    ];
-
-    /**
      * Tokens to ignore when determining the start of a statement for call to one of the functions.
      *
      * @since 9.1.0
@@ -428,7 +416,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     $variableToken = $j;
                 }
 
-                if ($beforeVar !== false && isset($this->plusPlusMinusMinus[$tokens[$beforeVar]['code']])) {
+                if ($beforeVar !== false && isset(Collections::incrementDecrementOperators()[$tokens[$beforeVar]['code']])) {
                     // Variable is being (pre-)incremented/decremented.
                     $scanResult    = 'error';
                     $variableToken = $j;
@@ -441,7 +429,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     continue; // @codeCoverageIgnore
                 }
 
-                if (isset($this->plusPlusMinusMinus[$tokens[$afterVar]['code']])) {
+                if (isset(Collections::incrementDecrementOperators()[$tokens[$afterVar]['code']])) {
                     // Variable is being (post-)incremented/decremented.
                     $scanResult    = 'error';
                     $variableToken = $j;

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -618,6 +618,11 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
      */
     private function isCallToGlobalFunction(File $phpcsFile, $stackPtr)
     {
+        if (Context::inAttribute($phpcsFile, $stackPtr) === true) {
+            // Class instantiation in attribute, not function call.
+            return false;
+        }
+
         $tokens       = $phpcsFile->getTokens();
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -518,6 +518,16 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     continue;
                 }
 
+                // Check for $obj::class, which can be safely ignored.
+                if ($tokens[$afterVar]['code'] === \T_DOUBLE_COLON) {
+                    $nextAfterAfterVar = $phpcsFile->findNext(Tokens::$emptyTokens, ($afterVar + 1), null, true);
+                    if ($tokens[$nextAfterAfterVar]['code'] === \T_STRING
+                        && \strtolower($tokens[$nextAfterAfterVar]['content']) === 'class'
+                    ) {
+                        continue;
+                    }
+                }
+
                 /*
                  * Ok, so we've found a variable which was passed as one of the parameters.
                  * Now, is this variable being changed, i.e. incremented, decremented, unset

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -193,7 +193,10 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                          */
                         case 'debug_backtrace':
                         case 'debug_print_backtrace':
-                            if (\preg_match('`(^|\|)\s*\\\\?DEBUG_BACKTRACE_IGNORE_ARGS`', $paramOne['clean']) === 1) {
+                            if (\preg_match('`(^|\|)\s*\\\\?DEBUG_BACKTRACE_IGNORE_ARGS`', $paramOne['clean']) === 1
+                                || $paramOne['clean'] === '2'
+                                || $paramOne['clean'] === '3'
+                            ) {
                                 // Debug_backtrace() called with ignore args option.
                                 continue 2;
                             }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -146,7 +146,9 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
             $i < $scopeCloser;
             $prevNonEmpty = (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) ? $prevNonEmpty : $i), $i++
         ) {
-            if (isset(Collections::closedScopes()[$tokens[$i]['code']]) && isset($tokens[$i]['scope_closer'])) {
+            if ((isset(Collections::closedScopes()[$tokens[$i]['code']]) || $tokens[$i]['code'] === \T_FN)
+                && isset($tokens[$i]['scope_closer'])
+            ) {
                 // Skip past nested structures.
                 $i = $tokens[$i]['scope_closer'];
                 continue;

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -179,6 +179,29 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
             }
 
             /*
+             * Check if the function is used as a PHP 8.1+ first class callable.
+             *
+             * Not allowed by PHP for the func_get_arg*() functions, so ignore.
+             * Allowed for the debug_*backtrace() functions, but please don't do this....
+             */
+            if (isset($tokens[$next]['parenthesis_closer'])) {
+                $hasEllipsis = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+                if ($hasEllipsis !== false && $tokens[$hasEllipsis]['code'] === \T_ELLIPSIS) {
+                    $isFirstClassCallable = $phpcsFile->findNext(Tokens::$emptyTokens, ($hasEllipsis + 1), null, true);
+                    if ($isFirstClassCallable !== false && $isFirstClassCallable === $tokens[$next]['parenthesis_closer']) {
+                        if ($foundFunctionName === 'debug_backtrace' || $foundFunctionName === 'debug_print_backtrace') {
+                            $error = 'Since PHP 7.0, functions inspecting arguments, like %1$s(), no longer report the original value as passed to a parameter, but will instead provide the current value. Using this function as a first class callable is a really bad idea.';
+                            $data  = [$foundFunctionName];
+
+                            $phpcsFile->addWarning($error, $i, 'AsFirstClassCallable', $data);
+                        }
+
+                        continue;
+                    }
+                }
+            }
+
+            /*
              * Address some special cases.
              */
             if ($foundFunctionName !== 'func_get_args') {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\FunctionUse;
 
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\TokenGroup;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
@@ -237,20 +238,21 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                         if ($functionNameLc === 'array_slice'
                             || $functionNameLc === 'array_splice'
                         ) {
-                            $parentFuncParamTwo = PassedParameters::getParameter($phpcsFile, $maybeFunctionCall, 2);
-                            $number             = $phpcsFile->findNext(
-                                \T_LNUMBER,
-                                $parentFuncParamTwo['start'],
-                                ($parentFuncParamTwo['end'] + 1)
-                            );
+                            $parentFuncOffsetParam = PassedParameters::getParameter($phpcsFile, $maybeFunctionCall, 2, 'offset');
+                            if ($parentFuncOffsetParam !== false) {
+                                $offsetValue = TokenGroup::isNumber($phpcsFile, $parentFuncOffsetParam['start'], $parentFuncOffsetParam['end']);
 
-                            if ($number !== false && isset($paramNames[$tokens[$number]['content']]) === false) {
-                                // Requesting non-named additional parameters. Ignore.
-                                continue ;
+                                if (\is_int($offsetValue)) {
+                                    $normalizedOffsetValue = ($offsetValue >= 0) ? $offsetValue : (\count($paramNames) + $offsetValue);
+                                    if (isset($paramNames[$normalizedOffsetValue]) === false) {
+                                        // Requesting non-named additional parameters. Ignore.
+                                        continue ;
+                                    }
+
+                                    // Slice starts at a named argument, but we know which params are being accessed.
+                                    $paramNamesSubset = \array_slice($paramNames, $offsetValue);
+                                }
                             }
-
-                            // Slice starts at a named argument, but we know which params are being accessed.
-                            $paramNamesSubset = \array_slice($paramNames, $tokens[$number]['content']);
                         }
                     }
                 }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -249,8 +249,17 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                                         continue ;
                                     }
 
+                                    $targetLength          = null;
+                                    $parentFuncLengthParam = PassedParameters::getParameter($phpcsFile, $maybeFunctionCall, 3, 'length');
+                                    if ($parentFuncLengthParam !== false) {
+                                        $lengthValue = TokenGroup::isNumber($phpcsFile, $parentFuncLengthParam['start'], $parentFuncLengthParam['end']);
+                                        if (\is_int($lengthValue) && $lengthValue !== 0) {
+                                            $targetLength = $lengthValue;
+                                        }
+                                    }
+
                                     // Slice starts at a named argument, but we know which params are being accessed.
-                                    $paramNamesSubset = \array_slice($paramNames, $offsetValue);
+                                    $paramNamesSubset = \array_slice($paramNames, $offsetValue, $targetLength);
                                 }
                             }
                         }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -311,7 +311,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
              * Ok, so we've found one of the target functions in the right scope.
              * Now, let's check if any of the passed parameters were touched.
              */
-            $scanResult = 'clean';
+            $scanResult    = 'clean';
+            $variableToken = null;
             for ($j = ($scopeOpener + 1); $j < $startOfStatement; $j++) {
                 if (isset(Collections::closedScopes()[$tokens[$j]['code']])
                     && isset($tokens[$j]['scope_closer'])

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -18,6 +18,7 @@ use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\Operators;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
@@ -313,6 +314,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
              */
             $scanResult    = 'clean';
             $variableToken = null;
+            $listsSeen     = [];
             for ($j = ($scopeOpener + 1); $j < $startOfStatement; $j++) {
                 if (isset(Collections::closedScopes()[$tokens[$j]['code']])
                     && isset($tokens[$j]['scope_closer'])
@@ -344,6 +346,16 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     }
                 }
 
+                // Keep track of the long/short lists structures seen.
+                if (isset(Collections::listOpenTokensBC()[$tokens[$j]['code']])) {
+                    $listOpenClose = Lists::getOpenClose($phpcsFile, $j);
+                    if ($listOpenClose !== false) {
+                        // Store in reverse order so we always have the last seen list first.
+                        $listOpenClose['list_token'] = $j;
+                        \array_unshift($listsSeen, $listOpenClose);
+                    }
+                }
+
                 if ($tokens[$j]['code'] !== \T_VARIABLE) {
                     continue;
                 }
@@ -365,6 +377,42 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     continue;
                 }
 
+                /*
+                 * Check if this is a variable in a list structure.
+                 *
+                 * For variables in a list, we need to:
+                 * - Flag assignments.
+                 * - Ignore list keys.
+                 */
+                if ($listsSeen !== []) {
+                    foreach ($listsSeen as $openClose) {
+                        if ($openClose['opener'] < $j && $j < $openClose['closer']) {
+                            $listInfo = Lists::getAssignments($phpcsFile, $openClose['list_token']);
+                            foreach ($listInfo as $listItem) {
+                                if ($listItem['is_empty'] === false
+                                    && $listItem['is_nested_list'] === false
+                                ) {
+                                    if ($listItem['assignment_token'] === $j) {
+                                        // We found a definite assignment within a list.
+                                        $scanResult    = 'error';
+                                        $variableToken = $j;
+                                        break 3;
+                                    }
+
+                                    if (isset($listItem['key_token'], $listItem['key_end_token'])
+                                        && $listItem['key_token'] <= $j && $j <= $listItem['key_end_token']
+                                    ) {
+                                        // The variable is used in the key for a list. We can safely disregard it.
+                                        continue 3;
+                                    }
+                                }
+                            }
+
+                            break;
+                        }
+                    }
+                }
+
                 $beforeVar                = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($j - 1), null, true);
                 $startOfVariableStatement = BCFile::findStartOfStatement(
                     $phpcsFile,
@@ -379,20 +427,38 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                  * - Variable is not nested in parenthesis, i.e. not used in a potential function call.
                  * - Not preceded by a reference operator.
                  * - Has an assignment operator before it and none after.
+                 *
+                 * Additionally, we also check if this is a list assignment and if so, if there are no reference
+                 * assignments within the list.
+                 * If there are no references in the list, we can ignore this assignment as plain.
                  */
                 if (empty($tokens[$j]['nested_parenthesis']) === true
                     && $beforeVar !== false
                     && Operators::isReference($phpcsFile, $beforeVar) === false
-                    && $tokens[$startOfVariableStatement]['code'] === \T_VARIABLE
+                    && ($tokens[$startOfVariableStatement]['code'] === \T_VARIABLE
+                        || isset(Collections::listOpenTokensBC()[$tokens[$startOfVariableStatement]['code']]))
                 ) {
+                    // If this was a list assignment, we need to make sure there are no reference assignments.
+                    $listHasReferenceAssignment = false;
+                    if (isset(Collections::listOpenTokensBC()[$tokens[$startOfVariableStatement]['code']])) {
+                        foreach ($listsSeen as $openClose) {
+                            if ($openClose['list_token'] === $startOfVariableStatement) {
+                                $listHasReferenceAssignment = $this->doesListHaveReferenceAssignments($phpcsFile, $openClose['list_token']);
+                                break;
+                            }
+                        }
+                    }
+
                     $endOfVariableStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($j + 1));
                     $lastAssignmentOperator = $phpcsFile->findPrevious(
                         Tokens::$assignmentTokens,
                         ($endOfVariableStatement - 1),
                         $startOfVariableStatement
                     );
+
                     if ($lastAssignmentOperator !== false
                         && $lastAssignmentOperator < $j
+                        && $listHasReferenceAssignment === false
                     ) {
                         continue;
                     }
@@ -522,5 +588,33 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
         }
 
         return true;
+    }
+
+    /**
+     * Check if there are any reference assignments in a list structure.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the list token.
+     *
+     * @return bool
+     */
+    private function doesListHaveReferenceAssignments(File $phpcsFile, $stackPtr)
+    {
+        $listInfo = Lists::getAssignments($phpcsFile, $stackPtr);
+        foreach ($listInfo as $listItem) {
+            if ($listItem['assign_by_reference'] === true) {
+                return true;
+            }
+
+            if ($listItem['is_nested_list'] === true
+                && $this->doesListHaveReferenceAssignments($phpcsFile, $listItem['assignment_token']) === true
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -22,6 +22,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Lists;
 use PHPCSUtils\Utils\Numbers;
 use PHPCSUtils\Utils\Operators;
+use PHPCSUtils\Utils\Parentheses;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -477,6 +478,45 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 }
 
                 /*
+                 * Check if this variable is used in a control structure condition.
+                 *
+                 * For the purposes of this check, this type of usage is non-problematic if:
+                 * - The variable is the only thing in the control structure condition,
+                 *   so no analysis of more complex comparisons.
+                 * - If the control structure is a `foreach()`, the variable is used in the "before as" part.
+                 * - And we're going to ignore `for()` structures as too complex.
+                 */
+
+                $inForeach = Context::inForeachCondition($phpcsFile, $j);
+                if ($inForeach === 'beforeAs') {
+                    // Safe to ignore.
+                    continue;
+                } elseif ($inForeach === 'afterAs') {
+                    // We know this is an assignment, so throw an error.
+                    $scanResult    = 'error';
+                    $variableToken = $j;
+                    break;
+                }
+
+                if (Parentheses::getLastOwner($phpcsFile, $j, \T_CATCH) !== false) {
+                    // The only variable in a catch statement is the one being assigned to, so throw an error.
+                    $scanResult    = 'error';
+                    $variableToken = $j;
+                    break;
+                }
+
+                $afterVar              = $phpcsFile->findNext(Tokens::$emptyTokens, ($j + 1), null, true);
+                $lastParenthesesOpener = Parentheses::getLastOpener($phpcsFile, $j);
+                if ($lastParenthesesOpener !== false
+                    && isset($tokens[$lastParenthesesOpener]['parenthesis_closer']) === true
+                    && Parentheses::isOwnerIn($phpcsFile, $lastParenthesesOpener, Collections::controlStructureTokens())
+                    && $beforeVar === $lastParenthesesOpener
+                    && $afterVar === $tokens[$lastParenthesesOpener]['parenthesis_closer']
+                ) {
+                    continue;
+                }
+
+                /*
                  * Ok, so we've found a variable which was passed as one of the parameters.
                  * Now, is this variable being changed, i.e. incremented, decremented, unset
                  * or assigned something ?
@@ -493,7 +533,6 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     break;
                 }
 
-                $afterVar = $phpcsFile->findNext(Tokens::$emptyTokens, ($j + 1), null, true);
                 if ($afterVar === false) {
                     // Shouldn't be possible, but just in case.
                     continue; // @codeCoverageIgnore

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -182,36 +182,38 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
              * Address some special cases.
              */
             if ($foundFunctionName !== 'func_get_args') {
-                $paramOne = PassedParameters::getParameter($phpcsFile, $i, 1);
-                if ($paramOne !== false) {
-                    switch ($foundFunctionName) {
-                        /*
-                         * Check if `debug_(print_)backtrace()` is called with the
-                         * `DEBUG_BACKTRACE_IGNORE_ARGS` option.
-                         */
-                        case 'debug_backtrace':
-                        case 'debug_print_backtrace':
-                            if (\preg_match('`(^|\|)\s*\\\\?DEBUG_BACKTRACE_IGNORE_ARGS`', $paramOne['clean']) === 1
-                                || $paramOne['clean'] === '2'
-                                || $paramOne['clean'] === '3'
-                            ) {
-                                // Debug_backtrace() called with ignore args option.
-                                continue 2;
-                            }
-                            break;
+                switch ($foundFunctionName) {
+                    /*
+                     * Check if `debug_(print_)backtrace()` is called with the
+                     * `DEBUG_BACKTRACE_IGNORE_ARGS` option.
+                     */
+                    case 'debug_backtrace':
+                    case 'debug_print_backtrace':
+                        $optionsParam = PassedParameters::getParameter($phpcsFile, $i, 1, 'options');
+                        if ($optionsParam !== false
+                            && (\preg_match('`(^|\|)\s*\\\\?DEBUG_BACKTRACE_IGNORE_ARGS`', $optionsParam['clean']) === 1
+                                || $optionsParam['clean'] === '2'
+                                || $optionsParam['clean'] === '3')
+                        ) {
+                            // Debug_backtrace() called with ignore args option.
+                            continue 2;
+                        }
+                        break;
 
-                        /*
-                         * Collect the necessary information to only throw a notice if the argument
-                         * touched/changed is in line with the passed $arg_num.
-                         *
-                         * Also, we can ignore `func_get_arg()` if the argument offset passed is
-                         * higher than the number of named parameters.
-                         *
-                         * {@internal Note: This does not take calculations into account!
-                         *  Should be exceptionally rare and can - if needs be - be addressed at a later stage.}
-                         */
-                        case 'func_get_arg':
-                            $number = $phpcsFile->findNext(\T_LNUMBER, $paramOne['start'], ($paramOne['end'] + 1));
+                    /*
+                     * Collect the necessary information to only throw a notice if the argument
+                     * touched/changed is in line with the passed $arg_num.
+                     *
+                     * Also, we can ignore `func_get_arg()` if the argument offset passed is
+                     * higher than the number of named parameters.
+                     *
+                     * {@internal Note: This does not take calculations into account!
+                     *  Should be exceptionally rare and can - if needs be - be addressed at a later stage.}
+                     */
+                    case 'func_get_arg':
+                        $positionParam = PassedParameters::getParameter($phpcsFile, $i, 1, 'position');
+                        if ($positionParam !== false) {
+                            $number = $phpcsFile->findNext(\T_LNUMBER, $positionParam['start'], ($positionParam['end'] + 1));
                             if ($number !== false) {
                                 $argNumber = (int) Numbers::getCompleteNumber($phpcsFile, $number)['decimal'];
 
@@ -220,8 +222,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                                     continue 2;
                                 }
                             }
-                            break;
-                    }
+                        }
+                        break;
                 }
             } else {
                 /*
@@ -232,9 +234,10 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                  * {@internal Note: This does not take offset calculations into account!
                  *  Should be exceptionally rare and can - if needs be - be addressed at a later stage.}
                  */
-                if ($tokens[$prevNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
+                $lastParenthesesOpener = Parentheses::getLastOpener($phpcsFile, $i);
+                if ($lastParenthesesOpener !== false) {
 
-                    $maybeFunctionCall = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+                    $maybeFunctionCall = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($lastParenthesesOpener - 1), null, true);
                     if ($tokens[$maybeFunctionCall]['code'] === \T_STRING
                         && $this->isCallToGlobalFunction($phpcsFile, $maybeFunctionCall) === true
                     ) {
@@ -242,33 +245,40 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                         if ($functionNameLc === 'array_slice'
                             || $functionNameLc === 'array_splice'
                         ) {
-                            $parentFuncOffsetParam = PassedParameters::getParameter($phpcsFile, $maybeFunctionCall, 2, 'offset');
-                            if ($parentFuncOffsetParam !== false) {
-                                $offsetValue = TokenGroup::isNumber($phpcsFile, $parentFuncOffsetParam['start'], $parentFuncOffsetParam['end']);
+                            // Verify the `func_get_args()` was seen in the correct parameter for this check.
+                            $parentFuncArrayParam = PassedParameters::getParameter($phpcsFile, $maybeFunctionCall, 1, 'array');
+                            if ($parentFuncArrayParam !== false
+                                && $parentFuncArrayParam['start'] <= $i && $i <= $parentFuncArrayParam['end']
+                            ) {
+                                $parentFuncOffsetParam = PassedParameters::getParameter($phpcsFile, $maybeFunctionCall, 2, 'offset');
+                                if ($parentFuncOffsetParam !== false) {
+                                    $offsetValue = TokenGroup::isNumber($phpcsFile, $parentFuncOffsetParam['start'], $parentFuncOffsetParam['end']);
 
-                                if (\is_int($offsetValue)) {
-                                    $normalizedOffsetValue = ($offsetValue >= 0) ? $offsetValue : (\count($paramNames) + $offsetValue);
-                                    if (isset($paramNames[$normalizedOffsetValue]) === false) {
-                                        // Requesting non-named additional parameters. Ignore.
-                                        continue ;
-                                    }
-
-                                    $targetLength          = null;
-                                    $parentFuncLengthParam = PassedParameters::getParameter($phpcsFile, $maybeFunctionCall, 3, 'length');
-                                    if ($parentFuncLengthParam !== false) {
-                                        $lengthValue = TokenGroup::isNumber($phpcsFile, $parentFuncLengthParam['start'], $parentFuncLengthParam['end']);
-                                        if (\is_int($lengthValue) && $lengthValue !== 0) {
-                                            $targetLength = $lengthValue;
+                                    if (\is_int($offsetValue)) {
+                                        $normalizedOffsetValue = ($offsetValue >= 0) ? $offsetValue : (\count($paramNames) + $offsetValue);
+                                        if (isset($paramNames[$normalizedOffsetValue]) === false) {
+                                            // Requesting non-named additional parameters. Ignore.
+                                            continue ;
                                         }
-                                    }
 
-                                    // Slice starts at a named argument, but we know which params are being accessed.
-                                    $paramNamesSubset = \array_slice($paramNames, $offsetValue, $targetLength);
+                                        $targetLength          = null;
+                                        $parentFuncLengthParam = PassedParameters::getParameter($phpcsFile, $maybeFunctionCall, 3, 'length');
+                                        if ($parentFuncLengthParam !== false) {
+                                            $lengthValue = TokenGroup::isNumber($phpcsFile, $parentFuncLengthParam['start'], $parentFuncLengthParam['end']);
+                                            if (\is_int($lengthValue) && $lengthValue !== 0) {
+                                                $targetLength = $lengthValue;
+                                            }
+                                        }
+
+                                        // Slice starts at a named argument, but we know which params are being accessed.
+                                        $paramNamesSubset = \array_slice($paramNames, $offsetValue, $targetLength);
+                                    }
                                 }
                             }
                         }
                     }
                 }
+                unset($lastParenthesesOpener, $functionNameLc);
             }
 
             /*

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -491,9 +491,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     }
                 }
 
-                if ($afterVar !== false
-                    && isset(Tokens::$assignmentTokens[$tokens[$afterVar]['code']])
-                ) {
+                if (isset(Tokens::$assignmentTokens[$tokens[$afterVar]['code']])) {
                     // Variable is being assigned something.
                     $scanResult    = 'error';
                     $variableToken = $j;

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -16,6 +16,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Operators;
 use PHPCSUtils\Utils\PassedParameters;
@@ -463,19 +464,11 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     break;
                 }
 
-                if (empty($tokens[$j]['nested_parenthesis']) === false) {
-                    $parentheses = $tokens[$j]['nested_parenthesis'];
-                    \end($parentheses);
-                    $openParens   = \key($parentheses);
-                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($openParens - 1), null, true);
-                    if ($prevNonEmpty !== false
-                        && $tokens[$prevNonEmpty]['code'] === \T_UNSET
-                    ) {
-                        // Variable is being unset.
-                        $scanResult    = 'error';
-                        $variableToken = $j;
-                        break;
-                    }
+                if (Context::inUnset($phpcsFile, $j)) {
+                    // Variable is being unset.
+                    $scanResult    = 'error';
+                    $variableToken = $j;
+                    break;
                 }
 
                 if ($tokens[$afterVar]['code'] === \T_OPEN_SQUARE_BRACKET

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -526,7 +526,9 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     }
                 }
 
-                if (isset(Tokens::$assignmentTokens[$tokens[$afterVar]['code']])) {
+                if (isset(Tokens::$assignmentTokens[$tokens[$afterVar]['code']])
+                    && $tokens[$afterVar]['code'] !== \T_COALESCE_EQUAL
+                ) {
                     // Variable is being assigned something.
                     $scanResult    = 'error';
                     $variableToken = $j;

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -137,7 +137,11 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
             $paramNames[] = $param['name'];
         }
 
-        for ($i = ($scopeOpener + 1); $i < $scopeCloser; $i++) {
+        $prevNonEmpty = $scopeOpener;
+        for ($i = ($scopeOpener + 1);
+            $i < $scopeCloser;
+            $prevNonEmpty = (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) ? $prevNonEmpty : $i), $i++
+        ) {
             if (isset(Collections::closedScopes()[$tokens[$i]['code']]) && isset($tokens[$i]['scope_closer'])) {
                 // Skip past nested structures.
                 $i = $tokens[$i]['scope_closer'];
@@ -164,18 +168,15 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 continue;
             }
 
-            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), null, true);
-            if ($prev !== false) {
-                if (isset(Collections::objectOperators()[$tokens[$prev]['code']])) {
-                    continue;
-                }
+            if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']])) {
+                continue;
+            }
 
-                // Check for namespaced functions, ie: \foo\bar() not \bar().
-                if ($tokens[ $prev ]['code'] === \T_NS_SEPARATOR) {
-                    $pprev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
-                    if ($pprev !== false && $tokens[ $pprev ]['code'] === \T_STRING) {
-                        continue;
-                    }
+            // Check for namespaced functions, ie: \foo\bar() not \bar().
+            if ($tokens[ $prevNonEmpty ]['code'] === \T_NS_SEPARATOR) {
+                $pprev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+                if ($pprev !== false && $tokens[ $pprev ]['code'] === \T_STRING) {
+                    continue;
                 }
             }
 
@@ -238,9 +239,9 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                  * {@internal Note: This does not take offset calculations into account!
                  *  Should be exceptionally rare and can - if needs be - be addressed at a later stage.}
                  */
-                if ($prev !== false && $tokens[$prev]['code'] === \T_OPEN_PARENTHESIS) {
+                if ($tokens[$prevNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
 
-                    $maybeFunctionCall = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+                    $maybeFunctionCall = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
                     if ($maybeFunctionCall !== false
                         && $tokens[$maybeFunctionCall]['code'] === \T_STRING
                         && ($tokens[$maybeFunctionCall]['content'] === 'array_slice'

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -193,15 +193,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                          */
                         case 'debug_backtrace':
                         case 'debug_print_backtrace':
-                            $hasIgnoreArgs = $phpcsFile->findNext(
-                                \T_STRING,
-                                $paramOne['start'],
-                                ($paramOne['end'] + 1),
-                                false,
-                                'DEBUG_BACKTRACE_IGNORE_ARGS'
-                            );
-
-                            if ($hasIgnoreArgs !== false) {
+                            if (\preg_match('`(^|\|)\s*\\\\?DEBUG_BACKTRACE_IGNORE_ARGS`', $paramOne['clean']) === 1) {
                                 // Debug_backtrace() called with ignore args option.
                                 continue 2;
                             }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -453,7 +453,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 $afterVar = $phpcsFile->findNext(Tokens::$emptyTokens, ($j + 1), null, true);
                 if ($afterVar === false) {
                     // Shouldn't be possible, but just in case.
-                    continue;
+                    continue; // @codeCoverageIgnore
                 }
 
                 if (isset($this->plusPlusMinusMinus[$tokens[$afterVar]['code']])) {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -168,16 +168,8 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 continue;
             }
 
-            if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']])) {
+            if ($this->isCallToGlobalFunction($phpcsFile, $i) === false) {
                 continue;
-            }
-
-            // Check for namespaced functions, ie: \foo\bar() not \bar().
-            if ($tokens[ $prevNonEmpty ]['code'] === \T_NS_SEPARATOR) {
-                $pprev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
-                if ($pprev !== false && $tokens[ $pprev ]['code'] === \T_STRING) {
-                    continue;
-                }
             }
 
             /*
@@ -237,7 +229,9 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 if ($tokens[$prevNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
 
                     $maybeFunctionCall = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
-                    if ($tokens[$maybeFunctionCall]['code'] === \T_STRING) {
+                    if ($tokens[$maybeFunctionCall]['code'] === \T_STRING
+                        && $this->isCallToGlobalFunction($phpcsFile, $maybeFunctionCall) === true
+                    ) {
                         $functionNameLc = \strtolower($tokens[$maybeFunctionCall]['content']);
                         if ($functionNameLc === 'array_slice'
                             || $functionNameLc === 'array_splice'
@@ -484,5 +478,48 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
 
             unset($variableToken);
         }
+    }
+
+    /**
+     * Check if a `T_STRING` token represents a function call to a global function.
+     *
+     * Note: not 100% precise, but should be sufficient for now. At a later point in
+     * time there will probably be a PHPCSUtils function for this.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the potential function call
+     *                                               token in the stack.
+     *
+     * @return bool
+     */
+    private function isCallToGlobalFunction(File $phpcsFile, $stackPtr)
+    {
+        $tokens       = $phpcsFile->getTokens();
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+        if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === true) {
+            // Method call.
+            return false;
+        }
+
+        if ($tokens[$prevNonEmpty]['code'] === \T_NEW
+            || $tokens[$prevNonEmpty]['code'] === \T_FUNCTION
+        ) {
+            return false;
+        }
+
+        if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
+            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+            if ($tokens[$prevPrevToken]['code'] === \T_STRING
+                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
+            ) {
+                // Namespaced function.
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -237,25 +237,26 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 if ($tokens[$prevNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
 
                     $maybeFunctionCall = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
-                    if ($maybeFunctionCall !== false
-                        && $tokens[$maybeFunctionCall]['code'] === \T_STRING
-                        && ($tokens[$maybeFunctionCall]['content'] === 'array_slice'
-                        || $tokens[$maybeFunctionCall]['content'] === 'array_splice')
-                    ) {
-                        $parentFuncParamTwo = PassedParameters::getParameter($phpcsFile, $maybeFunctionCall, 2);
-                        $number             = $phpcsFile->findNext(
-                            \T_LNUMBER,
-                            $parentFuncParamTwo['start'],
-                            ($parentFuncParamTwo['end'] + 1)
-                        );
+                    if ($tokens[$maybeFunctionCall]['code'] === \T_STRING) {
+                        $functionNameLc = \strtolower($tokens[$maybeFunctionCall]['content']);
+                        if ($functionNameLc === 'array_slice'
+                            || $functionNameLc === 'array_splice'
+                        ) {
+                            $parentFuncParamTwo = PassedParameters::getParameter($phpcsFile, $maybeFunctionCall, 2);
+                            $number             = $phpcsFile->findNext(
+                                \T_LNUMBER,
+                                $parentFuncParamTwo['start'],
+                                ($parentFuncParamTwo['end'] + 1)
+                            );
 
-                        if ($number !== false && isset($paramNames[$tokens[$number]['content']]) === false) {
-                            // Requesting non-named additional parameters. Ignore.
-                            continue ;
+                            if ($number !== false && isset($paramNames[$tokens[$number]['content']]) === false) {
+                                // Requesting non-named additional parameters. Ignore.
+                                continue ;
+                            }
+
+                            // Slice starts at a named argument, but we know which params are being accessed.
+                            $paramNamesSubset = \array_slice($paramNames, $tokens[$number]['content']);
                         }
-
-                        // Slice starts at a named argument, but we know which params are being accessed.
-                        $paramNamesSubset = \array_slice($paramNames, $tokens[$number]['content']);
                     }
                 }
             }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -55,22 +55,6 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
     ];
 
     /**
-     * Tokens to look out for to allow us to skip past nested scoped structures.
-     *
-     * @since 9.1.0
-     *
-     * @var array<string, true>
-     */
-    private $skipPastNested = [
-        'T_CLASS'      => true,
-        'T_ANON_CLASS' => true,
-        'T_INTERFACE'  => true,
-        'T_TRAIT'      => true,
-        'T_FUNCTION'   => true,
-        'T_CLOSURE'    => true,
-    ];
-
-    /**
      * The tokens for variable incrementing/decrementing.
      *
      * @since 9.1.0
@@ -166,7 +150,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
         }
 
         for ($i = ($scopeOpener + 1); $i < $scopeCloser; $i++) {
-            if (isset($this->skipPastNested[$tokens[$i]['type']]) && isset($tokens[$i]['scope_closer'])) {
+            if (isset(Collections::closedScopes()[$tokens[$i]['code']]) && isset($tokens[$i]['scope_closer'])) {
                 // Skip past nested structures.
                 $i = $tokens[$i]['scope_closer'];
                 continue;
@@ -350,7 +334,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
              */
             $scanResult = 'clean';
             for ($j = ($scopeOpener + 1); $j < $startOfStatement; $j++) {
-                if (isset($this->skipPastNested[$tokens[$j]['type']])
+                if (isset(Collections::closedScopes()[$tokens[$j]['code']])
                     && isset($tokens[$j]['scope_closer'])
                 ) {
                     // Skip past nested structures.

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -20,6 +20,7 @@ use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Context;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Lists;
+use PHPCSUtils\Utils\Numbers;
 use PHPCSUtils\Utils\Operators;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
@@ -209,7 +210,7 @@ class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                         case 'func_get_arg':
                             $number = $phpcsFile->findNext(\T_LNUMBER, $paramOne['start'], ($paramOne['end'] + 1));
                             if ($number !== false) {
-                                $argNumber = $tokens[$number]['content'];
+                                $argNumber = (int) Numbers::getCompleteNumber($phpcsFile, $number)['decimal'];
 
                                 if (isset($paramNames[$argNumber]) === false) {
                                     // Requesting a non-named additional parameter. Ignore.

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -569,6 +569,21 @@ function controlStructureHandling($c0, $c1, $c2, $c3, $c4, $c5, $c6, $c7, $c8, $
     func_get_arg(13); // Error.
 }
 
+// PHP 7.4 arrow function handling.
+function arrowFunctionsShouldBeIgnored() {
+    $a = fn($f) => [$f++, func_get_args()]; // Deliberately ignored.
+    $b = fn($g) => do_something($g) && func_get_arg(0); // Deliberately ignored.
+}
+
+// Making sure the sniff does not get confused over nested arrow functions when examining the surrounding scope.
+function handledNestedArrowFunctionsCorrectly($a, $b, ) {
+    $arrowFunctionsHaveAccessToVarsOutsideItsOwnScope = fn($add) => do_something($b) + $add;
+    $thisFuncGetArgsCanBeIgnoredAsItsForTheArrowFunction = fn($args) => \func_get_args(); // OK.
+
+    func_get_arg(0); // OK.
+    func_get_arg(1); // Warning, $b was used within an arrow function.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -609,6 +609,37 @@ $preventFalsePositivesOnPHP80ClassOnObjC = function ($obj) {
     func_get_args(); // OK.
 };
 
+function php80NamedArgsInFunctionCallsFuncGetArg($a, $b) {
+    $a++;
+
+    func_get_arg(position: 1); // OK, $b is unchanged.
+    func_get_arg(position: 0); // Error, $a was changed.
+    func_get_arg(positions: 1); // Error - typo in param name, so we cannot discount a position.
+}
+
+function php80NamedArgsInFunctionCallsFuncDebugBacktrace($a) {
+    $a++;
+
+    debug_backtrace(options: \DEBUG_BACKTRACE_PROVIDE_OBJECT | \DEBUG_BACKTRACE_IGNORE_ARGS); // OK, args are not retrieved.
+    debug_backtrace(limit: 2, options: 2); // OK, args are not retrieved. (reverse param order)
+    debug_print_backtrace(options: \DEBUG_BACKTRACE_IGNORE_ARGS); // OK, args are not retrieved.
+    debug_print_backtrace(limit: 0, options: 2); // OK, args are not retrieved. (reverse param order)
+
+    debug_backtrace(limit: 2);   // Error, $a was changed.
+    debug_print_backtrace(options: 1); // Error, $a was changed.
+}
+
+function php80NamedArgsInFunctionCallsFuncArraySliceSplice($p0, $p1, $p2, $p3, $p4) {
+    $p0++;
+    do_something($p3);
+
+    array_slice(offset: 2,  array: func_get_args(), preserve_keys: true, length: 1); // OK, $p2 was unchanged (mangled param order).
+    array_splice( offset: 4, array: func_get_args() ); // OK, $p4 was unchanged.
+
+    array_slice( array: func_get_args(), preserve_keys: true ); // Error, $p0 was changed. Missing required param, but that's not our concern.
+    array_splice( $array, offset: func_get_args()[1]); // Error, offset value undermined and func_get_args() not used in expected parameter.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -482,6 +482,29 @@ function nonDecimalIntegers( $named ) {
     $args = array_slice( func_get_args(), 0B0 ); // Error.
 }
 
+function php74NumericLiteralsWithUnderscoress( $n0, $n1, $n2, $n3, $n4, $n5, $n6, $n7, $n8, $n9, $n10, $n11, $n12, $n13, $n14, $n15, $n16, $n17 ) {
+    $n16 = 10;
+    $args = func_get_arg(1_7); // OK, param changed is not targetted.
+    $args = func_get_arg(0_21); // OK, param changed is not targetted.
+    $args = func_get_arg(0x1_1); // OK, param changed is not targetted.
+    $args = func_get_arg(0b10_001); // OK, param changed is not targetted.
+
+    $args = array_slice( func_get_args(), 1_7 ); // OK, param changed is not one of the ones targetted by array_slice.
+    $args = array_slice( func_get_args(), 0_21 ); // OK, param changed is not one of the ones targetted by array_slice.
+    $args = array_slice( func_get_args(), 0x1_1 ); // OK, param changed is not one of the ones targetted by array_slice.
+    $args = array_slice( func_get_args(), 0b10_001 ); // OK, param changed is not one of the ones targetted by array_slice.
+
+    $args = func_get_arg(1_6); // Error.
+    $args = func_get_arg(0_20); // Error.
+    $args = func_get_arg(0x1_0); // Error.
+    $args = func_get_arg(0b10_000); // Error.
+
+    $args = array_slice( func_get_args(), 1_6 ); // Error.
+    $args = array_slice( func_get_args(), 0_20 ); // Error.
+    $args = array_slice( func_get_args(), 0x1_0 ); // Error.
+    $args = array_slice( func_get_args(), 0b10_000 ); // Error.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -255,6 +255,15 @@ function dontIgnoreNonPlainAssignments($matches) {
     $args = func_get_args(); // Warning, non-plain assignment.
 }
 
+function flagPreIncrementDecrement($x, $y) {
+    --$x;
+    ++$y;
+    func_get_arg(0); // Error.
+    \func_get_arg(1); // Error.
+    Func_Get_Args(); // Error.
+    \debug_backtrace(); // Error.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -514,6 +514,22 @@ function php81OctalLiterals( $n0, $n1, $n2, $n3 ) {
     $args = array_slice( func_get_args(), 0O1 ); // Error.
 }
 
+function assignmentOperators($a0, $a1, $a2, $a3, $a4, $a5 = null) {
+    $a0   = 'abc';
+    $a1  .= 'abc';
+    $a2  += 10;
+    $a3 **= 10;
+    $a4  ^= 'abc';
+    $a5 ??= 'abc';
+
+    func_get_arg(0); // Error.
+    func_get_arg(1); // Error.
+    func_get_arg(2); // Error.
+    func_get_arg(3); // Error.
+    func_get_arg(4); // Error.
+    func_get_arg(5); // Warning. Null coalesce doesn't necessarily change the value.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -286,6 +286,21 @@ function usingFQNconstant($a) {
     debug_backtrace(Partially\Qualified\DEBUG_BACKTRACE_IGNORE_ARGS);    // Error, not the global constant being passed, value unknown.
 }
 
+// Ref: https://www.php.net/manual/en/function.debug-backtrace.php#refsect1-function.debug-backtrace-parameters
+function backtraceOptionsByTheNumber($a) {
+    $a = 'foo';
+    debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT); // Error, args index will be populated.
+    debug_backtrace(0); // Error, args index will be populated.
+    debug_backtrace(1); // Error, args index will be populated.
+    debug_backtrace(2); // OK, args index will be omitted.
+    debug_backtrace( \DEBUG_BACKTRACE_PROVIDE_OBJECT | \DEBUG_BACKTRACE_IGNORE_ARGS ); // OK, args index will be omitted.
+    debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS | DEBUG_BACKTRACE_PROVIDE_OBJECT ); // OK, args index will be omitted.
+    debug_backtrace(3); // OK, args index will be omitted.
+
+    debug_print_backtrace(0); // Error, args index will be populated.
+    debug_print_backtrace(2); // OK, args index will be omitted.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -2,7 +2,7 @@
 /*
  * Same behaviour across PHP versions as the passed argument(s) are not touched before the function(s) are called.
  */
-function foo($x) {
+function parametersNotTouched($x) {
     func_get_arg(0);
     func_get_args();
     debug_backtrace();
@@ -12,18 +12,18 @@ function foo($x) {
 $d = function($a, $b, ...$c) {
     func_get_arg(0);
     func_get_args();
-}
+};
 
 /*
  * Prevent false positives.
  */
-function foo($a) {
+function specialCasesA($a) {
     $a = 'foo';
     debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS); // 'args' is ignored, so not affected.
     debug_backtrace()[0]['class']; // Explicitly requesting a non-args index from the backtrace array.
 }
 
-function foo($a) {
+function notOurTarget($a) {
     $a   = 'changed!';
     $obj = new ABC();
     echo $obj->
@@ -39,35 +39,35 @@ debug_backtrace(); // Not called within the scope of a function, so 'args' is no
 $e = function() {
     $abc = 'abc';
     var_dump(func_get_args()); // OK, no named args, so no risk.
-}
+};
 
-function something( $a, $b ) {
+function requestingNonNamedArgWhichCannotBeChanged( $a, $b ) {
     $a = 'abc';
     func_get_arg(2); // OK, requesting a non-named additional argument.
 }
 
 // No scope opener/closer.
-class ABC {
-    abstract private function def();
+abstract class AbstractMethodsHaveNoScopeNorCode {
+    abstract protected function def();
 }
 
-interface ABC {
+interface InterfaceMethodsHaveNoScopeNorCode {
     public function def();
 }
 
 // Making sure the sniff does not get confused over nested structures.
-function foo($a, $b, ...$c) {
+function handledNestedClosedScopesCorrectly($a, $b, ...$c) {
     $d = function($args) {
         $a = 'abc';
         $b = \func_get_args();
-    }
+    };
 
     function local_function($b = 123) {
         -- /* comment */ $c;
         func_get_arg(0);
     }
 
-    class ABC {
+    class NestedClass {
         public function some_method() {
             debug_print_backtrace();
         }
@@ -79,7 +79,7 @@ function foo($a, $b, ...$c) {
 /*
  * PHP 7.0+ changed behaviour.
  */
-function bar($x) {
+function php70ChangedBehaviour($x) {
     $x++;
     func_get_arg(0); // Error.
     Func_Get_Args(); // Error.
@@ -108,9 +108,9 @@ $d = function($a, $b, ...$c) {
     debug_print_backtrace( $index ); // Error.
     debug_backtrace ( )  [ 1 ]; // Error. Index which will be used is unknown.
     debug_backtrace ( )  [ 2 ] [ 'args' ]; // Error.
-}
+};
 
-function foo($a, $b, ...$c) {
+function assignmentToSubArray($a, $b, ...$c) {
     $a[1]['a'][2] = 'abc';
 
     function local_function( $b = 123 ) {
@@ -124,12 +124,12 @@ function foo($a, $b, ...$c) {
 }
 
 
-function foo($x) {
+function functionCallsMayChangeParamByReferenceA($x) {
     array_sort($x);
-    \ func_get_args ( ); // Warning, $x may (in this case: will) have been changed by reference.
+    \func_get_args ( ); // Warning, $x may (in this case: will) have been changed by reference.
 }
 
-function foo($x) {
+function functionCallsMayChangeParamByReferenceB($x) {
     $y = function_call($x);
     debug_backtrace(); // Warning, $x may have been changed by reference.
 }
@@ -137,7 +137,7 @@ function foo($x) {
 /*
  * Some more tests based on real life code.
  */
-    public function add_node( $args ) {
+    function add_node( $args ) {
         // Shim for old method signature.
         if ( func_num_args() >= 3 && is_string( func_get_arg( 0 ) ) ) { // OK.
             $args = array_merge( array( 'parent' => func_get_arg( 0 ) ), func_get_arg( 2 ) ); // OK.
@@ -152,7 +152,7 @@ function author_can( $post, $capability ) {
     $args = array_slice( func_get_args(), 2 ); // OK, not accessing a named parameter.
 }
 
-    public function feedback( $string, $other ) {
+    function feedback( $string, $other ) {
         if ( isset( $this->upgrader->strings[ $string ] ) ) {
             $string = $this->upgrader->strings[ $string ];
         }
@@ -256,6 +256,6 @@ function dontIgnoreNonPlainAssignments($matches) {
 }
 
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
-function foo($x) {
+function LiveCoding($x) {
     $x = function_call($x);
     func_get_args(); // Ignored.

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -301,6 +301,14 @@ function backtraceOptionsByTheNumber($a) {
     debug_print_backtrace(2); // OK, args index will be omitted.
 }
 
+function arrayFunctionNamesAreCaseInsensitive( $string, $other ) {
+    $string = function_call([ $string ]);
+
+    $args = ARRAY_SLICE( func_get_args(), 0 ); // Error.
+    $args = \Array_Slice( func_get_args(), 1 ); // OK, param changed is not one of the ones targetted by array_slice.
+    $args = Array_SPLICE(func_get_args(), 2); // OK, not accessing a named parameter.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -30,7 +30,7 @@ function notOurTarget($a) {
         func_get_arg(0); // OK, not the PHP native function call.
     echo $obj?->debug_backtrace(); // OK, not the PHP native function call.
     echo ABC::func_get_args(); // OK, not the PHP native function call.
-    echo \myNS\debug_print_backtrace(); // OK, not the PHP native function call.
+    echo \Fully\Qualified\debug_print_backtrace(); // OK, not the PHP native function call.
     const DEBUG_BACKTRACE = 'abc';
 }
 
@@ -101,9 +101,9 @@ $d = function($a, $b, ...$c) {
     func_get_arg(2); // Warning.
     func_get_args(); // Error.
     $c[0] = 'something else';
-    func_get_arg(0); // OK - $a was not touched.
-    func_get_arg(1); // Error.
-    func_get_arg(2); // Error.
+    \func_get_arg(0); // OK - $a was not touched.
+    \func_get_arg(1); // Error.
+    \FUNC_GET_ARG(2); // Error.
     debug_backtrace(); // Error.
     debug_print_backtrace( $index ); // Error.
     debug_backtrace ( )  [ 1 ]; // Error. Index which will be used is unknown.
@@ -130,7 +130,7 @@ function functionCallsMayChangeParamByReferenceA($x) {
 }
 
 function functionCallsMayChangeParamByReferenceB($x) {
-    $y = function_call($x);
+    $y = \function_call($x);
     debug_backtrace(); // Warning, $x may have been changed by reference.
 }
 
@@ -160,7 +160,7 @@ function author_can( $post, $capability ) {
         if ( strpos( $string, '%' ) !== false ) {
             $args = array_slice( func_get_args(), 0 ); // Error.
             $args = array_slice( func_get_args(), 1 ); // OK, param changed is not one of the ones targetted by array_slice.
-            $args = array_splice(
+            $args = \array_splice(
                 func_get_args(),
                 2
             ); // OK, not accessing a named parameter.
@@ -262,6 +262,20 @@ function flagPreIncrementDecrement($x, $y) {
     \func_get_arg(1); // Error.
     Func_Get_Args(); // Error.
     \debug_backtrace(); // Error.
+}
+
+// Safeguard against false positives on namespaced function calls.
+function namespacedMirrorFunctionsAreNotOurTarget($a) {
+    $a = 'changed!';
+    Partially\Qualified\func_get_args(); // OK.
+    namespace\Relative\debug_backtrace(); // OK.
+}
+
+function hasNestedMirrorMethods() {
+    class MirrorMethods {
+        public function func_get_args() {} // OK.
+        public &function debug_backtrace() {} // OK.
+    }
 }
 
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -278,6 +278,14 @@ function hasNestedMirrorMethods() {
     }
 }
 
+function usingFQNconstant($a) {
+    $a = 'foo';
+    debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);                 // OK, 'args' is ignored, so not affected.
+    debug_backtrace(namespace\Relative\DEBUG_BACKTRACE_IGNORE_ARGS);     // Error, not the global constant being passed, value unknown.
+    debug_print_backtrace(\Fully\Qualified\DEBUG_BACKTRACE_IGNORE_ARGS); // Error, not the global constant being passed, value unknown.
+    debug_backtrace(Partially\Qualified\DEBUG_BACKTRACE_IGNORE_ARGS);    // Error, not the global constant being passed, value unknown.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -309,6 +309,27 @@ function arrayFunctionNamesAreCaseInsensitive( $string, $other ) {
     $args = Array_SPLICE(func_get_args(), 2); // OK, not accessing a named parameter.
 }
 
+// Safeguard against false negatives on method calls and namespaced function calls.
+function namespacedArraySliceOrSpliceDoNotGetException( $string, $other ) {
+    $string = function_call([ $string ]);
+
+    $args = new array_slice( func_get_args(), 1 ); // Error.
+    $args = MyClass::array_slice( func_get_args(), 1 ); // Error.
+    $args = $obj->array_slice( func_get_args(), 1 ); // Error.
+    $args = $obj?->array_slice( func_get_args(), 1 ); // Error.
+    $args = namespace\array_slice( func_get_args(), 1 ); // Error.
+    $args = \Fully\Qualified\array_slice( func_get_args(), 1 ); // Error.
+    $args = Partially\Qualified\array_slice( func_get_args(), 1 ); // Error.
+
+    $args = new array_splice( func_get_args(), 1 ); // Error.
+    $args = MyClass::array_splice( func_get_args(), 1 ); // Error.
+    $args = $obj->array_splice( func_get_args(), 1 ); // Error.
+    $args = $obj?->array_splice( func_get_args(), 1 ); // Error.
+    $args = namespace\Relative\array_splice( func_get_args(), 1 ); // Error.
+    $args = \Fully\Qualified\array_splice( func_get_args(), 1 ); // Error.
+    $args = Partially\Qualified\array_splice( func_get_args(), 1 ); // Error.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -530,6 +530,45 @@ function assignmentOperators($a0, $a1, $a2, $a3, $a4, $a5 = null) {
     func_get_arg(5); // Warning. Null coalesce doesn't necessarily change the value.
 }
 
+function controlStructureHandling($c0, $c1, $c2, $c3, $c4, $c5, $c6, $c7, $c8, $c9, $c10, $c11, $c12, $c13) {
+    // Not problematic
+    if ($c0) {
+    } elseif ($c1) {}
+    foreach ($c2[$c3] as $k => $v) {}
+    switch ($c4) {
+        case 0: break;
+    }
+    while($c5) {}
+    do {} while ($c6);
+    $match = match($c7) {
+        0 => 10,
+    };
+
+    // Problematic.
+    foreach ($array as $c8 => $v) {}
+    foreach ($array as $k => $c9) {}
+    try {
+    } catch (Exception $c10) {}
+
+    // Difficult to determine.
+    for ($i = $c11; $c12 < $end; $c13++) {}
+
+    func_get_arg(0); // OK, unchanged.
+    func_get_arg(1); // OK, unchanged.
+    func_get_arg(2); // OK, unchanged.
+    func_get_arg(3); // OK, unchanged.
+    func_get_arg(4); // OK, unchanged.
+    func_get_arg(5); // OK, unchanged
+    func_get_arg(6); // OK, unchanged.
+    func_get_arg(7); // OK, unchanged.
+    func_get_arg(8); // Error, $c8 is assigned new value.
+    func_get_arg(9); // Error, $c9 is assigned new value.
+    func_get_arg(10); // Error, $c10 is assigned new value.
+    func_get_arg(11); // Warning.
+    func_get_arg(12); // Warning.
+    func_get_arg(13); // Error.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -18,62 +18,62 @@ $d = function($a, $b, ...$c) {
  * Prevent false positives.
  */
 function foo($a) {
-	$a = 'foo';
+    $a = 'foo';
     debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS); // 'args' is ignored, so not affected.
     debug_backtrace()[0]['class']; // Explicitly requesting a non-args index from the backtrace array.
 }
 
 function foo($a) {
-	$a   = 'changed!';
-	$obj = new ABC();
-	echo $obj->
-		func_get_arg(0); // OK, not the PHP native function call.
-	echo $obj?->debug_backtrace(); // OK, not the PHP native function call.
-	echo ABC::func_get_args(); // OK, not the PHP native function call.
-	echo \myNS\debug_print_backtrace(); // OK, not the PHP native function call.
-	const DEBUG_BACKTRACE = 'abc';
+    $a   = 'changed!';
+    $obj = new ABC();
+    echo $obj->
+        func_get_arg(0); // OK, not the PHP native function call.
+    echo $obj?->debug_backtrace(); // OK, not the PHP native function call.
+    echo ABC::func_get_args(); // OK, not the PHP native function call.
+    echo \myNS\debug_print_backtrace(); // OK, not the PHP native function call.
+    const DEBUG_BACKTRACE = 'abc';
 }
 
 debug_backtrace(); // Not called within the scope of a function, so 'args' is not set/affected.
 
 $e = function() {
-	$abc = 'abc';
+    $abc = 'abc';
     var_dump(func_get_args()); // OK, no named args, so no risk.
 }
 
 function something( $a, $b ) {
-	$a = 'abc';
+    $a = 'abc';
     func_get_arg(2); // OK, requesting a non-named additional argument.
 }
 
 // No scope opener/closer.
 class ABC {
-	abstract private function def();
+    abstract private function def();
 }
 
 interface ABC {
-	public function def();
+    public function def();
 }
 
 // Making sure the sniff does not get confused over nested structures.
 function foo($a, $b, ...$c) {
-	$d = function($args) {
-		$a = 'abc';
-	    $b = \func_get_args();
-	}
+    $d = function($args) {
+        $a = 'abc';
+        $b = \func_get_args();
+    }
 
-	function local_function($b = 123) {
-		-- /* comment */ $c;
-	    func_get_arg(0);
-	}
+    function local_function($b = 123) {
+        -- /* comment */ $c;
+        func_get_arg(0);
+    }
 
-	class ABC {
-		public function some_method() {
-		    debug_print_backtrace();
-		}
-	}
+    class ABC {
+        public function some_method() {
+            debug_print_backtrace();
+        }
+    }
 
-	func_get_args(); // OK, nothing changed in the scope we're interested in.
+    func_get_args(); // OK, nothing changed in the scope we're interested in.
 }
 
 /*
@@ -88,19 +88,19 @@ function bar($x) {
 
 $d = function($a, $b, ...$c) {
     func_get_arg(
-		2
-	); // OK.
-	$b = array_map('strtolower', $b);
+        2
+    ); // OK.
+    $b = array_map('strtolower', $b);
     func_get_arg( 0 ); // OK - $a was not touched
     func_get_arg(1); // Error.
     func_get_arg(2); // OK - $c was not touched (yet).
     func_get_args(); // Error.
-	$d = array_map('strtolower', $c);
+    $d = array_map('strtolower', $c);
     func_get_arg( 0 ); // OK - $a was not touched
     func_get_arg(1); // Error.
     func_get_arg(2); // Warning.
     func_get_args(); // Error.
-	$c[0] = 'something else';
+    $c[0] = 'something else';
     func_get_arg(0); // OK - $a was not touched.
     func_get_arg(1); // Error.
     func_get_arg(2); // Error.
@@ -111,16 +111,16 @@ $d = function($a, $b, ...$c) {
 }
 
 function foo($a, $b, ...$c) {
-	$a[1]['a'][2] = 'abc';
+    $a[1]['a'][2] = 'abc';
 
-	function local_function( $b = 123 ) {
-		$c = 'something';
-	}
+    function local_function( $b = 123 ) {
+        $c = 'something';
+    }
 
-	func_get_arg(0); // Error.
-	func_get_arg(1); // OK. Changed in a different scope.
-	func_get_arg($var); // Error.
-	$c = func_get_arg(2); // OK. Assignment operator is right associative.
+    func_get_arg(0); // Error.
+    func_get_arg(1); // OK. Changed in a different scope.
+    func_get_arg($var); // Error.
+    $c = func_get_arg(2); // OK. Assignment operator is right associative.
 }
 
 
@@ -137,35 +137,35 @@ function foo($x) {
 /*
  * Some more tests based on real life code.
  */
-	public function add_node( $args ) {
-		// Shim for old method signature.
-		if ( func_num_args() >= 3 && is_string( func_get_arg( 0 ) ) ) { // OK.
-			$args = array_merge( array( 'parent' => func_get_arg( 0 ) ), func_get_arg( 2 ) ); // OK.
-		}
-	}
+    public function add_node( $args ) {
+        // Shim for old method signature.
+        if ( func_num_args() >= 3 && is_string( func_get_arg( 0 ) ) ) { // OK.
+            $args = array_merge( array( 'parent' => func_get_arg( 0 ) ), func_get_arg( 2 ) ); // OK.
+        }
+    }
 
 function author_can( $post, $capability ) {
-	if ( $post === 'abc' ) {
-		return false;
-	}
+    if ( $post === 'abc' ) {
+        return false;
+    }
 
-	$args = array_slice( func_get_args(), 2 ); // OK, not accessing a named parameter.
+    $args = array_slice( func_get_args(), 2 ); // OK, not accessing a named parameter.
 }
 
-	public function feedback( $string, $other ) {
-		if ( isset( $this->upgrader->strings[ $string ] ) ) {
-			$string = $this->upgrader->strings[ $string ];
-		}
+    public function feedback( $string, $other ) {
+        if ( isset( $this->upgrader->strings[ $string ] ) ) {
+            $string = $this->upgrader->strings[ $string ];
+        }
 
-		if ( strpos( $string, '%' ) !== false ) {
-			$args = array_slice( func_get_args(), 0 ); // Error.
-			$args = array_slice( func_get_args(), 1 ); // OK, param changed is not one of the ones targetted by array_slice.
-			$args = array_splice(
-				func_get_args(),
-				2
-			); // OK, not accessing a named parameter.
-		}
-	}
+        if ( strpos( $string, '%' ) !== false ) {
+            $args = array_slice( func_get_args(), 0 ); // Error.
+            $args = array_slice( func_get_args(), 1 ); // OK, param changed is not one of the ones targetted by array_slice.
+            $args = array_splice(
+                func_get_args(),
+                2
+            ); // OK, not accessing a named parameter.
+        }
+    }
 
 // Issue #1207.
 function ignoreParamInReturn ( $stuff ) {

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -505,6 +505,15 @@ function php74NumericLiteralsWithUnderscoress( $n0, $n1, $n2, $n3, $n4, $n5, $n6
     $args = array_slice( func_get_args(), 0b10_000 ); // Error.
 }
 
+function php81OctalLiterals( $n0, $n1, $n2, $n3 ) {
+    $n1 = (int) $n1;
+    $args = func_get_arg(0o3); // OK, param changed is not targetted.
+    $args = array_slice( func_get_args(), 0O2 ); // OK, param changed is not one of the ones targetted by array_slice.
+
+    $args = func_get_arg(0o1); // Error.
+    $args = array_slice( func_get_args(), 0O1 ); // Error.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -449,6 +449,20 @@ function arraySliceShouldTakeSignIntoAccount( $n0, $n1, $n2, $n3, $n4 ) {
     $args = array_slice( func_get_args(), -3 ); // Error.
 }
 
+function arraySliceShouldTakeLengthIntoAccount( $n0, $n1, $n2, $n3, $n4 ) {
+    $n3 = function_call();
+
+    $args = array_slice( func_get_args(), +1, 2 ); // OK, params being accessed are unchanged.
+    $args = array_slice( func_get_args(), -1, 1 ); // OK, params being accessed are unchanged.
+    $args = array_slice( func_get_args(), 2, 1 ); // OK, params being accessed are unchanged.
+    $args = array_slice( func_get_args(), -4, 2 ); // OK, params being accessed are unchanged.
+    $args = array_slice( func_get_args(), 4, null ); // OK, params being accessed are unchanged.
+
+    $args = array_slice( func_get_args(), +2, 2 ); // Error.
+    $args = array_slice( func_get_args(), -2, 1 ); // Error.
+    $args = array_slice( func_get_args(), 2, null ); // Error.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -640,6 +640,21 @@ function php80NamedArgsInFunctionCallsFuncArraySliceSplice($p0, $p1, $p2, $p3, $
     array_splice( $array, offset: func_get_args()[1]); // Error, offset value undermined and func_get_args() not used in expected parameter.
 }
 
+class constructorPropertyPromotion {
+    public function __construct(
+        protected string $propA,
+        public int $propB,
+        bool $param,
+    ) {
+        $this->propA = $param; // Changing the property value, not the parameter value.
+        $propB       = $param; // Changing the parameter value, not the property value.
+
+        func_get_arg(4); // OK, retrieving non-named param.
+        func_get_arg(0); // OK, property value was changed, not the value of the passed parameter.
+        func_get_arg(1); // Error.
+    }
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -584,6 +584,16 @@ function handledNestedArrowFunctionsCorrectly($a, $b, ) {
     func_get_arg(1); // Warning, $b was used within an arrow function.
 }
 
+function doNotGetConfusedOverPHP80Attributes($a) {
+    $a++;
+
+    $closure =
+        #[Func_Get_Args()] // OK, not the function.
+        function($a, $b) {
+            return $a + $b;
+        };
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -594,6 +594,21 @@ function doNotGetConfusedOverPHP80Attributes($a) {
         };
 }
 
+$preventFalsePositivesOnPHP80ClassOnObjA = function ($obj) {
+    $name = $obj::class;
+    func_get_args(); // OK.
+};
+
+$preventFalsePositivesOnPHP80ClassOnObjB = function ($obj) {
+    function_call($obj::CLASS);
+    func_get_args(); // OK.
+};
+
+$preventFalsePositivesOnPHP80ClassOnObjC = function ($obj) {
+    if ($obj::class === 'Foo\Bar') {}
+    func_get_args(); // OK.
+};
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -463,6 +463,25 @@ function arraySliceShouldTakeLengthIntoAccount( $n0, $n1, $n2, $n3, $n4 ) {
     $args = array_slice( func_get_args(), 2, null ); // Error.
 }
 
+function nonDecimalIntegers( $named ) {
+    ++$named;
+    $args = func_get_arg(02); // OK, param changed is not targetted.
+    $args = func_get_arg(0x2); // OK, param changed is not targetted.
+    $args = func_get_arg(0b10); // OK, param changed is not targetted.
+
+    $args = array_slice( func_get_args(), 02 ); // OK, param changed is not one of the ones targetted by array_slice.
+    $args = array_slice( func_get_args(), 0x2 ); // OK, param changed is not one of the ones targetted by array_slice.
+    $args = array_slice( func_get_args(), 0b10 ); // OK, param changed is not one of the ones targetted by array_slice.
+
+    $args = func_get_arg(00); // Error.
+    $args = func_get_arg(0x0); // Error.
+    $args = func_get_arg(0b0); // Error.
+
+    $args = array_slice( func_get_args(), 00 ); // Error.
+    $args = array_slice( func_get_args(), 0X0 ); // Error.
+    $args = array_slice( func_get_args(), 0B0 ); // Error.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -655,6 +655,22 @@ class constructorPropertyPromotion {
     }
 }
 
+function ignoreUseAsFirstClassCallableFuncGetArgs($a, $b) {
+    $fcc1 = func_get_arg(...); // OK. Well, not really, Fatal error "Cannot call func_get_arg() dynamically", but not our concern.
+    $fcc2 = func_get_args(...); // OK. Well, not really, Fatal error "Cannot call func_get_args() dynamically", but not our concern.
+    $a++;
+    echo $fcc1(0);
+    echo $fcc2();
+}
+
+function alwaysFlagUseAsFirstClassCallableDebugBacktrace($a, $b) {
+    $fcc1 = debug_backtrace(...); // Error.
+    $fcc2 = debug_print_backtrace(...); // Error.
+    $a++;
+    var_dump($fcc1(0)); // This will print 11 for $a.
+    $fcc2(); // This will print 11 for $a.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -152,7 +152,7 @@ function author_can( $post, $capability ) {
     $args = array_slice( func_get_args(), 2 ); // OK, not accessing a named parameter.
 }
 
-    function feedback( $string, $other ) {
+    function feedback( $string, $other, ) {
         if ( isset( $this->upgrader->strings[ $string ] ) ) {
             $string = $this->upgrader->strings[ $string ];
         }
@@ -208,7 +208,7 @@ function ignoreParamInReturnUnscopedCondition ( $stuff ) {
     $args = func_get_args(); // OK.
 }
 
-function ignoreParamInExitUnscopedCondition ( $stuff ) {
+function ignoreParamInExitUnscopedCondition ( $stuff, ) {
     if ( true === SOME_CONSTANT )
         do_something OR die( 'Did ' . functionCall( $stuff ) );
 
@@ -278,7 +278,7 @@ function hasNestedMirrorMethods() {
     }
 }
 
-function usingFQNconstant($a) {
+function usingFQNconstant($a,) {
     $a = 'foo';
     debug_print_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);                 // OK, 'args' is ignored, so not affected.
     debug_backtrace(namespace\Relative\DEBUG_BACKTRACE_IGNORE_ARGS);     // Error, not the global constant being passed, value unknown.
@@ -358,7 +358,7 @@ function paramIsAssignedNewValueInNestedLongListA($y) {
     func_get_args(); // Error, $y has been assigned a new value via list.
 }
 
-function paramIsAssignedNewValueInNestedShortListA($y) {
+function paramIsAssignedNewValueInNestedShortListA($y,) {
     [[$y], $x,] = function_call();
     debug_print_backtrace(); // Error, $y has been assigned a new value via short list.
 }
@@ -405,7 +405,7 @@ function ignoreParamUsedAsKeyInNestedShortList($y) {
 }
 
 // Handle PHP 7.3+ list reference assignments.
-function dontIgnoreReferenceAssignmentsinLongList($b) {
+function dontIgnoreReferenceAssignmentsinLongList($b,) {
     list(&$d) = $b;
     // Do some more.
     func_get_args(); // Warning, reference assignment.

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -330,6 +330,116 @@ function namespacedArraySliceOrSpliceDoNotGetException( $string, $other ) {
     $args = Partially\Qualified\array_splice( func_get_args(), 1 ); // Error.
 }
 
+/*
+ * Recognize list assignments correctly, including in PHP 7.1+ short lists and keyed lists.
+ */
+function ignoreParamAssignedToOtherVarinLongList($z) {
+    list($x, list($y)) = $z;
+    debug_print_backtrace(); // OK.
+}
+
+function ignoreParamAssignedToOtherVarinShortList($z) {
+    [$x, [$y]] = $z;
+    func_get_args(); // OK.
+}
+
+function paramIsAssignedNewValueInLongList($x) {
+    list($x) = function_call();
+    debug_backtrace(); // Error, $x has been assigned a new value via list.
+}
+
+function paramIsAssignedNewValueInShortList($x) {
+    [$x] = function_call();
+    func_get_args(); // Error, $x has been assigned a new value via short list.
+}
+
+function paramIsAssignedNewValueInNestedLongListA($y) {
+    list($x, , list($y)) = function_call();
+    func_get_args(); // Error, $y has been assigned a new value via list.
+}
+
+function paramIsAssignedNewValueInNestedShortListA($y) {
+    [[$y], $x,] = function_call();
+    debug_print_backtrace(); // Error, $y has been assigned a new value via short list.
+}
+
+function paramIsAssignedNewValueInNestedLongListB($y) {
+    list(list($y), , $x, ,) = function_call();
+    func_get_args(); // Error, $y has been assigned a new value via list.
+}
+
+function paramIsAssignedNewValueInNestedShortListB($y) {
+    [$x, , [$y]] = function_call();
+    debug_print_backtrace(); // Error, $y has been assigned a new value via short list.
+}
+
+function paramIsAssignedNewValueInLongListWithNestedList($z) {
+    list(list($y), , $z, ,) = function_call();
+    func_get_args(); // Error, $z has been assigned a new value via list.
+}
+
+function paramIsAssignedNewValueInShortListWithNestedList($z) {
+    [[$x], $z, , ] = function_call();
+    debug_print_backtrace(); // Error, $z has been assigned a new value via short list.
+}
+
+// Handle PHP 7.1+ keyed lists correctly.
+function ignoreParamUsedAsKeyInLongList($x) {
+    list($x => $y) = function_call();
+    debug_backtrace(); // OK, key is just used to retrieve the correct value from the array.
+}
+
+function ignoreParamUsedAsKeyInShortList($x) {
+    [$x => $y] = function_call();
+    func_get_args(); // OK, key is just used to retrieve the correct value from the array.
+}
+
+function ignoreParamUsedAsKeyInNestedLongList($y) {
+    list($x, list($y => $z)) = function_call();
+    func_get_args(); // OK, key is just used to retrieve the correct value from the array.
+}
+
+function ignoreParamUsedAsKeyInNestedShortList($y) {
+    [[$y => $z], $x, ] = function_call();
+    debug_print_backtrace(); // OK, key is just used to retrieve the correct value from the array.
+}
+
+// Handle PHP 7.3+ list reference assignments.
+function dontIgnoreReferenceAssignmentsinLongList($b) {
+    list(&$d) = $b;
+    // Do some more.
+    func_get_args(); // Warning, reference assignment.
+}
+
+function dontIgnoreReferenceAssignmentsinShortList($b) {
+    [&$d] = $b;
+    // Do some more.
+    debug_print_backtrace(); // Warning, reference assignment.
+}
+
+function dontIgnoreReferenceAssignmentsinNestedLongList($c) {
+    list($a, list(&$b)) = $c;
+    // Do some more.
+    debug_backtrace(); // Warning, reference assignment.
+}
+
+function dontIgnoreReferenceAssignmentsinNestedShortList($c) {
+    [$a, [&$b]] = $c;
+    // Do some more.
+    func_get_args(); // Warning, reference assignment.
+}
+
+// If the variable is used in the list, but not as a key and not directly assigned to, we throw a warning to err on the safe side.
+function paramIsUsedInAssignmentInLongList($x) {
+    list($this->property[$x]) = function_call();
+    debug_backtrace(); // Warning.
+}
+
+function paramIsUsedInAssignmentInShortList($x) {
+    [$this->{$x}] = function_call();
+    func_get_args(); // Warning.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -440,6 +440,15 @@ function paramIsUsedInAssignmentInShortList($x) {
     func_get_args(); // Warning.
 }
 
+function arraySliceShouldTakeSignIntoAccount( $n0, $n1, $n2, $n3, $n4 ) {
+    $n2 = function_call();
+
+    $args = array_slice( func_get_args(), -1 ); // OK, params being accessed are unchanged.
+    $args = array_slice( func_get_args(), -2 ); // OK, params being accessed are unchanged.
+
+    $args = array_slice( func_get_args(), -3 ); // Error.
+}
+
 // Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
 function LiveCoding($x) {
     $x = function_call($x);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -139,6 +139,7 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [629, 'debug_print_backtrace', '$a'],
             [639, 'func_get_args', '$p0'],
             [640, 'func_get_args', '$p0'],
+            [654, 'func_get_arg', '$propB'],
         ];
     }
 
@@ -304,7 +305,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [646]; // Parse error.
+        for ($line = 642; $line <= 653; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [661]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -286,7 +286,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [590]; // Parse error.
+        for ($line = 586; $line <= 596; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [600]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -122,6 +122,8 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [503, 'func_get_args', '$n16'],
             [504, 'func_get_args', '$n16'],
             [505, 'func_get_args', '$n16'],
+            [513, 'func_get_arg', '$n1'],
+            [514, 'func_get_args', '$n1'],
         ];
     }
 
@@ -255,7 +257,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [511]; // Parse error.
+        for ($line = 507; $line <= 512; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [520]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -286,11 +286,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        for ($line = 586; $line <= 596; $line++) {
+        for ($line = 586; $line <= 611; $line++) {
             $cases[] = [$line];
         }
 
-        $cases[] = [600]; // Parse error.
+        $cases[] = [615]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -70,6 +70,10 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [161, 'func_get_args', '$string'],
             [230, 'func_get_args', '$x'],
             [243, 'func_get_args', '$stuff'],
+            [261, 'func_get_arg', '$x'],
+            [262, 'func_get_arg', '$y'],
+            [263, 'func_get_args', '$x'],
+            [264, 'debug_backtrace', '$x'],
         ];
     }
 
@@ -160,7 +164,7 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [261]; // Parse error.
+        $cases[] = [270]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -74,6 +74,9 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [262, 'func_get_arg', '$y'],
             [263, 'func_get_args', '$x'],
             [264, 'debug_backtrace', '$x'],
+            [284, 'debug_backtrace', '$a'],
+            [285, 'debug_print_backtrace', '$a'],
+            [286, 'debug_backtrace', '$a'],
         ];
     }
 
@@ -164,11 +167,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        for ($line = 266; $line <= 279; $line++) {
+        for ($line = 266; $line <= 283; $line++) {
             $cases[] = [$line];
         }
 
-        $cases[] = [284]; // Parse error.
+        $cases[] = [292]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -190,6 +190,37 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
     }
 
     /**
+     * Verify the debug*backtrace() functions are always flagged when used as first class callable.
+     *
+     * @dataProvider dataFirstClassCallable
+     *
+     * @param int    $line         The line number where a warning is expected.
+     * @param string $functionName The name of the function to which the warning applies.
+     *
+     * @return void
+     */
+    public function testFirstClassCallable($line, $functionName)
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertWarning($file, $line, "Since PHP 7.0, functions inspecting arguments, like {$functionName}(), no longer report the original value as passed to a parameter, but will instead provide the current value. Using this function as a first class callable is a really bad idea.");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testFirstClassCallable()
+     *
+     * @return array
+     */
+    public static function dataFirstClassCallable()
+    {
+        return [
+            [667, 'debug_backtrace'],
+            [668, 'debug_print_backtrace'],
+        ];
+    }
+
+    /**
      * testNoFalsePositives.
      *
      * @dataProvider dataNoFalsePositives
@@ -309,7 +340,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [661]; // Parse error.
+        for ($line = 657; $line <= 666; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [677]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -133,6 +133,12 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [565, 'func_get_arg', '$c9'],
             [566, 'func_get_arg', '$c10'],
             [569, 'func_get_arg', '$c13'],
+            [616, 'func_get_arg', '$a'],
+            [617, 'func_get_arg', '$a'],
+            [628, 'debug_backtrace', '$a'],
+            [629, 'debug_print_backtrace', '$a'],
+            [639, 'func_get_args', '$p0'],
+            [640, 'func_get_args', '$p0'],
         ];
     }
 
@@ -286,11 +292,19 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        for ($line = 586; $line <= 611; $line++) {
+        for ($line = 586; $line <= 615; $line++) {
             $cases[] = [$line];
         }
 
-        $cases[] = [615]; // Parse error.
+        for ($line = 619; $line <= 627; $line++) {
+            $cases[] = [$line];
+        }
+
+        for ($line = 631; $line <= 638; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [646]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -178,6 +178,7 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [530, 'func_get_arg', '$a5'],
             [567, 'func_get_arg', '$c11'],
             [568, 'func_get_arg', '$c12'],
+            [584, 'func_get_arg', '$b'],
         ];
     }
 
@@ -281,7 +282,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [575]; // Parse error.
+        for ($line = 571; $line <= 583; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [590]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -147,21 +147,18 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
         $cases[] = [104];
         $cases[] = [121];
         $cases[] = [123];
-        $cases[] = [142];
-        $cases[] = [143];
-        $cases[] = [152];
-        $cases[] = [162];
-        $cases[] = [164];
-        $cases[] = [173];
-        $cases[] = [176];
-        $cases[] = [184];
-        $cases[] = [192];
-        $cases[] = [200];
-        $cases[] = [208];
-        $cases[] = [215];
-        $cases[] = [220];
-        $cases[] = [225];
-        $cases[] = [238];
+
+        for ($line = 137; $line <= 160; $line++) {
+            $cases[] = [$line];
+        }
+
+        for ($line = 162; $line <= 227; $line++) {
+            $cases[] = [$line];
+        }
+
+        for ($line = 233; $line <= 240; $line++) {
+            $cases[] = [$line];
+        }
 
         $cases[] = [261]; // Parse error.
 

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -129,6 +129,10 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [527, 'func_get_arg', '$a2'],
             [528, 'func_get_arg', '$a3'],
             [529, 'func_get_arg', '$a4'],
+            [564, 'func_get_arg', '$c8'],
+            [565, 'func_get_arg', '$c9'],
+            [566, 'func_get_arg', '$c10'],
+            [569, 'func_get_arg', '$c13'],
         ];
     }
 
@@ -172,6 +176,8 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [435, 'debug_backtrace', '$x'],
             [440, 'func_get_args', '$x'],
             [530, 'func_get_arg', '$a5'],
+            [567, 'func_get_arg', '$c11'],
+            [568, 'func_get_arg', '$c12'],
         ];
     }
 
@@ -271,7 +277,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [536]; // Parse error.
+        for ($line = 532; $line <= 563; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [575]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -82,6 +82,20 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [294, 'debug_backtrace', '$a'],
             [300, 'debug_print_backtrace', '$a'],
             [307, 'func_get_args', '$string'],
+            [316, 'func_get_args', '$string'],
+            [317, 'func_get_args', '$string'],
+            [318, 'func_get_args', '$string'],
+            [319, 'func_get_args', '$string'],
+            [320, 'func_get_args', '$string'],
+            [321, 'func_get_args', '$string'],
+            [322, 'func_get_args', '$string'],
+            [324, 'func_get_args', '$string'],
+            [325, 'func_get_args', '$string'],
+            [326, 'func_get_args', '$string'],
+            [327, 'func_get_args', '$string'],
+            [328, 'func_get_args', '$string'],
+            [329, 'func_get_args', '$string'],
+            [330, 'func_get_args', '$string'],
         ];
     }
 
@@ -181,11 +195,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
 
         $cases[] = [301];
 
-        for ($line = 308; $line <= 311; $line++) {
+        for ($line = 308; $line <= 314; $line++) {
             $cases[] = [$line];
         }
 
-        $cases[] = [315]; // Parse error.
+        $cases[] = [336]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -77,6 +77,10 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [284, 'debug_backtrace', '$a'],
             [285, 'debug_print_backtrace', '$a'],
             [286, 'debug_backtrace', '$a'],
+            [292, 'debug_backtrace', '$a'],
+            [293, 'debug_backtrace', '$a'],
+            [294, 'debug_backtrace', '$a'],
+            [300, 'debug_print_backtrace', '$a'],
         ];
     }
 
@@ -115,7 +119,6 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [255, 'func_get_args', '$matches'],
         ];
     }
-
 
     /**
      * testNoFalsePositives.
@@ -171,7 +174,13 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [292]; // Parse error.
+        for ($line = 295; $line <= 299; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [301];
+
+        $cases[] = [307]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -124,6 +124,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [505, 'func_get_args', '$n16'],
             [513, 'func_get_arg', '$n1'],
             [514, 'func_get_args', '$n1'],
+            [525, 'func_get_arg', '$a0'],
+            [526, 'func_get_arg', '$a1'],
+            [527, 'func_get_arg', '$a2'],
+            [528, 'func_get_arg', '$a3'],
+            [529, 'func_get_arg', '$a4'],
         ];
     }
 
@@ -166,6 +171,7 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [429, 'func_get_args', '$c'],
             [435, 'debug_backtrace', '$x'],
             [440, 'func_get_args', '$x'],
+            [530, 'func_get_arg', '$a5'],
         ];
     }
 
@@ -261,7 +267,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [520]; // Parse error.
+        for ($line = 516; $line <= 524; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [536]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -114,6 +114,14 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [480, 'func_get_args', '$named'],
             [481, 'func_get_args', '$named'],
             [482, 'func_get_args', '$named'],
+            [497, 'func_get_arg', '$n16'],
+            [498, 'func_get_arg', '$n16'],
+            [499, 'func_get_arg', '$n16'],
+            [500, 'func_get_arg', '$n16'],
+            [502, 'func_get_args', '$n16'],
+            [503, 'func_get_args', '$n16'],
+            [504, 'func_get_args', '$n16'],
+            [505, 'func_get_args', '$n16'],
         ];
     }
 
@@ -243,7 +251,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [488]; // Parse error.
+        for ($line = 484; $line <= 496; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [511]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -108,6 +108,12 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [461, 'func_get_args', '$n3'],
             [462, 'func_get_args', '$n3'],
             [463, 'func_get_args', '$n3'],
+            [476, 'func_get_arg', '$named'],
+            [477, 'func_get_arg', '$named'],
+            [478, 'func_get_arg', '$named'],
+            [480, 'func_get_args', '$named'],
+            [481, 'func_get_args', '$named'],
+            [482, 'func_get_args', '$named'],
         ];
     }
 
@@ -233,7 +239,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [469]; // Parse error.
+        for ($line = 465; $line <= 475; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [488]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -104,6 +104,7 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [373, 'debug_print_backtrace', '$y'],
             [378, 'func_get_args', '$z'],
             [383, 'debug_print_backtrace', '$z'],
+            [449, 'func_get_args', '$n2'],
         ];
     }
 
@@ -221,7 +222,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [446]; // Parse error.
+        for ($line = 442; $line <= 448; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [455]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -164,7 +164,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [270]; // Parse error.
+        for ($line = 266; $line <= 279; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [284]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -81,6 +81,7 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [293, 'debug_backtrace', '$a'],
             [294, 'debug_backtrace', '$a'],
             [300, 'debug_print_backtrace', '$a'],
+            [307, 'func_get_args', '$string'],
         ];
     }
 
@@ -180,7 +181,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
 
         $cases[] = [301];
 
-        $cases[] = [307]; // Parse error.
+        for ($line = 308; $line <= 311; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [315]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -96,6 +96,14 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [328, 'func_get_args', '$string'],
             [329, 'func_get_args', '$string'],
             [330, 'func_get_args', '$string'],
+            [348, 'debug_backtrace', '$x'],
+            [353, 'func_get_args', '$x'],
+            [358, 'func_get_args', '$y'],
+            [363, 'debug_print_backtrace', '$y'],
+            [368, 'func_get_args', '$y'],
+            [373, 'debug_print_backtrace', '$y'],
+            [378, 'func_get_args', '$z'],
+            [383, 'debug_print_backtrace', '$z'],
         ];
     }
 
@@ -132,6 +140,12 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [134, 'debug_backtrace', '$x'],
             [249, 'func_get_args', '$stuff'],
             [255, 'func_get_args', '$matches'],
+            [411, 'func_get_args', '$b'],
+            [417, 'debug_print_backtrace', '$b'],
+            [423, 'debug_backtrace', '$c'],
+            [429, 'func_get_args', '$c'],
+            [435, 'debug_backtrace', '$x'],
+            [440, 'func_get_args', '$x'],
         ];
     }
 
@@ -199,7 +213,15 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [336]; // Parse error.
+        for ($line = 333; $line <= 345; $line++) {
+            $cases[] = [$line];
+        }
+
+        for ($line = 386; $line <= 406; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [446]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -105,6 +105,9 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             [378, 'func_get_args', '$z'],
             [383, 'debug_print_backtrace', '$z'],
             [449, 'func_get_args', '$n2'],
+            [461, 'func_get_args', '$n3'],
+            [462, 'func_get_args', '$n3'],
+            [463, 'func_get_args', '$n3'],
         ];
     }
 
@@ -226,7 +229,11 @@ class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        $cases[] = [455]; // Parse error.
+        for ($line = 451; $line <= 460; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [469]; // Parse error.
 
         return $cases;
     }

--- a/PHPCompatibility/Util/Tests/Helpers/TokenGroup/IsNumberUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/TokenGroup/IsNumberUnitTest.inc
@@ -60,6 +60,14 @@ $a = null;
 /* test ZI7 */
 $a = - 'not a numeric string';
 
+/* test ZI8 */
+$a = 00_00;
+
+/* test ZI9 */
+$a = 0o0;
+
+/* test ZI10 */
+$a = 0O0;
 
 /*
  * Make sure that zero numbers are correctly identified.
@@ -72,6 +80,9 @@ $a = 0.0;
 
 /* test ZF2 */
 $a = - 0.0000000000;
+
+/* test ZF3 */
+$a = - 0_0.000_000_0000;
 
 
 /*
@@ -137,6 +148,34 @@ $a = + '  0123 things';
 /* test I16 */
 $a = -+-+10;
 
+/* test I17 */
+$hex = 0x123;
+
+/* test I18 */
+$binary = -0b10001;
+
+/* test I19 */
+$octal = 01234;
+
+/* test I20 */
+$php74dec = 10_456;
+
+/* test I21 */
+$php74hex = 0x1_23;
+
+/* test I22 */
+$php74binary = 0b10_001;
+
+/* test I23 */
+$php74octal = 01_234;
+
+/* test I24 */
+$php81octal = +0o1234;
+
+/* test I25 */
+$php81octal = 0O1234;
+
+
 /*
  * Make sure that numbers are correctly identified.
  *
@@ -179,6 +218,9 @@ EOT;
 
 /* test F11 */
 $a = +'0.123';
+
+/* test F12 */
+$a = 0.1_23;
 
 /* testHeredocNoEnd */
 $a = <<<EOD

--- a/PHPCompatibility/Util/Tests/Helpers/TokenGroup/IsNumberUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/TokenGroup/IsNumberUnitTest.php
@@ -149,6 +149,9 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
             'Evals to 0, no floats: - sign with string starting with 0'        => ['/* test ZI5 */', false, -0, false, false],
             'Evals to 0, no floats: null'                                      => ['/* test ZI6 */', false, 0, false, false],
             'Evals to 0, no floats: - sign with text string'                   => ['/* test ZI7 */', false, 0, false, false],
+            'Evals to 0, no floats: PHP 7.4+ underscore integer'               => ['/* test ZI8 */', false, 0, false, false],
+            'Evals to 0, no floats: PHP 8.1+ octal literal'                    => ['/* test ZI9 */', false, 0, false, false],
+            'Evals to 0, no floats: PHP 8.1+ octal literal uppercase O'        => ['/* test ZI10 */', false, 0, false, false],
 
             'Evals to 0, incl floats: int 0'                                   => ['/* test ZI1 */', true, 0.0, false, false],
             'Evals to 0, incl floats: + sign with int 0'                       => ['/* test ZI2 */', true, 0.0, false, false],
@@ -157,12 +160,17 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
             'Evals to 0, incl floats: - sign with string starting with 0'      => ['/* test ZI5 */', true, -0.0, false, false],
             'Evals to 0, incl floats: null'                                    => ['/* test ZI6 */', true, 0.0, false, false],
             'Evals to 0, incl floats: - sign with text string'                 => ['/* test ZI7 */', true, 0.0, false, false],
+            'Evals to 0, incl floats: PHP 7.4+ underscore integer'             => ['/* test ZI8 */', true, 0.0, false, false],
+            'Evals to 0, incl floats: PHP 8.1+ octal literal'                  => ['/* test ZI9 */', true, 0.0, false, false],
+            'Evals to 0, incl floats: PHP 8.1+ octal literal uppercase O'      => ['/* test ZI10 */', true, 0.0, false, false],
 
             'Evals to 0, no floats: float 0.0'                                 => ['/* test ZF1 */', false, false, false, false],
             'Evals to 0, no floats: - sign with float 0.0'                     => ['/* test ZF2 */', false, false, false, false],
+            'Evals to 0, no floats: PHP 7.4+ underscore float'                 => ['/* test ZF3 */', false, false, false, false],
 
             'Evals to 0, incl floats: float 0.0'                               => ['/* test ZF1 */', true, 0.0, false, false],
             'Evals to 0, incl floats: - sign with float 0.0'                   => ['/* test ZF2 */', true, -0.0, false, false],
+            'Evals to 0, incl floats: PHP 7.4+ underscore float'               => ['/* test ZF3 */', true, 0.0, false, false],
 
             'Evals to int, no floats: int 1'                                   => ['/* test I1 */', false, 1, true, false],
             'Evals to int, no floats: - sign with int 10'                      => ['/* test I2 */', false, -10, false, true],
@@ -184,6 +192,16 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
                                                                                => ['/* test I15 */', false, 123, true, false],
             'Evals to int, no floats: multiple signs with int'                 => ['/* test I16 */', false, 10, true, false],
 
+            'Evals to int, no floats: hexidecimal number'                      => ['/* test I17 */', false, 291, true, false],
+            'Evals to int, no floats: binary number'                           => ['/* test I18 */', false, -17, false, true],
+            'Evals to int, no floats: octal number'                            => ['/* test I19 */', false, 668, true, false],
+            'Evals to int, no floats: PHP 7.4+ decimal number with underscore' => ['/* test I20 */', false, 10456, true, false],
+            'Evals to int, no floats: PHP 7.4+ hex number with underscore'     => ['/* test I21 */', false, 291, true, false],
+            'Evals to int, no floats: PHP 7.4+ binary number with underscore'  => ['/* test I22 */', false, 17, true, false],
+            'Evals to int, no floats: PHP 7.4+ octal number with underscore'   => ['/* test I23 */', false, 668, true, false],
+            'Evals to int, no floats: PHP 8.1+ octal literal'                  => ['/* test I24 */', false, 668, true, false],
+            'Evals to int, no floats: PHP 8.1+ octal literal uppercase O'      => ['/* test I25 */', false, 668, true, false],
+
             'Evals to int, incl floats: int 1'                                 => ['/* test I1 */', true, 1.0, true, false],
             'Evals to int, incl floats: - sign with int 10'                    => ['/* test I2 */', true, -10.0, false, true],
             'Evals to int, incl floats: + sign with int 10 and whitespace'     => ['/* test I3 */', true, 10.0, true, false],
@@ -204,6 +222,16 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
                                                                                => ['/* test I15 */', true, 123.0, true, false],
             'Evals to int, incl floats: multiple signs with int'               => ['/* test I16 */', true, 10.0, true, false],
 
+            'Evals to int, incl floats: hexidecimal number'                    => ['/* test I17 */', true, 291.0, true, false],
+            'Evals to int, incl floats: binary number'                         => ['/* test I18 */', true, -17.0, false, true],
+            'Evals to int, incl floats: octal number'                          => ['/* test I19 */', true, 668.0, true, false],
+            'Evals to int, incl floats: PHP 7.4+ decimal num with underscore'  => ['/* test I20 */', true, 10456.0, true, false],
+            'Evals to int, incl floats: PHP 7.4+ hex number with underscore'   => ['/* test I21 */', true, 291.0, true, false],
+            'Evals to int, incl floats: PHP 7.4+ binary num with underscore'   => ['/* test I22 */', true, 17.0, true, false],
+            'Evals to int, incl floats: PHP 7.4+ octal number with underscore' => ['/* test I23 */', true, 668.0, true, false],
+            'Evals to int, incl floats: PHP 8.1+ octal literal'                => ['/* test I24 */', true, 668.0, true, false],
+            'Evals to int, incl floats: PHP 8.1+ octal literal uppercase O'    => ['/* test I25 */', true, 668.0, true, false],
+
             'Evals to float, no floats: float 1.23'                            => ['/* test F1 */', false, false, false, false],
             'Evals to float, no floats: float -10.123'                         => ['/* test F2 */', false, false, false, false],
             'Evals to float, no floats: float +10.123 with whitespace'         => ['/* test F3 */', false, false, false, false],
@@ -217,6 +245,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
                                                                                => ['/* test F9 */', false, false, false, false],
             'Evals to float, no floats: heredoc containing float'              => ['/* test F10 */', false, false, false, false],
             'Evals to float, no floats: + sign with text string'               => ['/* test F11 */', false, false, false, false],
+            'Evals to float, no floats: PHP 7.4+ underscore number'            => ['/* test F12 */', false, false, false, false],
 
             'Evals to float, incl floats: float 1.23'                          => ['/* test F1 */', true, 1.23, true, false],
             'Evals to float, incl floats: float -10.123'                       => ['/* test F2 */', true, -10.123, false, true],
@@ -231,6 +260,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
                                                                                => ['/* test F9 */', true, -10e8, false, true],
             'Evals to float, incl floats: heredoc containing float'            => ['/* test F10 */', true, 10.123, true, false],
             'Evals to float, incl floats: + sign with text string'             => ['/* test F11 */', true, 0.123, true, false],
+            'Evals to float, incl floats: PHP 7.4+ underscore number'          => ['/* test F12 */', true, 0.123, true, false],
         ];
     }
 


### PR DESCRIPTION
⚠️ This PR depends on PR #1891 :warning:

---

### FunctionUse/ArgumentFunctionsReportCurrentValue: test case file - tabs vs spaces

### FunctionUse/ArgumentFunctionsReportCurrentValue: make "no false positives" data provider more robust

(and easier to maintain).

### FunctionUse/ArgumentFunctionsReportCurrentValue: test case file - fix parse and compile errors

These parse errors and compile errors did not affect the tests in any way.

The changes in the function/class names are intended to make it more straight-forward to see what is being tested in each case (aside from fixing compile errors "redeclaration of function ....").

### FunctionUse/ArgumentFunctionsReportCurrentValue: add some extra tests 

... for code in the sniff previously uncovered.

### FunctionUse/ArgumentFunctionsReportCurrentValue: add more tests with variations of FQN function calls

### FunctionUse/ArgumentFunctionsReportCurrentValue: minor code simplification

A few lines earlier there is already a `continue` for when `$afterVar` would be `false`.

### FunctionUse/ArgumentFunctionsReportCurrentValue: simplify code with PHPCSUtils [1]

### FunctionUse/ArgumentFunctionsReportCurrentValue: simplify code with PHPCSUtils [2]

### FunctionUse/ArgumentFunctionsReportCurrentValue: simplify code with PHPCSUtils [3]

### FunctionUse/ArgumentFunctionsReportCurrentValue: track "previous non empty" for the loop

... to prevent some unnecessary token walking.

Also: as we are searching a known set of tokens, we know that the "previous token" will always exist, so no need to check against `false`.

### FunctionUse/ArgumentFunctionsReportCurrentValue: bug fix - handling of constant in debug*backtrace()

The `DEBUG_BACKTRACE_IGNORE_ARGS` should only be recognized as a reason to ignore the call to the target functions if it refers to the PHP native global constant.

This commit fixes the sniff to not have false negatives if a namespaced constant is used instead of the global one.

Includes tests.

### FunctionUse/ArgumentFunctionsReportCurrentValue: allow for numeric $options in debug*backtrace()

As per the PHP manual, while the use of the PHP native constants is recommended, it is also perfectly fine to use a numeric value to set the option flags and this is even documented as such in the manual.

This commit adds handling of the documented/known numeric option values which mean the "args" index will not be set, to the sniff.

Note: this handling presumes that a plain decimal number would have been passed.
It is possible to pass a non-decimal number or even a calculation, and while that is supported in PHP, I deem it extremely unlikely anyone would do so and if they do, it just means they get the warning/error, despite the numeric value being equal to one of the values we're now detecting as flags to ignore the function call, so no harm, no foul.

Includes tests.

Ref: https://www.php.net/manual/en/function.debug-backtrace.php#refsect1-function.debug-backtrace-parameters

### FunctionUse/ArgumentFunctionsReportCurrentValue: bug fix - check function names case-insensitively

This was already done correctly for the target functions, but not for the check whether a call to any of the target functions was nested in a call to `array_slice()` or `array_splice()`.

Includes tests.

### FunctionUse/ArgumentFunctionsReportCurrentValue: bug fix - false negatives for methods and namespaced functions

The sniff contains special casing for when any of the target functions are nested within the PHP native global `array_splice()` or `array_splice()` functions.

However, this special casing did not take namespaced functions or methods mirroring the name of the PHP native functions, into account.

This commit adds more defensive coding to verify we're really dealing with the PHP native global functions.

As the code to check this was already used elsewhere too, it has been moved to a function, so it can be used in both places.

Includes tests.

### FunctionUse/ArgumentFunctionsReportCurrentValue: set redundant default value

This variable is only accessed within conditions and those conditions already sufficiently ensure that the variable will be set for the conditions path.

Even so, PHPStan cannot handle this, so we may as well declare a sensible default for this variable to make things more explicit.

#FunctionUse/ArgumentFunctionsReportCurrentValue: improve handling of list assignments

Array variables can be destructured via lists and the sniff did not take this into account until now.

The net effect of this was:
* False positive warning "needs inspection" when a function parameter is list-destructured to variables which are not parameters.
* Warning instead of error when a function parameter is assigned a new value via list-destructuring.
* False positive error when a function parameter is used as a key in list-destructuring. The key is just used to retrieve the target value from the array and is not changed, so we can safely ignore these.
* Accidentally correct handling (warning "needs inspection") for when a reference assignment is used in the list-destructuring of a function parameter.

This commit adds dedicated handling of lists to this sniff, which fixes each of these problems.

Includes tests.

### FunctionUse/ArgumentFunctionsReportCurrentValue: improve handling of array_slice/splice [1]

The offset passed to `array_slice()`/`array_splice()` can be a negative number (offset from the end of the array).

Until now, the sniff did not handle this and would threat all numbers as positives numbers, which could lead to both false positives as well as false negatives.

Fixed now.

Includes tests.

### FunctionUse/ArgumentFunctionsReportCurrentValue: improve handling of array_slice/splice [2]

Both `array_slice()`/`array_splice()` take a `$length` parameter which affects which elements are retrieved.

Until now, the sniff did not handle this and would presume all parameter from `$offset` to the end of the list should be taken into account, while if we take length into account, we can prevent some more false positives.

Fixed now.

Includes tests.

### FunctionUse/ArgumentFunctionsReportCurrentValue: handle non-decimal numbers

While probably rare, it is perfectly valid to pass the `$arg_num` parameter for `func_get_arg()` or the `$offset` or `$length` parameters for `array_slice()` and `array_splice()` as non-decimal numbers.

And while the second case (`array_slice()`/`array_splice()`) was fixed in a previous commit, the former (`$arg_num`) was not.

Fixed now.

Includes tests.

### FunctionUse/ArgumentFunctionsReportCurrentValue: add tests with PHP 7.4 underscore integers

These are handled correctly since some of the fixes in the previous commit went in (same fixes were needed for other reasons).

These tests just safeguard this.

### FunctionUse/ArgumentFunctionsReportCurrentValue: add tests with PHP 8.1 octal literals

These are handled correctly since support for non-decimal numbers was added (same fix was needed).

### FunctionUse/ArgumentFunctionsReportCurrentValue: special case PHP 7.4+ null coalesce assignment

In contrast to all other assignment operators, the null coalesce assignment operator _may_ or _may not_ change the value of a variable.

With that in mind, I believe it is more appropriate to throw a warning when a parameter is being assigned to with the null coalesce operator (in contrast to the error being thrown for other assignment operators).

Includes tests, both for a variety of assignment operators as well as for the null coalesce assignment operator.

### FunctionUse/ArgumentFunctionsReportCurrentValue: improve handling of simple control structure conditions

If a function parameter is only used in a control structure condition without further conditions/comparisons, we can be sure it has not been changed.

This commit adds support for detecting this to reduce false positives further.

Notes:
* `foreach()` is special cased as we can ignore use of the variable before the `as`, but should error on use of the variable after the `as`.
* `catch()` is special cased as any variable in catch will always be an assignment, so we should error on that.
* In all other cases, when we're in a control structure condition without other non-empty tokens, we can ignore the use of the variable.

Includes handling of PHP 8.0+ `match()` control structures.

Includes tests.

Loosely related to #796

### FunctionUse/ArgumentFunctionsReportCurrentValue: ignore target functions in PHP 7.4+ arrow functions

Arrow functions can engage with variables outside of their own scope, so should not blindly be skipped over, but if one of the target functions is seen within the arrow function body, it applies to the arrow function, not the outside scope, so this needs careful handling.

Now, while arrow functions can only contain a single statement in their body, they can still run into the problem this sniff flags (see example code in the tests).
Having said that, arrow functions were introduced in PHP 7.4, four years after the change this sniff checks for entered PHP, so anyone who uses any of the target functions in the body of an arrow function should expect the "new" behaviour.

With this in mind, this commit explicit does NOT add checking of arrow functions to the sniff.

However, it does change the sniff to prevent false positives on any of the target functions being seen within the body of an arrow function.

Includes tests.

### FunctionUse/ArgumentFunctionsReportCurrentValue: prevent false positives on PHP 8.0+ attributes

`T_STRING` tokens in PHP 8.0+ attributes are either class names or possibly constant names (as a parameter for the class instantiation).
They are never function calls.

This commit ensures that `T_STRING` tokens in attributes are not confused with function calls.

Includes tests.

### FunctionUse/ArgumentFunctionsReportCurrentValue: update tests to include PHP 8.0 trailing commas in param lists

### FunctionUse/ArgumentFunctionsReportCurrentValue: ignore PHP 8.0+ $obj::class

If a the class name of an object parameter is retrieved using the `$obj::class` syntax, we know the parameter is not being changed, so we can safely ignore it.

Includes tests.

### FunctionUse/ArgumentFunctionsReportCurrentValue: add support for PHP 8.0+ named arguments in function calls

For the `array_*()` functions to was incidentally and partially added in some of the previous commits, though the code still needed to be adjusted to allow for an unexpected parameter order.
For the "target functions", support was not handled so far, so this commit adds support for named parameters.

Verified the parameter name used is in line with the name as per the PHP 8.0 release. PHP itself renamed a lot of parameters in PHP 8.0. As named parameters did not exist before PHP 8.0, the parameter name as per PHP 8.0 (or above) is the only relevant name.

Name verification reference:
* `func_get_arg`: https://3v4l.org/liZU1#veol
* `debug_backtrace`: https://3v4l.org/sFqA7#veol
* `debug_print_backtrace`: https://3v4l.org/LtnLq#veol
* `array_slice`: https://3v4l.org/7hUY7#veol
* `array_splice`: https://3v4l.org/XU9KW#veol

Includes adding the unit tests to include tests using named parameters.

Related to #1239

:point_right: This commit will be more straight-forward to review while ignoring whitespace changes.

### FunctionUse/ArgumentFunctionsReportCurrentValue: add test with PHP 8.0+ constructor property promotion

Shouldn't have any impact, just safeguarding this with a test.

### FunctionUse/ArgumentFunctionsReportCurrentValue: add new error for use as PHP 8.1+ first class callable

Using the `func_get_arg*()` functions as first class callables is not allowed in PHP. See: https://3v4l.org/ISt2r and https://3v4l.org/aTjjQ

However, using the `debug_*backtrace()` function as first class callable is allowed, but seems like a really bad idea....
See: https://3v4l.org/j8lWg and https://3v4l.org/8qbJF

This commit adds handling for this by:
* Ignoring the use of `func_get_arg*()` functions when used as first class callables. That's forbidden by PHP, so not our concern.
* And flagging the use of `debug_*backtrace()` functions when used as first class callables with a warning with its own error code.

Includes tests.