### PR TITLE
FunctionDeclarations/RemovedImplicitlyNullableParam: bug fix x 2 (uppercase null/mixed & FQN null)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedImplicitlyNullableParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedImplicitlyNullableParamSniff.php
@@ -109,9 +109,10 @@ final class RemovedImplicitlyNullableParamSniff extends Sniff
                 continue;
             }
 
-            if ($param['type_hint'] === 'null'
-                || $param['type_hint'] === 'mixed'
-                || TypeString::isNullable($param['type_hint'])
+            $typeHint = \strtolower($param['type_hint']);
+            if ($typeHint === 'null'
+                || $typeHint === 'mixed'
+                || TypeString::isNullable($typeHint)
             ) {
                 // Type is nullable, no issue.
                 continue;

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedImplicitlyNullableParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedImplicitlyNullableParamSniff.php
@@ -11,11 +11,11 @@
 namespace PHPCompatibility\Sniffs\FunctionDeclarations;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\TypeString;
 
 /**
@@ -38,19 +38,6 @@ final class RemovedImplicitlyNullableParamSniff extends Sniff
 {
 
     /**
-     * Tokens allowed in the default value.
-     *
-     * This property will be enriched in the register() method.
-     *
-     * @since 10.0.0
-     *
-     * @var array<int|string, int|string>
-     */
-    private $allowedInDefault = [
-        \T_NULL => \T_NULL,
-    ];
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 10.0.0
@@ -59,8 +46,6 @@ final class RemovedImplicitlyNullableParamSniff extends Sniff
      */
     public function register()
     {
-        $this->allowedInDefault += Tokens::$emptyTokens;
-
         return Collections::functionDeclarationTokens();
     }
 
@@ -130,10 +115,11 @@ final class RemovedImplicitlyNullableParamSniff extends Sniff
              */
 
             // Determine the end of the parameter.
-            $paramEnd   = ($param['comma_token'] === false) ? $closeParens : $param['comma_token'];
-            $hasNull    = $phpcsFile->findNext(\T_NULL, $param['default_token'], $paramEnd);
-            $hasNonNull = $phpcsFile->findNext($this->allowedInDefault, $param['default_token'], $paramEnd, true);
-            if ($hasNull === false || $hasNonNull !== false) {
+            $paramEnd          = ($param['comma_token'] === false) ? $closeParens : $param['comma_token'];
+            $cleanDefaultValue = GetTokensAsString::noEmpties($phpcsFile, $param['default_token'], ($paramEnd - 1));
+            $cleanDefaultValue = \strtolower($cleanDefaultValue);
+
+            if ($cleanDefaultValue !== 'null' && $cleanDefaultValue !== '\null') {
                 // No null default value, we're okay.
                 continue;
             }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.inc
@@ -62,5 +62,11 @@ class AsymVisibility {
     ) {}
 }
 
+// Safeguard handling of fully qualified null as default value.
+function fqnNullDefaultNoType($var = \null) {} // OK.
+function fqnNullDefaultWithNullInUnionType(Countable|null $var = \NULL) {} // OK.
+function fqnNullDefaultWithNonNullableType(Type $var = \null) {} // Not OK.
+$arrow = fn(iterable $i = \NULL /*comment*/): bool => doSomething($i); // Not OK.
+
 // Intentional parse error. This has to be the last test in the file.
 $closure = function( Type $a = null, $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.inc
@@ -11,11 +11,11 @@ function noNullDefaultValueButContainsNull(Type $var = new Type(null)) {}
 
 function nullDefaultNoType($var = null) {}
 function nullDefaultWithNullableType(?T $var = null) {}
-function nullDefaultWithNullInUnionType(Countable|null $var = null) {}
+function nullDefaultWithNullInUnionType(Countable|NULL $var = null) {}
 function nullDefaultWithNullInDNFType((Foo&Bar)|null $var = /*comment*/ null) {}
-function nullDefaultWithNullType(null $var = null /*comment*/ ) {}
+function nullDefaultWithNullType(NULL $var = null /*comment*/ ) {}
 function nullDefaultWithMixedType(mixed $var = null) {}
-function nullDefaultWithMixedTypeAndComments( /*comment*/ mixed /*comment*/ $var = null) {}
+function nullDefaultWithMixedTypeAndComments( /*comment*/ MIXED /*comment*/ $var = null) {}
 
 // Fatal error on all versions.
 // The old exception did not apply to properties. A non-nullable typed property with a non-null default value

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.php
@@ -58,6 +58,8 @@ final class RemovedImplicitlyNullableParamUnitTest extends BaseSniffTestCase
             [49],
             [50],
             [54],
+            [68],
+            [69],
         ];
     }
 
@@ -95,9 +97,11 @@ final class RemovedImplicitlyNullableParamUnitTest extends BaseSniffTestCase
         $cases[] = [51];
         $cases[] = [60];
         $cases[] = [61];
+        $cases[] = [66];
+        $cases[] = [67];
 
         // Parse error test case.
-        $cases[] = [66];
+        $cases[] = [72];
 
         return $cases;
     }


### PR DESCRIPTION
### FunctionDeclarations/RemovedImplicitlyNullableParam: bug fix - allow for uppercase `null`/`mixed` in type declaration

Includes tests via updating some pre-existing tests.

### FunctionDeclarations/RemovedImplicitlyNullableParam: bug fix - allow for FQN `null` in default value

Not commonly used, but it is valid PHP.

Note: FQN `null` in a type declaration is not allowed and therefor not accounted for.

Includes tests.