### PR TITLE
PHP 8.4 | :sparkles: New `PHPCompatibility.Syntax.NewClassMemberAccessWithoutParentheses` sniff [RFC]

### DIFF
--- a/PHPCompatibility/Docs/Syntax/NewClassMemberAccessWithoutParenthesesStandard.xml
+++ b/PHPCompatibility/Docs/Syntax/NewClassMemberAccessWithoutParenthesesStandard.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Class Member Access Without Parentheses"
+    >
+    <standard>
+    <![CDATA[
+    New expressions with constructor argument parentheses are directly dereferencable since PHP 8.4.
+
+    This means chaining method calls, property accesses, etc. without enclosing
+    the expression in parentheses, is now allowed.
+
+    Note: it is not necessary to pass arguments to the constructor, it is only required for the constructor argument parentheses to be present.
+
+    Prior to PHP 8.4, the new expression had to be wrapped in parentheses to allow dereferencing.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: wrapping a new expression within parentheses.">
+        <![CDATA[
+$a = <em>(</em>new MyClass()<em>)::</em>CONSTANT;
+$b = <em>(</em>new MyClass()<em>)::</em>staticMethod();
+$c = <em>(</em>new $myClass()<em>)-></em>property;
+$d = <em>(</em>new $myClass()<em>)?-></em>method();
+$e = <em>(</em>new (trim(' MyClass '))()<em>)[</em>'key'];
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.4: omitting the wrapping parentheses as long as there are constructor argument parentheses.">
+        <![CDATA[
+$a = new MyClass()<em>::</em>CONSTANT;
+$b = new MyClass()<em>::</em>staticMethod();
+$c = new $myClass()<em>-></em>property;
+$d = new $myClass()<em>?-></em>method();
+$e = new (trim(' MyClass '))()<em>[</em>'key'];
+        ]]>
+        </code>
+    </code_comparison>
+    <standard>
+    <![CDATA[
+    For new expressions involving anonymous classes, the constructor argument parentheses are not required to dereference the resulting object directly.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: wrapping a new anonymous class expression within parentheses.">
+        <![CDATA[
+$anon = <em>(</em>new class {
+    const CONSTANT = 'constant';
+}<em>)::</em>CONSTANT;
+
+$anon = <em>(</em>new class {
+    public $property = 'property';
+}<em>)-></em>property;
+
+$anon = <em>(</em>new class {
+    public function method() {
+        return 'method';
+    }
+}<em>)-></em>method();
+
+$anon = <em>(</em>new class (['value'])
+    extends ArrayObject {}<em>)[</em>0];
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.4: dereferencing a new anonymous class expression without wrapping parentheses.">
+        <![CDATA[
+$anon = new class {
+    const CONSTANT = 'constant';
+}<em>::</em>CONSTANT;
+
+$anon = new class {
+    public $property = 'property';
+}<em>-></em>property;
+
+$anon = new class {
+    public function method() {
+        return 'method';
+    }
+}<em>-></em>method();
+
+$anon = new class (['value'])
+    extends ArrayObject {}<em>[</em>0];
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessWithoutParenthesesSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessWithoutParenthesesSniff.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Syntax;
+
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+
+/**
+ * Detect class member access on object instantiation/cloning without parentheses wrappers.
+ *
+ * As of PHP 8.4, a new expression with constructor arguments' parentheses no longer needs
+ * to be wrapped within parentheses when accessing members on the object.
+ *
+ * PHP version 8.4
+ *
+ * Also {@see \PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff}.
+ *
+ * @link https://wiki.php.net/rfc/new_without_parentheses
+ *
+ * {@internal The reason for splitting the logic of this sniff into different methods is
+ *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}
+ *
+ * @since 10.0.0
+ */
+final class NewClassMemberAccessWithoutParenthesesSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_NEW];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrBelow('8.3') === false) {
+            return;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
+            // Live coding/parse error.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Skip over a parenthesized expression at the start of the new expression,
+        // so as not to mess up the parentheses count.
+        $start = $nextNonEmpty;
+        if ($tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
+            if (isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false) {
+                // Live coding/parse error.
+                return;
+            }
+
+            $start = ($tokens[$nextNonEmpty]['parenthesis_closer'] + 1);
+        }
+
+        $endOfStatement = $phpcsFile->findEndOfStatement($stackPtr);
+
+        $ignore              = Tokens::$emptyTokens;
+        $ignore             += Collections::namespacedNameTokens();
+        $ignore[\T_READONLY] = \T_READONLY; // PHP 8.3 readonly anonymous classes.
+        $ignore[\T_VARIABLE] = \T_VARIABLE;
+        $ignore[\T_DOLLAR]   = \T_DOLLAR; // Variable variables.
+
+        $requiresConstructorParentheses = true;
+        $seenParentheses                = 0;
+        for ($i = $start; $i < $endOfStatement; $i++) {
+            if (isset($ignore[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            // Skip over attributes for anonymous classes.
+            if (isset($tokens[$i]['attribute_closer']) === true) {
+                $i = $tokens[$i]['attribute_closer'];
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_ANON_CLASS) {
+                $requiresConstructorParentheses = false;
+
+                if (isset($tokens[$i]['scope_closer']) === true) {
+                    $i = $tokens[$i]['scope_closer'];
+                    continue;
+                }
+            }
+
+            // Skip nested statements.
+            if (isset($tokens[$i]['parenthesis_closer']) === true
+                && $i === $tokens[$i]['parenthesis_opener']
+            ) {
+                ++$seenParentheses;
+                $i = $tokens[$i]['parenthesis_closer'];
+                continue;
+            }
+
+            if (isset($tokens[$i]['bracket_closer']) === true
+                && $i === $tokens[$i]['bracket_opener']
+                && $requiresConstructorParentheses === true
+                && $seenParentheses === 0
+            ) {
+                $i = $tokens[$i]['bracket_closer'];
+                continue;
+            }
+
+            break;
+        }
+
+        if ($requiresConstructorParentheses === true && $seenParentheses < 1) {
+            // Missing required constructor argument parentheses. Ignore.
+            return;
+        }
+
+        // Normalize the parentheses count to exclude the constructor argument parentheses.
+        $parenthesesAfter = $seenParentheses;
+        if ($requiresConstructorParentheses === true) {
+            --$parenthesesAfter;
+        }
+
+        if (isset(Collections::objectOperators()[$tokens[$i]['code']])
+            || $tokens[$i]['code'] === \T_OPEN_SQUARE_BRACKET
+            || $parenthesesAfter >= 1
+        ) {
+            $error = 'Class member access on object instantiation, without parentheses around the new expression, was not supported in PHP 8.3 or earlier';
+            $phpcsFile->addError($error, $i, 'Found');
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesUnitTest.inc
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This is fine pre-PHP 8.4.
+ */
+$a = new stdClass();
+$b = $a->foo();
+
+$a = new Bar;
+$a = new \Bar();
+$a = (new Bar());
+
+// Dereferencing the expression when wrapped in parentheses is already supported since PHP 5.4 - see the ClassMemberAccess sniff.
+$a = (new foo())->bar();
+$a = (new $foo())->bar;
+$a = (new namespace\foo)[0];
+
+// This is already supported since PHP 7.0 - see the ClassMemberAccess sniff.
+$b = ($a = new foo())->bar();
+
+// Member access for anonymous classes with parentheses wrappers has been supported since their introduction in PHP 7.0.
+var_dump(
+    (new class { const CONSTANT = 'constant'; })::CONSTANT,
+    (new class { public static $staticProperty = 'staticProperty'; })::$staticProperty,
+    (new readonly class { public static function staticMethod() { return 'staticMethod'; } })::staticMethod(),
+    (new class { public $property = 'property'; })->property,
+    (new class { public function method() { return 'method'; } })->method(),
+    (new class { public function __invoke() { return '__invoke'; } })(),
+    (new readonly class (['value']) extends ArrayObject {})[0],
+    isset((new #[SomeAttribute] #[AnotherAttribute] class (['value']) extends ArrayObject {})[0])
+);
+
+// Nullsafe object operator is also supported since its introduction in PHP 8.0.
+var_dump((new Partially\Qualified\Bar)?->y);
+
+// Some more variations of code the sniff could get confused over.
+function_call( new Bar(), $b->something, $c->method(), $d['a']);
+$container->register('foo', 'FooClass')->addArgument(new \stdClass())->setPublic(true);
+$request = (new Request())->withMethod('GET')->withUri('/hello-world');
+$a = $request->wantsJson() ? new JsonResponse($a, $b) : back()->with($status, trans($this->status));
+
+// Omitting the wrapping parentheses is still not allowed when there are no constructor argument parentheses.
+$a = new foo->bar();
+$X = new foo->setX(10)->getX();
+new A::test();
+
+// The behaviour for the following syntaxes is unchanged. These should be ignored by the sniff.
+$a = new MyClass::CONSTANT;         // will continue to throw a syntax error.
+$a = new $myClass::CONSTANT;        // will continue to throw a syntax error.
+$a = new MyClass::$staticProperty;  // will continue to work as `new (MyClass::$staticProperty)`.
+$a = new $myClass::$staticProperty; // will continue to work as `new ($myClass::$staticProperty)`.
+$a = new $myObject->property;       // will continue to work as `new ($myObject->property)`.
+$a = new $myObject?->property;      // will continue to work as `new ($myObject?->property)`.
+$a = new MyArrayConst['class'];     // will continue to throw a syntax error.
+$a = new $myArray['class'];         // will continue to work as `new ($myArray['class'])`.
+$a = new (Something()));            // will call the global function `Something()` and will create an instance
+                                    // for the class name returned by `Something()`.
+
+// Rightfully (still) not allowed:
+new ArrayObject() = 1;
+unset(new ArrayObject());
+
+
+/*
+ * PHP 8.4: class member access on new expression without wrapping parentheses (but with constructor argument parentheses).
+ */
+$a = [
+    new \Fully\Qualified\MyClass()::CONSTANT,
+    new MyClass()::{'CONSTANT'},
+    new Partially\Qualified\MyClass()::$staticProperty,
+    new MyClass()::staticMethod(),
+    new MyClass()->property,
+    new namespace\MyClass()->method(),
+    new MyClass()?->property,
+    new \MyClass()?->method(),
+    new MyClass()(),
+    $condition ? new MyClass()['key'] : false,
+    new MyClass(['value'])[0],
+];
+
+var_dump(
+    new $myClass()::CONSTANT,
+    new ${$a}[1]()::{'CONSTANT'},
+    new $myClass()::$staticProperty,
+    new ${'myClass'}()::staticMethod(),
+    new $myClass()->property,
+    new $myClass()->method(),
+    new ${$myClass[1]}()?->property,
+    new $$myClass()?->method(),
+    new $myClass()(),
+    new ${$myClass}()['key'],
+    new $myClass(['value'])[0],
+);
+
+$a = new (trim(' MyClass '))()::CONSTANT;
+$a = new (trim(' MyClass '))()::{'CONSTANT'};
+$a = new (trim(' MyClass '))()::$staticProperty;
+$a = new (trim(' MyClass '))()::staticMethod();
+$a = new (trim(' MyClass '))()->property;
+$a = new (trim(' MyClass '))()->method();
+$a = new (trim(' MyClass '))()?->property;
+$a = new (trim(' MyClass '))()?->method();
+$a = new (trim(' MyClass '))()();
+$a = new (trim(' MyClass '))()['key'];
+$a = new (trim(' MyClass '))(['value'])[0];
+
+// For anonymous classes, the constructor argument parentheses are not required.
+var_dump(
+    new class { const CONSTANT = 'constant'; }::CONSTANT,
+    new readonly class { public static $staticProperty = 'staticProperty'; }::$staticProperty,
+    new class { public static function staticMethod() { return 'staticMethod'; } }::staticMethod(),
+    new class { public $property = 'property'; }->property,
+    new #[SomeAttribute] #[AnotherAttribute] class { public function method() { return 'method'; } }->method(),
+    new class { public function __invoke() { return '__invoke'; } }(),
+    new readonly class (['value']) extends ArrayObject {}['key'],
+    isset(new class implements ArrayAccess {}[0])
+);
+
+// Parse error test.
+$a = new (trim(' MyClass ');
+
+// Parse error test.
+// This must be the last test in the file.
+$a = new

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesUnitTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewClassMemberAccessWithoutParentheses sniff.
+ *
+ * @group newClassMemberAccessWithoutParentheses
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessWithoutParenthesesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewClassMemberAccessWithoutParenthesesUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Test detection of new expressions with member access without wrapping parentheses.
+     *
+     * @dataProvider dataNewClassMemberAccessWithoutParentheses
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewClassMemberAccessWithoutParentheses($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertError($file, $line, 'Class member access on object instantiation, without parentheses around the new expression, was not supported in PHP 8.3 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNewClassMemberAccessWithoutParentheses()
+    {
+        return [
+            [68],
+            [69],
+            [70],
+            [71],
+            [72],
+            [73],
+            [74],
+            [75],
+            [76],
+            [77],
+            [78],
+
+            [82],
+            [83],
+            [84],
+            [85],
+            [86],
+            [87],
+            [88],
+            [89],
+            [90],
+            [91],
+            [92],
+
+            [95],
+            [96],
+            [97],
+            [98],
+            [99],
+            [100],
+            [101],
+            [102],
+            [103],
+            [104],
+            [105],
+
+            [109],
+            [110],
+            [111],
+            [112],
+            [113],
+            [114],
+            [115],
+            [116],
+        ];
+    }
+
+
+    /**
+     * Verify that there are no false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+        for ($line = 1; $line <= 63; $line++) {
+            $data[] = [$line];
+        }
+
+        // Live coding/parse error.
+        $data[] = [120];
+        $data[] = [124];
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
>  . new expressions with constructor arguments are now dereferencable, meaning
>    they allow chaining method calls, property accesses, etc. without enclosing
>    the expression in parentheses.
>    RFC: https://wiki.php.net/rfc/new_without_parentheses

This commit adds a new sniff to detect use of this new feature.

The sniff has a close relation with/is similar to the `PHPCompatibility.Syntax.NewClassMemberAccess` sniff and I did consider adding detection of this new PHP 8.4 feature to the pre-existing sniff, though I ultimately decided against this to have more freedom in how to write the sniff and to prevent quite a mess with test changes for the pre-existing sniff.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/new_without_parentheses
* https://www.php.net/manual/en/migration84.new-features.php#migration84.new-features.core.new-chaining
* php/php-src#13029
* https://github.com/php/php-src/commit/b6b16a1758150cc8992f9a99ac222c5d2998bc1b