### PR TITLE
PHP 8.5 | TypeCasts/RemovedTypeCasts: detect newly deprecated type casts (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -38,24 +38,45 @@ final class RemovedTypeCastsSniff extends Sniff
      * A list of deprecated and removed type casts with their alternatives.
      *
      * The array lists : version number with false (deprecated) or true (removed) and an alternative function.
-     * If no alternative exists, it is NULL, i.e, the function should just not be used.
+     * If no alternative exists, it is NULL, i.e, the type cast should just not be used.
      *
      * @since 8.0.1
+     * @since 10.0.0 The array format was changed to allow for tokens covering multiple different casts.
      *
      * @var array<string, array<string, bool|string>>
      */
     protected $deprecatedTypeCasts = [
-        'T_UNSET_CAST' => [
+        'unset' => [
+            'token_type'  => 'T_UNSET_CAST',
             '7.2'         => false,
             '8.0'         => true,
             'alternative' => 'unset()',
-            'description' => 'unset',
         ],
-        'T_DOUBLE_CAST' => [
+        'real' => [
+            'token_type'  => 'T_DOUBLE_CAST',
             '7.4'         => false,
             '8.0'         => true,
             'alternative' => '(float)',
-            'description' => 'real',
+        ],
+        'integer' => [
+            'token_type'  => 'T_INT_CAST',
+            '8.5'         => false,
+            'alternative' => '(int)',
+        ],
+        'boolean' => [
+            'token_type'  => 'T_BOOL_CAST',
+            '8.5'         => false,
+            'alternative' => '(bool)',
+        ],
+        'double' => [
+            'token_type'  => 'T_DOUBLE_CAST',
+            '8.5'         => false,
+            'alternative' => '(float)',
+        ],
+        'binary' => [
+            'token_type'  => 'T_BINARY_CAST',
+            '8.5'         => false,
+            'alternative' => '(string)',
         ],
     ];
 
@@ -70,8 +91,9 @@ final class RemovedTypeCastsSniff extends Sniff
     public function register()
     {
         $tokens = [];
-        foreach ($this->deprecatedTypeCasts as $token => $versions) {
-            $tokens[] = \constant($token);
+        foreach ($this->deprecatedTypeCasts as $versions) {
+            $tokenConstant          = \constant($versions['token_type']);
+            $tokens[$tokenConstant] = $tokenConstant;
         }
 
         return $tokens;
@@ -91,18 +113,22 @@ final class RemovedTypeCastsSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        $tokens    = $phpcsFile->getTokens();
-        $tokenType = $tokens[$stackPtr]['type'];
+        $tokens = $phpcsFile->getTokens();
 
-        // Special case `T_DOUBLE_CAST` as the same token is used for (float) and (double) casts.
-        if ($tokenType === 'T_DOUBLE_CAST' && \strpos($tokens[$stackPtr]['content'], 'real') === false) {
-            // Float/double casts, not (real) cast.
+        // Type casts are case-insensitive and can contain whitespace, but no new lines.
+        // Normalize them to make them comparable.
+        $contents      = $tokens[$stackPtr]['content'];
+        $castToCompare = \substr($contents, 1, (\strlen($contents) - 2));
+        $castToCompare = \trim($castToCompare, " \t");
+        $castToCompare = \strtolower($castToCompare);
+
+        if (isset($this->deprecatedTypeCasts[$castToCompare]) === false) {
+            // Type cast which is still supported, using the same token as a deprecated type cast.
             return;
         }
 
         $itemInfo = [
-            'name'        => $tokenType,
-            'description' => $this->deprecatedTypeCasts[$tokenType]['description'],
+            'name' => $castToCompare,
         ];
         $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
     }
@@ -170,7 +196,7 @@ final class RemovedTypeCastsSniff extends Sniff
         // Overrule the default message template.
         $this->msgTemplate = 'The %s cast is ';
 
-        $msgInfo = $this->getMessageInfo($itemInfo['description'], $itemInfo['name'], $versionInfo);
+        $msgInfo = $this->getMessageInfo($itemInfo['name'], $itemInfo['name'], $versionInfo);
 
         MessageHelper::addMessage(
             $phpcsFile,

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.inc
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.inc
@@ -11,7 +11,17 @@
 (	unset	) $a;
 ( Unset ) $a;
 
-// Deprecated real type cast.
+// PHP 7.4 deprecated real type cast.
 $a = (real) '1.5';
 $a = ( real ) '1.5';
 $a = (double) '1.5'; // Make sure this doesn't throw a false positive.
+
+// PHP 8.5 deprecated type casts.
+$a = (integer) '15';
+$a = (boolean) 1;
+$a = (   DOUBLE   ) '1.5';
+$a = (binary) '15';
+
+// More false positives safeguards.
+$a = (int) '15';
+$a = (Bool) 1;

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
@@ -26,6 +26,51 @@ final class RemovedTypeCastsUnitTest extends BaseSniffTestCase
 {
 
     /**
+     * Verify deprecations are flagged correctly.
+     *
+     * @dataProvider dataDeprecatedTypeCastWithAlternative
+     *
+     * @param string $castDescription The type of type cast.
+     * @param string $deprecatedIn    The PHP version in which the function was deprecated.
+     * @param string $alternative     An alternative function.
+     * @param array  $lines           The line numbers in the test file which apply to this function.
+     * @param string $okVersion       A PHP version in which the function was still valid.
+     *
+     * @return void
+     */
+    public function testDeprecatedTypeCastWithAlternative($castDescription, $deprecatedIn, $alternative, $lines, $okVersion)
+    {
+        $file = $this->sniffFile(__FILE__, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        $file  = $this->sniffFile(__FILE__, $deprecatedIn);
+        $error = "{$castDescription} is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead";
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, $error);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDeprecatedTypeCastWithAlternative()
+     *
+     * @return array
+     */
+    public static function dataDeprecatedTypeCastWithAlternative()
+    {
+        return [
+            ['The integer cast', '8.5', '(int)', [20], '8.4'],
+            ['The boolean cast', '8.5', '(bool)', [21], '8.4'],
+            ['The double cast', '8.5', '(float)', [17, 22], '8.4'],
+            ['The binary cast', '8.5', '(string)', [23], '8.4'],
+        ];
+    }
+
+
+   /**
      * testDeprecatedRemovedTypeCastWithAlternative
      *
      * @dataProvider dataDeprecatedRemovedTypeCastWithAlternative
@@ -108,7 +153,8 @@ final class RemovedTypeCastsUnitTest extends BaseSniffTestCase
         return [
             [4],
             [5],
-            [17],
+            [26],
+            [27],
         ];
     }
 


### PR DESCRIPTION
> . Non-canonical cast names (boolean), (integer), (double), and (binary) have
>   been deprecated, use (bool), (int), (float), and (string) respectively.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_non-standard_cast_names

This commit adds detection of these newly deprecated type casts to the existing `RemovedTypeCasts` sniff.

Note: as a number of "cast" tokens cover multiple type casts, some of which are deprecated, some which are not, the setup of the sniff needed to change to be focussed on the text between the parentheses, not on the token type.

This also left me with a conundrum about the error codes. The pre-existing error codes were token type based, i.e.: `PHPCompatibility.TypeCasts.RemovedTypeCasts.t_double_castDeprecatedRemoved`. But the `T_DOUBLE_CAST` token covers three different type casts: `(float)`, `(double)` and `(real)`. The first `(float)` is still perfectly valid. The second is deprecated since PHP 8.5, while the third was deprecated in PHP 7.4 and removed in PHP 8.0.

So, leaving the error codes as they were, would create a confusing situation where, for now, we'd have `t_double_castDeprecatedRemoved` for the `(real)` cast and `t_double_castDeprecated` for the `(double)` cast, though that would also become `t_double_castDeprecatedRemoved` once support for the `(double)` cast is removed in PHP 9.0, which means we'd then have two different deprecations, which would be flagged with the same error code.

With this in mind and given that we are currently at a major release, I'm changing the error codes to be based on the contents of the cast, i.e. `realDeprecatedRemoved` vs `doubleDeprecated`.

:point_right: This change in error codes will need to be annotated in the changelog as a breaking change!

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_non-standard_cast_names
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L364-L366
* php/php-src#19372
* https://github.com/php/php-src/commit/3bf21a0d43e8bc8084a19937e5d5dc354f0c07cd
* php/php-src#19438
* https://github.com/php/php-src/commit/bc475ada134af6bf9530ffbcda494ed6f37a3c98

Related to #1849