### PR TITLE
Syntax/ForbiddenCallTimePassByReference: recognize in additional syntaxes

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -58,10 +58,7 @@ final class ForbiddenCallTimePassByReferenceSniff extends Sniff
     {
         $this->assignOrCompare = Tokens::$assignmentTokens + Tokens::$equalityTokens;
 
-        $targets              = Collections::nameTokens();
-        $targets[\T_VARIABLE] = \T_VARIABLE;
-
-        return $targets;
+        return Collections::functionCallTokens();
     }
 
     /**

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.inc
@@ -109,3 +109,10 @@ $wrong = \Fully\Qualified\abc(&$a); // Bad: pass by reference.
 $wrong = Partially\Qualified\abc(&$a); // Bad: pass by reference.
 namespace\foobar(3 & $a); // OK.
 \Fully\Qualified\efg( true == &$b ); // OK.
+
+$obj = new self(&$a);
+$obj = new parent(&$a);
+$obj = new static(&$a);
+$anon = new class(&$a) {};
+exit(&$status); // PHP 8.4 exit as a function call.
+\die(&$status); // PHP 8.4 exit as a function call.

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
@@ -66,6 +66,12 @@ final class ForbiddenCallTimePassByReferenceUnitTest extends BaseSniffTestCase
             [107], // Bad: call time pass by reference.
             [108], // Bad: call time pass by reference.
             [109], // Bad: call time pass by reference.
+            [113], // Bad: call time pass by reference.
+            [114], // Bad: call time pass by reference.
+            [115], // Bad: call time pass by reference.
+            [116], // Bad: call time pass by reference.
+            [117], // Bad: call time pass by reference.
+            [118], // Bad: call time pass by reference.
         ];
     }
 


### PR DESCRIPTION
Noticed this sniff wasn't catching all it could catch while working on something else.

Includes tests.