### PR TITLE
PHP 8.5 | RemovedIniDirectives: detect use of report_memleaks (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -745,6 +745,10 @@ final class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.4'       => false,
             'extension' => 'session',
         ],
+
+        'report_memleaks' => [
+            '8.5' => false,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -525,3 +525,6 @@ $test = ini_get('session.sid_bits_per_character');
 namespace\ini_set('pfpro.defaulthost', 'string');
 \Fully\Qualified\ini_get('phar.extract_list');
 Partially\Qualified\ini_set('assert.bail', 0);
+
+ini_set('report_memleaks', 1);
+$test = ini_get('report_memleaks');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -165,6 +165,8 @@ final class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
 
             ['session.sid_length', '8.4', [518, 519], '8.3'],
             ['session.sid_bits_per_character', '8.4', [521, 522], '8.3'],
+
+            ['report_memleaks', '8.5', [529, 530], '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . The report_memleaks INI directive has been deprecated.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_report_memleaks_ini_directive

This commit accounts for the deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_report_memleaks_ini_directive
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L378-L379
* php/php-src#19481
* https://github.com/php/php-src/commit/a84a82ed88cde4dd2e73c2448e089d31c876705a

Related to #1849