### PR TITLE
Tests: split off parse error tests to own test files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -84,6 +84,8 @@ Naming conventions and repository structure
 * Unit test files should be named the same as the sniff, replacing the `Sniff` suffix with `UnitTest`.
 * The test case file for the unit tests should be named the same as the unit test file, but should use the `.inc` file extension.
     If several test case files are needed to test a sniff, the convention is to number the files starting with `1`, i.e. `SniffNameUnitTest.1.inc`, `SniffNameUnitTest.2.inc` etc.
+* Tests specifically testing the handling of live coding/parse error code which could impact the token stream for any code after that code sample, should be placed in a stand-alone, separate test case file with a `ParseError` + number annotation between the sniff name name and the `UnitTest` suffix.
+    This means that for a live coding/parse error test for the `NewLateStaticBinding` sniff, the test case file could be called `NewLateStaticBindingParseError1UnitTest.inc` with the associated test code in a `NewLateStaticBindingParseError1UnitTest.php` file.
 * Test case files should be placed in the same directory as the unit test file.
 
 

--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -117,7 +117,10 @@ abstract class BaseSniffTestCase extends TestCase
      */
     protected function getSniffCode()
     {
-        return Common::getSniffCode(\get_class($this));
+        $className = \get_class($this);
+        $className = \preg_replace('`ParseError[0-9]*UnitTest$`i', 'UnitTest', $className);
+
+        return Common::getSniffCode($className);
     }
 
     /**

--- a/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+class

--- a/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenClassNameUnderscore sniff.
+ *
+ * @group forbiddenClassNameUnderscore
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\ForbiddenClassNameUnderscoreSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenClassNameUnderscoreParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreUnitTest.inc
@@ -27,6 +27,3 @@ class _ {}
 interface _ {}
 Trait _ {}
 eNuM /*comment*/_ {}
-
-// Live coding, this has to be the last test in the file.
-class

--- a/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/ForbiddenClassNameUnderscoreUnitTest.php
@@ -95,8 +95,6 @@ final class ForbiddenClassNameUnderscoreUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
-        $data[] = [32];
-
         return $data;
     }
 

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+static

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewLateStaticBinding sniff.
+ *
+ * @group newLateStaticBinding
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewLateStaticBindingSniff
+ *
+ * @since 10.0.0
+ */
+final class NewLateStaticBindingParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '5.2');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.inc
@@ -38,7 +38,3 @@ class Foo {
     public function hasStaticReturnIntersectionType(): static&MyInterface {}
     public function static() {}
 }
-
-// Live coding/parse error.
-// This has to be the last test in the file.
-static

--- a/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewLateStaticBindingUnitTest.php
@@ -133,7 +133,6 @@ final class NewLateStaticBindingUnitTest extends BaseSniffTestCase
             [37],
             [38],
             [39],
-            [44],
         ];
     }
 

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesParseError1UnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+class ParseError {
+    public readonly $propertyWithoutSemiColon
+}

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewReadonlyProperties sniff.
+ *
+ * @group newReadonlyProperties
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewReadonlyPropertiesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewReadonlyPropertiesParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will still thrown an error during live coding.
+     *
+     * @return void
+     */
+    public function testSniffThrowsErrorDuringLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertError($file, 5, 'Readonly properties are not supported in PHP 8.0 or earlier.');
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.inc
@@ -124,8 +124,3 @@ class FinalProp {
     final readonly private string $FinalReadOnly;
     protected final $notReadonly;
 }
-
-// Parse error. This has to be the last test in the file.
-class ParseError {
-    public readonly $propertyWithoutSemiColon
-}

--- a/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewReadonlyPropertiesUnitTest.php
@@ -68,8 +68,6 @@ final class NewReadonlyPropertiesUnitTest extends BaseSniffTestCase
             [118],
             [123],
             [124],
-
-            [130],
         ];
     }
 

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentParseError1UnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+class SomeClass extends Something
+    public function test() {
+        return parent::test();
+    }

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedOrphanedParent sniff.
+ *
+ * @group removedOrphanedParent
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\RemovedOrphanedParentSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedOrphanedParentParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.inc
@@ -123,9 +123,3 @@ enum PlainEnum
         return parent::test();
     }
 }
-
-// Intentional parse error. This has to be the last test in the file.
-class SomeClass extends Something
-    public function test() {
-        return parent::test();
-    }

--- a/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/RemovedOrphanedParentUnitTest.php
@@ -157,9 +157,6 @@ final class RemovedOrphanedParentUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        // Add parse error test case.
-        $cases[] = [128];
-
         return $cases;
     }
 

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+switch ($something) {

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenSwitchWithMultipleDefaultBlocks sniff.
+ *
+ * @group forbiddenSwitchWithMultipleDefaultBlocks
+ * @group controlStructures
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\ForbiddenSwitchWithMultipleDefaultBlocksSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenSwitchWithMultipleDefaultBlocksParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.inc
@@ -129,6 +129,3 @@ switch ($something) {
     default:
         break;
 }
-
-// Don't throw errors on live code review.
-switch ($something) {

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksUnitTest.php
@@ -90,7 +90,6 @@ final class ForbiddenSwitchWithMultipleDefaultBlocksUnitTest extends BaseSniffTe
             [23],
             [43],
             [120],
-            [134], // Live coding.
         ];
     }
 

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesParseError1UnitTest.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+// Incomplete directive.
+declare(

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesParseError1UnitTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewExecutionDirectives sniff.
+ *
+ * @group newExecutionDirectives
+ * @group controlStructures
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\NewExecutionDirectivesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewExecutionDirectivesParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify that the sniff stays silent for incomplete declare statements (live coding/parse error).
+     *
+     * @return void
+     */
+    public function testIncompleteDirective()
+    {
+        $file = $this->sniffFile(__FILE__);
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.inc
@@ -42,6 +42,3 @@ declare(
 ); // All valid.
 
 declare(ticks = new stdClass, encoding=$encoding, strict_types=false, unknown = 'invalid', ); // All invalid in one way or another; also: trailing comma not allowed.
-
-// Incomplete directive.
-declare(

--- a/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewExecutionDirectivesUnitTest.php
@@ -217,17 +217,6 @@ final class NewExecutionDirectivesUnitTest extends BaseSniffTestCase
     }
 
 
-    /**
-     * Verify that the sniff stays silent for incomplete declare statements (live coding/parse error).
-     *
-     * @return void
-     */
-    public function testIncompleteDirective()
-    {
-        $this->assertNoViolation($this->sniffResult, 47);
-    }
-
-
     /*
      * `testNoViolationsInFileOnValidVersion` test omitted as the directive value checks are version independent.
      */

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+foreach ( $data $this->prop['key'] ) {}

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewListInForeach sniff.
+ *
+ * @group newListInForeach
+ * @group controlStructures
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\NewListInForeachSniff
+ *
+ * @since 10.0.0
+ */
+final class NewListInForeachParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '5.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.5');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachParseError2UnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachParseError2UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+foreach ( $data

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachParseError2UnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachParseError2UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewListInForeach sniff.
+ *
+ * @group newListInForeach
+ * @group controlStructures
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\NewListInForeachSniff
+ *
+ * @since 10.0.0
+ */
+final class NewListInForeachParseError2UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '5.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.5');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewListInForeachUnitTest.inc
@@ -24,8 +24,3 @@ foreach ($data as $key => [$id, [$name, $address]]) {}
 
 // Make sure there's no false positives on incorrectly tokenized short array tokens in older PHPCS versions.
 foreach ( $data as $this->prop['key'] ) {}
-
-// Safeguards against parse errors/live coding.
-// These tests have to be the last in the file.
-foreach ( $data $this->prop['key'] ) {}
-foreach ( $data

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchParseError1UnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+try {
+   // Some code...
+} catch (

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchParseError1UnitTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewMultiCatch sniff.
+ *
+ * @group newMultiCatch
+ * @group controlStructures
+ * @group exceptions
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\NewMultiCatchSniff
+ *
+ * @since 10.0.0
+ */
+final class NewMultiCatchParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.inc
@@ -32,8 +32,3 @@ try {
 } catch (\Exception) {
    // ...
 }
-
-// Don't throw errors during live code review.
-try {
-   // Some code...
-} catch (

--- a/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewMultiCatchUnitTest.php
@@ -87,7 +87,6 @@ final class NewMultiCatchUnitTest extends BaseSniffTestCase
             [12],
             [23],
             [32],
-            [39], // Live coding.
         ];
     }
 

--- a/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchParseError1UnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+try {
+   // Some code...
+} catch (

--- a/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchParseError1UnitTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewNonCapturingCatch sniff.
+ *
+ * @group newNonCapturingCatch
+ * @group controlStructures
+ * @group exceptions
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\NewNonCapturingCatchSniff
+ *
+ * @since 10.0.0
+ */
+final class NewNonCapturingCatchParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchUnitTest.inc
@@ -27,8 +27,3 @@ try {
 } catch (\Exception) {
    // ...
 }
-
-// Don't throw errors during live code review.
-try {
-   // Some code...
-} catch (

--- a/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/NewNonCapturingCatchUnitTest.php
@@ -87,7 +87,6 @@ final class NewNonCapturingCatchUnitTest extends BaseSniffTestCase
             [8],
             [10],
             [12],
-            [34], // Live coding.
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+function foobar($a,$a

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenParametersWithSameName sniff.
+ *
+ * @group forbiddenParametersWithSameName
+ * @group functionDeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenParametersWithSameNameSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenParametersWithSameNameParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.inc
@@ -17,6 +17,3 @@ interface Foo {
 abstract class Foo {
     abstract public function bar( $a, $a );
 }
-
-// Don't throw errors during live code review.
-function foobar($a,$a

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenParametersWithSameNameUnitTest.php
@@ -86,7 +86,6 @@ final class ForbiddenParametersWithSameNameUnitTest extends BaseSniffTestCase
         return [
             [5],
             [9],
-            [22],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+$f = function ($param) use

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseParseError1UnitTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenVariableNamesInClosureUse sniff.
+ *
+ * @group forbiddenVariableNamesInClosureUse
+ * @group closures
+ * @group functionDeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenVariableNamesInClosureUseSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenVariableNamesInClosureUseParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseParseError2UnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseParseError2UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+$f = function ($param) use ($param

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseParseError2UnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseParseError2UnitTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenVariableNamesInClosureUse sniff.
+ *
+ * @group forbiddenVariableNamesInClosureUse
+ * @group closures
+ * @group functionDeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\ForbiddenVariableNamesInClosureUseSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenVariableNamesInClosureUseParseError2UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.inc
@@ -36,9 +36,3 @@ class ezcReflectionMethod extends ReflectionMethod {
     use ezcReflectionReturnInfo { sayHello as private myPrivateHello; };
     /* ... */
 }
-
-// Live coding.
-$f = function ($param) use
-
-// Live coding.
-$f = function ($param) use ($param

--- a/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/ForbiddenVariableNamesInClosureUseUnitTest.php
@@ -100,8 +100,6 @@ final class ForbiddenVariableNamesInClosureUseUnitTest extends BaseSniffTestCase
             [32],
             [33],
             [36],
-            [41],
-            [44],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+function Unfinished( $foo, $bar,

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewTrailingComma sniff.
+ *
+ * @group newTrailingComma
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\NewTrailingCommaSniff
+ *
+ * @since 10.0.0
+ */
+final class NewTrailingCommaParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.inc
@@ -97,7 +97,3 @@ $a = fn($foo, $bar,,) => $bar; // Parse error, but throw an error anyway.
 function Leading(, $foo, $bar) {} // Parse error, but not our concern.
 
 $clo = function ($foo) use {}; // Parse error.
-
-// Live coding.
-// Intentional parse error. This has to be the last test in the file.
-function Unfinished( $foo, $bar,

--- a/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NewTrailingCommaUnitTest.php
@@ -125,7 +125,6 @@ final class NewTrailingCommaUnitTest extends BaseSniffTestCase
 
         $data[] = [97];
         $data[] = [99];
-        $data[] = [103];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+$closure = function( Type $a = null, $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedImplicitlyNullableParam sniff.
+ *
+ * @group removedImplicitlyNullableParam
+ * @group functiondeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\RemovedImplicitlyNullableParamSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedImplicitlyNullableParamParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.inc
@@ -67,6 +67,3 @@ function fqnNullDefaultNoType($var = \null) {} // OK.
 function fqnNullDefaultWithNullInUnionType(Countable|null $var = \NULL) {} // OK.
 function fqnNullDefaultWithNonNullableType(Type $var = \null) {} // Not OK.
 $arrow = fn(iterable $i = \NULL /*comment*/): bool => doSomething($i); // Not OK.
-
-// Intentional parse error. This has to be the last test in the file.
-$closure = function( Type $a = null, $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedImplicitlyNullableParamUnitTest.php
@@ -100,9 +100,6 @@ final class RemovedImplicitlyNullableParamUnitTest extends BaseSniffTestCase
         $cases[] = [66];
         $cases[] = [67];
 
-        // Parse error test case.
-        $cases[] = [72];
-
         return $cases;
     }
 

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+$closure = function( $a = [], $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedOptionalBeforeRequiredParam sniff.
+ *
+ * @group removedOptionalBeforeRequiredParam
+ * @group functiondeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\RemovedOptionalBeforeRequiredParamSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedOptionalBeforeRequiredParamParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.inc
@@ -139,6 +139,3 @@ function explicitNullableTypeUppercaseMixed(MIXED $var = null, callable $call = 
 $nullableTypedWithFqnNullDefaultValueBeforeOptional = function (T1 $a, ?T2 $b = \null, T3 $c = \NULL) {}; // This is fine, even on PHP 8.4.
 function fqnNullableTypedOptionalBeforeRequired(Okay $a, ?NotOkay $b = \NULL, Required $c) {} // PHP 8.1.
 function implicitNullableTypeClass(T $var = \null, $c) {} // Warning PHP 8.4.
-
-// Intentional parse error. This has to be the last test in the file.
-$closure = function( $a = [], $b

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -188,9 +188,6 @@ final class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
         $cases['line 123 - deprecated in PHP 8.4'] = [123];
         $cases['line 141 - deprecated in PHP 8.4'] = [141];
 
-        // Add parse error test case.
-        $cases['line 139 - parse error'] = [139];
-
         return $cases;
     }
 

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsParseError1UnitTest.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+// Testing class without scope closer.
+class Something {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsParseError1UnitTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionNameRestrictions;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedPHP4StyleConstructors sniff.
+ *
+ * @group removedPHP4StyleConstructors
+ * @group functionNameRestrictions
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedPHP4StyleConstructorsSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedPHP4StyleConstructorsParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersionPHP5()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersionPHP8()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedPHP4StyleConstructorsUnitTest.inc
@@ -86,6 +86,3 @@ class FooBÃÈ {
     function fOOBÃÈ() {}
     function FooBãè() {} // OK - not PHP 4-type constructor - POC: https://3v4l.org/YOc2R.
 }
-
-// Must be last test: testing class without scope closer.
-class Something {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+function

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesParseError1UnitTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionNameRestrictions;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ReservedFunctionNames sniff.
+ *
+ * @group reservedFunctionNames
+ * @group functionNameRestrictions
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\ReservedFunctionNamesSniff
+ *
+ * @since 10.0.0
+ */
+final class ReservedFunctionNamesParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__);
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.inc
@@ -207,7 +207,3 @@ enum LimitedMagic {
     function __autoload() {} // Error.
     function __myFunction() {} // Error.
 }
-
-// Live coding/parse error.
-// This has to be the last test in the file.
-function

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/ReservedFunctionNamesUnitTest.php
@@ -188,9 +188,6 @@ final class ReservedFunctionNamesUnitTest extends BaseSniffTestCase
             [203],
             [204],
             [205],
-
-            // Live coding/parse error test.
-            [214],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueParseError1UnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Live coding/parse error (missing closing scope brace). This test should be the only test in this test case file.
+function LiveCoding($x) {
+    $x = function_call($x);
+    func_get_args(); // Ignored.

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionUse;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ArgumentFunctionsReportCurrentValue sniff.
+ *
+ * @group argumentFunctionsReportCurrentValue
+ * @group functionUse
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionUse\ArgumentFunctionsReportCurrentValueSniff
+ *
+ * @since 10.0.0
+ */
+final class ArgumentFunctionsReportCurrentValueParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -670,8 +670,3 @@ function alwaysFlagUseAsFirstClassCallableDebugBacktrace($a, $b) {
     var_dump($fcc1(0)); // This will print 11 for $a.
     $fcc2(); // This will print 11 for $a.
 }
-
-// Parse error on purpose (missing closing scope brace). This has to be the last test in the file.
-function LiveCoding($x) {
-    $x = function_call($x);
-    func_get_args(); // Ignored.

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.php
@@ -344,8 +344,6 @@ final class ArgumentFunctionsReportCurrentValueUnitTest extends BaseSniffTestCas
             $cases[] = [$line];
         }
 
-        $cases[] = [677]; // Parse error.
-
         return $cases;
     }
 

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesParseError1UnitTest.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+try {
+} catch (

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesParseError1UnitTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Interfaces;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewInterfaces sniff.
+ *
+ * @group newInterfaces
+ * @group interfaces
+ *
+ * @covers \PHPCompatibility\Sniffs\Interfaces\NewInterfacesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewInterfacesParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '4.4');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.inc
@@ -254,8 +254,3 @@ class NamespacedNames {
     ): \Fully\Qualified\Reflector {
     }
 }
-
-// Test parse error/live coding.
-// This MUST be the last test in the file!
-try {
-} catch (

--- a/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/NewInterfacesUnitTest.php
@@ -225,7 +225,7 @@ final class NewInterfacesUnitTest extends BaseSniffTestCase
             [241],
         ];
 
-        for ($line = 237; $line <= 262; $line++) {
+        for ($line = 237; $line <= 256; $line++) {
             $data[] = [$line];
         }
 

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error (class without scope closer). This test should be the only test in this test case file.
+class Something implements Serializable {

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableParseError1UnitTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2022 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Interfaces;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedSerializable sniff.
+ *
+ * @group removedSerializable
+ * @group interfaces
+ *
+ * @covers \PHPCompatibility\Sniffs\Interfaces\RemovedSerializableSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedSerializableParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3-8.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.inc
@@ -198,6 +198,3 @@ enum HasSerializable implements Serializable { // Deprecation warning.
     }
 }
 enum HasSerializableToo: string implements Serializable, ArrayAccess {} // Deprecation warning.
-
-// Must be last test: testing class without scope closer.
-class Something implements Serializable {

--- a/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
+++ b/PHPCompatibility/Tests/Interfaces/RemovedSerializableUnitTest.php
@@ -98,9 +98,6 @@ final class RemovedSerializableUnitTest extends BaseSniffTestCase
         $data[] = [188];
         $data[] = [189];
 
-        // Parse error.
-        $data[] = [203];
-
         return $data;
     }
 

--- a/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error (unclosed parenthesis). This test should be the only test in this test case file.
+empty(

--- a/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\LanguageConstructs;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewEmptyNonVariable sniff.
+ *
+ * @group newEmptyNonVariable
+ * @group languageConstructs
+ *
+ * @covers \PHPCompatibility\Sniffs\LanguageConstructs\NewEmptyNonVariableSniff
+ *
+ * @since 10.0.0
+ */
+final class NewEmptyNonVariableParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '5.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.5');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.inc
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.inc
@@ -59,7 +59,3 @@ empty(a::${$b});
 empty($a::${$b});
 empty(a::${$b . 'c'});
 empty($a::${$b . 'c'});
-
-
-// Unclosed - live coding, don't examine.
-empty(

--- a/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/NewEmptyNonVariableUnitTest.php
@@ -134,9 +134,6 @@ final class NewEmptyNonVariableUnitTest extends BaseSniffTestCase
             [59],
             [60],
             [61],
-
-            // Live coding.
-            [65],
         ];
     }
 

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+list(

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Lists;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the AssignmentOrder sniff.
+ *
+ * @group assignmentOrder
+ * @group lists
+ *
+ * @covers \PHPCompatibility\Sniffs\Lists\AssignmentOrderSniff
+ *
+ * @since 10.0.0
+ */
+final class AssignmentOrderParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.inc
@@ -63,7 +63,3 @@ list("id" => $id, "name" => $name, $label => $id) = $data[0];
 // Safeguard handling of PHP 7.3+ lists with reference assignment.
 list($a, &$b, &$a) = $array;
 [$a, &$b, &$a] = $array;
-
-// Don't trigger on unfinished code during live code review.
-// This has to be the last test in the file!
-list(

--- a/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/AssignmentOrderUnitTest.php
@@ -108,7 +108,6 @@ final class AssignmentOrderUnitTest extends BaseSniffTestCase
             [42],
             [56],
             [57],
-            [69],
         ];
     }
 

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+list(

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Lists;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenEmptyListAssignment sniff.
+ *
+ * @group forbiddenEmptyListAssignment
+ * @group lists
+ *
+ * @covers \PHPCompatibility\Sniffs\Lists\ForbiddenEmptyListAssignmentSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenEmptyListAssignmentParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.inc
@@ -32,6 +32,3 @@ list(,(),) = $infoArray;
 
 // Issue #1341, safeguard against a false positive.
 foreach(["a"=>[]] as $v){}
-
-// Don't trigger on unfinished code during live code review.
-list(

--- a/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/ForbiddenEmptyListAssignmentUnitTest.php
@@ -98,7 +98,6 @@ final class ForbiddenEmptyListAssignmentUnitTest extends BaseSniffTestCase
             [30],
             [31],
             [34],
-            [37],
         ];
     }
 

--- a/PHPCompatibility/Tests/Lists/NewKeyedListParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+list(

--- a/PHPCompatibility/Tests/Lists/NewKeyedListParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Lists;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewKeyedList sniff.
+ *
+ * @group newKeyedList
+ * @group lists
+ *
+ * @covers \PHPCompatibility\Sniffs\Lists\NewKeyedListSniff
+ *
+ * @since 10.0.0
+ */
+final class NewKeyedListParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.1');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.inc
@@ -71,7 +71,3 @@ $a = ["x" => $x1, "y" => $y1];
 // Safeguard handling of PHP 7.3+ lists with reference assignment.
 list("id" => &$id1, "name" => $name1) = $data[0];
 [$id1, & /*comment*/ $name1] = $data[0];
-
-// Don't trigger on unfinished code during live code review.
-// This has to be the last test in the file!
-list(

--- a/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewKeyedListUnitTest.php
@@ -112,7 +112,6 @@ final class NewKeyedListUnitTest extends BaseSniffTestCase
             [49],
             [69],
             [73],
-            [77],
         ];
     }
 

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+list(

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Lists;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewListReferenceAssignment sniff.
+ *
+ * @group newListReferenceAssignment
+ * @group lists
+ *
+ * @covers \PHPCompatibility\Sniffs\Lists\NewListReferenceAssignmentSniff
+ *
+ * @since 10.0.0
+ */
+final class NewListReferenceAssignmentParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.2');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.inc
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.inc
@@ -46,7 +46,3 @@ $a = [&$x1, $y1];
 // Safeguard handling of PHP 7.1+ keyed lists.
 list("id" => &$id1, "name" => $name1) = $data[0];
 ["id" => $id1, "name" => & /*comment*/ $name1] = $data[0];
-
-// Don't trigger on unfinished code during live code review.
-// This has to be the last test in the file!
-list(

--- a/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
+++ b/PHPCompatibility/Tests/Lists/NewListReferenceAssignmentUnitTest.php
@@ -103,7 +103,6 @@ final class NewListReferenceAssignmentUnitTest extends BaseSniffTestCase
             [31],
             [32],
             [44],
-            [52],
         ];
     }
 

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+namespace PHP\Cli

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Namespaces;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ReservedNames sniff.
+ *
+ * @group reservedNames
+ * @group namespaces
+ *
+ * @covers \PHPCompatibility\Sniffs\Namespaces\ReservedNamesSniff
+ *
+ * @since 10.0.0
+ */
+final class ReservedNamesParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.2');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
@@ -78,6 +78,3 @@ namespace Odbc\Connect;
 namespace Soap\Something;
 NAMESPACE Pdo\Subbie;
 namespace BcMath;
-
-// Intentional parse error. This has to be the last test in the file.
-namespace PHP\Cli

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -203,7 +203,6 @@ final class ReservedNamesUnitTest extends BaseSniffTestCase
             [30],
             [31],
             [32],
-            [81],
         ];
     }
 

--- a/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+var_dump(1 >>

--- a/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Operators;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenNegativeBitshift sniff.
+ *
+ * @group forbiddenNegativeBitshift
+ * @group operators
+ *
+ * @covers \PHPCompatibility\Sniffs\Operators\ForbiddenNegativeBitshiftSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenNegativeBitshiftParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.inc
+++ b/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.inc
@@ -14,6 +14,3 @@ var_dump(1 >> ($variable - 1)); // Ok - as we don't know whether the contents of
 
 // Issue #294/#466.
 return ($a >> $b) & ~(1 << (8 * PHP_INT_SIZE - 1) >> ($b - 1));
-
-// Don't throw errors on live code review.
-var_dump(1 >>

--- a/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
+++ b/PHPCompatibility/Tests/Operators/ForbiddenNegativeBitshiftUnitTest.php
@@ -89,7 +89,6 @@ final class ForbiddenNegativeBitshiftUnitTest extends BaseSniffTestCase
             [12],
             [13],
             [16],
-            [19],
         ];
     }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+declare(

--- a/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewExitAsFunctionCall sniff.
+ *
+ * @group newExitAsFunctionCall
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewExitAsFunctionCallSniff
+ *
+ * @since 10.0.0
+ */
+final class NewExitAsFunctionCallParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallUnitTest.inc
@@ -147,7 +147,3 @@ declare(STRICT_TYPES=0, encoding='utf-8') {
  */
 \exit();
 \die(10);
-
-// Parse error/Live coding test.
-// This should be the last test in the file.
-declare(

--- a/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewExitAsFunctionCallUnitTest.php
@@ -256,11 +256,6 @@ final class NewExitAsFunctionCallUnitTest extends BaseSniffTestCase
             $data[] = [124];
         }
 
-        // Parse error/live coding.
-        for ($line = 150; $line <= 153; $line++) {
-            $data[] = [$line];
-        }
-
         return $data;
     }
 

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+Hooks::run( 'SecondaryDataUpdates', [ $title, $old,

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenCallTimePassByReference sniff.
+ *
+ * @group forbiddenCallTimePassByReference
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\ForbiddenCallTimePassByReferenceSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenCallTimePassByReferenceParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '5.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.2');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.inc
@@ -95,8 +95,8 @@ $d(&$a); // Bad: pass by reference.
 // From PHPCS native Generic.Functions.CallTimePassByReference test file.
 Hooks::run( 'SecondaryDataUpdates', array( $title, $old, $recursive, $parserOutput, &$updates ) );
 Hooks::run( 'SecondaryDataUpdates', [ $title, $old, $recursive, $parserOutput, &$updates ] );
-// Similar, but live coding, parse error.
-Hooks::run( 'SecondaryDataUpdates', [ $title, $old,
+
+
 
 // Treat PHP 7.4 arrow functions same as closures.
 $d = fn ( &$a ) => $a;

--- a/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/ForbiddenCallTimePassByReferenceUnitTest.php
@@ -144,7 +144,6 @@ final class ForbiddenCallTimePassByReferenceUnitTest extends BaseSniffTestCase
             // Reference within an array argument.
             [96],
             [97],
-            [99],
 
             // References in combination with arrow functions.
             [102],

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+$array = [{];

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewArrayUnpacking sniff.
+ *
+ * @group newArrayUnpacking
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewArrayUnpackingSniff
+ *
+ * @since 10.0.0
+ */
+final class NewArrayUnpackingParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingParseError2UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingParseError2UnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+$arr5 = array(
+    ...$arr1,
+    array(...$arr1

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingParseError2UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingParseError2UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewArrayUnpacking sniff.
+ *
+ * @group newArrayUnpacking
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewArrayUnpackingSniff
+ *
+ * @since 10.0.0
+ */
+final class NewArrayUnpackingParseError2UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.inc
@@ -50,9 +50,3 @@ class Foo {
 // Intentional parse error. These are not valid syntax. We should not identify any errors here.
 $array = [(...$test)];
 $array = array({...$test});
-$array = [{];
-
-// Intentional parse error. This has to be the last test in the file.
-$arr5 = array(
-    ...$arr1,
-    array(...$arr1

--- a/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewArrayUnpackingUnitTest.php
@@ -105,11 +105,6 @@ final class NewArrayUnpackingUnitTest extends BaseSniffTestCase
         // Parse errors, but not necessarily live coding.
         $data[] = [51];
         $data[] = [52];
-        $data[] = [53];
-
-        // Don't report for live coding.
-        $data[] = [57];
-        $data[] = [58];
 
         return $data;
     }

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+$a = new (trim(' MyClass ');

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewClassMemberAccessWithoutParentheses sniff.
+ *
+ * @group newClassMemberAccessWithoutParentheses
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessWithoutParenthesesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewClassMemberAccessWithoutParenthesesParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesParseError2UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesParseError2UnitTest.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+
+$a = new

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesParseError2UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesParseError2UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewClassMemberAccessWithoutParentheses sniff.
+ *
+ * @group newClassMemberAccessWithoutParentheses
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessWithoutParenthesesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewClassMemberAccessWithoutParenthesesParseError2UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesUnitTest.inc
@@ -115,10 +115,3 @@ var_dump(
     new readonly class (['value']) extends ArrayObject {}['key'],
     isset(new class implements ArrayAccess {}[0])
 );
-
-// Parse error test.
-$a = new (trim(' MyClass ');
-
-// Parse error test.
-// This must be the last test in the file.
-$a = new

--- a/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewClassMemberAccessWithoutParenthesesUnitTest.php
@@ -123,10 +123,6 @@ final class NewClassMemberAccessWithoutParenthesesUnitTest extends BaseSniffTest
             $data[] = [$line];
         }
 
-        // Live coding/parse error.
-        $data[] = [120];
-        $data[] = [124];
-
         return $data;
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+echo test(

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewFunctionArrayDereferencing sniff.
+ *
+ * @group newFunctionArrayDereferencing
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff
+ *
+ * @since 10.0.0
+ */
+final class NewFunctionArrayDereferencingParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '5.3');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.inc
@@ -40,6 +40,3 @@ echo $foo?->bar()[1];
 namespace\test()[0];
 \Fully\Qualified\test()[0];
 Partially\Qualified\test()[0];
-
-// Don't throw errors during live code review.
-echo test(

--- a/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFunctionArrayDereferencingUnitTest.php
@@ -137,7 +137,6 @@ final class NewFunctionArrayDereferencingUnitTest extends BaseSniffTestCase
             [10],
             [11],
             [32],
-            [45],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+echo __METHOD__[

--- a/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewMagicConstantDereferencing sniff.
+ *
+ * @group newMagicConstantDereferencing
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewMagicConstantDereferencingSniff
+ *
+ * @since 10.0.0
+ */
+final class NewMagicConstantDereferencingParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.inc
@@ -34,7 +34,3 @@ __namespace__[0][1][2] *= 'x';
 
 // Dereferencing using curly braces is not supported.
 echo __LINE__{0};
-
-// Live coding.
-// Intentional parse error, this has to be the last test case in the file.
-echo __METHOD__[

--- a/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewMagicConstantDereferencingUnitTest.php
@@ -96,7 +96,6 @@ final class NewMagicConstantDereferencingUnitTest extends BaseSniffTestCase
             [32],
             [33],
             [36],
-            [40],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+$a = $b[0] + $c['something']{

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedCurlyBraceArrayAccess sniff.
+ *
+ * @group removedCurlyBraceArrayAccess
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\RemovedCurlyBraceArrayAccessSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedCurlyBraceArrayAccessParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '7.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc
@@ -147,6 +147,3 @@ Partially\Qualified\ClassName::FOO[1]{0};
 namespace\callMe(){0};
 \Fully\Qualified\callMe($input){0};
 Partially\Qualified\callMe($a, $b){0};
-
-/* Live coding. Intentional parse error. This has to be the last test in the file. */
-$a = $b[0] + $c['something']{

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
@@ -147,6 +147,3 @@ Partially\Qualified\ClassName::FOO[1][0];
 namespace\callMe()[0];
 \Fully\Qualified\callMe($input)[0];
 Partially\Qualified\callMe($a, $b)[0];
-
-/* Live coding. Intentional parse error. This has to be the last test in the file. */
-$a = $b[0] + $c['something']{

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
@@ -123,11 +123,6 @@ final class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTestCase
         for ($line = 1; $line <= 49; $line++) {
             $this->assertNoViolation($file, $line);
         }
-
-        // ...and on the last few lines.
-        for ($line = 150; $line <= 153; $line++) {
-            $this->assertNoViolation($file, $line);
-        }
     }
 
 

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+use function

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\UseDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewUseConstFunction sniff.
+ *
+ * @group newUseConstFunction
+ * @group useDeclarations
+ *
+ * @covers \PHPCompatibility\Sniffs\UseDeclarations\NewUseConstFunctionSniff
+ *
+ * @since 10.0.0
+ */
+final class NewUseConstFunctionParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '5.5');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.inc
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.inc
@@ -45,7 +45,3 @@ class Foobar {
     use const Baz;
     use function Bar;
 }
-
-// Live coding.
-// Intentional parse error. This should be the last test in the file.
-use function

--- a/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
+++ b/PHPCompatibility/Tests/UseDeclarations/NewUseConstFunctionUnitTest.php
@@ -94,7 +94,6 @@ final class NewUseConstFunctionUnitTest extends BaseSniffTestCase
             [39],
             [45],
             [46],
-            [51],
         ];
     }
 

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+global $$test

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Variables;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenGlobalVariableVariable sniff.
+ *
+ * @group forbiddenGlobalVariableVariable
+ * @group variables
+ *
+ * @covers \PHPCompatibility\Sniffs\Variables\ForbiddenGlobalVariableVariableSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenGlobalVariableVariableParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.inc
@@ -53,6 +53,3 @@ global $test,
 
 // Prevent false negatives on PHP 8.0+ nullsafe property access.
 global $$var?->key;
-
-// Live coding. Ignore.
-global $$test

--- a/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/ForbiddenGlobalVariableVariableUnitTest.php
@@ -137,7 +137,6 @@ final class ForbiddenGlobalVariableVariableUnitTest extends BaseSniffTestCase
             [15],
             [16],
             [50],
-            [58],
         ];
     }
 

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+echo $$var['key'

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Variables;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewUniformVariableSyntax sniff.
+ *
+ * @group newUniformVariableSyntax
+ * @group variables
+ *
+ * @covers \PHPCompatibility\Sniffs\Variables\NewUniformVariableSyntaxSniff
+ *
+ * @since 10.0.0
+ */
+final class NewUniformVariableSyntaxParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.inc
@@ -46,6 +46,3 @@ echo $obj?->$var['key'];
 echo $obj?->$var['key']();
 echo $obj?->{$var['key']};
 echo $obj?->{$var['key']}();
-
-// Live coding.
-echo $$var['key'

--- a/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/NewUniformVariableSyntaxUnitTest.php
@@ -111,7 +111,6 @@ final class NewUniformVariableSyntaxUnitTest extends BaseSniffTestCase
             [42],
             [47],
             [48],
-            [51],
         ];
     }
 

--- a/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+$GLOBALS[ = 'x';

--- a/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Variables;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedIndirectModificationOfGlobals sniff.
+ *
+ * @group removedIndirectModificationOfGlobals
+ * @group variables
+ *
+ * @covers \PHPCompatibility\Sniffs\Variables\RemovedIndirectModificationOfGlobalsSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedIndirectModificationOfGlobalsParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsParseError2UnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsParseError2UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+$GLOBALS

--- a/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsParseError2UnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsParseError2UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2021 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Variables;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedIndirectModificationOfGlobals sniff.
+ *
+ * @group removedIndirectModificationOfGlobals
+ * @group variables
+ *
+ * @covers \PHPCompatibility\Sniffs\Variables\RemovedIndirectModificationOfGlobalsSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedIndirectModificationOfGlobalsParseError2UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.1');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.0');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsUnitTest.inc
+++ b/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsUnitTest.inc
@@ -170,9 +170,3 @@ array_shift($GLOBALS);
 // Note: these tests will only work on PHP 8.0 due to PHP having renamed the relevant parameters in PHP 8.0...
 array_splice(offset: 0, array: $GLOBALS, length: count($GLOBALS));
 array_walk(callback: functionName, arg: $extra, array: $GLOBALS);
-
-// Live coding.
-// These tests have to be the last tests in the file.
-$GLOBALS[ = 'x';
-
-$GLOBALS

--- a/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsUnitTest.php
+++ b/PHPCompatibility/Tests/Variables/RemovedIndirectModificationOfGlobalsUnitTest.php
@@ -356,11 +356,6 @@ final class RemovedIndirectModificationOfGlobalsUnitTest extends BaseSniffTestCa
             $cases[] = [$line];
         }
 
-        // No errors for the parse errors at the end of the file.
-        for ($line = 173; $line <= 179; $line++) {
-            $cases[] = [$line];
-        }
-
         return $cases;
     }
 

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenParseError1UnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenParseError1UnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+
+// Issue #338 - no infinite loop on unfinished code.
+/* testLiveCoding */
+$var = new

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenParseError1UnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenParseError1UnitTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Util\Tests\Helpers\ResolveHelper;
+
+use PHPCompatibility\Helpers\ResolveHelper;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the `getFQClassNameFromNewToken()` utility function.
+ *
+ * @group utilityGetFQClassNameFromNewToken
+ * @group utilityFunctions
+ *
+ * @since 10.0.0
+ *
+ * @covers \PHPCompatibility\Helpers\ResolveHelper::getFQClassNameFromNewToken
+ */
+final class GetFQClassNameFromNewTokenParseError1UnitTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test handling of live coding/code with parse errors.
+     *
+     * @return void
+     */
+    public function testLiveCoding()
+    {
+        $stackPtr = $this->getTargetToken('/* testLiveCoding */', \T_NEW);
+        $result   = ResolveHelper::getFQClassNameFromNewToken(self::$phpcsFile, $stackPtr);
+        $this->assertSame('', $result);
+    }
+}

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.inc
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.inc
@@ -52,7 +52,3 @@ $anon = new #[SomeAttribute] class() {};
 
 /* test 19 */
 $anon = new readonly class() {};
-
-// Issue #338 - no infinite loop on unfinished code.
-/* test 16 */
-$var = new

--- a/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ResolveHelper/GetFQClassNameFromNewTokenUnitTest.php
@@ -68,7 +68,7 @@ final class GetFQClassNameFromNewTokenUnitTest extends UtilityMethodTestCase
             ['/* test 13 */', '\DateTime'],
             ['/* test 14 */', '\AnotherTesting\DateTime'],
             ['/* test 15 */', ''],
-            ['/* test 16 */', ''],
+            // Test 16 was moved to separate test file.
             ['/* test 17 */', ''],
             ['/* test 18 */', ''],
             ['/* test 19 */', ''],


### PR DESCRIPTION
Initially, the tests didn't contain any tests which related to parse errors and how sniffs should handle these.
Slowly, more and more of  these have been added in various test case files.

As the token stream for anything following particular parse error code may be broken, these tests are generally placed at the end of a test case file, but that also makes these tests fiddly.
* New tests for the sniff need to be added _above_ the live coding/parse error test (to avoid a broken token stream)
* And the test expectation (line number) for the live coding/parse error test then needs to be updated again and again.

Additionally, a sniff may contain defensive coding against multiple different parse errors, while with the current set up, we can only test one.

This is impractical and undesirable. So this PR separates the existing live coding/parse error tests from the "normal" tests by moving them to separate test case files with their own test class.

---

👉🏻 Note: it's fine to squash merge this PR. I only committed this as one commit per sniff to make reviewing this PR more straight-forward.