### PR TITLE
:sparkles: New `PHPCompatibility.LanguageConstructs.RemovedLanguageConstructs` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/LanguageConstructs/RemovedLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/RemovedLanguageConstructsSniff.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\LanguageConstructs;
+
+use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\MessageHelper;
+
+/**
+ * Detect use of deprecated and removed PHP language constructs.
+ *
+ * PHP version All
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_backticks_as_an_alias_for_shell_exec
+ *
+ * @since 10.0.0
+ */
+final class RemovedLanguageConstructsSniff extends Sniff
+{
+    use ComplexVersionDeprecatedRemovedFeatureTrait;
+
+    /**
+     * A list of deprecated/removed language constructs.
+     *
+     * The array lists : version number with false (deprecated) or true (removed).
+     * It's sufficient to list the first version where the language construct was deprecated/removed.
+     *
+     * Optional, the array can contain an `alternative` key listing an alternative to using the language construct.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, array<string, bool|string>>
+     */
+    protected $removedConstructs = [
+        'T_BACKTICK' => [
+            '8.5'         => false,
+            'description' => 'The backtick operator',
+            'alternative' => 'shell_exec()',
+        ],
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        $tokens = [];
+        foreach ($this->removedConstructs as $token => $versions) {
+            $tokens[] = \constant($token);
+        }
+
+        return $tokens;
+    }
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens   = $phpcsFile->getTokens();
+        $itemInfo = [
+            'name' => $tokens[$stackPtr]['type'],
+        ];
+
+        $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
+    }
+
+
+    /**
+     * Handle the retrieval of relevant information and - if necessary - throwing of an
+     * error for a matched item.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the relevant token in
+     *                                               the stack.
+     * @param array                       $itemInfo  Base information about the item.
+     *
+     * @return void
+     */
+    protected function handleFeature(File $phpcsFile, $stackPtr, array $itemInfo)
+    {
+        $itemArray   = $this->removedConstructs[$itemInfo['name']];
+        $versionInfo = $this->getVersionInfo($itemArray);
+        $isError     = null;
+
+        if (empty($versionInfo['removed']) === false
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['removed']) === true
+        ) {
+            $isError = true;
+        } elseif (empty($versionInfo['deprecated']) === false
+            && ScannedCode::shouldRunOnOrAbove($versionInfo['deprecated']) === true
+        ) {
+            $isError = false;
+
+            // Reset the 'removed' info as it is not relevant for the current notice.
+            $versionInfo['removed'] = '';
+        }
+
+        if (isset($isError) === false) {
+            return;
+        }
+
+        $this->addMessage($phpcsFile, $stackPtr, $isError, $itemInfo, $itemArray, $versionInfo);
+    }
+
+
+    /**
+     * Generates the error or warning for this item.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the relevant token in
+     *                                                 the stack.
+     * @param bool                        $isError     Whether this should be an error or a warning.
+     * @param array                       $itemInfo    Base information about the item.
+     * @param array                       $itemArray   The sub-array with all the details about
+     *                                                 this item.
+     * @param string[]                    $versionInfo Array with detail (version) information
+     *                                                 relevant to the item.
+     *
+     * @return void
+     */
+    protected function addMessage(File $phpcsFile, $stackPtr, $isError, array $itemInfo, array $itemArray, array $versionInfo)
+    {
+        $msgInfo = $this->getMessageInfo($itemArray['description'], $itemInfo['name'], $versionInfo);
+
+        MessageHelper::addMessage(
+            $phpcsFile,
+            $msgInfo['message'],
+            $stackPtr,
+            $isError,
+            $msgInfo['errorcode'],
+            $msgInfo['data']
+        );
+    }
+}

--- a/PHPCompatibility/Tests/LanguageConstructs/RemovedLanguageConstructsUnitTest.inc
+++ b/PHPCompatibility/Tests/LanguageConstructs/RemovedLanguageConstructsUnitTest.inc
@@ -1,0 +1,10 @@
+<?php
+
+/*
+ * PHP 8.5: the backtick operator is deprecated.
+ */
+// Don't flag backticks in `comments`
+echo 'or when `backticks` are used in text strings';
+
+$output = `ls -al`;
+$output = `mklink /J $junk0 $dir0`;

--- a/PHPCompatibility/Tests/LanguageConstructs/RemovedLanguageConstructsUnitTest.php
+++ b/PHPCompatibility/Tests/LanguageConstructs/RemovedLanguageConstructsUnitTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\LanguageConstructs;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedLanguageConstructs sniff.
+ *
+ * @group removedLanguageConstructs
+ * @group languageConstructs
+ *
+ * @covers \PHPCompatibility\Sniffs\LanguageConstructs\RemovedLanguageConstructsSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedLanguageConstructsUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * PHP 8.5: backtick operator as alias for shell_exec().
+     *
+     * @dataProvider dataBacktickOperator
+     *
+     * @param int $line The line number where an error is expected.
+     *
+     * @return void
+     */
+    public function testBacktickOperator($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        // Warning will appear twice, once for the opener backtick, once for the closer.
+        $this->assertWarning($file, $line, 'The backtick operator is deprecated since PHP 8.5; Use shell_exec() instead');
+
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataBacktickOperator()
+    {
+        return [
+            [9],
+            [10],
+        ];
+    }
+
+
+    /**
+     * Test against false positives for the backtick operator.
+     *
+     * @dataProvider dataBacktickOperatorNoFalsePositives
+     *
+     * @param int $line The line number where an error is expected.
+     *
+     * @return void
+     */
+    public function testBacktickOperatorNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataBacktickOperatorNoFalsePositives()
+    {
+        return [
+            [6],
+            [7],
+        ];
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4'); // Low version before first deprecation.
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
... to facilitate detection of the PHP 8.5 deprecated backtick operator:

> . The backtick operator as an alias for shell_exec() has been deprecated.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_backticks_as_an_alias_for_shell_exec

This commit introduces a new `RemovedLanguageConstruct` sniff to detect this deprecation and allow for other language constructs to be deprecated/removed in the future.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_backticks_as_an_alias_for_shell_exec
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L373
* php/php-src#19443
* https://github.com/php/php-src/commit/3d9d68e1cacf8d185de6281bfec058b22e3094f8

Related to #1849