### PR TITLE
NewConstants: add some missing MHash constants

### DIFF
--- a/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsSniff.php
@@ -6786,6 +6786,11 @@ final class NewConstantsSniff extends Sniff
             '7.4'       => true,
             'extension' => 'mbstring',
         ],
+        'MHASH_CRC32C' => [
+            '7.3'       => false,
+            '7.4'       => true,
+            'extension' => 'mhash',
+        ],
         'SO_LABEL' => [
             '7.3' => false,
             '7.4' => true,
@@ -7117,6 +7122,21 @@ final class NewConstantsSniff extends Sniff
             '8.0'       => false,
             '8.1'       => true,
             'extension' => 'gd',
+        ],
+        'MHASH_MURMUR3A' => [
+            '8.0'       => false,
+            '8.1'       => true,
+            'extension' => 'mhash',
+        ],
+        'MHASH_MURMUR3C' => [
+            '8.0'       => false,
+            '8.1'       => true,
+            'extension' => 'mhash',
+        ],
+        'MHASH_MURMUR3F' => [
+            '8.0'       => false,
+            '8.1'       => true,
+            'extension' => 'mhash',
         ],
         'MYSQLI_REFRESH_REPLICA' => [
             '8.0'       => false,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5042,27 +5042,27 @@ final class RemovedFunctionsSniff extends Sniff
         'mhash_count' => [
             '8.1'         => false,
             'alternative' => 'the hash_*() functions',
-            'extension'   => 'hash',
+            'extension'   => 'mhash',
         ],
         'mhash_get_block_size' => [
             '8.1'         => false,
             'alternative' => 'the hash_*() functions',
-            'extension'   => 'hash',
+            'extension'   => 'mhash',
         ],
         'mhash_get_hash_name' => [
             '8.1'         => false,
             'alternative' => 'the hash_*() functions',
-            'extension'   => 'hash',
+            'extension'   => 'mhash',
         ],
         'mhash_keygen_s2k' => [
             '8.1'         => false,
             'alternative' => 'the hash_*() functions',
-            'extension'   => 'hash',
+            'extension'   => 'mhash',
         ],
         'mhash' => [
             '8.1'         => false,
             'alternative' => 'the hash_*() functions',
-            'extension'   => 'hash',
+            'extension'   => 'mhash',
         ],
         'odbc_result_all' => [
             '8.1'       => false,

--- a/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.inc
@@ -1691,3 +1691,8 @@ echo ClassName::PHP_ZTS;
 echo namespace\PHP_INT_MIN;
 echo \Fully\Qualified\IDNA_ALLOW_UNASSIGNED;
 echo Partially\Qualified\TIDY_TAG_BDO;
+
+echo MHASH_CRC32C;
+echo MHASH_MURMUR3A;
+echo MHASH_MURMUR3C;
+echo MHASH_MURMUR3F;

--- a/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/NewConstantsUnitTest.php
@@ -1425,6 +1425,7 @@ final class NewConstantsUnitTest extends BaseSniffTestCase
 
             ['IMG_FILTER_SCATTER', '7.3', 863, '7.4'],
             ['MB_ONIGURUMA_VERSION', '7.3', 824, '7.4'],
+            ['MHASH_CRC32C', '7.3', 1695, '7.4'],
             ['SO_LABEL', '7.3', 825, '7.4'],
             ['SO_PEERLABEL', '7.3', 826, '7.4'],
             ['SO_LISTENQLIMIT', '7.3', 827, '7.4'],
@@ -1493,6 +1494,9 @@ final class NewConstantsUnitTest extends BaseSniffTestCase
             ['CURLOPT_SSLKEY_BLOB', '8.0', 1421, '8.1'],
             ['IMG_AVIF', '8.0', 1422, '8.1'],
             ['IMG_WEBP_LOSSLESS', '8.0', 1423, '8.1'],
+            ['MHASH_MURMUR3A', '8.0', 1696, '8.1'],
+            ['MHASH_MURMUR3C', '8.0', 1697, '8.1'],
+            ['MHASH_MURMUR3F', '8.0', 1698, '8.1'],
             ['MYSQLI_REFRESH_REPLICA', '8.0', 1424, '8.1'],
             ['POSIX_RLIMIT_KQUEUES', '8.0', 1425, '8.1'],
             ['POSIX_RLIMIT_NPTS', '8.0', 1426, '8.1'],


### PR DESCRIPTION
👉🏻 Came across these while looking at the PHP 8.5 deprecations, so figured this should be fixed first.

### NewConstants: add some missing MHash constants

Ref: https://www.php.net/manual/en/mhash.constants.php

### RemovedFunctions: fix up extension key for mhash 