### PR TITLE
PHP 8.4 | :sparkles: New `PHPCompatibility.Classes.NewAbstractProperties` sniff

### DIFF
--- a/PHPCompatibility/Docs/Classes/NewAbstractPropertiesStandard.xml
+++ b/PHPCompatibility/Docs/Classes/NewAbstractPropertiesStandard.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Abstract Properties"
+    >
+    <standard>
+    <![CDATA[
+    Hooked OO properties can be declared as abstract since PHP 8.4.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: not using the abstract modifier.">
+        <![CDATA[
+class Foo {
+    public string $name;
+}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.4: using the abstract modifier.">
+        <![CDATA[
+abstract class Foo {
+    <em>abstract</em> public string $name { get; }
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Classes/NewAbstractPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAbstractPropertiesSniff.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\ObjectDeclarations;
+use PHPCSUtils\Utils\Scopes;
+use PHPCSUtils\Utils\Variables;
+
+/**
+ * Using the "abstract" modifier for (hooked) properties is available since PHP 8.4.
+ *
+ * Notes:
+ * - The "abstract" modifier is not supported for multi-property declarations,
+ *   as a hook is required and hooks are not supported for multi-property.
+ * - The "abstract" modifier is not supported in constructor property promotion as that wouldn't make sense.
+ * - The "abstract" modifier is also not supported for interface properties as those are implicitly abstract
+ *   (but that's not the concern of this sniff).
+ *
+ * PHP version 8.4
+ *
+ * @link https://wiki.php.net/rfc/property-hooks#abstract_properties
+ *
+ * @since 10.0.0
+ */
+final class NewAbstractPropertiesSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return Collections::ooPropertyScopes();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrBelow('8.3') === false) {
+            return;
+        }
+
+        $properties = ObjectDeclarations::getDeclaredProperties($phpcsFile, $stackPtr);
+        if (empty($properties)) {
+            // There are no declared properties.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $skipTo = $stackPtr;
+        foreach ($properties as $name => $ptr) {
+            if (Scopes::isOOProperty($phpcsFile, $ptr) === false) {
+                // This must be a constructor promoted property. Abstract is not supported.
+                continue;
+            }
+
+            $propertyInfo = Variables::getMemberProperties($phpcsFile, $ptr);
+            if ($propertyInfo['is_abstract'] === false) {
+                // Not a abstract property.
+                continue;
+            }
+
+            $abstractPtr = $phpcsFile->findPrevious([\T_SEMICOLON, \T_ABSTRACT], ($ptr - 1));
+            if ($abstractPtr === false || $tokens[$abstractPtr]['code'] !== \T_ABSTRACT) {
+                // Shouldn't be possible, but just in case.
+                $abstractPtr = $ptr; // @codeCoverageIgnore
+            }
+
+            $phpcsFile->addError(
+                'The abstract modifier for OO properties is not supported in PHP 8.3 or earlier.',
+                $abstractPtr,
+                'Found'
+            );
+
+            $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($ptr + 1));
+            if ($endOfStatement !== false) {
+                // Don't throw the same error multiple times for multi-property declarations.
+                $skipTo = ($endOfStatement + 1);
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewAbstractPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewAbstractPropertiesUnitTest.inc
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Valid cross-version/not our targets.
+ */
+
+// Variables defined in the global namespace can not have the abstract modifier,
+// but this is outside the scope of this library. Would cause a parse error anyway.
+abstract $abstractOutsideOOScope = 'not valid';
+
+class ClassWithoutProperties {}
+
+
+// The sniff should not trigger on uses of the "abstract" keyword other than for properties.
+// The sniff should also not trigger on non-abstract properties or on variables which are not properties.
+abstract class ClassWithoutAbstractProperties
+{
+    protected $notAbstract, $alsoNotAbstract;
+
+    abstract function bar($notAbstract);
+
+    public function __construct(
+        public $promotedPropA,
+        protected $promotedPropB,
+    ) {}
+}
+
+interface InterfaceWithoutAbstractProperties
+{
+    public $notAbstract { get; }
+
+    public function bar($notAbstract);
+}
+
+trait TraitWithoutAbstractProperties
+{
+    private $notAbstract { set; }
+
+    abstract protected function bar($notAbstract);
+}
+
+// Note: Anonymous classes cannot be declared as abstract.
+$anonClass = new class
+{
+    readonly int $notAbstract;
+
+    protected static function bar($notAbstract) {}
+};
+
+enum EnumWithAbstractProperties
+{
+    // Properties are not allowed in enums. Ignore.
+    // Fatal error: Enum EnumWithAbstractProperties cannot include properties.
+    abstract $illegal { get; }
+
+    // Abstract methods are also not supported as enums cannot be extended, but that's not the point of this test.
+    // Fatal error: Enum EnumWithAbstractProperties must implement 1 abstract private method.
+    abstract public function bar($notAbstract);
+}
+
+
+/*
+ * PHP 8.4: Detect abstract properties.
+ *
+ * Note: hooks are not supported on multi-property declarations. That also means they cannot abstract.
+ */
+abstract class ClassWithAbstractProperties
+{
+    abstract $onlyAbstract { get; }
+    abstract public $abstractPublic { set; }
+    public /*comment*/ abstract int $publicAbstractTyped { get; }
+    abstract protected /*comment*/ MyType|false $protectedAbstractTyped { set; }
+
+    // Illegal, readonly and static properties cannot be abstract, but that's not the concern of this sniff.
+    static abstract $abstractStatic { get; }
+    abstract
+     readonly
+      ?int
+       $abstractReadonlyErrorLineCheck { set; }
+
+    // Fatal error as abstract with private is an oxymoron, but that's not the concern of this sniff.
+    abstract private $abstractPrivate { get; }
+    private abstract $privateAbstract { set; }
+}
+
+trait TraitWithAbstractProperties
+{
+    protected abstract $protectedAbstract { get; }
+}
+
+$anonClass = new class
+{
+    // Illegal, but that's not the concern of this sniff.
+    // Fatal error: Class class@anonymous contains 1 abstract method and must therefore be declared abstract or implement the remaining methods.
+    abstract string|false $abstractTyped { set; }
+};
+
+interface InterfaceWithAbstractProperties
+{
+    // Illegal, but that's not the concern of this sniff.
+    // Fatal error: Property in interface cannot be explicitly abstract. All interface members are implicitly abstract.
+    abstract public $abstractPublic { get; }
+}

--- a/PHPCompatibility/Tests/Classes/NewAbstractPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewAbstractPropertiesUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewAbstractProperties sniff.
+ *
+ * @group newAbstractProperties
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewAbstractPropertiesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewAbstractPropertiesUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test that an error is thrown for OO properties declared as abstract.
+     *
+     * @dataProvider dataAbstractProperties
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testAbstractProperties($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertError($file, $line, 'The abstract modifier for OO properties is not supported in PHP 8.3 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataAbstractProperties()
+    {
+        return [
+            [69],
+            [70],
+            [71],
+            [72],
+            [75],
+            [76],
+            [82],
+            [83],
+            [88],
+            [95],
+            [102],
+        ];
+    }
+
+
+    /**
+     * Verify that there are no false positives for valid code/code errors outside the scope of this sniff.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+        for ($line = 1; $line <= 61; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
As of PHP 8.4, (hooked) properties can be declared as `abstract`.

Notes:
* The "abstract" modifier is not supported in constructor property promotion as that wouldn't make sense.
* The "abstract" modifier is also not supported for interface properties as those are implicitly abstract (but that's not the concern of this sniff).

This commit adds a new sniff to detect abstract properties as supported in PHP 8.4.

For this sniff to function correctly, the PHPCSUtils minimum version needs to be v 1.1.2, which includes support for abstract properties via the `Variables::getMemberProperties()` method.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/property-hooks#abstract_properties
* php/php-src#13455
* https://github.com/php/php-src/commit/780a8280d23453ebab5df0dbc35ac897c07c1f0d