### PR TITLE
ParameterValues/NewPasswordAlgoConstantValues: allow for fully qualified true/false/null

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -112,7 +112,9 @@ final class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParam
 
         $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true
+                || $tokens[$i]['code'] === \T_NS_SEPARATOR
+            ) {
                 continue;
             }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
@@ -44,3 +44,13 @@ $obj?->password_hash( $password, '2y', $options );
 namespace\password_hash( $password, +1, $options );
 \Fully\Qualified\password_needs_rehash( $password, 2, $options );
 Partially\Qualified\password_hash( $password, '2y', $options );
+
+// Safeguard that fully qualified and uppercase true/false/null are handled correctly, not OK.
+password_hash( $password, NULL, $options );
+password_hash( $password, \null, $options );
+password_hash( $password, true, $options );
+password_hash( $password, TRUE, $options );
+password_hash( $password, \true, $options );
+password_hash( $password, false, $options );
+password_hash( $password, FALSE, $options );
+password_hash( $password, \false, $options );

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.inc
@@ -33,3 +33,14 @@ $hash = password_hash( $password, get_algo( 'argon' ), $options );
 $hash = password_hash( $password, $obj?->get_algo( 10 ), $options );
 $hash = password_hash( $password, $algos['argon'], $options );
 $hash = password_hash( $password, $algos{'argon'}, $options );
+$hash = \password_hash( $password, namespace\get_algo( 'argon' ), $options );
+$hash = password_hash( $password, \Fully\Qualified\get_algo( 'argon' ), $options );
+$hash = password_hash( $password, Partially\Qualified\get_algo( 'argon' ), $options );
+
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::password_hash( $password, +1, $options );
+$obj->password_needs_rehash( $password, 2, $options );
+$obj?->password_hash( $password, '2y', $options );
+namespace\password_hash( $password, +1, $options );
+\Fully\Qualified\password_needs_rehash( $password, 2, $options );
+Partially\Qualified\password_hash( $password, '2y', $options );

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
@@ -59,6 +59,14 @@ final class NewPasswordAlgoConstantValuesUnitTest extends BaseSniffTestCase
             [26],
             [27],
             [28],
+            [49],
+            [50],
+            [51],
+            [52],
+            [53],
+            [54],
+            [55],
+            [56],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPasswordAlgoConstantValuesUnitTest.php
@@ -94,7 +94,7 @@ final class NewPasswordAlgoConstantValuesUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
-        for ($line = 30; $line <= 36; $line++) {
+        for ($line = 30; $line <= 46; $line++) {
             $data[] = [$line];
         }
 


### PR DESCRIPTION
### ParameterValues/NewPasswordAlgoConstantValues: add extra tests

### ParameterValues/NewPasswordAlgoConstantValues: allow for fully qualified true/false/null

Includes tests.