### PR TITLE
PHP 8.4 | Various sniffs: add tests with properties in interfaces

### DIFF
--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.inc
@@ -110,6 +110,14 @@ class AsymVisibility {
     ) {}
 }
 
+// PHP 8.4: safeguard the sniff functions correctly for properties in interfaces.
+interface PropertiesInInterfaces
+{
+    // Illegal, but that's not the concern of this sniff.
+    // Fatal error: Hooked properties cannot be readonly.
+    readonly int $readonly { get; }
+}
+
 // Parse error. This has to be the last test in the file.
 class ParseError {
     public readonly $propertyWithoutSemiColon

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.php
@@ -65,8 +65,9 @@ final class NewReadonlyPropertiesUnitTest extends BaseSniffTestCase
             [104],
             [105],
             [109],
+            [118],
 
-            [115],
+            [123],
         ];
     }
 

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.inc
@@ -198,3 +198,13 @@ class AsymVisibility {
         protected private(set) (My&\DNF)|false $asymInConstructor,
     ) {}
 }
+
+// PHP 8.4: safeguard the sniff functions correctly for properties in interfaces.
+interface PropertiesInInterfaces
+{
+    public $untyped { get; }
+    public int $typed { get; }
+
+    // Any visibility but "public" is invalid, but that's not the concern of this sniff.
+    protected string|false $unionType { get; set; }
+}

--- a/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewTypedPropertiesUnitTest.php
@@ -112,6 +112,8 @@ final class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             [189],
             [195, true],
             [198],
+            [206, true],
+            [209],
         ];
     }
 
@@ -153,6 +155,7 @@ final class NewTypedPropertiesUnitTest extends BaseSniffTestCase
         $cases[] = [127];
         $cases[] = [153];
         $cases[] = [154];
+        $cases[] = [205];
 
         return $cases;
     }
@@ -272,6 +275,7 @@ final class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             ['true', '8.1', 147, '8.2'],
             ['null', '7.4', 175, '8.2'],
             ['false', '7.4', 198, '8.0', false],
+            ['false', '7.4', 209, '8.0'],
         ];
     }
 
@@ -344,6 +348,7 @@ final class NewTypedPropertiesUnitTest extends BaseSniffTestCase
             ['iterable|array|Traversable', 105],
             ['int|string|INT', 108],
             ['float|int', 114],
+            ['string|false', 209],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.4 | Classes/NewReadonlyProperties: add tests with properties in interfaces

Already handled correctly by the sniff, just safeguarding this.

### PHP 8.4 | Classes/NewTypedProperties: add tests with properties in interfaces

Already handled correctly by the sniff, just safeguarding this.