### PR TITLE
PHP 8.4 | Various sniffs: add extra tests with FQN exit/die

### DIFF
--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitUnitTest.inc
@@ -43,7 +43,7 @@ $anon = new class() extends ClassWhichMayOrMayNotContainADestructMethod {
         if ($something) {
             die(); // Warning.
         } else {
-            exit(2); // Warning.
+            \exit(2); // Warning.
         }
     }
 };
@@ -140,7 +140,7 @@ abstract class DoesntExtendAndDoesntHaveDestructMethodButMayUseTrait {
      */
     #[AttributeWhichCouldBeLong, ShouldBeSkippedOver( 10, self::CONST_VALUE)]
     public function __construct() {
-        die(1); // Warning.
+        \die(1); // Warning.
     }
 
     abstract function skipOverParenthesis($a, $b);

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -186,7 +186,7 @@ function ignoreParamInExit ( $stuff ) {
 
 function ignoreParamInDie ( $stuff ) {
     if ( true === SOME_CONSTANT ) {
-        die ( 'Did ' . $stuff );
+        \die ( 'Did ' . $stuff );
     }
 
     $args = func_get_args(); // OK.


### PR DESCRIPTION
### FunctionDeclarations/RemovedCallingDestructAfterConstructorExit: safeguard handling FQN exit/die

Already handled correctly for PHPCS 3.13.3+. Just making sure there are tests safeguarding this.

### FunctionUse/ArgumentFunctionsReportCurrentValue: safeguard handling FQN exit/die

Already handled correctly for PHPCS 3.13.3+. Just making sure there are tests safeguarding this.