### PR TITLE
PHP 8.5 | ParameterValues/ChangedIntToBoolParamType: detect Zlib $use_include_path change

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
@@ -37,10 +37,28 @@ final class ChangedIntToBoolParamTypeSniff extends AbstractFunctionCallParameter
      * @var array<string, array<int, array<string, string>>>
      */
     protected $targetFunctions = [
+        'gzfile' => [
+            2 => [
+                'name'  => 'use_include_path',
+                'since' => '8.5',
+            ],
+        ],
+        'gzopen' => [
+            3 => [
+                'name'  => 'use_include_path',
+                'since' => '8.5',
+            ],
+        ],
         'ob_implicit_flush' => [
             1 => [
                 'name'  => 'enable',
                 'since' => '8.0',
+            ],
+        ],
+        'readgzfile' => [
+            2 => [
+                'name'  => 'use_include_path',
+                'since' => '8.5',
             ],
         ],
         'sem_get' => [

--- a/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.inc
@@ -34,3 +34,11 @@ $obj?->sem_get( $key, $max_acquire, $perm, 0 );
 namespace\ob_implicit_flush(0);
 \Fully\Qualified\sem_get( $key, $max_acquire, $perm, 0 );
 Partially\Qualified\ob_implicit_flush(0);
+
+// PHP 8.5.
+gzfile($filename, true); // OK.
+gzopen($filename, $mode, true); // OK.
+readgzfile($filename, true); // OK.
+gzfile($filename, 1); // Error.
+gzopen($filename, $mode, 0); // Error.
+readgzfile($filename, 1); // Error.

--- a/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ChangedIntToBoolParamTypeUnitTest.php
@@ -63,6 +63,9 @@ final class ChangedIntToBoolParamTypeUnitTest extends BaseSniffTestCase
             [26, '8.0', '$auto_release', 'sem_get'],
             [27, '8.0', '$enable', 'ob_implicit_flush'],
             [28, '8.0', '$enable', 'ob_implicit_flush'],
+            [42, '8.5', '$use_include_path', 'gzfile'],
+            [43, '8.5', '$use_include_path', 'gzopen'],
+            [44, '8.5', '$use_include_path', 'readgzfile'],
         ];
     }
 
@@ -98,7 +101,7 @@ final class ChangedIntToBoolParamTypeUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
-        for ($line = 30; $line <= 36; $line++) {
+        for ($line = 30; $line <= 41; $line++) {
             $data[] = [$line];
         }
 


### PR DESCRIPTION
> - Zlib:
>   . The "use_include_path" argument for the
>     gzfile, gzopen and readgzfile functions has been changed
>     from int to boolean.

This commit accounts for detecting this change.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L725-L728
* php/php-src#16424
* https://github.com/php/php-src/commit/6d1881b42d3498ad81150fcd119575b7ba3c2d49
* https://www.php.net/manual/en/function.gzfile.php
* https://www.php.net/manual/en/function.gzopen.php
* https://www.php.net/manual/en/function.readgzfile.php

Related to #1849