### PR TITLE
PHP 8.3 | NewClasses: detect new DateTime Error + Exception classes (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1320,6 +1320,51 @@ final class NewClassesSniff extends Sniff
             'extension' => 'random',
         ],
 
+        'DateError' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'datetime',
+        ],
+        'DateObjectError' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'datetime',
+        ],
+        'DateRangeError' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'datetime',
+        ],
+        'DateException' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'datetime',
+        ],
+        'DateInvalidTimeZoneException' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'datetime',
+        ],
+        'DateInvalidOperationException' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'datetime',
+        ],
+        'DateMalformedStringException' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'datetime',
+        ],
+        'DateMalformedIntervalStringException' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'datetime',
+        ],
+        'DateMalformedPeriodStringException' => [
+            '8.2'       => false,
+            '8.3'       => true,
+            'extension' => 'datetime',
+        ],
         'SQLite3Exception' => [
             '8.2'       => false,
             '8.3'       => true,

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -613,3 +613,14 @@ try {
 
 try {
 } catch (SQLite3Exception $e) {}
+
+class MyOwnDateException extends DateInvalidTimeZoneException {}
+throw new DateInvalidOperationException();
+function handleDateException(DateException $e) {}
+
+try {
+} catch(DateMalformedIntervalStringException | DateMalformedPeriodStringException $e) {
+} catch(DateMalformedStringException $e) {
+} catch(DateObjectError | DateRangeError $e) {
+} catch(DateError) {
+}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -323,6 +323,15 @@ final class NewClassesUnitTest extends BaseSniffTestCase
             ['Random\BrokenRandomEngineError', '8.1', [481], '8.2'],
             ['Random\RandomException', '8.1', [482], '8.2'],
             ['SQLite3Exception', '8.2', [615], '8.3'],
+            ['DateError', '8.2', [625], '8.3'],
+            ['DateObjectError', '8.2', [624], '8.3'],
+            ['DateRangeError', '8.2', [624], '8.3'],
+            ['DateException', '8.2', [619], '8.3'],
+            ['DateInvalidTimeZoneException', '8.2', [617], '8.3'],
+            ['DateInvalidOperationException', '8.2', [618], '8.3'],
+            ['DateMalformedStringException', '8.2', [623], '8.3'],
+            ['DateMalformedIntervalStringException', '8.2', [622], '8.3'],
+            ['DateMalformedPeriodStringException', '8.2', [622], '8.3'],
             ['RequestParseBodyException', '8.3', [559], '8.4'],
         ];
     }


### PR DESCRIPTION
> - Date:
>  . Implement More Appropriate Date/Time Exceptions RFC.

This commit adds detection for the new classes.

Refs:
* https://wiki.php.net/rfc/datetime-exceptions
* https://github.com/php/php-src/blob/ce0df1a9d82dbb3166a889327ebb1c59a640f95f/NEWS#L2182-L2183
* php/php-src#10366
* https://github.com/php/php-src/commit/66a1a911f1d6cd4b89c0bb5577fa77f1d6a2cb96

Related to #1589