### PR TITLE
PHP 8.5 | :sparkles: New `PHPCompatibility.Classes.NewStaticAvizProperties` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/Classes/NewStaticAvizPropertiesStandard.xml
+++ b/PHPCompatibility/Docs/Classes/NewStaticAvizPropertiesStandard.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Asymmetric Visibility on Static Properties"
+    >
+    <standard>
+    <![CDATA[
+    Static properties can be declared with asymmetric visibility since PHP 8.5.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: static properties without asymmetric visibility.">
+        <![CDATA[
+class NoAviz
+{
+    <em>public static</em> $foo;
+    <em>static protected</em> ClassName $baz;
+    <em>private static</em> ?string $bar;
+}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.5: static properties with asymmetric visibility.">
+        <![CDATA[
+class Aviz
+{
+    <em>public(set) static</em> $foo;
+    <em>static protected(set)</em> ClassName $baz;
+    <em>protected private(set) static</em> ?string $bar;
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Classes/NewStaticAvizPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewStaticAvizPropertiesSniff.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Exceptions\ValueError;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\ObjectDeclarations;
+use PHPCSUtils\Utils\Parentheses;
+use PHPCSUtils\Utils\Variables;
+
+/**
+ * Detects declarations of asymmetric visibility for static properties, as introduced in PHP 8.5.
+ *
+ * PHP version 8.5
+ *
+ * {@internal Asymmetric visibility in general, as introduced in PHP 8.4, is detected via the NewKeywords sniff.}
+ *
+ * @link https://wiki.php.net/rfc/static-aviz
+ *
+ * @since 10.0.0
+ */
+final class NewStaticAvizPropertiesSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return Collections::ooPropertyScopes();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrBelow('8.4') === false) {
+            return;
+        }
+
+        $ooProperties = ObjectDeclarations::getDeclaredProperties($phpcsFile, $stackPtr);
+        if (empty($ooProperties)) {
+            // No properties, no problem.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $error  = 'Asymmetric visibility on static properties is not supported in PHP 8.4 or earlier.';
+
+        $endOfStatement = false;
+        foreach ($ooProperties as $varToken) {
+            if ($endOfStatement !== false && $varToken < $endOfStatement) {
+                // Don't throw the same error multiple times for multi-property declarations.
+                // Also skip over any other constructor promoted properties.
+                continue;
+            }
+
+            try {
+                $properties = Variables::getMemberProperties($phpcsFile, $varToken);
+            } catch (ValueError $e) {
+                // This must be constructor property promotion.
+                // Ignore as static properties cannot be defined as promoted properties.
+                // Skip over the rest of the constructor arguments.
+                $deepestOpen = Parentheses::getLastOpener($phpcsFile, $varToken);
+                if ($deepestOpen !== false
+                    && $stackPtr < $deepestOpen
+                    && Parentheses::isOwnerIn($phpcsFile, $deepestOpen, \T_FUNCTION)
+                    && isset($tokens[$deepestOpen]['parenthesis_closer'])
+                ) {
+                    $endOfStatement = $tokens[$deepestOpen]['parenthesis_closer'];
+                }
+
+                continue;
+            }
+
+            if ($properties['is_static'] === false || $properties['set_scope'] === false) {
+                // Not a static property with asymmetric visbility.
+                continue;
+            }
+
+            $phpcsFile->addError($error, $varToken, 'Found', [$tokens[$varToken]['content']]);
+
+            $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($varToken + 1));
+        }
+    }
+}

--- a/PHPCompatibility/Tests/Classes/NewStaticAvizPropertiesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewStaticAvizPropertiesUnitTest.inc
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * OK: Non-static and/or non-asym visibility properties.
+ */
+class NoProperties {}
+
+class NonStaticAviz {
+    var $oldStyle;
+    static $oldStyleStatic;
+
+    static public $publicStatic;
+    final protected static /* comment */ $protectedStatic;
+    private static $privateStatic;
+
+    public(set) int $scalarType;
+    protected(set) ClassName $classType;
+    private(set) ?ClassName $nullableClassType;
+    public static Iterable $staticPropWithType;
+
+    // Multi-property declarations.
+    public static float $a, $b;
+    final public(set) int $x,
+        /**
+         * Docblock
+         */
+        $y,
+        // comment.
+        $z = 15;
+
+    protected(set) \MyNamespace\InterfaceName $namespacedInterfaceType;
+    final static bool $bool = true;
+    static public inT $int = 0;
+
+    // Intentional parse error.
+    $invalidProperty;
+
+    // Constructor property promotion does not support static properties.
+    public function __construct(
+        protected(set) float|int $promotedProtected,
+        public ?string &$promotedPublic,
+        private(set) mixed $promotedPrivate,
+        callable $normalParamIgnore1,
+        mixed $normalParamIgnore2,
+    ) {}
+
+    // Function parameter and function local var, not property.
+    public function method(?int $param) {
+        $localVar = 'abc';
+    }
+}
+
+
+/*
+ * PHP 8.5: static properties with asymmetric visibility.
+ */
+class PHP85StaticAviz {
+    static protected(set) ClassName $classType;
+    private(set) static ?ClassName $nullableClassType;
+    final public static public(set) int $typed = 10;
+
+    // Readonly static aviz properties are not supported, but that's not the concern of this sniff.
+    protected(set) readonly static bool $noVisibility;
+
+    // Asymmetric visibility can only be applied to typed properties, but that's not the concern of this sniff.
+    public(set) static $unTyped;
+
+    // Multi-property declarations.
+    protected(set) static float $a, $b;
+    static private(set) int $x,
+        /**
+         * Docblock
+         */
+        $y,
+        // comment.
+        $z;
+}

--- a/PHPCompatibility/Tests/Classes/NewStaticAvizPropertiesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewStaticAvizPropertiesUnitTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Classes;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewStaticAvizProperties sniff.
+ *
+ * @group newStaticAvizProperties
+ * @group classes
+ *
+ * @covers \PHPCompatibility\Sniffs\Classes\NewStaticAvizPropertiesSniff
+ *
+ * @since 10.0.0
+ */
+final class NewStaticAvizPropertiesUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify that asymmetric visibility on static properties is correctly detected.
+     *
+     * @dataProvider dataNewStaticAvizProperties
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewStaticAvizProperties($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertError($file, $line, 'Asymmetric visibility on static properties is not supported in PHP 8.4 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewStaticAvizProperties()
+     *
+     * @return array
+     */
+    public static function dataNewStaticAvizProperties()
+    {
+        return [
+            [58],
+            [59],
+            [60],
+            [63],
+            [66],
+            [69],
+            [70],
+        ];
+    }
+
+
+    /**
+     * Verify there are no false positives for similar syntaxes.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 53 lines.
+        for ($line = 1; $line <= 53; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> . Added asymmetric visibility support for static properties.
>   RFC: https://wiki.php.net/rfc/static-aviz

The use of asymmetric visibility keywords in general is flagged for PHP < 8.4 via the `NewKeywords` sniff (see #1809).

PHP 8.5 now allows for asymmetric visibility to be used for static properties, which was explicitly excluded in the PHP 8.4 RFC.

This new sniff detects code allowed since the PHP 8.5 change.

Note: this does mean that code _may_ be flagged by both sniffs:
* For PHP 8.4 for the use of the keywords.
* For PHP 8.5 specifically for the use of the keywords with static properties.

I did consider moving the "general" check from the `NewKeywords` sniff to this new sniff, but that would be a breaking change for the error code for the PHP 8.4 error without much added benefit, other than potentially preventing two notices about slightly different aspects of the same issue.

Refs:
* https://wiki.php.net/rfc/static-aviz
* https://github.com/php/php-src/blob/34721745833b4c9e69ed22f1b17c4c1c421f7179/UPGRADING#L194-L195
* php/php-src#16486
* https://github.com/php/php-src/commit/1f6fdde6469675058509a27f2bd3325b2b01910b

Related to #1849