### PR TITLE
Keywords/NewKeywords: split test case file

### DIFF
--- a/PHPCompatibility/Tests/Keywords/NewKeywordsHaltCompilerUnitTest.inc
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsHaltCompilerUnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+__halt_compiler();
+
+bla();
+const ok = 'a';

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.inc
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.inc
@@ -279,8 +279,3 @@ class WithAsym {
         public(set) int $pubYear,
     ) {}
 }
-
-__halt_compiler();
-
-bla();
-const ok = 'a';

--- a/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/NewKeywordsUnitTest.php
@@ -693,8 +693,8 @@ final class NewKeywordsUnitTest extends BaseSniffTestCase
          * So testing that any violations created *after* the compiler is halted will
          * not be reported.
          */
-        $file = $this->sniffFile(__FILE__, '5.2');
-        $this->assertNoViolation($file, 286);
+        $file = $this->sniffFile(__DIR__ . '/NewKeywordsHaltCompilerUnitTest.inc', '5.2');
+        $this->assertNoViolation($file);
     }
 
 


### PR DESCRIPTION
The test related to `__halt_compiler()` has to be at the end of the file as everything after will not be compiled/tokenized.

In practice, this means that any new tests which need to be added have to be added _above_ the `__halt_compiler()` test and the line number related to the `__halt_compiler()` test needs to be updated every single time.

This makes this test fiddly and prone to getting out of sync, so with this in mind, I'm moving this particular test to its own test case file, which should stabilize the test code for the future.