### PR TITLE
GH Actions: add new check for consistency in markdown files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 .coveralls.yml                export-ignore
 .gitattributes                export-ignore
 .gitignore                    export-ignore
+.markdownlint-cli2.yaml       export-ignore
 .yamllint.yml                 export-ignore
 phpcs.xml.dist                export-ignore
 phpunit.xml.dist              export-ignore

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,22 +1,21 @@
+# Contributing to PHPCompatibility
+
 Hi, thank you for your interest in contributing to PHPCompatibility! We look forward to working with you.
 
-Reporting bugs
---------------
+## Reporting bugs
 
 Before reporting a bug, you should check what sniff an error is coming from.
 Running `phpcs` with the `-s` flag will show the name of the sniff with each error.
 
 Bug reports containing a minimal code sample which can be used to reproduce the issue are highly appreciated as those are most easily actionable.
 
-Requesting features
--------------------
+## Requesting features
 
 The PHPCompatibility standard only concerns itself with cross-version PHP compatibility of code.
 
 When requesting a new feature, please add a link to a relevant page in the [PHP Manual](http://php.net/manual/en/) / PHP Changelog / [PHP RFC website](https://wiki.php.net/rfc) which illustrates the feature you are requesting.
 
-Pull requests
--------------
+## Pull requests
 
 Contributions in the form of pull requests are very welcome.
 
@@ -63,10 +62,9 @@ The communities behind these PHP frameworks/CMSes/polyfill libraries are strongl
     As support for overruling a `<config>` directive [is patchy](https://github.com/squizlabs/PHP_CodeSniffer/issues/1821), it should be recommended to set the desired `testVersion` either from the command line or in a project-specific custom ruleset.
 
 
-Naming conventions and repository structure
------------------------
+## Naming conventions and repository structure
 
-### Regarding sniff names:
+### Regarding sniff names
 * Per PHPCS convention, sniff files and class names have the `Sniff` suffix.
 * The name of sniffs relating to new PHP features should start with `New`.
 * The name of sniffs relating to deprecated or removed PHP features should start with `Removed` - as everything which has been deprecated is slated for removal in a later PHP version -.
@@ -80,15 +78,15 @@ Naming conventions and repository structure
     Additionally:
     - The `Miscellaneous` category should be avoided if at all possible and should only be used as a last resort.
 
-### About the unit tests:
+### About the unit tests
 * Unit test files should be named the same as the sniff, replacing the `Sniff` suffix with `UnitTest`.
 * The test case file for the unit tests should be named the same as the unit test file, but should use the `.inc` file extension.
     If several test case files are needed to test a sniff, the convention is to number the files starting with `1`, i.e. `SniffNameUnitTest.1.inc`, `SniffNameUnitTest.2.inc` etc.
 * Test case files should be placed in the same directory as the unit test file.
 
 
-Running the Sniff Tests
------------------------
+## Running the Sniff Tests
+
 All the sniffs are fully tested with PHPUnit tests and have `@group` annotations matching their categorization to allow for running subsets of the unit tests more easily.
 
 In order to run the tests on the sniffs, the following installation steps are required.
@@ -112,16 +110,16 @@ In order to run the tests on the sniffs, the following installation steps are re
 
     1. Copy the existing `phpunit.xml.dist` file in the root directory of the PHPCompatibility repository and name it `phpunit.xml`.
     2. Add the following snippet to the new file, replacing the value `/path/to/PHPCS` with the path to the directory in which you installed PHP CodeSniffer on your system:
-    ```xml
-    <php>
-        <env name="PHPCS_DIR" value="/path/to/PHPCS"/>
-    </php>
-    ```
+        ```xml
+        <php>
+            <env name="PHPCS_DIR" value="/path/to/PHPCS"/>
+        </php>
+        ```
     3. Run the tests by running `phpunit` from the root directory of your PHPCompatibility install.
        It will automatically read the `phpunit.xml` file and execute the tests.
 
 
-#### Issues when running the PHPCS Unit tests for another standard
+### Issues when running the PHPCS Unit tests for another standard
 
 This sniff library uses its own PHPUnit setup rather than the PHP CodeSniffer native unit testing framework to allow for testing the sniffs with various settings for the `testVersion` config variable.
 
@@ -139,8 +137,7 @@ To fix these errors, add the following to the `phpunit.xml` file for the sniff l
 This will prevent PHPCS trying to include the PHPCompatibility unit tests when creating the test suite.
 
 
-Checking Code Style Locally
------------------------
+## Checking Code Style Locally
 
 PHPCompatibility uses the [PHPCSDevCS](https://github.com/PHPCSStandards/PHPCSDevCS) standard for code style.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F41B Bug report for sniffs"
 about: I got unexpected behavior and think it is a bug.
-
+title: ''
 ---
 
 <!--
@@ -75,4 +75,5 @@ To find out the versions used:
 
 
 ## Tested Against `develop` branch?
+
 - [ ] I have verified the issue still exists in the `develop` branch of PHPCompatibility.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: "\U0001F680 Feature request"
 about: I have a suggestion (and may want to implement it).
+title: ''
 ---
 
 ## Is your feature request related to a problem?

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -1,5 +1,4 @@
-Release checklist
------------------
+# Release checklist
 
 Use the below text for a release PR to merge `develop` into `master` and adjust the placeholders between [square brackets] to the correct information for that release:
 
@@ -17,7 +16,7 @@ PR for tracking changes for the [x.x.x] release. Target release date: **[Weekday
 - [ ] [Major releases only] Update the `COMPOSER_ROOT_VERSION` in the `.travis.yml` file
 - [ ] Add changelog for the release - PR #[#]
     :pencil2: _Remember to create a link to the milestone and to the diff at the bottom of the file._
-    
+
 ### Release
 - [ ] Merge this PR
 - [ ] Add release tag against `master` (careful, GH defaults to `develop`!) & copy & paste the changelog to it
@@ -28,5 +27,3 @@ PR for tracking changes for the [x.x.x] release. Target release date: **[Weekday
 - [ ] Tweet about the release.
 - [ ] Post about it in Slack. (WordPress #tide channel and any others people deem relevant)
 - [ ] Fast-forward `develop` to be equal to `master`
-
----

--- a/.github/XML_docs_review_checklist.md
+++ b/.github/XML_docs_review_checklist.md
@@ -1,5 +1,4 @@
-XML Docs review checklist
------------------
+# XML Docs review checklist
 
 Use the below list as a basic check for PRs submitting XML docs for sniffs.
 
@@ -24,4 +23,4 @@ Add one of the following emoji's to each item to indicate compliance.
 * The line length of the code samples stays within the character limit (48 chars).
 * The readability of the code samples is good.
 
-A more detailed description of the requirements for XML docs can be found in the associated issue: https://github.com/PHPCompatibility/PHPCompatibility/issues/1285
+A more detailed description of the requirements for XML docs can be found in the associated issue: <https://github.com/PHPCompatibility/PHPCompatibility/issues/1285>

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -2,10 +2,7 @@ name: CS
 
 on:
   # Run on all pushes and on all pull requests.
-  # Prevent the build from running when there are only irrelevant changes.
   push:
-    paths-ignore:
-      - '**.md'
   pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:
@@ -149,6 +146,10 @@ jobs:
       # If the regeneration of the test files yielded changes, this will ensure we fail the build.
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
+
+  markdownlint:
+    name: 'Lint Markdown'
+    uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@main
 
   yamllint:
     name: 'Lint Yaml'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ phpunit.xml
 .phpunit.result.cache
 .phpcs.cache
 *~
+/node_modules/

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,119 @@
+#
+# Configuration file for MarkdownLint-CLI2.
+#
+# Example file with all options:
+# https://github.com/DavidAnson/markdownlint-cli2/blob/main/test/markdownlint-cli2-yaml-example/.markdownlint-cli2.yaml
+#
+
+# Do not fix any fixable errors.
+fix: false
+
+# Define glob expressions to use (only valid at root).
+globs:
+  - "**/*.md"
+  - ".github/**/*.md"
+
+# Show found files on stdout (only valid at root)
+showFound: true
+
+# Define glob expressions to ignore.
+ignores:
+  - "node_modules/"
+  - "vendor/"
+
+# Disable inline config comments.
+noInlineConfig: true
+
+# Disable progress on stdout (only valid at root).
+noProgress: false
+
+# Adjust the configuration for some built-in rules.
+# For full information on the options and defaults, see:
+# https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
+config:
+  ######################
+  # Disable a few rules.
+  ######################
+  # MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines.
+  MD031: false
+  # MD032/blanks-around-lists - Lists should be surrounded by blank lines.
+  MD032: false
+
+  ##############################
+  # Customize a few other rules.
+  ##############################
+  # MD003/heading-style/header-style - Heading style.
+  MD003:
+    # Heading style - Always use hashes.
+    style: "atx"
+
+  # MD004/ul-style - Unordered list style.
+  MD004:
+    # List style - each level has a different, but consistent symbol.
+    style: "sublist"
+
+  # MD007/ul-indent - Unordered list indentation.
+  MD007:
+    indent: 4
+    # Whether to indent the first level of the list.
+    start_indented: false
+
+  # MD012/no-multiple-blanks - Multiple consecutive blank lines.
+  MD012:
+    maximum: 2
+
+  # MD013/line-length - Line length.
+  MD013:
+    # Number of characters. No need for being too fussy.
+    line_length: 1000
+    # Number of characters for headings.
+    heading_line_length: 100
+    # Number of characters for code blocks.
+    code_block_line_length: 130
+    # Stern length checking (applies to tables, code blocks etc which have their own max line length).
+    stern: true
+
+  # MD022/blanks-around-headings : Headings should be surrounded by blank lines.
+  MD022:
+    # Blank lines above heading
+    lines_above: [2, 1, 1, 1, 1]
+    # Blank lines below heading
+    lines_below: [1, 1, -1, -1, -1]
+
+  # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content.
+  MD024:
+    # Only check sibling headings.
+    siblings_only: true
+
+  # MD033/no-inline-html - Inline HTML.
+  MD033:
+    # Allowed elements.
+    allowed_elements:
+      - div
+      - details
+      - summary
+      - b
+      - code
+
+  # MD044/proper-names - Proper names should have the correct capitalization.
+  MD044:
+    # List of proper names.
+    names: ["PHPCompatibility", "PHPCSUtils", "PHP_CodeSniffer", "CodeSniffer", "PHPUnit"]
+    # Include code blocks.
+    code_blocks: false
+
+  # MD046/code-block-style - Code block style
+  MD046:
+    style: "fenced"
+
+  # MD048/code-fence-style - Code fence style
+  MD048:
+    style: "backtick"
+
+  # MD049/emphasis-style - Emphasis style should be consistent
+  MD049:
+    style: "underscore"
+
+  # MD050/strong-style - Strong style should be consistent
+  MD050:
+    style: "asterisk"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# Change Log for the PHPCompatibility standard for PHP Codesniffer
+# Change Log for the PHPCompatibility standard for PHP CodeSniffer
 
 All notable changes to this project will be documented in this file.
 
 This projects adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 Up to version 8.0.0, the `major.minor` version numbers were based on the PHP version for which compatibility check support was added, with `patch` version numbers being specific to this library.
-From version 8.0.0 onwards, [Semantic Versioning](http://semver.org/) is used.
+From version 8.0.0 onwards, [Semantic Versioning](https://semver.org/) is used.
 
 <!-- Legend to the icons used: https://github.com/PHPCompatibility/PHPCompatibility/pull/506#discussion_r131650488 -->
 
@@ -175,7 +175,7 @@ The `10.0.0` release is expected around the same time as the release of PHP 7.4 
 - :star2: New `PHPCompatibility.ParameterValues.RemovedImplodeFlexibleParamOrder` sniff to detect `implode()` being called with `$glue` and `$pieces` in reverse order from the documented argument order. This was previously allowed for historical reasons, but will be deprecated in PHP 7.4. [#846]
 - :star2: New `PHPCompatibility.ParameterValues.RemovedMbStrrposEncodingThirdParam` sniff to detect the `$encoding` being passed as the third, instead of the fourth parameter, to `mb_strrpos()` as has been soft deprecated since PHP 5.2 and will be hard deprecated as of PHP 7.4. [#860]
 - :star2: New `PHPCompatibility.Syntax.RemovedCurlyBraceArrayAccess` sniff to detect array and string offset access using curly braces as will be deprecated as of PHP 7.4. [#855]
-    - In contrast to any other sniff in the PHPCompatibility standard, this sniff contains an auto-fixer.
+    * In contrast to any other sniff in the PHPCompatibility standard, this sniff contains an auto-fixer.
 - :star2: New `PHPCompatibility.TextStrings.NewUnicodeEscapeSequence` sniff to detect use of the PHP 7.0+ unicode codepoint escape sequences and issues with invalid sequences. [#856]
 - :star2: New `PHPCompatibility.Upgrade.LowPHP` sniff to give users of old PHP versions advance warning when support will be dropped in the near future. [#838]
     At this moment, the intention is to drop support for PHP 5.3 by the end of this year.
@@ -208,13 +208,13 @@ The `10.0.0` release is expected around the same time as the release of PHP 7.4 
 - :pushpin: `PHPCompatibility.FunctionDeclarations.NewExceptionsFromToString` sniff: the sniff will now also examine the function docblock, if available, and will throw an error when a `@throws` tag is found in the docblock. [#880]. Fixes [#863]
 - :pushpin: `PHPCompatibility.FunctionDeclarations.NonStaticMagicMethods` sniff: will now also check the visibility and `static` (or not) requirements of the magic `__construct()`, `__destruct()`, `__clone()`, `__debugInfo()`, `__invoke()` and `__set_state()` methods. [#885]
 - :pushpin: `PHPCompatibility.Syntax.NewArrayStringDereferencing` sniff: the sniff will now also recognize array string dereferencing using curly braces as was (silently) supported since PHP 7.0. [#851]
-    - The sniff will now also throw errors for each dereference found on the array/string, not just the first one.
+    * The sniff will now also throw errors for each dereference found on the array/string, not just the first one.
 - :pushpin: `PHPCompatibility.Syntax.NewClassMemberAccess` sniff: the sniff will now also recognize class member access on instantiation and cloning using curly braces as was (silently) supported since PHP 7.0. [#852]
-    - The sniff will now also throw errors for each access detected, not just the first one.
-    - The line number on which the error is thrown in now set more precisely.
+    * The sniff will now also throw errors for each access detected, not just the first one.
+    * The line number on which the error is thrown in now set more precisely.
 - :pushpin: `PHPCompatibility.Syntax.NewFunctionArrayDereferencing` sniff: the sniff will now also recognize function array dereferencing using curly braces as was (silently) supported since PHP 7.0. [#853]
-    - The sniff will now also throw errors for each access detected, not just the first one.
-    - The line number on which the error is thrown in now set more precisely.
+    * The sniff will now also throw errors for each access detected, not just the first one.
+    * The line number on which the error is thrown in now set more precisely.
 - :recycle: Various code clean-up and improvements. [#849], [#850]
 - :recycle: Various minor inline documentation fixes. [#854], [#886]
 - :wrench: Travis: various tweaks to the build script. [#834], [#842]
@@ -403,7 +403,7 @@ See all related issues and PRs in the [9.1.0 milestone].
 - :recycle: Various code clean-up and improvements. [#745], [#756], [#774]
 - :recycle: Various minor inline documentation fixes. [#749], [#757]
 - :umbrella: Improved code coverage recording. [#744], [#776]
-- :green_heart: Travis: build tests are now being run against PHP 7.3 as well. [#511]
+- :green_heart: Travis: build tests are now being run against PHP 7.3 as well. [#764]
     Note: full PHP 7.3 support is only available in combination with PHP_CodeSniffer 2.9.2 or 3.3.1+ due to an incompatibility within PHP_CodeSniffer itself.
 
 ### Fixed
@@ -422,7 +422,6 @@ See all related issues and PRs in the [9.1.0 milestone].
 Thanks go out to [Jonathan Champ] for his contribution to this version. :clap:
 
 [#262]: https://github.com/PHPCompatibility/PHPCompatibility/issues/262
-[#511]: https://github.com/PHPCompatibility/PHPCompatibility/pull/511
 [#585]: https://github.com/PHPCompatibility/PHPCompatibility/pull/585
 [#629]: https://github.com/PHPCompatibility/PHPCompatibility/issues/629
 [#740]: https://github.com/PHPCompatibility/PHPCompatibility/issues/740
@@ -443,6 +442,7 @@ Thanks go out to [Jonathan Champ] for his contribution to this version. :clap:
 [#758]: https://github.com/PHPCompatibility/PHPCompatibility/pull/758
 [#760]: https://github.com/PHPCompatibility/PHPCompatibility/pull/760
 [#762]: https://github.com/PHPCompatibility/PHPCompatibility/pull/762
+[#764]: https://github.com/PHPCompatibility/PHPCompatibility/pull/764
 [#767]: https://github.com/PHPCompatibility/PHPCompatibility/pull/767
 [#768]: https://github.com/PHPCompatibility/PHPCompatibility/pull/768
 [#769]: https://github.com/PHPCompatibility/PHPCompatibility/pull/769
@@ -546,8 +546,8 @@ See all related issues and PRs in the [9.0.0 milestone].
 - :bug: `PHPCompatibility.Generators.NewGeneratorReturn` sniff: The sniff would throw false positives for `return` statements in nested constructs and did not correctly detect the scope which should be examined. [#725]. Fixes [#724].
 - :bug: `PHPCompatibility.Keywords.NewKeywords` sniff: PHP magic constants are case _in_sensitive. This sniff now accounts for this. [#707]
 - :bug: Various bugs in the `PHPCompatibility.Syntax.ForbiddenCallTimePassByReference` sniff [#723]:
-    - Closures called via a variable will now also be examined. (false negative)
-    - References within arrays/closures passed as function call parameters would incorrectly trigger an error. (false positive)
+    * Closures called via a variable will now also be examined. (false negative)
+    * References within arrays/closures passed as function call parameters would incorrectly trigger an error. (false positive)
 - :green_heart: Compatibility with PHPUnit 7.2. [#712]
 
 ### Credits
@@ -556,7 +556,6 @@ Thanks go out to [Jonathan Champ] for his contribution to this version. :clap:
 [polyfills-password_compat]: https://github.com/ircmaxell/password_compat
 [polyfills-paragonie]:       https://github.com/paragonie?utf8=?&q=polyfill
 [polyfills-symfony]:         https://github.com/symfony?utf8=?&q=polyfill
-[phpcs-3.2.0-release]:       https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/3.2.0
 
 [#248]: https://github.com/PHPCompatibility/PHPCompatibility/issues/248
 [#252]: https://github.com/PHPCompatibility/PHPCompatibility/issues/252
@@ -636,8 +635,8 @@ Composer users are advised to update their `composer.json`. The dependency is no
 Within this new organization, hosting will be offered for framework/CMS specific PHPCompatibility rulesets.
 
 The first two such repositories have been created and are now available for use:
-* PHPCompatibilityJoomla [GitHub][gh-phpcompat-joomla]|[Packagist][packagist-phpcompat-joomla]
-* PHPCompatibilityWP [GitHub][gh-phpcompat-wp]|[Packagist][packagist-phpcompat-wp]
+- PHPCompatibilityJoomla [GitHub][gh-phpcompat-joomla]|[Packagist][packagist-phpcompat-joomla]
+- PHPCompatibilityWP [GitHub][gh-phpcompat-wp]|[Packagist][packagist-phpcompat-wp]
 
 If you want to make sure you have all PHPCompatibility rulesets available at any time, you can use the PHPCompatibilityAll package [GitHub][gh-phpcompat-all]|[Packagist][packagist-phpcompat-all].
 
@@ -875,7 +874,6 @@ See all related issues and PRs in the [8.1.0 milestone].
 ### Credits
 Thanks go out to [Juliette Reinders Folmer] and [Jonathan Van Belle] for their contributions to this version. :clap:
 
-[#39]:  https://github.com/PHPCompatibility/PHPCompatibility/issues/39
 [#263]: https://github.com/PHPCompatibility/PHPCompatibility/issues/263
 [#507]: https://github.com/PHPCompatibility/PHPCompatibility/pull/507
 [#511]: https://github.com/PHPCompatibility/PHPCompatibility/pull/511
@@ -939,7 +937,7 @@ See all related issues and PRs in the [8.0.1 milestone].
 ### Credits
 Thanks go out to [Juliette Reinders Folmer] for her contributions to this version. :clap:
 
-[phpcs-squiz-fix-1591]: https://github.com/squizlabs/PHP_CodeSniffer/issues/1591)
+[phpcs-squiz-fix-1591]: https://github.com/squizlabs/PHP_CodeSniffer/issues/1591
 
 [#497]: https://github.com/PHPCompatibility/PHPCompatibility/pull/497
 [#498]: https://github.com/PHPCompatibility/PHPCompatibility/pull/498
@@ -1191,7 +1189,6 @@ Thanks go out to [Juliette Reinders Folmer] and [Mark Clements] for their contri
 [#422]: https://github.com/PHPCompatibility/PHPCompatibility/pull/422
 [#423]: https://github.com/PHPCompatibility/PHPCompatibility/pull/423
 [#424]: https://github.com/PHPCompatibility/PHPCompatibility/pull/424
-[#424]: https://github.com/PHPCompatibility/PHPCompatibility/pull/424
 [#425]: https://github.com/PHPCompatibility/PHPCompatibility/pull/425
 [#426]: https://github.com/PHPCompatibility/PHPCompatibility/pull/426
 [#428]: https://github.com/PHPCompatibility/PHPCompatibility/pull/428
@@ -1313,7 +1310,7 @@ See all related issues and PRs in the [7.1.2 milestone].
 ### Credits
 Thanks go out to [Juliette Reinders Folmer] for her contributions to this version. :clap:
 
-[#68-comment]: https://github.com/PHPCompatibility/PHPCompatibility/issues/68#issuecomment-231366445)
+[#68-comment]: https://github.com/PHPCompatibility/PHPCompatibility/issues/68#issuecomment-231366445
 [#300]:        https://github.com/PHPCompatibility/PHPCompatibility/pull/300
 [#302]:        https://github.com/PHPCompatibility/PHPCompatibility/pull/302
 [#303]:        https://github.com/PHPCompatibility/PHPCompatibility/pull/303
@@ -1410,8 +1407,8 @@ See all related issues and PRs in the [7.0.8 milestone].
 ### Credits
 Thanks go out to [Juliette Reinders Folmer] for her contributions to this version. :clap:
 
-[php-reserved-keywords]:       http://php.net/manual/en/reserved.keywords.php).
-[php-other-reserved-keywords]: http://php.net/manual/en/reserved.other-reserved-words.php)
+[php-reserved-keywords]:       https://www.php.net/reserved.keywords
+[php-other-reserved-keywords]: https://www.php.net/reserved.other-reserved-words
 
 [#115]: https://github.com/PHPCompatibility/PHPCompatibility/issues/115
 [#271]: https://github.com/PHPCompatibility/PHPCompatibility/pull/271
@@ -1585,8 +1582,8 @@ See all related issues and PRs in the [7.0.5 milestone].
 ### Credits
 Thanks go out to [Juliette Reinders Folmer] and [Yoshiaki Yoshida] for their contributions to this version. :clap:
 
-[26d0b6]: https://github.com/PHPCompatibility/PHPCompatibility/commit/26d0b6cf0921f75d93a4faaf09c390f386dde9ff)
-[841616]: https://github.com/PHPCompatibility/PHPCompatibility/commit/8416162ea81f4067226324f5948f4a50f7958a9b)
+[26d0b6]: https://github.com/PHPCompatibility/PHPCompatibility/commit/26d0b6cf0921f75d93a4faaf09c390f386dde9ff
+[841616]: https://github.com/PHPCompatibility/PHPCompatibility/commit/8416162ea81f4067226324f5948f4a50f7958a9b
 
 [#170]: https://github.com/PHPCompatibility/PHPCompatibility/pull/170
 [#188]: https://github.com/PHPCompatibility/PHPCompatibility/pull/188
@@ -1727,7 +1724,7 @@ See all related issues and PRs in the [7.0.3 milestone].
 - :bug: A number of sniffs would return `false` if the examined construct was not found. This could potentially cause race conditions/infinite sniff loops. [#138]
 - :wrench: The unit tests would fail to run when used in combination with a PEAR install of PHPCS. [#157].
 - :green_heart: Unit tests failing against PHPCS 2.6.1. [#158]
-    The unit tests *will* still fail against PHPCS 2.6.2 due to a bug in PHPCS itself. This bug does not affect the running of the sniffs outside of a unit test context.
+    The unit tests _will_ still fail against PHPCS 2.6.2 due to a bug in PHPCS itself. This bug does not affect the running of the sniffs outside of a unit test context.
 
 ### Credits
 Thanks go out to [Juliette Reinders Folmer] for her contributions to this version. :clap:
@@ -1939,7 +1936,7 @@ See all related issues and PRs in the [5.6 milestone].
 - :green_heart: The sniffs are now tested using the new container-based infrastructure in Travis CI. [#37]
 
 ### Fixed
-- :bug: The `ForbiddenCallTimePassByReference` sniff was throwing false positives when a bitwise and `&` was used in combination with class constants and class properties within function calls. [#44]. Fixes [#39].
+- :bug: The `ForbiddenCallTimePassByReference` sniff was throwing false positives when a bitwise and `&` was used in combination with class constants and class properties within function calls. [#44]. Partially fixes [#39].
 - :bug: The `ForbiddenNamesAsInvokedFunctions` sniff was throwing false positives in certain cases when a comment separated a `try` from the `catch` block. [#29]
 - :bug: The `ForbiddenNamesAsInvokedFunctions` sniff was incorrectly reporting `instanceof` as being introduced in PHP 5.4 while it has been around since PHP 5.0. [#80]
 - :white_check_mark: Compatibility with PHPCS 2.0 - 2.3. [#63], [#65]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-PHP Compatibility Coding Standard for PHP CodeSniffer
-=====================================================
+# PHP Compatibility Coding Standard for PHP CodeSniffer
+
 [![Latest Stable Version](https://img.shields.io/packagist/v/phpcompatibility/php-compatibility?label=stable)](https://packagist.org/packages/phpcompatibility/php-compatibility)
 [![Latest Unstable Version](https://img.shields.io/badge/unstable-dev--develop-e68718.svg?maxAge=2419200)](https://packagist.org/packages/phpcompatibility/php-compatibility#dev-develop)
 ![Awesome](https://img.shields.io/badge/awesome%3F-yes!-brightgreen.svg)
@@ -14,7 +14,7 @@ PHP Compatibility Coding Standard for PHP CodeSniffer
 
 
 This is a set of sniffs for [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) that checks for PHP cross-version compatibility.
-It will allow you to analyse your code for compatibility with higher and lower versions of PHP. 
+It will allow you to analyse your code for compatibility with higher and lower versions of PHP.
 
 * [PHP Version Support](#php-version-support)
 * [Requirements](#requirements)
@@ -23,23 +23,21 @@ It will allow you to analyse your code for compatibility with higher and lower v
 * [Installation in a Composer project (method 1)](#installation-in-a-composer-project-method-1)
 * [Installation via a git check-out to an arbitrary directory (method 2)](#installation-via-a-git-check-out-to-an-arbitrary-directory-method-2)
 * [Sniffing your code for compatibility with specific PHP version(s)](#sniffing-your-code-for-compatibility-with-specific-php-versions)
-    + [Using a framework/CMS/polyfill specific ruleset](#using-a-frameworkcmspolyfill-specific-ruleset)
+    - [Using a framework/CMS/polyfill specific ruleset](#using-a-frameworkcmspolyfill-specific-ruleset)
 * [Using a custom ruleset](#using-a-custom-ruleset)
-    + [`testVersion` in the ruleset versus command-line](#testversion-in-the-ruleset-versus-command-line)
-    + [PHPCompatibility specific options](#phpcompatibility-specific-options)
+    - [`testVersion` in the ruleset versus command-line](#testversion-in-the-ruleset-versus-command-line)
+    - [PHPCompatibility specific options](#phpcompatibility-specific-options)
 * [Projects extending PHPCompatibility](#projects-extending-phpcompatibility)
 * [Contributing](#contributing)
 * [License](#license)
 
-PHP Version Support
--------
+## PHP Version Support
 
 The project aims to cover all PHP compatibility changes introduced since PHP 5.0 up to the latest PHP release. This is an ongoing process and coverage is not yet 100% (if, indeed, it ever could be). Progress is tracked on [our GitHub issue tracker](https://github.com/PHPCompatibility/PHPCompatibility/issues).
 
 Pull requests that check for compatibility issues in PHP 4 code - in particular between PHP 4 and PHP 5.0 - are very welcome as there are still situations where people need help upgrading legacy systems. However, coverage for changes introduced before PHP 5.1 will remain patchy as sniffs for this are not actively being developed at this time.
 
-Requirements
--------
+## Requirements
 
 * PHP 5.4+
 * PHP CodeSniffer: 3.13.3+ / 4.0.0+.
@@ -51,15 +49,15 @@ As of version 9.0.0, support for PHP CodeSniffer 1.5.x and low 2.x versions < 2.
 As of version 10.0.0, support for PHP < 5.4 and PHP CodeSniffer < 3.13.3 has been dropped.
 
 
-Thank you
----------
+## Thank you
+
 Thanks to all [contributors](https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors) for their valuable contributions.
 
 Thanks to [WP Engine](https://wpengine.com) for their support on the PHP 7.0 sniffs.
 
 
-:warning: Upgrading to PHPCompatibility 9.0.0 :warning:
---------
+## :warning: Upgrading to PHPCompatibility 9.0.0 :warning:
+
 This library has been reorganized. All sniffs have been placed in categories and a significant number of sniffs have been renamed.
 
 If you use the complete `PHPCompatibility` standard without `exclude` directives in a custom ruleset and do not (yet) use the new-style PHP_CodeSniffer annotation as introduced in [PHP_CodeSniffer 3.2.0](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.2.0), this will have no noticeable effect and everything should work as before.
@@ -70,8 +68,7 @@ The changelog contains detailed information about all the sniff renames.
 Please read the changelog for version [9.0.0](https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0) carefully before upgrading.
 
 
-Installation in a Composer project (method 1)
--------------------------------------------
+## Installation in a Composer project (method 1)
 
 * Add the following lines to the `require-dev` section of your `composer.json` file.
     ```json
@@ -90,11 +87,11 @@ Installation in a Composer project (method 1)
         ```
     - Alternatively - and **_strongly recommended_** if you use more than one external PHP CodeSniffer standard - you can use any of the following Composer plugins to handle this for you.
 
-       Just add the Composer plugin you prefer to the `require-dev` section of your `composer.json` file.
+        Just add the Composer plugin you prefer to the `require-dev` section of your `composer.json` file.
 
-       * [DealerDirect/phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.6.0"
-       * [higidi/composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin)
-       * [SimplyAdmire/ComposerPlugins](https://github.com/SimplyAdmire/ComposerPlugins). This plugin *might* still work, but appears to be abandoned.
+        * [DealerDirect/phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.6.0"
+        * [higidi/composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin)
+        * [SimplyAdmire/ComposerPlugins](https://github.com/SimplyAdmire/ComposerPlugins). This plugin _might_ still work, but appears to be abandoned.
     - As a last alternative in case you use a custom ruleset, you can tell PHP CodeSniffer the path to the PHPCompatibility standard by adding the following snippet to your custom ruleset:
         ```xml
         <config name="installed_paths" value="vendor/phpcompatibility/php-compatibility" />
@@ -106,8 +103,7 @@ Installation in a Composer project (method 1)
     ./vendor/bin/phpcs -p . --standard=PHPCompatibility
     ```
 
-Installation via a git check-out to an arbitrary directory (method 2)
------------------------
+## Installation via a git check-out to an arbitrary directory (method 2)
 
 * Install [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) via [your preferred method](https://github.com/PHPCSStandards/PHP_CodeSniffer#installation).
 
@@ -138,8 +134,8 @@ Installation via a git check-out to an arbitrary directory (method 2)
     phpcs -p . --standard=PHPCompatibility
     ```
 
-Sniffing your code for compatibility with specific PHP version(s)
-------------------------------
+## Sniffing your code for compatibility with specific PHP version(s)
+
 * Run the coding standard from the command-line with `phpcs -p . --standard=PHPCompatibility`.
 * By default, you will only receive notifications about deprecated and/or removed PHP features.
 * To get the most out of the PHPCompatibility standard, you should specify a `testVersion` to check against. That will enable the checks for both deprecated/removed PHP features as well as the detection of code using new PHP features.
@@ -166,8 +162,8 @@ If you want to make sure you have all PHPCompatibility rulesets available at any
 **IMPORTANT:** Framework/CMS/Polyfill specific rulesets do not set the minimum PHP version for your project, so you will still need to pass a `testVersion` to get the most accurate results.
 
 
-Using a custom ruleset
-------------------------------
+## Using a custom ruleset
+
 Like with any PHP CodeSniffer standard, you can add PHPCompatibility to a custom PHP CodeSniffer ruleset.
 
 ```xml
@@ -235,8 +231,8 @@ To inform the sniff about additional interfaces providing the Serializable inter
     </rule>
 ```
 
-Projects extending PHPCompatibility
---------------------------------------
+## Projects extending PHPCompatibility
+
 There are hundreds of public projects using PHPCompatibility or extending on top of it. A short list of some that you might know or have a look at :
 * [adamculp/php-code-quality](https://github.com/adamculp/php-code-quality) - a Docker image doing a lot of code quality checks
 * PHPCompatibility Checker WordPress plugin : [Wordpress site](https://wordpress.org/plugins/php-compatibility-checker/) and [Github](https://github.com/wpengine/phpcompat/)
@@ -245,10 +241,10 @@ There are hundreds of public projects using PHPCompatibility or extending on top
 * [Moodle codechecker](https://github.com/moodlehq/moodle-local_codechecker) - A [plugin](https://moodle.org/plugins/local_codechecker) for Moodle [coding style](https://docs.moodle.org/dev/Coding_style), including PHPCompatibility.
 * [Github Action](https://github.com/marketplace/actions/php-compatibility) - A Github Action that runs this PHPCS standard on your source code.
 
-Contributing
--------
+## Contributing
+
 Contributions are very welcome. Please read the [CONTRIBUTING](.github/CONTRIBUTING.md) documentation to get started.
 
-License
--------
-This code is released under the GNU Lesser General Public License (LGPL). For more information, visit http://www.gnu.org/copyleft/lesser.html
+## License
+
+This code is released under the GNU Lesser General Public License (LGPL). For more information, visit <http://www.gnu.org/copyleft/lesser.html>


### PR DESCRIPTION
### GH Actions: add new check for consistency in markdown files

This new check uses the NPM MarkdownLint-CLI2 package via the `DavidAnson/markdownlint-cli2-action` action runner from the same maintainer.

It executes a loose check for consistency and some common errors.
Some of the more annoying rules/rules which could impact display of markdown files on GitHub have been disabled.

All necessary configuration is contained in the `.markdownlint-cli2.yaml` file.

To run locally, install via:
```bash
npm install -g markdownlint-cli2
```
... and then run via:
```bash
markdownlint-cli2
```

The reusable workflow includes a problem matcher which allows for displaying the results inline in GitHub PR code review view.

Includes adding `node_modules` to the `.gitignore` in case anyone would install these tools locally (to prevent them committing them).

Refs:
* https://github.com/DavidAnson/markdownlint
* https://github.com/DavidAnson/markdownlint-cli2
* https://github.com/marketplace/actions/markdownlint-cli2-action

### Docs: various fixes to allow for passing the markdownlint check

Mostly just making the markdown formatting more consistent, though the CHANGELOG file also includes various fixes to URL references (like removing duplicate links, removing a link no longer in use (moved to Wiki), fixing an incorrect link, making PHP manual URLs language agnositic etc).