### PR TITLE
ResolveHelper::getFQClassNameFromDoubleColonToken(): various improvements

### DIFF
--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -158,7 +158,7 @@ final class ResolveHelper
             ) {
                 return '';
             }
-            $className = $phpcsFile->getDeclarationName($classDeclarationPtr);
+            $className = ObjectDeclarations::getName($phpcsFile, $classDeclarationPtr);
             return self::getFQName($phpcsFile, $classDeclarationPtr, $className);
         }
 

--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -162,12 +162,8 @@ final class ResolveHelper
             return self::getFQName($phpcsFile, $classDeclarationPtr, $className);
         }
 
-        $find = [
-            \T_NS_SEPARATOR,
-            \T_STRING,
-            \T_NAMESPACE,
-            \T_WHITESPACE,
-        ];
+        $find  = Collections::namespacedNameTokens();
+        $find += Tokens::$emptyTokens;
 
         $start = $phpcsFile->findPrevious($find, $stackPtr - 1, null, true, null, true);
         if ($start === false || isset($tokens[($start + 1)]) === false) {
@@ -175,7 +171,7 @@ final class ResolveHelper
         }
 
         $start     = ($start + 1);
-        $className = $phpcsFile->getTokensAsString($start, ($stackPtr - $start));
+        $className = GetTokensAsString::noEmpties($phpcsFile, $start, ($stackPtr - 1));
         $className = \trim($className);
 
         return self::getFQName($phpcsFile, $stackPtr, $className);

--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Helpers;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\ObjectDeclarations;
@@ -150,8 +151,11 @@ final class ResolveHelper
 
         // Get the classname from the class declaration if self is used.
         if ($tokens[$stackPtr - 1]['code'] === \T_SELF) {
-            $classDeclarationPtr = $phpcsFile->findPrevious(\T_CLASS, $stackPtr - 1);
-            if ($classDeclarationPtr === false) {
+            $classDeclarationPtr = Conditions::getLastCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
+            if ($classDeclarationPtr === false
+                || $tokens[$classDeclarationPtr]['code'] === \T_ANON_CLASS
+                || $tokens[$classDeclarationPtr]['code'] === \T_TRAIT
+            ) {
                 return '';
             }
             $className = $phpcsFile->getDeclarationName($classDeclarationPtr);

--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -165,11 +165,7 @@ final class ResolveHelper
         $find  = Collections::namespacedNameTokens();
         $find += Tokens::$emptyTokens;
 
-        $start = $phpcsFile->findPrevious($find, $stackPtr - 1, null, true, null, true);
-        if ($start === false || isset($tokens[($start + 1)]) === false) {
-            return '';
-        }
-
+        $start     = $phpcsFile->findPrevious($find, $stackPtr - 1, null, true, null, true);
         $start     = ($start + 1);
         $className = GetTokensAsString::noEmpties($phpcsFile, $start, ($stackPtr - 1));
         $className = \trim($className);

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.inc
@@ -26,7 +26,7 @@ namespace Testing {
     /* test 11 */
     DateTime::$static_property;
     /* test 12 */
-    DateTime::static_function();
+    namespace\DateTime::static_function();
 
     class MyClass extends Foo {
         function test() {

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.inc
@@ -91,3 +91,10 @@ interface HasConstantScalarDeclaration {
 \DateTime
     /*comment*/
         ::comment_tolerance();
+
+$anon = new readonly class {
+    public function foo() {
+        /* test 25 */
+        self::INSIDE_READONLY_ANON_CLASS;
+    }
+};

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.inc
@@ -21,35 +21,35 @@ $var = (5+AnotherNS\DateTime::$static_property);
 
 
 namespace Testing {
-	/* test 10 */
-	DateTime::CONSTANT;
-	/* test 11 */
-	DateTime::$static_property;
-	/* test 12 */
-	DateTime::static_function();
+    /* test 10 */
+    DateTime::CONSTANT;
+    /* test 11 */
+    DateTime::$static_property;
+    /* test 12 */
+    DateTime::static_function();
 
-	class MyClass extends Foo {
-		function test() {
-			/* test 13 */
-			echo self::CONSTANT;
-			/* test 14 */
-			echo parent::$static_property;
-			/* test 15 */
-			static::test_function();
-		}
-	}
+    class MyClass extends Foo {
+        function test() {
+            /* test 13 */
+            echo self::CONSTANT;
+            /* test 14 */
+            echo parent::$static_property;
+            /* test 15 */
+            static::test_function();
+        }
+    }
 }
 
 
 class MyClass extends Bar {
-	function test() {
-		/* test 16 */
-		echo self::CONSTANT;
-		/* test 17 */
-		echo parent::$static_property;
-		/* test 18 */
-		static::test_function();
-	}
+    function test() {
+        /* test 16 */
+        echo self::CONSTANT;
+        /* test 17 */
+        echo parent::$static_property;
+        /* test 18 */
+        static::test_function();
+    }
 }
 
 // Issue #205

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.inc
@@ -86,3 +86,8 @@ interface HasConstantScalarDeclaration {
     /* test 23 */
     public CONST_B = self::CONST_A + 10;
 }
+
+/* test 24 */
+\DateTime
+    /*comment*/
+        ::comment_tolerance();

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.inc
@@ -61,3 +61,28 @@ class Foo {
 $theclass = 'Foo';
 /* test 19 */
 $theclass::bar(42);
+
+/* test 20 */
+// Intentional fatal error / cannot access self when no class scope is active.
+class Unrelated {}
+self::OUTSIDE_CLASS;
+
+$anon = new class {
+    public function foo() {
+        /* test 21 */
+        self::INSIDE_ANON_CLASS;
+    }
+};
+
+trait TraitNameIsNotClassName {
+    public function foo() {
+        /* test 22 */
+        self::INSIDE_TRAIT;
+    }
+}
+
+interface HasConstantScalarDeclaration {
+    public CONST_A = 10;
+    /* test 23 */
+    public CONST_B = self::CONST_A + 10;
+}

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
@@ -27,6 +27,29 @@ final class GetFQClassNameFromDoubleColonTokenUnitTest extends UtilityMethodTest
 {
 
     /**
+     * Test an empty string is returned when the stackptr to a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testGetFQClassNameFromDoubleColonTokenNonExistentToken()
+    {
+        $result = ResolveHelper::getFQClassNameFromDoubleColonToken(self::$phpcsFile, 100000);
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * Test an empty string is returned when an invalid token is passed.
+     *
+     * @return void
+     */
+    public function testGetFQClassNameFromDoubleColonTokenInvalidToken()
+    {
+        $stackPtr = $this->getTargetToken('/* test 1 */', \T_STRING);
+        $result   = ResolveHelper::getFQClassNameFromDoubleColonToken(self::$phpcsFile, $stackPtr);
+        $this->assertSame('', $result);
+    }
+
+    /**
      * Test retrieving a fully qualified class name based on a T_DOUBLE_COLON token.
      *
      * @dataProvider dataGetFQClassNameFromDoubleColonToken

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
@@ -22,6 +22,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  * @since 7.0.5
  *
  * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQClassNameFromDoubleColonToken
+ * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQName
  */
 final class GetFQClassNameFromDoubleColonTokenUnitTest extends UtilityMethodTestCase
 {

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
@@ -101,6 +101,7 @@ final class GetFQClassNameFromDoubleColonTokenUnitTest extends UtilityMethodTest
             ['/* test 22 */', ''],
             ['/* test 23 */', '\HasConstantScalarDeclaration'],
             ['/* test 24 */', '\DateTime'],
+            ['/* test 25 */', ''],
         ];
     }
 }

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
@@ -95,6 +95,10 @@ final class GetFQClassNameFromDoubleColonTokenUnitTest extends UtilityMethodTest
             ['/* test 17 */', ''],
             ['/* test 18 */', ''],
             ['/* test 19 */', ''],
+            ['/* test 20 */', ''],
+            ['/* test 21 */', ''],
+            ['/* test 22 */', ''],
+            ['/* test 23 */', '\HasConstantScalarDeclaration'],
         ];
     }
 }

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromDoubleColonTokenUnitTest.php
@@ -99,6 +99,7 @@ final class GetFQClassNameFromDoubleColonTokenUnitTest extends UtilityMethodTest
             ['/* test 21 */', ''],
             ['/* test 22 */', ''],
             ['/* test 23 */', '\HasConstantScalarDeclaration'],
+            ['/* test 24 */', '\DateTime'],
         ];
     }
 }


### PR DESCRIPTION
### ResolveHelper::getFQClassNameFromDoubleColonToken(): clean up test case file

Use spaces not tabs (unless testing something specific to tabs).

### ResolveHelper::getFQClassNameFromDoubleColonToken(): add some extra tests

### ResolveHelper::getFQClassNameFromDoubleColonToken(): bug + performance fix - misidentification of class for "self"

If the "self" keyword would be found before a double colon, the utility method would try to get the class name for "self", however, it did not do so correctly.

Previously, the method would try to find the applicable class declaration by walking the tokens to find the first use of the `class` keyword. However, the `self` keyword may be used within an anonymous class, enum, trait etc, in which case, the `class` keyword would never be found, while for enums and interfaces, the name `self` resolves to, can be determined.

On top of that, the `class` keyword found this way may not be the scope in which the `self` keyword is being used, leading to incorrectly resolved names.

This token walking was also highly inefficient and had a negative performance impact.

These problems have now been fixed by:
1. Using the PHPCSUtils `Conditions::getLastCondition()` method to get the applicable OO scope.
    This also effectively removes the token walking.
2. Searching via the `Conditions::getLastCondition()` method for **all** OO scopes and bowing out if the `self` keyword is not found in an OO scope or the OO scope found is an anonymous class or a trait.

Includes tests proving the bug and safeguarding the fix.
All four tests would previously resolve the `self` keyword to the `Unrelated` class.

### ResolveHelper::getFQClassNameFromDoubleColonToken(): bug fix - improve comment handling

A comment in an unexpected place, like between the Class name and the double colon, could previously throw off the method and lead to unusable results (class names including the comment, which makes them incomparable for our purposes).

Fixed now by on the one hand allowing for comments while trying to find the start of the name, and on the other hand by using the PHPCSUtils `GetTokensAsString::noEmpties()` method to get the name without stray whitespace or comments.

Includes an additional test proving the bug and safeguarding the fix.

### ResolveHelper::getFQClassNameFromDoubleColonToken(): further implement PHPCSUtils

### ResolveHelper::getFQClassNameFromDoubleColonToken(): remove redundant condition

There will always be something before a double colon, even if it is only the opening PHP tag.
And there will always be a token after the "start", even if only the `$stackPtr`.

### ResolveHelper::getFQName(): indicate that method is covered 

... via the tests for the `ResolveHelper::getFQClassNameFromDoubleColonToken()` method.

Includes minor adjustment to one of the tests to make sure it is properly covered.

### PHP 8.3 | ResolveHelper::getFQClassNameFromDoubleColonToken(): add test with readonly anon class