### PR TITLE
NewAttributes: minor clean up

### DIFF
--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -183,7 +183,6 @@ final class NewAttributesSniff extends Sniff
     private $phpunitAttributes = [
         // Generic.
         'Test'                                       => true,
-        'TestDox'                                    => true,
         'DisableReturnValueGenerationForTestDoubles' => true,
         'DoesNotPerformAssertions'                   => true,
         'IgnoreDeprecations'                         => true,


### PR DESCRIPTION
Follow up on #1926, which updated this attributes list, but accidentally introduced a duplicate name.