### PR TITLE
PHP 8.5 | RemovedConstants: detect use of DATE_RFC7231 (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedConstantsSniff.php
@@ -3319,6 +3319,11 @@ final class RemovedConstantsSniff extends Sniff
             '8.4'       => false,
             'extension' => 'soap',
         ],
+
+        'DATE_RFC7231' => [
+            '8.5'       => false,
+            'extension' => 'datetime',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.inc
@@ -833,3 +833,5 @@ echo ClassName::SWF_SOUND_22KHZ;
 echo namespace\IBASE_SVC_SERVER_VERSION;
 echo \Fully\Qualified\NCURSES_KEY_PPAGE;
 echo Partially\Qualified\MCRYPT_RIJNDAEL_256;
+
+echo DATE_RFC7231;

--- a/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedConstantsUnitTest.php
@@ -102,6 +102,7 @@ final class RemovedConstantsUnitTest extends BaseSniffTestCase
             ['MYSQLI_REFRESH_MASTER', '8.4', 815, '8.3'],
             ['MYSQLI_REFRESH_BACKUP_LOG', '8.4', 816, '8.3'],
             ['CURLOPT_BINARYTRANSFER', '8.4', 817, '8.3'],
+            ['DATE_RFC7231', '8.5', 837, '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . The DATE_RFC7231 and DateTimeInterface::RFC7231 constants have been
>   deprecated. This is because the associated timezone is ignored and always
>   uses GMT.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_date_rfc7231_and_datetimeinterfacerfc7231

This commit accounts for the constant deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_date_rfc7231_and_datetimeinterfacerfc7231
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L419-L422
* php/php-src#12989
* https://github.com/php/php-src/commit/25cbc1571916ef49693c5d8381f377aea2c803a7

Related to #1849