### PR TITLE
PHP 8.3 | NewClasses: detect SQLite3Exception class (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1320,6 +1320,12 @@ final class NewClassesSniff extends Sniff
             'extension' => 'random',
         ],
 
+        'SQLite3Exception' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'sqlite3',
+        ],
+
         'RequestParseBodyException' => [
             '8.3' => false,
             '8.4' => true,

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -610,3 +610,6 @@ class TestC extends Partially\Qualified\CallbackFilterIterator {}
 
 try {
 } catch (namespace\Exception | \Fully\Qualified\DomainException | Partially\Qualified\UnderflowException $e) {
+
+try {
+} catch (SQLite3Exception $e) {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -322,6 +322,7 @@ final class NewClassesUnitTest extends BaseSniffTestCase
             ['Random\RandomError', '8.1', [481], '8.2'],
             ['Random\BrokenRandomEngineError', '8.1', [481], '8.2'],
             ['Random\RandomException', '8.1', [482], '8.2'],
+            ['SQLite3Exception', '8.2', [615], '8.3'],
             ['RequestParseBodyException', '8.3', [559], '8.4'],
         ];
     }


### PR DESCRIPTION
> . The SQLite3 class now throws \SQLite3Exception (extends \Exception) instead
>   of \Exception.

This commit adds detection for the new class.

Refs:
* https://wiki.php.net/rfc/sqlite3_exceptions
* https://github.com/php/php-src/blob/ce0df1a9d82dbb3166a889327ebb1c59a640f95f/UPGRADING#L494-L495
* php/php-src#11058
* https://github.com/php/php-src/commit/ddd9a08f566d86083d04de320e24f0751a1de759

Related to #1589