### PR TITLE
PHP 8.5 | RemovedFunctions: detect use of socket_set_timeout() (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5701,6 +5701,12 @@ final class RemovedFunctionsSniff extends Sniff
             'alternative' => 'a fully formed callback in a xml_set_*_handler() function',
             'extension'   => 'xml',
         ],
+
+        'socket_set_timeout' => [
+            '8.5'         => false,
+            'alternative' => 'stream_set_timeout()',
+            'extension'   => 'streams',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1393,3 +1393,6 @@ mysqli_ping();
 mysqli_refresh();
 mysqli_kill();
 lcg_value();
+
+// PHP 8.5.
+\socket_set_timeout();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -169,6 +169,8 @@ final class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['mysqli_refresh', '8.4', 'a FLUSH SQL statement', 1393, '8.3'],
             ['mysqli_kill', '8.4', 'a KILL CONNECTION/QUERY SQL statement', 1394, '8.3'],
             ['lcg_value', '8.4', 'Random\Randomizer::getFloat()', 1395, '8.3'],
+
+            ['socket_set_timeout', '8.5', 'stream_set_timeout()', 1398, '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . The socket_set_timeout() alias function has been deprecated.
>   Use stream_set_timeout() instead.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_5#formally_deprecate_socket_set_timeout

This commit accounts for the function deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#formally_deprecate_socket_set_timeout
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L570-L572
* php/php-src#19285
* https://github.com/php/php-src/commit/21625006e5e20b21f0f814ef6a3903de273f88e2
* https://www.php.net/manual/en/function.socket-set-timeout.php
* https://www.php.net/manual/en/function.stream-set-timeout.php

Related to #1849