### PR TITLE
Composer: raise the minimum supported PHPCS + PHPCSUtils versions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To start contributing, fork the repository, create a new branch in your fork, ma
 
 Please make sure that your pull request contains unit tests covering what's being addressed by it.
 
-* All code should be compatible with PHPCS >= 3.13.0.
+* All code should be compatible with PHPCS >= 3.13.3.
 * All code should be compatible with PHP 5.4 to PHP nightly.
 * All code should comply with the PHPCompatibility coding standards.
     The [ruleset used by PHPCompatibility](https://github.com/PHPCSStandards/PHPCSDevCS) is largely based on PSR-12 with minor variations and some additional checks for array layout and documentation and such.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
 
         include:
           - php: '7.2'
-            phpcs_version: '^3.13.0'
+            phpcs_version: '^3.13.3'
             custom_ini: true
             experimental: false
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Requirements
 -------
 
 * PHP 5.4+
-* PHP CodeSniffer: 3.13.0+.
+* PHP CodeSniffer: 3.13.3+.
 
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP CodeSniffer. You should get consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on a recent PHP version in combination with a recent PHP_CodeSniffer version.
 
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP CodeSniffer 3.x.
 As of version 9.0.0, support for PHP CodeSniffer 1.5.x and low 2.x versions < 2.3.0 has been dropped.
-As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 3.13.0 has been dropped.
+As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 3.13.3 has been dropped.
 
 
 Thank you

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
   },
   "require": {
     "php": ">=5.4",
-    "squizlabs/php_codesniffer": "^3.13.0",
-    "phpcsstandards/phpcsutils": "^1.1.1"
+    "squizlabs/php_codesniffer": "^3.13.3",
+    "phpcsstandards/phpcsutils": "^1.1.2"
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.4.0",


### PR DESCRIPTION
PHP_CodeSniffer 3.13.3 + 3.13.4 and PHPCSUtils 1.1.2 have been released. This commit raises the minimum supported PHPCS/Utils versions for improved PHP 8.4 support.

Note: raising to 3.13.4 is not necessary for PHPCompatibility as the fixes includes in that mostly don't affect us.

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

Ref:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.1.2
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.13.3
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.13.4