### PR TITLE
Make codebase compatible with PHPCS 4.0

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -35,6 +35,12 @@ jobs:
         php: ['5.4', 'latest']
         phpcs_version: ['lowest', 'dev-master']
 
+        include:
+          - php: '7.2'
+            phpcs_version: '4.x-dev'
+          - php: 'latest'
+            phpcs_version: '4.x-dev'
+
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
     steps:
@@ -46,7 +52,7 @@ jobs:
       - name: Setup ini config
         id: set_ini
         run: |
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+          if [ "${{ contains( matrix.phpcs_version, 'dev') }}" == "false" ]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, display_startup_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
@@ -59,8 +65,12 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: "Composer: set PHPCS version for tests (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      - name: 'Composer: remove PHPCSDevCS'
+        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
+
+      - name: "Composer: set PHPCS version for tests (dev)"
+        if: ${{ contains( matrix.phpcs_version, 'dev') }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Enable creation of `composer.lock` file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,8 +88,21 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
-        phpcs_version: ['lowest', 'dev-master']
+        phpcs_version: ['lowest', 'dev-master', '4.x-dev']
         experimental: [false]
+
+        exclude:
+          - php: '5.5'
+            phpcs_version: '4.x-dev'
+          - php: '5.6'
+            phpcs_version: '4.x-dev'
+          - php: '7.0'
+            phpcs_version: '4.x-dev'
+          - php: '7.1'
+            phpcs_version: '4.x-dev'
+          # Also exclude the 7.2 build as that's run in code coverage, no need to duplicate.
+          - php: '7.2'
+            phpcs_version: '4.x-dev'
 
         include:
           - php: '7.2'
@@ -98,15 +111,12 @@ jobs:
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-          - php: '7.2'
-            phpcs_version: '4.x-dev'
-            experimental: true
-          - php: '8.4'
-            phpcs_version: '4.x-dev'
+          - php: '8.5' # Nightly.
+            phpcs_version: 'dev-master'
             experimental: true
 
           - php: '8.5' # Nightly.
-            phpcs_version: 'dev-master'
+            phpcs_version: '4.x-dev'
             experimental: true
 
     name: "Test: PHP ${{ matrix.php }}${{ matrix.custom_ini && ' (ini)' || '' }} - PHPCS ${{ matrix.phpcs_version }}"
@@ -149,7 +159,7 @@ jobs:
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 
       - name: "Composer: set PHPCS version for tests (dev)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
+        if: ${{ contains( matrix.phpcs_version, 'dev') }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Enable creation of `composer.lock` file
@@ -214,10 +224,16 @@ jobs:
       matrix:
         include:
           - php: '8.4'
+            phpcs_version: '4.x-dev'
+          - php: '8.4'
             phpcs_version: 'dev-master'
             custom_ini: true
           - php: '8.4'
             phpcs_version: 'lowest'
+
+          - php: '7.2'
+            phpcs_version: '4.x-dev'
+            custom_ini: true
 
           - php: '5.4'
             phpcs_version: 'dev-master'
@@ -238,13 +254,13 @@ jobs:
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
           if [ ${{ matrix.custom_ini }} == "true" ]; then
-            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+            if [ "${{ contains( matrix.phpcs_version, 'dev') }}" == "false" ]; then
               echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, display_startup_errors=On, zend.assertions=1, short_open_tag=On' >> "$GITHUB_OUTPUT"
             else
-              echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On, short_open_tag=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
+              echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1, short_open_tag=On' >> "$GITHUB_OUTPUT"
             fi
           else
-            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+            if [ "${{ contains( matrix.phpcs_version, 'dev') }}" == "false" ]; then
               echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, display_startup_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             else
               echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
@@ -258,8 +274,12 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
 
-      - name: "Composer: set PHPCS version for tests (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      - name: 'Composer: remove PHPCSDevCS'
+        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
+
+      - name: "Composer: set PHPCS version for tests (dev)"
+        if: ${{ contains( matrix.phpcs_version, 'dev') }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Enable creation of `composer.lock` file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,9 +98,12 @@ jobs:
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-          #- php: '7.4'
-          #  phpcs_version: '4.0.x-dev@dev'
-          #  experimental: true
+          - php: '7.2'
+            phpcs_version: '4.x-dev'
+            experimental: true
+          - php: '8.4'
+            phpcs_version: '4.x-dev'
+            experimental: true
 
           - php: '8.5' # Nightly.
             phpcs_version: 'dev-master'
@@ -121,13 +124,13 @@ jobs:
           # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
           # Also set the "short_open_tag" ini to make sure specific conditions are tested.
           if [ ${{ matrix.custom_ini }} == "true" ]; then
-            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+            if [ "${{ contains( matrix.phpcs_version, 'dev') }}" == "false" ]; then
               echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, display_startup_errors=On, zend.assertions=1, short_open_tag=On' >> "$GITHUB_OUTPUT"
             else
               echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On, short_open_tag=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             fi
           else
-            if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+            if [ "${{ contains( matrix.phpcs_version, 'dev') }}" == "false" ]; then
               echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, display_startup_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
             else
               echo 'PHP_INI=error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1' >> "$GITHUB_OUTPUT"
@@ -141,7 +144,11 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: "Composer: set PHPCS version for tests (master)"
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      - name: 'Composer: remove PHPCSDevCS'
+        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
+
+      - name: "Composer: set PHPCS version for tests (dev)"
         if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
@@ -158,7 +165,7 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
+      # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
         if: ${{ matrix.php >= 8.5 }}
         uses: "ramsey/composer-install@v3"

--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -80,7 +80,10 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
         // Handle case-insensitivity of function names.
         $this->targetFunctions = \array_change_key_case($this->targetFunctions, \CASE_LOWER);
 
-        return [\T_STRING];
+        return [
+            \T_STRING,
+            \T_NAME_FULLY_QUALIFIED,
+        ];
     }
 
 
@@ -103,7 +106,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
         }
 
         $tokens     = $phpcsFile->getTokens();
-        $function   = $tokens[$stackPtr]['content'];
+        $function   = \ltrim($tokens[$stackPtr]['content'], '\\');
         $functionLc = \strtolower($function);
 
         if (isset($this->targetFunctions[$functionLc]) === false) {
@@ -113,7 +116,9 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
         $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($nextToken === false
             || $tokens[$nextToken]['code'] !== \T_OPEN_PARENTHESIS
-            || isset($tokens[$nextToken]['parenthesis_owner']) === true
+            || (isset($tokens[$nextToken]['parenthesis_owner']) === true
+                // Don't bow out for PHP 8.4 exit as a function call, which is a parenthesis owner in PHPCS 4.x.
+                && $tokens[$tokens[$nextToken]['parenthesis_owner']]['code'] !== \T_EXIT)
         ) {
             return;
         }
@@ -123,26 +128,28 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
             return;
         }
 
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($tokens[$stackPtr]['code'] === \T_STRING) {
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
-        if ($this->isMethod === true) {
-            if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === false) {
-                // Not a call to a PHP method.
-                return;
-            }
-        } else {
-            if (isset($this->ignoreTokens[$tokens[$prevNonEmpty]['code']]) === true) {
-                // Not a call to a PHP function.
-                return;
-            }
-
-            if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
-                $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
-                if ($tokens[$prevPrevToken]['code'] === \T_STRING
-                    || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
-                ) {
-                    // Namespaced function.
+            if ($this->isMethod === true) {
+                if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === false) {
+                    // Not a call to a PHP method.
                     return;
+                }
+            } else {
+                if (isset($this->ignoreTokens[$tokens[$prevNonEmpty]['code']]) === true) {
+                    // Not a call to a PHP function.
+                    return;
+                }
+
+                if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
+                    $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+                    if ($tokens[$prevPrevToken]['code'] === \T_STRING
+                        || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
+                    ) {
+                        // Namespaced function.
+                        return;
+                    }
                 }
             }
         }

--- a/PHPCompatibility/Helpers/MiscHelper.php
+++ b/PHPCompatibility/Helpers/MiscHelper.php
@@ -32,7 +32,7 @@ final class MiscHelper
 {
 
     /**
-     * Determine whether an arbitrary T_STRING token is the use of a global constant.
+     * Determine whether an arbitrary T_STRING or T_NAME_FULLY_QUALIFIED token is the use of a global constant.
      *
      * @since 8.1.0
      * @since 10.0.0 This method is now static.
@@ -52,7 +52,16 @@ final class MiscHelper
         }
 
         // Is this one of the tokens this function handles ?
-        if ($tokens[$stackPtr]['code'] !== \T_STRING) {
+        if ($tokens[$stackPtr]['code'] !== \T_STRING
+            && $tokens[$stackPtr]['code'] !== \T_NAME_FULLY_QUALIFIED
+        ) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['code'] === \T_NAME_FULLY_QUALIFIED
+            && \strpos($tokens[$stackPtr]['content'], '\\', 1) !== false
+        ) {
+            // This is a fully qualified name with a namespace, not for the global namespace.
             return false;
         }
 
@@ -89,6 +98,20 @@ final class MiscHelper
             return false;
         }
 
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($tokens[$prev]['code'] === \T_NS_SEPARATOR) {
+            $prevPrev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+            if ($tokens[$prevPrev]['code'] === \T_STRING
+                || $tokens[$prevPrev]['code'] === \T_NAMESPACE
+            ) {
+                // Namespaced constant on PHPCS 3.x.
+                return false;
+            }
+
+            // If not a namespaced constant, skip over the NS separator when looking at the "previous" token.
+            $prev = $prevPrev;
+        }
+
         // Array of tokens which if found preceding the $stackPtr indicate that a T_STRING is not a global constant.
         $tokensToIgnore  = [
             \T_NAMESPACE             => true,
@@ -110,20 +133,9 @@ final class MiscHelper
         $tokensToIgnore += Collections::objectOperators();
         $tokensToIgnore += Tokens::$scopeModifiers;
 
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset($tokensToIgnore[$tokens[$prev]['code']]) === true) {
             // Not the use of a constant.
             return false;
-        }
-
-        if ($tokens[$prev]['code'] === \T_NS_SEPARATOR) {
-            $prevPrev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
-            if ($tokens[$prevPrev]['code'] === \T_STRING
-                || $tokens[$prevPrev]['code'] === \T_NAMESPACE
-            ) {
-                // Namespaced constant.
-                return false;
-            }
         }
 
         // Handle plain return types.

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -70,7 +70,7 @@ final class NewLateStaticBindingSniff extends Sniff
 
         switch ($tokens[$stackPtr]['code']) {
             case \T_STRING:
-                // PHPCS changes T_STATIC to T_STRING when used with instanceof.
+                // PHPCS 3.x changes T_STATIC to T_STRING when used with instanceof.
                 if ($tokens[$stackPtr]['content'] !== 'static') {
                     return;
                 }
@@ -92,8 +92,8 @@ final class NewLateStaticBindingSniff extends Sniff
 
                 if ($tokens[$nextNonEmpty]['code'] !== \T_DOUBLE_COLON) {
                     $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-                    if ($prevNonEmpty === false
-                        || $tokens[$prevNonEmpty]['code'] !== \T_NEW
+                    if ($tokens[$prevNonEmpty]['code'] !== \T_NEW
+                        && $tokens[$prevNonEmpty]['code'] !== \T_INSTANCEOF // PHPCS 4.x.
                     ) {
                         return;
                     }

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -8364,7 +8364,10 @@ final class NewConstantsSniff extends Sniff
      */
     public function register()
     {
-        return [\T_STRING];
+        return [
+            \T_STRING,
+            \T_NAME_FULLY_QUALIFIED,
+        ];
     }
 
     /**
@@ -8381,7 +8384,7 @@ final class NewConstantsSniff extends Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens       = $phpcsFile->getTokens();
-        $constantName = $tokens[$stackPtr]['content'];
+        $constantName = \ltrim($tokens[$stackPtr]['content'], '\\');
 
         if (isset($this->newConstants[$constantName]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -99,7 +99,7 @@ final class NewMagicClassConstantSniff extends Sniff
 
         $preSubjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($subjectPtr - 1), null, true);
         if (isset(Collections::ooHierarchyKeywords()[$tokens[$subjectPtr]['code']]) === true
-            || ($tokens[$subjectPtr]['code'] === \T_STRING
+            || (isset(Collections::namespacedNameTokens()[$tokens[$subjectPtr]['code']]) === true
                 && isset(Collections::objectOperators()[$tokens[$preSubjectPtr]['code']]) === false)
         ) {
             // This is a syntax which is supported on PHP 5.5 and higher.

--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -3331,7 +3331,10 @@ final class RemovedConstantsSniff extends Sniff
      */
     public function register()
     {
-        return [\T_STRING];
+        return [
+            \T_STRING,
+            \T_NAME_FULLY_QUALIFIED,
+        ];
     }
 
 
@@ -3349,7 +3352,7 @@ final class RemovedConstantsSniff extends Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens       = $phpcsFile->getTokens();
-        $constantName = $tokens[$stackPtr]['content'];
+        $constantName = \ltrim($tokens[$stackPtr]['content'], '\\');
 
         if (isset($this->removedConstants[$constantName]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Numbers;
 
 /**
@@ -97,8 +98,8 @@ final class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
         $nextSemicolonToken = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr), null, false);
         $errorType          = '';
         for ($curToken = $stackPtr + 1; $curToken < $nextSemicolonToken; $curToken++) {
-            if ($tokens[$curToken]['code'] === \T_STRING) {
-                // If the next non-whitespace token after the string
+            if (isset(Collections::nameTokens()[$tokens[$curToken]['code']]) === true) {
+                // If the next non-whitespace token after the (potentially namespaced) name
                 // is an opening parenthesis then it's a function call.
                 $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, $curToken + 1, null, true);
                 if ($tokens[$openBracket]['code'] === \T_OPEN_PARENTHESIS) {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -212,7 +212,8 @@ final class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
         }
 
         foreach ($exits as $ptr) {
-            MessageHelper::addMessage($phpcsFile, $error, $ptr, $hasDestruct, $errorCode, [$tokens[$ptr]['content']]);
+            $data = [\ltrim($tokens[$ptr]['content'], '\\')];
+            MessageHelper::addMessage($phpcsFile, $error, $ptr, $hasDestruct, $errorCode, $data);
         }
     }
 }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -155,11 +155,13 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 continue;
             }
 
-            if ($tokens[$i]['code'] !== \T_STRING) {
+            if ($tokens[$i]['code'] !== \T_STRING
+                && $tokens[$i]['code'] !== \T_NAME_FULLY_QUALIFIED
+            ) {
                 continue;
             }
 
-            $foundFunctionName = \strtolower($tokens[$i]['content']);
+            $foundFunctionName = \strtolower(\ltrim($tokens[$i]['content'], '\\'));
 
             if (isset($this->changedFunctions[$foundFunctionName]) === false) {
                 // Not one of the target functions.
@@ -262,10 +264,11 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 if ($lastParenthesesOpener !== false) {
 
                     $maybeFunctionCall = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($lastParenthesesOpener - 1), null, true);
-                    if ($tokens[$maybeFunctionCall]['code'] === \T_STRING
+                    if (($tokens[$maybeFunctionCall]['code'] === \T_STRING
+                        || $tokens[$maybeFunctionCall]['code'] === \T_NAME_FULLY_QUALIFIED)
                         && $this->isCallToGlobalFunction($phpcsFile, $maybeFunctionCall) === true
                     ) {
-                        $functionNameLc = \strtolower($tokens[$maybeFunctionCall]['content']);
+                        $functionNameLc = \strtolower(\ltrim($tokens[$maybeFunctionCall]['content'], '\\'));
                         if ($functionNameLc === 'array_slice'
                             || $functionNameLc === 'array_splice'
                         ) {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -66,6 +66,7 @@ final class ArgumentFunctionsUsageSniff extends Sniff
     {
         return [
             \T_STRING,
+            \T_NAME_FULLY_QUALIFIED,
             // Only registering arrow functions to allow for skipping over them.
             \T_FN,
         ];
@@ -95,7 +96,7 @@ final class ArgumentFunctionsUsageSniff extends Sniff
             return $tokens[$stackPtr]['scope_closer'];
         }
 
-        $functionLc = \strtolower($tokens[$stackPtr]['content']);
+        $functionLc = \strtolower(\ltrim($tokens[$stackPtr]['content'], '\\'));
         if (isset($this->targetFunctions[$functionLc]) === false) {
             return;
         }
@@ -128,7 +129,7 @@ final class ArgumentFunctionsUsageSniff extends Sniff
             if ($tokens[$prevPrevToken]['code'] === \T_STRING
                 || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
             ) {
-                // Namespaced function.
+                // Namespaced function on PHPCS 3.x.
                 return;
             }
         }
@@ -169,7 +170,7 @@ final class ArgumentFunctionsUsageSniff extends Sniff
         }
 
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
-        if ($tokens[$prevNonEmpty]['code'] !== \T_STRING) {
+        if (isset(Collections::nameTokens()[$tokens[$prevNonEmpty]['code']]) === false) {
             // Not nested in a function call.
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5182,7 +5182,10 @@ final class NewFunctionsSniff extends Sniff
         // Handle case-insensitivity of function names.
         $this->newFunctions = \array_change_key_case($this->newFunctions, \CASE_LOWER);
 
-        return [\T_STRING];
+        return [
+            \T_STRING,
+            \T_NAME_FULLY_QUALIFIED,
+        ];
     }
 
     /**
@@ -5200,7 +5203,7 @@ final class NewFunctionsSniff extends Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $function   = $tokens[$stackPtr]['content'];
+        $function   = \ltrim($tokens[$stackPtr]['content'], '\\');
         $functionLc = \strtolower($function);
 
         if (isset($this->newFunctions[$functionLc]) === false) {
@@ -5223,7 +5226,9 @@ final class NewFunctionsSniff extends Sniff
             // Not a call to a PHP function.
             return;
 
-        } elseif ($tokens[$prevToken]['code'] === \T_NS_SEPARATOR) {
+        } elseif ($tokens[$stackPtr]['code'] === \T_STRING
+            && $tokens[$prevToken]['code'] === \T_NS_SEPARATOR
+        ) {
             $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
             if ($tokens[$prevPrevToken]['code'] === \T_STRING
                 || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5710,7 +5710,10 @@ final class RemovedFunctionsSniff extends Sniff
         // Handle case-insensitivity of function names.
         $this->removedFunctions = \array_change_key_case($this->removedFunctions, \CASE_LOWER);
 
-        return [\T_STRING];
+        return [
+            \T_STRING,
+            \T_NAME_FULLY_QUALIFIED,
+        ];
     }
 
 
@@ -5729,7 +5732,7 @@ final class RemovedFunctionsSniff extends Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $function   = $tokens[$stackPtr]['content'];
+        $function   = \ltrim($tokens[$stackPtr]['content'], '\\');
         $functionLc = \strtolower($function);
 
         if (isset($this->removedFunctions[$functionLc]) === false) {
@@ -5752,7 +5755,9 @@ final class RemovedFunctionsSniff extends Sniff
             // Not a call to a PHP function.
             return;
 
-        } elseif ($tokens[$prevToken]['code'] === \T_NS_SEPARATOR) {
+        } elseif ($tokens[$stackPtr]['code'] === \T_STRING
+            && $tokens[$prevToken]['code'] === \T_NS_SEPARATOR
+        ) {
             $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
             if ($tokens[$prevPrevToken]['code'] === \T_STRING
                 || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -15,6 +15,7 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\MessageHelper;
@@ -69,11 +70,6 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
 
         // Special cases:
         \T_NS_SEPARATOR             => \T_NS_SEPARATOR,
-        /*
-         * This can be neigh anything, but for any usage except constants,
-         * the T_STRING will be combined with non-allowed tokens, so we should be good.
-         */
-        \T_STRING                   => \T_STRING,
     ];
 
 
@@ -104,6 +100,11 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
         $this->safeOperands += Tokens::$heredocTokens;
         $this->safeOperands += Tokens::$magicConstants;
         $this->safeOperands += Tokens::$emptyTokens;
+        /*
+         * This can be neigh anything, but for any usage except constants,
+         * the namespaced name will be combined with non-allowed tokens, so we should be good.
+         */
+        $this->safeOperands += Collections::nameTokens();
     }
 
     /**
@@ -203,7 +204,7 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
                         return false;
                     }
                 } elseif ($tokens[$nextNonSimple]['code'] === \T_DOUBLE_COLON) {
-                    // Allow only `T_STRING::T_STRING`.
+                    // Allow only `NAME_TOKEN::T_STRING`.
                     if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_STRING) {
                         return false;
                     }
@@ -211,7 +212,9 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
                     $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nextNonSimple - 1), null, true);
                     // No need to worry about parent/self, that's handled above and
                     // the double colon is skipped over in that case.
-                    if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== \T_STRING) {
+                    if ($prevNonEmpty === false
+                        || isset(Collections::nameTokens()[$tokens[$prevNonEmpty]['code']]) === false
+                    ) {
                         return false;
                     }
                 }

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -129,7 +129,7 @@ final class ForbiddenNamesSniff extends Sniff
     ];
 
     /**
-     * T_STRING keywords to recognize as forbidden names.
+     * Other keywords to recognize as forbidden names.
      *
      * These keywords cannot be used to name a class, interface or trait.
      * Prior to PHP 8.0, they were also prohibited from being used in namespaces.
@@ -155,7 +155,7 @@ final class ForbiddenNamesSniff extends Sniff
     ];
 
     /**
-     * T_STRING keywords to recognize as soft reserved names.
+     * Keywords to recognize as soft reserved names.
      *
      * Using any of these keywords to name a class, interface, trait or namespace
      * is highly discouraged since they may be used in future versions of PHP.
@@ -224,6 +224,7 @@ final class ForbiddenNamesSniff extends Sniff
         \T_FUNCTION,
         \T_CONST,
         \T_STRING, // Function calls to `define()`.
+        \T_NAME_FULLY_QUALIFIED, // FQN function calls to `define()`.
         \T_USE,
         \T_ANON_CLASS, // Only for a specific tokenizer issue.
     ];
@@ -331,6 +332,10 @@ final class ForbiddenNamesSniff extends Sniff
                     return;
                 }
 
+                $this->processString($phpcsFile, $stackPtr);
+                return;
+
+            case \T_NAME_FULLY_QUALIFIED:
                 $this->processString($phpcsFile, $stackPtr);
                 return;
 
@@ -680,6 +685,7 @@ final class ForbiddenNamesSniff extends Sniff
      * @since 5.5
      * @since 10.0.0 - Removed the $tokens parameter.
      *               - Visibility changed from `public` to `protected`.
+     *               - Now also handles T_NAME_FULLY_QUALIFIED tokens for PHPCS 4.x support.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the current token in the
@@ -692,7 +698,7 @@ final class ForbiddenNamesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Look for function calls to `define()`.
-        if (\strtolower($tokens[$stackPtr]['content']) !== 'define') {
+        if (\strtolower(\ltrim($tokens[$stackPtr]['content'], '\\')) !== 'define') {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -226,6 +226,9 @@ final class NewKeywordsSniff extends Sniff
             $tokens[]                      = \T_STRING;
         }
 
+        // Special case for namespace relative names for which the tokenization has changed in PHPCS 4.0.
+        $tokens[] = \T_NAME_RELATIVE;
+
         return $tokens;
     }
 
@@ -277,6 +280,15 @@ final class NewKeywordsSniff extends Sniff
                 }
             }
             unset($i);
+        }
+
+        // Special case for `namespace\something` code for which the tokenization has changed in PHPCS 4.0.
+        if ($tokenType === 'T_NAME_RELATIVE') {
+            $itemInfo = [
+                'name' => 'T_NAMESPACE',
+            ];
+            $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
+            return ($end + 1);
         }
 
         if (isset($this->newKeywords[$tokenType]) === false) {

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewLanguageConstructsSniff.php
@@ -50,6 +50,24 @@ final class NewLanguageConstructsSniff extends Sniff
             '5.3'         => true,
             'description' => 'The \ operator (for namespaces)',
         ],
+
+        // The namespace separator won't be tokenized as a separate token as of PHPCS 4.0 (except for in group use).
+        'T_NAME_QUALIFIED' => [
+            '5.2'         => false,
+            '5.3'         => true,
+            'description' => 'The \ operator (for namespaces)',
+        ],
+        'T_NAME_FULLY_QUALIFIED' => [
+            '5.2'         => false,
+            '5.3'         => true,
+            'description' => 'The \ operator (for namespaces)',
+        ],
+        'T_NAME_RELATIVE' => [
+            '5.2'         => false,
+            '5.3'         => true,
+            'description' => 'The \ operator (for namespaces)',
+        ],
+
         'T_ELLIPSIS' => [
             '5.5'         => false,
             '5.6'         => true,

--- a/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
@@ -142,26 +142,34 @@ final class RemovedHexadecimalNumericStringsSniff extends Sniff
         $nested = Parentheses::getLastOpener($phpcsFile, $stackPtr);
         if ($nested !== false) {
             $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nested - 1), null, true);
-            $contentLc    = \strtolower($tokens[$prevNonEmpty]['content']);
             if ($tokens[$prevNonEmpty]['code'] === \T_STRING
-                && isset($this->excludedFunctions[$contentLc]) === true
-                && $this->isCallToGlobalFunction($phpcsFile, $prevNonEmpty) === true
+                || $tokens[$prevNonEmpty]['code'] === \T_NAME_FULLY_QUALIFIED
             ) {
-                /*
-                 * Okay, so the string is apparently used in a function call to a function which still supports it.
-                 * Now verify it is used in a valid parameter position.
-                 */
-                if ($this->excludedFunctions[$contentLc] === true) {
-                    // All parameters support hex numeric strings. Bow out.
-                    return;
+                $contentLc = \strtolower($tokens[$prevNonEmpty]['content']);
+                if ($tokens[$prevNonEmpty]['code'] === \T_NAME_FULLY_QUALIFIED) {
+                    $contentLc = \ltrim($contentLc, '\\');
                 }
 
-                $parameters = PassedParameters::getParameters($phpcsFile, $prevNonEmpty);
-                foreach ($this->excludedFunctions[$contentLc] as $paramOffset => $paramName) {
-                    $param = PassedParameters::getParameterFromStack($parameters, $paramOffset, $paramName);
-                    if ($stackPtr >= $param['start'] && $stackPtr <= $param['end']) {
-                        // Parameter used in a position which supports hex numeric strings. Bow out.
+                if (isset($this->excludedFunctions[$contentLc]) === true
+                    && ($tokens[$prevNonEmpty]['code'] === \T_NAME_FULLY_QUALIFIED
+                    || $this->isCallToGlobalFunction($phpcsFile, $prevNonEmpty) === true) // This check only needs to be executed for T_STRING.
+                ) {
+                    /*
+                     * Okay, so the string is apparently used in a function call to a function which still supports it.
+                     * Now verify it is used in a valid parameter position.
+                     */
+                    if ($this->excludedFunctions[$contentLc] === true) {
+                        // All parameters support hex numeric strings. Bow out.
                         return;
+                    }
+
+                    $parameters = PassedParameters::getParameters($phpcsFile, $prevNonEmpty);
+                    foreach ($this->excludedFunctions[$contentLc] as $paramOffset => $paramName) {
+                        $param = PassedParameters::getParameterFromStack($parameters, $paramOffset, $paramName);
+                        if ($stackPtr >= $param['start'] && $stackPtr <= $param['end']) {
+                            // Parameter used in a position which supports hex numeric strings. Bow out.
+                            return;
+                        }
                     }
                 }
             }

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -76,7 +77,7 @@ final class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCall
 
         $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if ($tokens[$i]['code'] === \T_STRING
+            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -45,18 +46,33 @@ final class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameter
      * Tokens which, for the purposes of this sniff, indicate that there is
      * a variable element to the value passed.
      *
+     * {@internal This token array gets enriched from within the register() method.}
+     *
      * @since 9.0.0
      *
      * @var array<int|string>
      */
     private $variableValueTokens = [
-        \T_VARIABLE,
-        \T_STRING,
-        \T_SELF,
-        \T_PARENT,
-        \T_STATIC,
-        \T_DOUBLE_QUOTED_STRING,
+        \T_VARIABLE             => \T_VARIABLE,
+        \T_DOUBLE_QUOTED_STRING => \T_DOUBLE_QUOTED_STRING,
     ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        // Enrich the variable value tokens array only once.
+        $this->variableValueTokens += Collections::namespacedNameTokens();
+        $this->variableValueTokens += Collections::ooHierarchyKeywords();
+
+        return parent::register();
+    }
 
 
     /**

--- a/PHPCompatibility/Sniffs/ParameterValues/NewExitAsFunctionCallSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewExitAsFunctionCallSniff.php
@@ -15,6 +15,7 @@ use PHPCompatibility\Helpers\MiscHelper;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -169,13 +170,24 @@ final class NewExitAsFunctionCallSniff extends AbstractFunctionCallParameterSnif
         }
 
         // Check if this is exit/die used as a fully qualified function call.
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($tokens[$prev]['code'] === \T_NS_SEPARATOR) {
+        $isFullyQualified = false;
+        if ($tokens[$stackPtr]['content'][0] === '\\') {
+            // PHPCS 4.x.
+            $isFullyQualified = true;
+        } else {
+            // PHPCS 3.x.
+            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            if ($tokens[$prev]['code'] === \T_NS_SEPARATOR) {
+                $isFullyQualified = true;
+            }
+        }
+
+        if ($isFullyQualified === true) {
             $phpcsFile->addError(
                 'Using "%s" as a fully qualified function call is not allowed in PHP 8.3 or earlier.',
                 $stackPtr,
                 'FullyQualified',
-                [$tokens[$stackPtr]['content']]
+                [\ltrim($tokens[$stackPtr]['content'], '\\')]
             );
         }
 
@@ -245,11 +257,13 @@ final class NewExitAsFunctionCallSniff extends AbstractFunctionCallParameterSnif
             }
 
             // Check for use of PHP native global constants for which we know the type.
-            if ($tokens[$i]['code'] === \T_STRING
-                && isset($this->phpNativeConstants[$tokens[$i]['content']]) === true
+            $trimmedContent = \ltrim($tokens[$i]['content'], '\\');
+            if (($tokens[$i]['code'] === \T_STRING
+                || $tokens[$i]['code'] === \T_NAME_FULLY_QUALIFIED)
+                && isset($this->phpNativeConstants[$trimmedContent]) === true
                 && MiscHelper::isUseOfGlobalConstant($phpcsFile, $i) === true
             ) {
-                $type = \gettype($this->phpNativeConstants[$tokens[$i]['content']]);
+                $type = \gettype($this->phpNativeConstants[$trimmedContent]);
                 switch ($type) {
                     case 'integer':
                         ++$integer;
@@ -283,7 +297,7 @@ final class NewExitAsFunctionCallSniff extends AbstractFunctionCallParameterSnif
                 continue;
             }
 
-            if ($tokens[$i]['code'] === \T_STRING
+            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, non-PHP-native constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -79,7 +80,7 @@ final class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
         $errors = [];
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if ($tokens[$i]['code'] === \T_STRING
+            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -100,7 +101,7 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
         $tokens = $phpcsFile->getTokens();
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if ($tokens[$i]['code'] === \T_STRING
+            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -116,8 +116,13 @@ final class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
             foreach ($items as $item) {
                 for ($i = $item['start']; $i <= $item['end']; $i++) {
                     if ($tokens[$i]['code'] !== \T_STRING
-                        || \strtolower($tokens[$i]['content']) !== 'escapeshellarg'
+                        && $tokens[$i]['code'] !== \T_NAME_FULLY_QUALIFIED
                     ) {
+                        continue;
+                    }
+
+                    $contentLc = \strtolower($tokens[$i]['content']);
+                    if ($contentLc !== 'escapeshellarg' && $contentLc !== '\escapeshellarg') {
                         continue;
                     }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -112,7 +113,7 @@ final class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallPara
 
             foreach ($items as $item) {
                 for ($i = $item['start']; $i <= $item['end']; $i++) {
-                    if ($tokens[$i]['code'] === \T_STRING
+                    if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
                         || $tokens[$i]['code'] === \T_VARIABLE
                     ) {
                         // Variable, constant, function call. Ignore complete item as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -168,7 +168,10 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                 continue;
             }
 
-            if ($tokenCode === \T_STRING && isset($this->constantStrings[$tokens[$i]['content']])) {
+            if ($tokenCode === \T_NS_SEPARATOR
+                || ($tokenCode === \T_STRING && isset($this->constantStrings[$tokens[$i]['content']]))
+                || ($tokenCode === \T_NAME_FULLY_QUALIFIED && isset($this->constantStrings[\ltrim($tokens[$i]['content'], '\\')]))
+            ) {
                 continue;
             }
 
@@ -185,7 +188,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                 return;
             }
 
-            if ($tokenCode === \T_STRING) {
+            if ($tokenCode === \T_STRING || $tokenCode === \T_NAME_FULLY_QUALIFIED) {
                 /*
                  * Check for specific functions which return an array (i.e. $pieces).
                  */
@@ -195,6 +198,10 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                 }
 
                 $nameLc = \strtolower($tokens[$i]['content']);
+                if ($tokenCode === \T_NAME_FULLY_QUALIFIED) {
+                    $nameLc = \ltrim($nameLc, '\\');
+                }
+
                 if (isset($this->arrayFunctions[$nameLc]) === false
                     && (\strpos($nameLc, 'array_') !== 0
                     || isset($this->arrayFunctionExceptions[$nameLc]) === true)
@@ -202,18 +209,20 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                     continue;
                 }
 
-                // Now make sure it's the PHP native function being called.
-                $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), $start, true);
-                if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === true) {
-                    // Method call, not a call to the PHP native function.
-                    continue;
-                }
+                if ($tokenCode === \T_STRING) {
+                    // Now make sure it's the PHP native function being called.
+                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), $start, true);
+                    if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === true) {
+                        // Method call, not a call to the PHP native function.
+                        continue;
+                    }
 
-                if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR
-                    && $tokens[$prevNonEmpty - 1]['code'] === \T_STRING
-                ) {
-                    // Namespaced function.
-                    continue;
+                    if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR
+                        && $tokens[$prevNonEmpty - 1]['code'] === \T_STRING
+                    ) {
+                        // Namespaced function.
+                        continue;
+                    }
                 }
 
                 // Ok, so we know that there is an array function in the first param.
@@ -258,7 +267,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
         for ($i = $start; $i < $end; $i++) {
             $tokenCode = $tokens[$i]['code'];
 
-            if (isset(Tokens::$emptyTokens[$tokenCode])) {
+            if (isset(Tokens::$emptyTokens[$tokenCode]) || $tokenCode === \T_NS_SEPARATOR) {
                 continue;
             }
 
@@ -267,13 +276,15 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                 return;
             }
 
-            if ($tokenCode === \T_STRING && isset($this->constantStrings[$tokens[$i]['content']])) {
+            if (($tokenCode === \T_STRING && isset($this->constantStrings[$tokens[$i]['content']]))
+                || ($tokenCode === \T_NAME_FULLY_QUALIFIED && isset($this->constantStrings[\ltrim($tokens[$i]['content'], '\\')]))
+            ) {
                 // One of the special cased, PHP native string constants found.
                 $this->throwNotice($phpcsFile, $stackPtr, $functionName);
                 return;
             }
 
-            if ($tokenCode === \T_STRING || $tokenCode === \T_VARIABLE) {
+            if (isset(Collections::nameTokens()[$tokenCode]) || $tokenCode === \T_VARIABLE) {
                 // Function call, constant or variable encountered.
                 // No matter what this is combined with, we won't be able to reliably determine the value.
                 return;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedLdapConnectSignaturesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedLdapConnectSignaturesSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 use PHP_CodeSniffer\Files\File;
 
@@ -129,7 +130,9 @@ final class RemovedLdapConnectSignaturesSniff extends AbstractFunctionCallParame
                 return;
             }
 
-            $hasVariableContent = $phpcsFile->findNext([\T_VARIABLE, \T_STRING], $portParam['start'], ($portParam['end'] + 1));
+            $find               = Collections::namespacedNameTokens();
+            $find[\T_VARIABLE]  = \T_VARIABLE;
+            $hasVariableContent = $phpcsFile->findNext($find, $portParam['start'], ($portParam['end'] + 1));
             if ($hasVariableContent !== false) {
                 // We don't have access to the contents of the parameter. Bow out.
                 return;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -103,7 +104,7 @@ final class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterS
          * Get the content of any string tokens in the options parameter and remove the quotes and variables.
          */
         for ($i = $optionsParam['start']; $i <= $optionsParam['end']; $i++) {
-            if ($tokens[$i]['code'] === \T_STRING
+            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -82,7 +83,7 @@ final class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSni
 
         $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if ($tokens[$i]['code'] === \T_STRING
+            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -58,10 +58,10 @@ final class ForbiddenCallTimePassByReferenceSniff extends Sniff
     {
         $this->assignOrCompare = Tokens::$assignmentTokens + Tokens::$equalityTokens;
 
-        return [
-            \T_STRING,
-            \T_VARIABLE,
-        ];
+        $targets              = Collections::nameTokens();
+        $targets[\T_VARIABLE] = \T_VARIABLE;
+
+        return $targets;
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Parentheses;
 
 /**
@@ -150,7 +151,9 @@ final class NewClassMemberAccessSniff extends Sniff
         $parenthesisCloser = $tokens[$parenthesisOpener]['parenthesis_closer'];
 
         $prevBeforeParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($parenthesisOpener - 1), null, true);
-        if ($prevBeforeParenthesis !== false && $tokens[$prevBeforeParenthesis]['code'] === \T_STRING) {
+        if ($prevBeforeParenthesis !== false
+            && isset(Collections::nameTokens()[$tokens[$prevBeforeParenthesis]['code']]) === true
+        ) {
             // This is most likely a function call with the new/cloned object as a parameter.
             return [];
         }

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Detect dynamic access to static methods and properties, as well as class constants.
@@ -82,6 +83,12 @@ final class NewDynamicAccessToStaticSniff extends Sniff
             ) {
                 return;
             }
+        }
+
+        if (isset(Collections::nameTokens()[$tokens[$prevNonEmpty]['code']]) === true
+            && $tokens[$prevNonEmpty]['code'] !== \T_STRING
+        ) {
+            return;
         }
 
         $phpcsFile->addError(

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -51,7 +51,7 @@ final class NewFunctionArrayDereferencingSniff extends Sniff
      */
     public function register()
     {
-        return [\T_STRING];
+        return Collections::nameTokens();
     }
 
     /**
@@ -132,28 +132,30 @@ final class NewFunctionArrayDereferencingSniff extends Sniff
             return [];
         }
 
-        // Is this T_STRING really a function or method call ?
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($prevToken !== false
-            && isset(Collections::objectOperators()[$tokens[$prevToken]['code']]) === false
-        ) {
-            if ($tokens[$prevToken]['code'] === \T_BITWISE_AND) {
-                // This may be a function declared by reference.
-                $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
-            }
+        // Is this token really a function or method call ?
+        if ($tokens[$stackPtr]['code'] === \T_STRING) {
+            $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            if ($prevToken !== false
+                && isset(Collections::objectOperators()[$tokens[$prevToken]['code']]) === false
+            ) {
+                if ($tokens[$prevToken]['code'] === \T_BITWISE_AND) {
+                    // This may be a function declared by reference.
+                    $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
+                }
 
-            $ignore = [
-                \T_FUNCTION  => true,
-                \T_CONST     => true,
-                \T_USE       => true,
-                \T_NEW       => true,
-                \T_CLASS     => true,
-                \T_INTERFACE => true,
-            ];
+                $ignore = [
+                    \T_FUNCTION  => true,
+                    \T_CONST     => true,
+                    \T_USE       => true,
+                    \T_NEW       => true,
+                    \T_CLASS     => true,
+                    \T_INTERFACE => true,
+                ];
 
-            if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
-                // Not a call to a PHP function or method.
-                return [];
+                if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
+                    // Not a call to a PHP function or method.
+                    return [];
+                }
             }
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -17,6 +17,7 @@ use PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff;
 use PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Using the curly brace syntax to access array or string offsets has been deprecated in PHP 7.4
@@ -114,9 +115,10 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
         $targets = [
             [
                 \T_VARIABLE,
-                \T_STRING, // Constants.
             ],
         ];
+
+        $targets[] = Collections::nameTokens(); // Constants.
 
         // Registers T_ARRAY, T_OPEN_SHORT_ARRAY and T_CONSTANT_ENCAPSED_STRING.
         $additionalTargets                        = $this->newArrayStringDereferencing->register();
@@ -128,7 +130,7 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
         $this->newClassMemberAccessTargets = \array_flip($additionalTargets);
         $targets[]                         = $additionalTargets;
 
-        // Registers T_STRING.
+        // Registers Collections::nameTokens().
         $additionalTargets = $this->newFunctionArrayDereferencing->register();
         $this->newFunctionArrayDereferencingTargets = \array_flip($additionalTargets);
         $targets[] = $additionalTargets;
@@ -177,7 +179,7 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
             $braces = $this->newFunctionArrayDereferencing->isFunctionArrayDereferencing($phpcsFile, $stackPtr);
         }
 
-        if (empty($braces) && $tokens[$stackPtr]['code'] === \T_STRING) {
+        if (empty($braces) && isset(Collections::nameTokens()[$tokens[$stackPtr]['code']])) {
             $braces = $this->isConstantArrayAccess($phpcsFile, $stackPtr);
         }
 
@@ -298,7 +300,7 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
 
 
     /**
-     * Determine whether a T_STRING is a constant being dereferenced using curly brace syntax.
+     * Determine whether a name token is a constant being dereferenced using curly brace syntax.
      *
      * {@internal Note: the first braces for array access to a constant, for some unknown reason,
      *            can never be curlies, but have to be square brackets.

--- a/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
@@ -270,7 +270,10 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
         }
 
         $maybeLabel = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($lastOpenParens - 1), null, true);
-        if ($maybeLabel === false || $tokens[$maybeLabel]['code'] !== \T_STRING) {
+        if ($maybeLabel === false
+            || ($tokens[$maybeLabel]['code'] !== \T_STRING
+            && $tokens[$maybeLabel]['code'] !== \T_NAME_FULLY_QUALIFIED)
+        ) {
             // Not a named function call.
             return false;
         }
@@ -282,7 +285,12 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
             $this->phpNativeFunctions = \array_change_key_case($functions, \CASE_LOWER);
         }
 
-        if (isset($this->phpNativeFunctions[\strtolower($tokens[$maybeLabel]['content'])]) === false) {
+        $functionName = \strtolower($tokens[$maybeLabel]['content']);
+        if ($tokens[$maybeLabel]['code'] === \T_NAME_FULLY_QUALIFIED) {
+            $functionName = \ltrim($functionName, '\\');
+        }
+
+        if (isset($this->phpNativeFunctions[$functionName]) === false) {
             // Definitely not a PHP native function call.
             return false;
         }

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -175,7 +175,7 @@ try {
 class ConstructorProp {
     public function __construct(
         protected $property,
-        public Reflector | \ | ParseErrorMissingTypeBetweenUnion $reflProp,
+        public Reflector | AllGood $reflProp,
         private Stringable $stringProp,
     ) {}
 }

--- a/PHPCompatibility/Util/Tests/Helpers/MiscHelper/IsUseOfGlobalConstantUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/MiscHelper/IsUseOfGlobalConstantUnitTest.inc
@@ -302,6 +302,133 @@ class NameInConstantType {
     public const false|(PHP_VERSION_ID&Something) CONST_NAME_J = 'Type is class name, not constant';
 }
 
+/* test 96 */
+#[MyAttribute(), \PHP_VERSION_ID]
+function HasMultiAttribute() {}
+
+/* test 97 */
+attributeNestedInParenthesis1(
+    new #[MyAttribute(), \PHP_VERSION_ID] class () {}
+);
+
+/* test 98 */
+try {
+} catch (\PHP_VERSION_ID $e) {
+/* test 99 */
+} catch (\PHP_VERSION_ID) {}
+
+/* test 100 */
+if ( $abc instanceof \PHP_VERSION_ID ) {}
+
+class EverythingTypedFQN {
+    /* test 101 */
+    final const \PHP_VERSION_ID CONST_NAME_A = 'Type is class name, not constant';
+
+    /* test 102 */
+    public const ?\PHP_VERSION_ID CONST_NAME_B = 'Type is class name, not constant';
+
+    /* test 103 */
+    protected const \PHP_VERSION_ID|false CONST_NAME_C = 'Type is class name, not constant';
+
+    /* test 104 */
+    private const false|\PHP_VERSION_ID CONST_NAME_D = 'Type is class name, not constant';
+
+    /* test 105 */
+    const string|\PHP_VERSION_ID|false CONST_NAME_E = 'Type is class name, not constant';
+
+    /* test 106 */
+    final const \PHP_VERSION_ID&Something CONST_NAME_F = 'Type is class name, not constant';
+
+    /* test 107 */
+    public const Something&\PHP_VERSION_ID CONST_NAME_G = 'Type is class name, not constant';
+
+    /* test 108 */
+    protected const Something&\PHP_VERSION_ID&SomethingElse CONST_NAME_H = 'Type is class name, not constant';
+
+    /* test 109 */
+    private const (Something&\PHP_VERSION_ID)|null CONST_NAME_I = 'Type is class name, not constant';
+
+    /* test 110 */
+    public const false|(\PHP_VERSION_ID&Something) CONST_NAME_J = 'Type is class name, not constant';
+
+    /* test 111 */
+    final \PHP_VERSION_ID $typedPropA = 'Type is class name, not constant';
+
+    /* test 112 */
+    public ?\PHP_VERSION_ID $typedPropB = 'Type is class name, not constant';
+
+    /* test 113 */
+    protected \PHP_VERSION_ID|false $typedPropC = 'Type is class name, not constant';
+
+    /* test 114 */
+    private false|\PHP_VERSION_ID $typedPropD = 'Type is class name, not constant';
+
+    /* test 115 */
+    var string|\PHP_VERSION_ID|false $typedPropE = 'Type is class name, not constant';
+
+    /* test 116 */
+    static \PHP_VERSION_ID&Something $typedPropF = 'Type is class name, not constant';
+
+    /* test 117 */
+    readonly Something&\PHP_VERSION_ID $typedPropG = 'Type is class name, not constant';
+
+    /* test 118 */
+    public(set) Something&\PHP_VERSION_ID&SomethingElse $typedPropH = 'Type is class name, not constant';
+
+    /* test 119 */
+    protected(set) (Something&\PHP_VERSION_ID)|null $typedPropI = 'Type is class name, not constant';
+
+    /* test 120 */
+    private(set) false|(\PHP_VERSION_ID&Something) $typedPropJ = 'Type is class name, not constant';
+
+    public function paramTypes(
+        /* test 121 */
+        \PHP_VERSION_ID $typedParamA,
+        /* test 122 */
+        ?\PHP_VERSION_ID $typedParamB,
+        /* test 123 */
+        \PHP_VERSION_ID|false $typedParamC,
+        /* test 124 */
+        false|\PHP_VERSION_ID $typedParamD,
+        /* test 125 */
+        string|\PHP_VERSION_ID|false $typedParamE,
+        /* test 126 */
+        \PHP_VERSION_ID&Something $typedParamF,
+        /* test 127 */
+        Something&\PHP_VERSION_ID $typedParamG,
+        /* test 128 */
+        Something&\PHP_VERSION_ID&SomethingElse $typedParamH,
+        /* test 129 */
+        (Something&\PHP_VERSION_ID)|null $typedParamI,
+        /* test 130 */
+        false|(\PHP_VERSION_ID&Something) $typedParamJ,
+    ) {}
+
+    /* test 131 */
+    public function returnTypeA(): \PHP_VERSION_ID {}
+    /* test 132 */
+    public function returnTypeB(): ?\PHP_VERSION_ID {}
+    /* test 133 */
+    public function returnTypeC(): \PHP_VERSION_ID|false {}
+    /* test 134 */
+    public function returnTypeD(): false|\PHP_VERSION_ID {}
+    /* test 135 */
+    public function returnTypeE(): string|\PHP_VERSION_ID|false {}
+    /* test 136 */
+    public function returnTypeF(): \PHP_VERSION_ID&Something {}
+    /* test 137 */
+    public function returnTypeG(): Something&\PHP_VERSION_ID {}
+    /* test 138 */
+    public function returnTypeH(): Something&\PHP_VERSION_ID&SomethingElse {}
+    /* test 139 */
+    public function returnTypeI(): (Something&\PHP_VERSION_ID)|null {}
+    /* test 140 */
+    public function returnTypeJ(): false|(\PHP_VERSION_ID&Something) {}
+
+    /* test 141 */
+    abstract public function returnTypeK(): \PHP_VERSION_ID;
+}
+
 /*
  * Make sure that global constants are correctly identified.
  *
@@ -383,3 +510,12 @@ class UseOfGlobalConstantsWithinAClass {
         $var = $a + PHP_VERSION_ID;
     }
 }
+
+/* test A23 */
+#[MyAttribute(\PHP_VERSION_ID)]
+function HasAttribute() {}
+
+/* test A24 */
+attributeNestedInParenthesis2(
+    new #[MyAttribute(\PHP_VERSION_ID)] class () {}
+);

--- a/PHPCompatibility/Util/Tests/Helpers/MiscHelper/IsUseOfGlobalConstantUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/MiscHelper/IsUseOfGlobalConstantUnitTest.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Util\Tests\Helpers\MiscHelper;
 
 use PHPCompatibility\Helpers\MiscHelper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Tests for the `isUseOfGlobalConstant()` utility function.
@@ -56,13 +57,20 @@ final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase
      *
      * @param string $commentString The comment which prefaces the target token in the test file.
      * @param string $expected      The expected boolean return value.
+     * @param string $targetContent Optional. The expected contents of the target token.
      *
      * @return void
      */
-    public function testIsUseOfGlobalConstant($commentString, $expected)
+    public function testIsUseOfGlobalConstant($commentString, $expected, $targetContent = null)
     {
-        $stackPtr = $this->getTargetToken($commentString, \T_STRING, 'PHP_VERSION_ID');
-        $result   = MiscHelper::isUseOfGlobalConstant(self::$phpcsFile, $stackPtr);
+        // Work around tokenization difference between PHPCS 3.x/4.x.
+        if (self::usesPhp8NameTokens() === true && $targetContent !== null) {
+            $stackPtr = $this->getTargetToken($commentString, Collections::nameTokens(), $targetContent);
+        } else {
+            $stackPtr = $this->getTargetToken($commentString, \T_STRING, 'PHP_VERSION_ID');
+        }
+
+        $result = MiscHelper::isUseOfGlobalConstant(self::$phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
 
@@ -77,7 +85,7 @@ final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase
     {
         return [
             ['/* test 1 */', false],
-            ['/* test 2 */', false],
+            ['/* test 2 */', false, 'MY\OTHER\PHP_VERSION_ID\NS'],
             ['/* test 3 */', false],
             ['/* test 4 */', false],
             ['/* test 5 */', false],
@@ -91,14 +99,14 @@ final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase
             ['/* test 13 */', false],
             ['/* test 14 */', false],
             ['/* test 15 */', false],
-            ['/* test 16 */', false],
-            ['/* test 17 */', false],
+            ['/* test 16 */', false, 'My\UsedAsNamespace\PHP_VERSION_ID\something'],
+            ['/* test 17 */', false, 'My\UsedAsNamespace\PHP_VERSION_ID\something'],
             ['/* test 18 */', false],
             ['/* test 19 */', false],
-            ['/* test 20 */', false],
+            ['/* test 20 */', false, '\mynamespace\PHP_VERSION_ID'],
             ['/* test 21 */', false],
             ['/* test 22 */', false],
-            ['/* test 23 */', false],
+            ['/* test 23 */', false, 'SomeNamespace\PHP_VERSION_ID'],
             ['/* test 24 */', false],
             ['/* test 25 */', false],
             ['/* test 26 */', false],
@@ -110,7 +118,7 @@ final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase
             ['/* test 32 */', false],
             ['/* test 33 */', false],
             ['/* test 34 */', false],
-            ['/* test 35 */', false],
+            ['/* test 35 */', false, 'namespace\PHP_VERSION_ID'],
             ['/* test 36 */', false],
             ['/* test 37 */', false],
             ['/* test 38 */', false],
@@ -171,9 +179,55 @@ final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase
             ['/* test 93 */', false],
             ['/* test 94 */', false],
             ['/* test 95 */', false],
+            ['/* test 96 */', false, '\PHP_VERSION_ID'],
+            ['/* test 97 */', false, '\PHP_VERSION_ID'],
+            ['/* test 98 */', false, '\PHP_VERSION_ID'],
+            ['/* test 99 */', false, '\PHP_VERSION_ID'],
+            ['/* test 100 */', false, '\PHP_VERSION_ID'],
+            ['/* test 101 */', false, '\PHP_VERSION_ID'],
+            ['/* test 102 */', false, '\PHP_VERSION_ID'],
+            ['/* test 103 */', false, '\PHP_VERSION_ID'],
+            ['/* test 104 */', false, '\PHP_VERSION_ID'],
+            ['/* test 105 */', false, '\PHP_VERSION_ID'],
+            ['/* test 106 */', false, '\PHP_VERSION_ID'],
+            ['/* test 107 */', false, '\PHP_VERSION_ID'],
+            ['/* test 108 */', false, '\PHP_VERSION_ID'],
+            ['/* test 109 */', false, '\PHP_VERSION_ID'],
+            ['/* test 110 */', false, '\PHP_VERSION_ID'],
+            ['/* test 111 */', false, '\PHP_VERSION_ID'],
+            ['/* test 112 */', false, '\PHP_VERSION_ID'],
+            ['/* test 113 */', false, '\PHP_VERSION_ID'],
+            ['/* test 114 */', false, '\PHP_VERSION_ID'],
+            ['/* test 115 */', false, '\PHP_VERSION_ID'],
+            ['/* test 116 */', false, '\PHP_VERSION_ID'],
+            ['/* test 117 */', false, '\PHP_VERSION_ID'],
+            ['/* test 118 */', false, '\PHP_VERSION_ID'],
+            ['/* test 119 */', false, '\PHP_VERSION_ID'],
+            ['/* test 120 */', false, '\PHP_VERSION_ID'],
+            ['/* test 121 */', false, '\PHP_VERSION_ID'],
+            ['/* test 122 */', false, '\PHP_VERSION_ID'],
+            ['/* test 123 */', false, '\PHP_VERSION_ID'],
+            ['/* test 124 */', false, '\PHP_VERSION_ID'],
+            ['/* test 125 */', false, '\PHP_VERSION_ID'],
+            ['/* test 126 */', false, '\PHP_VERSION_ID'],
+            ['/* test 127 */', false, '\PHP_VERSION_ID'],
+            ['/* test 128 */', false, '\PHP_VERSION_ID'],
+            ['/* test 129 */', false, '\PHP_VERSION_ID'],
+            ['/* test 130 */', false, '\PHP_VERSION_ID'],
+            ['/* test 131 */', false, '\PHP_VERSION_ID'],
+            ['/* test 132 */', false, '\PHP_VERSION_ID'],
+            ['/* test 133 */', false, '\PHP_VERSION_ID'],
+            ['/* test 134 */', false, '\PHP_VERSION_ID'],
+            ['/* test 135 */', false, '\PHP_VERSION_ID'],
+            ['/* test 136 */', false, '\PHP_VERSION_ID'],
+            ['/* test 137 */', false, '\PHP_VERSION_ID'],
+            ['/* test 138 */', false, '\PHP_VERSION_ID'],
+            ['/* test 139 */', false, '\PHP_VERSION_ID'],
+            ['/* test 140 */', false, '\PHP_VERSION_ID'],
+            ['/* test 141 */', false, '\PHP_VERSION_ID'],
 
             ['/* test A1 */', true],
-            ['/* test A2 */', true],
+            ['/* test A2 */', true, '\PHP_VERSION_ID'],
             ['/* test A3 */', true],
             ['/* test A4 */', true],
             ['/* test A5 */', true],
@@ -189,11 +243,13 @@ final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase
             ['/* test A15 */', true],
             ['/* test A16 */', true],
             ['/* test A17 */', true],
-            ['/* test A18 */', true],
+            ['/* test A18 */', true, '\PHP_VERSION_ID'],
             ['/* test A19 */', true],
-            ['/* test A20 */', true],
+            ['/* test A20 */', true, '\PHP_VERSION_ID'],
             ['/* test A21 */', true],
             ['/* test A22 */', true],
+            ['/* test A23 */', true, '\PHP_VERSION_ID'],
+            ['/* test A24 */', true, '\PHP_VERSION_ID'],
         ];
     }
 }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Requirements
 -------
 
 * PHP 5.4+
-* PHP CodeSniffer: 3.13.3+.
+* PHP CodeSniffer: 3.13.3+ / 4.0.0+.
 
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP CodeSniffer. You should get consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on a recent PHP version in combination with a recent PHP_CodeSniffer version.
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require": {
     "php": ">=5.4",
-    "squizlabs/php_codesniffer": "^3.13.3",
+    "squizlabs/php_codesniffer": "^3.13.3 || ^4.0",
     "phpcsstandards/phpcsutils": "^1.1.2"
   },
   "require-dev": {


### PR DESCRIPTION
### GH Actions: start running the tests against PHPCS 4.x (again) 

This was previously disabled, but now the release of PHPCS 4.0 is imminent, it is relevant again.

### Classes/NewLateStaticBinding: handle change in tokenization for `instanceof static`

The `static` keyword is generally tokenized as `T_STATIC`. However, in PHPCS 3.x, there was one exception - when `static` was used in an `instanceof static` expression, the `static` keyword was tokenized as `T_STRING`.

As of PHPCS 4.0, this exception has been removed and `static` in `instanceof static` will now also be tokenized as `T_STATIC`.

This commit updates the sniff for compatibility with that change.

### AbstractFunctionCallParameterSniff: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

The tokenization of (namespaced) "names" has changed in PHP 8.0 and while this new tokenization was "undone" for PHPCS 3.x, as of PHP_CodeSniffer 4.0.0, the new tokenization is used.

This is relevant for this abstract sniff as it looks for method calls (unchanged, still `T_STRING`) and calls to global functions which may be called either in unqualified or fully qualified form, i.e. `callMe()` or `\callMe()`, with the first needing special handling on PHPCS 3.x to prevent recognizing `Something\callMe()` as the global function, while the second is tokenized differently on PHPCS 4.x, which removes the need for the special handling, but does mean we need to sniff for an extra token.

This commit sorts this all out.

:point_right: Reviewing this commit will be more straight-forward while ignoring whitespace changes.

### MiscHelper::isUseOfGlobalConstant(): allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

The tokenization of (namespaced) "names" has changed in PHP 8.0 and while this new tokenization was "undone" for PHPCS 3.x, as of PHP_CodeSniffer 4.0.0, the new tokenization is used.

This commit adds handling for the new tokenization of namespaced names to this sniff.

Includes a slew of extra tests just to be sure.

### Constants/NewConstants: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

The tokenization of (namespaced) "names" has changed in PHP 8.0 and while this new tokenization was "undone" for PHPCS 3.x, as of PHP_CodeSniffer 4.0.0, the new tokenization is used.

This commit adds handling for the new tokenization of namespaced names to this sniff.

### Constants/NewMagicClassConstant: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Constants/RemovedConstants: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ControlStructures/ForbiddenBreakContinueVariableArguments: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### FunctionDeclarations/RemovedCallingDestructAfterConstructorExit: make error message consistent

... in light of the different way fully qualified exit/die is tokenized in PHPCS 4.0.

### FunctionUse/ArgumentFunctionsReportCurrentValue: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### FunctionUse/ArgumentFunctionsUsage: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### FunctionUse/NewFunctions: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### FunctionUse/RemovedFunctions: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### InitialValue/NewConstantScalarExpressions: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Interfaces/NewInterfaces: remove a specific parse error test 

... as it will be incompatible with PHPCS 4.0.

### Keywords/ForbiddenNames: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Keywords/NewKeywords: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### LanguageConstructs/NewLanguageConstructs: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Numbers/RemovedHexadecimalNumericStrings: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

Note: this commit will be more straight forward to review while ignoring whitespace changes.

### ParameterValues/ForbiddenStripTagsSelfClosingXHTML: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ParameterValues/NewArrayReduceInitialType: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ParameterValues/NewExitAsFunctionCall: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ParameterValues/NewFopenModes: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ParameterValues/NewPackFormat: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ParameterValues/NewProcOpenCmdArray: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ParameterValues/NewStripTagsAllowableTagsArray: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ParameterValues/RemovedImplodeFlexibleParamOrder: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ParameterValues/RemovedLdapConnectSignatures: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ParameterValues/RemovedMbstringModifiers: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### ParameterValues/RemovedSetlocaleString: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Syntax/ForbiddenCallTimePassByReference: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Syntax/NewClassMemberAccess: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Syntax/NewDynamicAccessToStatic: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Syntax/NewFunctionArrayDereferencing: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Syntax/RemovedCurlyBraceArrayAccess: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Variables/RemovedIndirectModificationOfGlobals: allow for PHPCS 4.0/PHP 8.0 namespaced name tokenization

### Make PHPCS 4.x support official 

* Allow for Composer installation with PHPCS `^4.0`.
* Update GH Actions workflows to test all PHP versions against PHPCS 4.x and those builds are no longer allowed to fail.

Note: once PHPCS 4.0 has been released, the workflows will get another update to also test against "low" 4.x, but that should wait until the release.