### PR TITLE
PHP 8.5 | RemovedFunctionParameters: detect use of get_defined_functions() $exclude_disabled (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -69,6 +69,17 @@ final class RemovedFunctionParametersSniff extends AbstractFunctionCallParameter
                 '8.0'  => true,
             ],
         ],
+        /*
+         * Closely related to the `PHPCompatibility.ParameterValues.RemovedGetDefinedFunctionsExcludeDisabledFalse` sniff.
+         * That sniff detects the change in PHP 8.0, this sniff detect the follow-up step of deprecating the parameter
+         * completely in PHP 8.5.
+         */
+        'get_defined_functions' => [
+            1 => [
+                'name' => 'exclude_disabled',
+                '8.5'  => false,
+            ],
+        ],
         'gmmktime' => [
             7 => [
                 'name' => 'isDST',

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedGetDefinedFunctionsExcludeDisabledFalseSniff.php
@@ -21,6 +21,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * > Calling `get_defined_functions()` with `$exclude_disabled` explicitly set to `false`
  * > is deprecated. `get_defined_functions()` will never include disabled functions.
  *
+ * Note: as of PHP 8.5, the parameter is completely deprecated.
+ * This is handled via the PHPCompatibility.FunctionUse.RemovedFunctionParameters sniff.
+ *
  * PHP version 8.0
  *
  * @link https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L514-L516

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -76,3 +76,6 @@ $obj->odbc_do($connection_id, $query_string, $flags);
 namespace\mysqli_get_client_info($mysql);
 \Fully\Qualified\imagerotate($image, $angle, $bg_color, $ignore_transparent);
 Partially\Qualified\mysqli_store_result($mysql, $mode);
+
+get_defined_functions(); // OK.
+get_defined_functions($exclude_disabled); // Warning.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -187,6 +187,7 @@ final class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             ['session_set_save_handler', 'validate_sid', '8.4', [68], '8.3'],
             ['session_set_save_handler', 'update_timestamp', '8.4', [68], '8.3'],
             ['mysqli_store_result', 'mode', '8.4', [71], '8.3'],
+            ['get_defined_functions', 'exclude_disabled', '8.5', [81], '8.4'],
         ];
     }
 
@@ -233,6 +234,7 @@ final class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             [76],
             [77],
             [78],
+            [80],
         ];
     }
 


### PR DESCRIPTION
> . The $exclude_disabled parameter of the get_defined_functions() function has
>   been deprecated, as it no longer has any effect since PHP 8.0.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_exclude_disabled_parameter_of_get_defined_functions

This commit accounts for the parameter deprecation.

Includes adding a note to a closely related sniff to prevent confusion later.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_exclude_disabled_parameter_of_get_defined_functions
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L367-L369
* php/php-src#19425
* https://github.com/php/php-src/commit/94a15cc92f2593c4f7bbf0a4ef734e3f80e43e07
* https://www.php.net/manual/en/function.get-defined-functions.php

Related to #1849