### PR TITLE
GH Actions: add Yamllint to `basics` workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 .coveralls.yml                export-ignore
 .gitattributes                export-ignore
 .gitignore                    export-ignore
+.yamllint.yml                 export-ignore
 phpcs.xml.dist                export-ignore
 phpunit.xml.dist              export-ignore
 phpunit10.xml.dist            export-ignore

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -148,3 +148,9 @@ jobs:
       # If the regeneration of the test files yielded changes, this will ensure we fail the build.
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
+
+  yamllint:
+    name: 'Lint Yaml'
+    uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@main
+    with:
+      strict: true

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -51,12 +51,14 @@ jobs:
       # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
       - name: Setup ini config
         id: set_ini
+        # yamllint disable rule:line-length
         run: |
           if [ "${{ contains( matrix.phpcs_version, 'dev') }}" == "false" ]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, display_startup_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
           fi
+          # yamllint enable rule:line-length
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -95,6 +97,7 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
+        # yamllint disable-line rule:line-length
         run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: Determine PHPUnit config file to use

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,7 @@ jobs:
 
       - name: Setup ini config
         id: set_ini
+        # yamllint disable rule:line-length
         run: |
           # On stable PHPCS versions, allow for PHP deprecation notices.
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
@@ -146,6 +147,7 @@ jobs:
               echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             fi
           fi
+          # yamllint enable rule:line-length
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -189,6 +191,7 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
+        # yamllint disable-line rule:line-length
         run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: Determine PHPUnit config file to use
@@ -249,6 +252,7 @@ jobs:
 
       - name: Setup ini config
         id: set_ini
+        # yamllint disable rule:line-length
         run: |
           # On stable PHPCS versions, allow for PHP deprecation notices.
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
@@ -266,6 +270,7 @@ jobs:
               echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             fi
           fi
+          # yamllint enable rule:line-length
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -298,6 +303,7 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
+        # yamllint disable-line rule:line-length
         run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: "DEBUG: Show grabbed version"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,23 @@
+# Details on the default config:
+# https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration
+extends: default
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+  - 'phpstan.neon*'
+
+# Rule documentation: https://yamllint.readthedocs.io/en/stable/rules.html
+rules:
+  colons:
+    max-spaces-after: -1  # Disabled to allow aligning of values.
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: {}
+  document-start:
+    present: false
+  line-length:
+    max: 145
+  truthy:
+    allowed-values: ["true", "false", "on", "off"]


### PR DESCRIPTION
... to loosely safeguard valid and consistent yaml files and prevent issues.

Includes adding a configuration file which loosens up the `default` ruleset to a degree I'm comfortable with.

Includes adding a few inline ignore comments for lines which can't easily be broken up to shorter lines.

Ref: https://yamllint.readthedocs.io/