### PR TITLE
Generators/NewYieldFromComment: remove superfluous test

### DIFF
--- a/PHPCompatibility/Tests/Generators/NewYieldFromCommentUnitTest.inc
+++ b/PHPCompatibility/Tests/Generators/NewYieldFromCommentUnitTest.inc
@@ -34,8 +34,3 @@ function YieldFromMultiLineWithAnnotation() {
     // phpcs:ignore Stnd.Cat -- for reasons.
     From foo();
 }
-
-// Intentional parse error.
-// Only needed for PHPCS < 3.11.0 with PHP < 8.3. This test can be removed once support for PHPCS < 3.11.0 has been dropped.
-function YieldLiveCoding() {
-    yield

--- a/PHPCompatibility/Tests/Generators/NewYieldFromCommentUnitTest.php
+++ b/PHPCompatibility/Tests/Generators/NewYieldFromCommentUnitTest.php
@@ -88,9 +88,6 @@ final class NewYieldFromCommentUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
-        // Live coding test.
-        $data[] = [41];
-
         return $data;
     }
 


### PR DESCRIPTION
Follow up on #1812

As annotated inline, this test no longer has a function now support for PHPCS < 3.11.0 has been dropped.