### PR TITLE
Classes/RemovedClasses: prevent false positives on imported namespaced classes

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -24,6 +24,7 @@ use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Parentheses;
 use PHPCSUtils\Utils\TypeString;
+use PHPCSUtils\Utils\UseStatements;
 use PHPCSUtils\Utils\Variables;
 
 /**
@@ -237,6 +238,29 @@ final class RemovedClassesSniff extends Sniff
         ],
     ];
 
+    /**
+     * Current file being scanned.
+     *
+     * @since 10.0.0
+     *
+     * @var string
+     */
+    private $currentFile = '';
+
+    /**
+     * Stores information about imported, namespaced classes with names which are also in use by PHP.
+     *
+     * When those classes are used, they do not point to the PHP classes, but to the
+     * namespaced, imported class and those usages should be ignored by the sniff.
+     *
+     * The array is indexed by unqualified class names in lower case. The value is always true.
+     * It is structured this way to utilize the isset() function for faster lookups.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, true>
+     */
+    private $importedClasses = [];
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -255,6 +279,7 @@ final class RemovedClassesSniff extends Sniff
         $this->removedClasses = \array_merge($this->removedClasses, $this->removedExceptions);
 
         $targets = [
+            \T_USE          => \T_USE,
             \T_NEW          => \T_NEW,
             \T_CLASS        => \T_CLASS,
             \T_ANON_CLASS   => \T_ANON_CLASS,
@@ -283,9 +308,20 @@ final class RemovedClassesSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
+        $fileName = $phpcsFile->getFilename();
+        if ($this->currentFile !== $fileName) {
+            // Reset the properties for each new file.
+            $this->currentFile     = $fileName;
+            $this->importedClasses = [];
+        }
+
         $tokens = $phpcsFile->getTokens();
 
         switch ($tokens[$stackPtr]['code']) {
+            case \T_USE:
+                $this->processUseToken($phpcsFile, $stackPtr);
+                break;
+
             case \T_CONST:
                 $this->processConstantToken($phpcsFile, $stackPtr);
                 break;
@@ -568,6 +604,39 @@ final class RemovedClassesSniff extends Sniff
 
 
     /**
+     * Processes this test for when a use token is encountered.
+     *
+     * - Save imported classes for later use.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    private function processUseToken(File $phpcsFile, $stackPtr)
+    {
+        if (!UseStatements::isImportUse($phpcsFile, $stackPtr)) {
+            return;
+        }
+
+        $splitUseStatement = UseStatements::splitImportUseStatement($phpcsFile, $stackPtr);
+
+        foreach ($splitUseStatement['name'] as $name => $fullyQualifiedName) {
+            $lowerFullyQualifiedName = \strtolower($fullyQualifiedName);
+
+            if (isset($this->removedClasses[$lowerFullyQualifiedName])) {
+                continue;
+            }
+
+            $this->importedClasses[\strtolower($name)] = true;
+        }
+    }
+
+
+    /**
      * Handle the retrieval of relevant information and - if necessary - throwing of an
      * error/warning for a matched item.
      *
@@ -582,6 +651,10 @@ final class RemovedClassesSniff extends Sniff
      */
     protected function handleFeature(File $phpcsFile, $stackPtr, array $itemInfo)
     {
+        if (isset($this->importedClasses[$itemInfo['nameLc']])) {
+            return;
+        }
+
         $itemArray   = $this->removedClasses[$itemInfo['nameLc']];
         $versionInfo = $this->getVersionInfo($itemArray);
         $isError     = null;

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUnitTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCompatibility\Tests\Classes;
 
+use PHP_CodeSniffer\Files\LocalFile;
 use PHPCompatibility\Tests\BaseSniffTestCase;
 
 /**
@@ -161,5 +162,32 @@ final class RemovedClassesUnitTest extends BaseSniffTestCase
     {
         $file = $this->sniffFile(__FILE__, '5.0'); // Low version below the first deprecation.
         $this->assertNoViolation($file);
+    }
+
+    /**
+     * If classes with same name are used in other namespaces, they should not be flagged.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileIfOtherNamespace()
+    {
+        $file          = $this->sniffFile(__DIR__ . '/RemovedClassesUsesUnitTest.inc', '99.99');
+        $sharedRuleSet = $file->ruleset;
+        $sharedConfig  = $file->config;
+
+        $forgedLocalFile = new LocalFile(
+            \realpath(__DIR__ . '/RemovedClassesUsesNoLeakUnitTest.inc'),
+            $sharedRuleSet,
+            $sharedConfig
+        );
+        $forgedLocalFile->parse();
+        $forgedLocalFile->process();
+
+        $this->assertNoViolation($file);
+        $this->assertError(
+            $forgedLocalFile,
+            3,
+            'The built-in class HW_API_Error is removed since PHP 5.2'
+        );
     }
 }

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUsesNoLeakUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUsesNoLeakUnitTest.inc
@@ -1,0 +1,3 @@
+<?php
+
+new HW_API_Error();

--- a/PHPCompatibility/Tests/Classes/RemovedClassesUsesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedClassesUsesUnitTest.inc
@@ -1,0 +1,18 @@
+<?php
+
+use SomeThingElse\HW_Api;
+use SomeThingElse\HW_API_OBJECT;
+use SomeThingElse\hw_api_attribute;
+use SomeThingElse\HW_API_Error;
+use SomeThingElse\{
+    HW_API_Content,
+    HW_API_Reason,
+};
+
+new HW_API();
+HW_API_Object::test();
+function testingParamType(HW_API_ATTRIBUTE $param) {}
+function testingReturnType(): HW_API_Error {}
+$anon = new class extends HW_API_Content {
+    public HW_API_Reason $prop;
+};


### PR DESCRIPTION
Follow up on PRs #1695 and #1700 in which this same change was already made for the `NewClasses`, `InternalInterfaces` and `NewInterfaces` sniffs.

This commit adds rudimentary tracking of the seen import `use` statements in a file to prevent false positives on imported namespaced classes for which the class name overlaps with a removed/deprecated global PHP class name.