### PR TITLE
ForbiddenNames: add `parent` + `self` to "other" reserved names

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -140,6 +140,8 @@ final class ForbiddenNamesSniff extends Sniff
      * @var array<string, string>
      */
     protected $otherForbiddenNames = [
+        'parent'   => '5.0',
+        'self'     => '5.0',
         'null'     => '7.0',
         'true'     => '7.0',
         'false'    => '7.0',

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/class.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/class.inc
@@ -77,6 +77,8 @@ class __LINE__ {}
 class __METHOD__ {}
 class __NAMESPACE__ {}
 class __TRAIT__ {}
+class parent {}
+class self {}
 class null {}
 class true {}
 class false {}

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/enum-backed.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/enum-backed.inc
@@ -77,6 +77,8 @@ enum __LINE__: string implements Foo {}
 enum __METHOD__: string implements Foo {}
 enum __NAMESPACE__: string implements Foo {}
 enum __TRAIT__: string implements Foo {}
+enum Parent: string implements Foo {}
+enum Self: string implements Foo {}
 enum Null: string implements Foo {}
 enum True: string implements Foo {}
 enum False: string implements Foo {}

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/enum.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/enum.inc
@@ -77,6 +77,8 @@ enum __LINE__ {}
 enum __METHOD__ {}
 enum __NAMESPACE__ {}
 enum __TRAIT__ {}
+enum Parent {}
+enum Self {}
 enum Null {}
 enum True {}
 enum False {}

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/group-use-as.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/group-use-as.inc
@@ -77,6 +77,8 @@ use My\NS\{ Foobar as __LINE__ };
 use My\NS\{ Foobar as __METHOD__ };
 use My\NS\{ Foobar as __NAMESPACE__ };
 use My\NS\{ Foobar as __TRAIT__ };
+use My\NS\{ Foobar as parent };
+use My\NS\{ Foobar as self };
 use My\NS\{ Foobar as null };
 use My\NS\{ Foobar as true };
 use My\NS\{ Foobar as false };

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/interface.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/interface.inc
@@ -77,6 +77,8 @@ interface __LINE__ {}
 interface __METHOD__ {}
 interface __NAMESPACE__ {}
 interface __TRAIT__ {}
+interface Parent {}
+interface Self {}
 interface Null {}
 interface True {}
 interface False {}

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/multi-use-as.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/multi-use-as.inc
@@ -77,6 +77,8 @@ use Foobar as Foo, BarFoo as __LINE__;
 use Foobar as Foo, BarFoo as __METHOD__;
 use Foobar as Foo, BarFoo as __NAMESPACE__;
 use Foobar as Foo, BarFoo as __TRAIT__;
+use Foobar as Foo, BarFoo as parent;
+use Foobar as Foo, BarFoo as self;
 use Foobar as Foo, BarFoo as null;
 use Foobar as Foo, BarFoo as true;
 use Foobar as Foo, BarFoo as false;

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/namespace.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/namespace.inc
@@ -74,6 +74,8 @@ namespace __LINE__;
 namespace __METHOD__;
 namespace __NAMESPACE__;
 namespace __TRAIT__;
+namespace parent;
+namespace self;
 namespace null;
 namespace true;
 namespace false;

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/nested-namespace.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/nested-namespace.inc
@@ -75,6 +75,8 @@ namespace Foo\__LINE__\Bar;
 namespace Foo\__METHOD__\Bar;
 namespace Foo\__NAMESPACE__\Bar;
 namespace Foo\__TRAIT__\Bar;
+namespace Foo\Parent\Bar;
+namespace Foo\Self\Bar;
 namespace Foo\Null\Bar;
 namespace Foo\True\Bar;
 namespace Foo\False\Bar;

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/trait.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/trait.inc
@@ -77,6 +77,8 @@ trait __LINE__ {}
 trait __METHOD__ {}
 trait __NAMESPACE__ {}
 trait __TRAIT__ {}
+trait Parent {}
+trait Self {}
 trait Null {}
 trait True {}
 trait False {}

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNames/use-as.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNames/use-as.inc
@@ -77,6 +77,8 @@ use Foobar as __LINE__;
 use Foobar as __METHOD__;
 use Foobar as __NAMESPACE__;
 use Foobar as __TRAIT__;
+use Foobar as Parent;
+use Foobar as Self;
 use Foobar as Null;
 use Foobar as True;
 use Foobar as False;

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -32,7 +32,7 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
      *
      * @var int
      */
-    const OTHER_KEYWORD_COUNT = 15;
+    const OTHER_KEYWORD_COUNT = 17;
 
     /**
      * Count of "soft" reserved keywords.

--- a/bin/generate-forbidden-names-test-files
+++ b/bin/generate-forbidden-names-test-files
@@ -97,6 +97,8 @@ $invalidNames = [
 
 // This array is pulled from PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
 $otherInvalidNames = [
+    'parent'   => '5.0',
+    'self'     => '5.0',
     'null'     => '7.0',
     'true'     => '7.0',
     'false'    => '7.0',
@@ -152,7 +154,8 @@ $tests = [
                     || $invalidNames[$name][0] === '5'
                     || $invalidNames[$name][0] === '7'))
             || (isset($otherInvalidNames[$name])
-                && $otherInvalidNames[$name][0] === '7')
+                && ($otherInvalidNames[$name][0] === '7'
+                    || $otherInvalidNames[$name][0] === '5'))
         ) {
             return "namespace $name;\n";
         }
@@ -168,7 +171,8 @@ $tests = [
                     || $invalidNames[$name][0] === '5'
                     || $invalidNames[$name][0] === '7'))
             || (isset($otherInvalidNames[$name])
-                && $otherInvalidNames[$name][0] === '7')
+                && ($otherInvalidNames[$name][0] === '7'
+                    || $otherInvalidNames[$name][0] === '5'))
         ) {
             $name = ucfirst($name);
             return "namespace Foo\\{$name}\\Bar;\n";


### PR DESCRIPTION
Looks like these have been forbidden for use as OO construct names since PHP 5.0, but are still allowed as function/constant names, making these "other" reserved names.

Verified via 3v4l.
Examples:
https://3v4l.org/P6c7v
https://3v4l.org/Ib9Qk

Also see: https://github.com/php/doc-en/pull/4955