### PR TITLE
PHP 8.3 | :sparkles: New `PHPCompatibility.ParameterValues.NewClassAliasInternalClass` sniff

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/NewClassAliasInternalClassStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/NewClassAliasInternalClassStandard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Class Alias Internal Class"
+    >
+    <standard>
+    <![CDATA[
+    Internal PHP classes can be aliased to another name since PHP 8.3.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: aliasing a userland PHP class.">
+        <![CDATA[
+class_alias(<em>'MyClass'</em>, 'MyAlias');
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.3: aliasing a PHP native class.">
+        <![CDATA[
+class_alias(<em>'DateTime'</em>, 'MyAlias');
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/NewClassAliasInternalClassSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewClassAliasInternalClassSniff.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\PassedParameters;
+use PHPCSUtils\Utils\TextStrings;
+use ReflectionClass;
+
+/**
+ * PHP native classes/interfaces/traits/enums can be aliased since PHP 8.3.
+ *
+ * Prior to PHP 8.3, only userland classes could be aliased.
+ *
+ * Mind: this sniff may yield false negatives for:
+ * - Classes declared in extensions, when the extension is not loaded during the PHPCS run.
+ * - PHP native classes which are not available in the PHP version on which PHPCS is being run.
+ *
+ * PHP version 8.3
+ *
+ * @link https://www.php.net/manual/en/function.class-alias.php
+ *
+ * @since 10.0.0
+ */
+final class NewClassAliasInternalClassSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, true>
+     */
+    protected $targetFunctions = [
+        'class_alias' => true,
+    ];
+
+    /**
+     * List of all OO names currently registered with PHP.
+     *
+     * This property is set in the register() method.
+     *
+     * This list will include classes from PHPCS + PHPCompatibility and we will filter those out
+     * at a later point in the logic.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, int>
+     */
+    private $declaredOONamesLC = [];
+
+    /**
+     * Tokens which we are looking for in the parameter.
+     *
+     * This property is set in the register() method.
+     *
+     * @since 10.0.0
+     *
+     * @var array<int|string, int|string>
+     */
+    private $targetTokens = [];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        /*
+         * Gather the names of all currently declared classes/interfaces/traits/enums.
+         * Mind: there is no `get_declared_enums()` function, but enums are included
+         * in the return value from `get_declared_classes()`.
+         */
+        $classes    = \get_declared_classes();
+        $interfaces = \get_declared_interfaces();
+        $traits     = \get_declared_traits();
+
+        $allOONames = \array_merge($classes, $interfaces, $traits);
+        $allOONames = \array_flip($allOONames);
+
+        $this->declaredOONamesLC = \array_change_key_case($allOONames, \CASE_LOWER);
+
+        // Only set the $targetTokens property once.
+        $this->targetTokens  = Tokens::$emptyTokens;
+        $this->targetTokens += Tokens::$heredocTokens;
+        $this->targetTokens += Tokens::$stringTokens;
+        unset($this->targetTokens[\T_DOUBLE_QUOTED_STRING]);
+
+        return parent::register();
+    }
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrBelow('8.2') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $param = PassedParameters::getParameterFromStack($parameters, 1, 'class');
+        if ($param === false) {
+            return;
+        }
+
+        $firstNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, $param['start'], ($param['end'] + 1), true);
+        $hasNonTextToken = $phpcsFile->findNext($this->targetTokens, $firstNonEmpty, ($param['end'] + 1), true);
+        if ($hasNonTextToken !== false) {
+            // Non text string token found.
+            return;
+        }
+
+        $content   = TextStrings::getCompleteTextString($phpcsFile, $firstNonEmpty);
+        $contentLC = \strtolower(\ltrim($content, '\\'));
+
+        if (isset($this->declaredOONamesLC[$contentLC]) === false) {
+            return;
+        }
+
+        // Make sure this is a PHP native class and not a userland (PHPCS or PHPCompatibility) class.
+        $reflectionClass = new ReflectionClass($contentLC);
+        if ($reflectionClass->isInternal() === false) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'PHP internal classes can not be aliased prior to PHP 8.3. Found aliasing of class: %s',
+            $firstNonEmpty,
+            'Found',
+            [$content]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/NewClassAliasInternalClassUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewClassAliasInternalClassUnitTest.inc
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * OK, not our target.
+ * Safeguard against false positives on method calls and namespaced function calls.
+ */
+ClassName::class_alias('ArrayObject', 'MyAlias');
+$obj->class_alias('RecursiveIteratorIterator', 'MyAlias');
+$obj?->class_alias('Reflection', 'MyAlias');
+namespace\Sub\class_alias('SoapClient', 'MyAlias');
+\Fully\Qualified\class_alias('DOMDocument', 'MyAlias');
+Partially\Qualified\class_alias('SimpleXMLElement', 'MyAlias');
+
+
+/*
+ * OK.
+ */
+// Not PHP internal class.
+class_alias('MyClass', 'MyAlias');
+class_alias(alias: 'MyAlias', class: '\MyClass');
+class_alias('MyNS\DOMDocument', 'MyAlias');
+class_alias('PHP_CodeSniffer\Util\Tokens', 'MyAlias'); // Make sure PHPCS native classes being aliased don't get flagged.
+
+// Safeguard against false positives when target param not found.
+class_alias();
+\class_alias(alias: $alias, autoload: false);
+class_alias(classs: $class, alias: 'string'); // Typo in param name, not our concern.
+
+// Ignore as undetermined.
+class_alias("$className", 'MyAlias');
+class_alias(<<<EOD
+$className
+EOD
+, 'MyAlias'
+);
+
+\class_alias($className, 'MyAlias', $autoload);
+class_alias(get_className('AddressInfo'), 'MyAlias');
+class_alias(ClassName::CLASS_NAME_TO_ALIAS, 'MyAlias');
+class_alias(namespace\CLASS_NAME_TO_ALIAS, 'MyAlias', );
+
+class_alias(__NAMESPACE__ . '\GMP', 'MyAlias');
+class_alias($namespace . '\\' . 'ReflectionIntersectionType', 'MyAlias');
+
+// At this moment we don't handle this (yet), but we should start handling this once the Utils namespace and use trackers are available.
+class_alias(GMP::class, 'MyAlias');
+class_alias(Partial\GMP::class, 'MyAlias');
+class_alias(namespace\GMP::class, 'MyAlias');
+
+
+/*
+ * PHP 8.3: Aliasing PHP internal classes.
+ *
+ * Mind: use PHP native classes which are available in the lowest PHP version supported by PHPCompatibility for these tests!
+ */
+class_alias('FilterIterator', 'MyAlias');
+\class_alias("IteratorIterator", 'MyAlias');
+class_alias(<<<'EOD'
+SplObjectStorage
+EOD
+, 'MyAlias'
+);
+\Class_Alias(<<<"EOD"
+datetime
+EOD
+, 'MyAlias'
+);
+class_alias(
+    // Also testing case handling.
+    '\DateINTERVAL', // phpcs:ignore Stnd.Cat.SniffName
+    'MyAlias',
+);
+
+class_alias(alias: 'MyAlias', class: 'ResourceBundle');
+CLASS_ALIAS(/*comment*/ 'TransLiterator'/*comment*/, 'MyAlias');
+class_alias(<<<EOD
+Phar
+EOD
+, 'MyAlias'
+);
+
+\class_alias('\Traversable', 'MyAlias'); // Also applies to Internal interfaces.
+
+// This test will only be flagged if the mysqli extension is loaded.
+class_alias('MySqlI', 'MyAlias'); // Also testing use of different case than case used by PHP internally.
+
+// This test will only be flagged if the tests are run on PHP 7.2+.
+class_alias('HashContext', 'MyAlias');
+
+// This test will only be flagged if the tests are run on PHP 8.0+.
+class_alias("\WeakMap", 'MyAlias');

--- a/PHPCompatibility/Tests/ParameterValues/NewClassAliasInternalClassUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewClassAliasInternalClassUnitTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewClassAliasInternalClass sniff.
+ *
+ * @group mewClassAliasInternalClass
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewClassAliasInternalClassSniff
+ *
+ * @since 10.0.0
+ */
+final class NewClassAliasInternalClassUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify that aliasing a PHP internal class is flagged.
+     *
+     * @dataProvider dataNewClassAliasInternalClass
+     *
+     * @param int $line Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testNewClassAliasInternalClass($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertError($file, $line, 'PHP internal classes can not be aliased prior to PHP 8.3. Found aliasing of class:');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewClassAliasInternalClass()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNewClassAliasInternalClass()
+    {
+        $data = [
+            [56],
+            [57],
+            [58],
+            [63],
+            [70],
+            [74],
+            [75],
+            [76],
+            [82],
+        ];
+
+        if (\extension_loaded('mysqli')) {
+            $data[] = [85];
+        }
+
+        if (\PHP_VERSION_ID >= 70200) {
+            $data[] = [88];
+        }
+
+        if (\PHP_VERSION_ID >= 80000) {
+            $data[] = [91];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify there are no false positives on valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $cases = [];
+
+        // No errors expected on the first 50 lines.
+        for ($line = 1; $line <= 50; $line++) {
+            $cases[] = [$line];
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
> . class_alias() now supports creating an alias of an internal class.

This commit introduces a new sniff which does best-effort detection for calls to the `class_alias()` function where the class being aliased is a PHP native class.

Mind:
* If a PHP native class is being aliased, but that class does not exist in the PHP version on which PHPCS is being run, the sniff will stay silent (false negative).
* If a PHP native class is being aliased, but the extension which declares the class is not loaded for the PHP environment on which PHPCS is being run, the sniff will stay silent (false negative).

Future scope:
* The sniff currently does not handle `class_alias()` class with the class being aliased in the following format: `ClassName::class`. Once the namespace and use statement trackers are available in PHPCSUtils, handling of that syntax should be added to the sniff.

Includes tests.
Includes documentation.

Ref:
* https://github.com/php/php-src/blob/ed9529a7d3c1f5dfbf16c2d388d944af8ec86a76/UPGRADING#L248
* php/php-src#9826
* php/php-src#10483
* https://github.com/php/php-src/commit/821fc55a6831a27138c251e846469a21c39b52bf

Related to #1589