### PR TITLE
PHP 8.5 | NewIniDirectives: detect new fatal_error_backtraces ini directive (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -1081,6 +1081,11 @@ final class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.3'       => true,
             'extension' => 'opcache',
         ],
+
+        'fatal_error_backtraces' => [
+            '8.4' => false,
+            '8.5' => true,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -633,3 +633,6 @@ $obj->ini_get('opcache.jit_hot_func');
 namespace\ini_set('max_file_uploads', 1);
 \Fully\Qualified\ini_get('exit_on_timeout');
 Partially\Qualified\ini_set('soap.wsdl_cache_dir', 1);
+
+ini_set('fatal_error_backtraces', 1);
+$test = ini_get('fatal_error_backtraces');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -297,6 +297,8 @@ final class NewIniDirectivesUnitTest extends BaseSniffTestCase
             ['zend.max_allowed_stack_size', '8.3', [621, 622], '8.2'],
             ['zend.reserved_stack_size', '8.3', [624, 625], '8.2'],
             ['opcache.jit_max_trace_length', '8.3', [627, 628], '8.2'],
+
+            ['fatal_error_backtraces', '8.5', [637, 638], '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . Added fatal_error_backtraces to control whether fatal errors should include
>   a backtrace.
>   RFC: https://wiki.php.net/rfc/error_backtraces_v2

This commit accounts for detecting the ini setting.

Note: the PR for the RFC also mentions the following:
> It defaults to `E_FATAL_ERRORS`, which I've also exposed as a userland constant.

However, by the looks of it, this new constant didn't make it into the final implementation (and isn't mentioned in the RFC either), so I've not updated the `NewConstants` sniff.

Refs:
* https://wiki.php.net/rfc/error_backtraces_v2
* https://github.com/php/php-src/blob/34721745833b4c9e69ed22f1b17c4c1c421f7179/UPGRADING#L946-L948
* php/php-src#17056
* https://github.com/php/php-src/commit/0a14ab18d2b3bcf1358aa9f25efc1ad72c18d000

Related to #1849