### PR TITLE
:sparkles: New `PHPCompatibility.Keywords.ForbiddenClassAlias` sniff

### DIFF
--- a/PHPCompatibility/Docs/Keywords/ForbiddenClassAliasStandard.xml
+++ b/PHPCompatibility/Docs/Keywords/ForbiddenClassAliasStandard.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Forbidden Class Alias"
+    >
+    <standard>
+    <![CDATA[
+    Type keywords are not allowed to be used as class aliases.
+
+    An initial set of type keywords were forbidden for use as class alias names in PHP 7.0.
+    Additional type keywords were forbidden in later PHP versions.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: using an alias which is not a type keyword.">
+        <![CDATA[
+class_alias('MyClass', <em>'NotTypeKeyword'</em>);
+        ]]>
+        </code>
+        <code title="PHP &lt; 7.0: using an alias which is a type keyword.">
+        <![CDATA[
+class_alias('MyClass', <em>'int'</em>);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenClassAliasSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenClassAliasSniff.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Keywords;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\PassedParameters;
+use PHPCSUtils\Utils\TextStrings;
+
+/**
+ * Type keywords cannot be used as class alias names.
+ *
+ * PHP version All
+ *
+ * @link https://www.php.net/manual/en/function.class-alias.php
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenClassAliasSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, true>
+     */
+    protected $targetFunctions = [
+        'class_alias' => true,
+    ];
+
+    /**
+     * Keywords to recognize as forbidden alias names.
+     *
+     * List source: {@link https://github.com/php/php-src/blob/master/Zend/zend_compile.c}
+     * See `reserved_class_name` struct.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, string>
+     */
+    private $forbiddenNames = [
+        'bool'     => '7.0',
+        'false'    => '7.0',
+        'float'    => '7.0',
+        'int'      => '7.0',
+        'null'     => '7.0',
+        'parent'   => '7.0',
+        'self'     => '7.0',
+        'static'   => '7.0',
+        'string'   => '7.0',
+        'true'     => '7.0',
+        'iterable' => '7.1',
+        'void'     => '7.1',
+        'object'   => '7.2',
+        'mixed'    => '8.0',
+        'never'    => '8.1',
+        'array'    => '8.5',
+        'callable' => '8.5',
+    ];
+
+    /**
+     * Tokens which we are looking for in the parameter.
+     *
+     * This property is set in the register() method.
+     *
+     * @since 10.0.0
+     *
+     * @var array<int|string, int|string>
+     */
+    private $targetTokens = [];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        // Only set the $targetTokens property once.
+        $this->targetTokens  = Tokens::$emptyTokens;
+        $this->targetTokens += Tokens::$heredocTokens;
+        $this->targetTokens += Tokens::$stringTokens;
+        unset($this->targetTokens[\T_DOUBLE_QUOTED_STRING]);
+
+        return parent::register();
+    }
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrAbove('7.0') === false);
+    }
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return int|void Integer stack pointer to skip forward or void to continue
+     *                  normal file processing.
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $param = PassedParameters::getParameterFromStack($parameters, 2, 'alias');
+        if ($param === false) {
+            return;
+        }
+
+        $firstNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, $param['start'], ($param['end'] + 1), true);
+        $hasNonTextToken = $phpcsFile->findNext($this->targetTokens, $firstNonEmpty, ($param['end'] + 1), true);
+        if ($hasNonTextToken !== false) {
+            // Non text string token found.
+            return;
+        }
+
+        $content   = TextStrings::getCompleteTextString($phpcsFile, $firstNonEmpty);
+        $contentLC = \strtolower(\ltrim($content, '\\'));
+
+        if (isset($this->forbiddenNames[$contentLC]) === false) {
+            return;
+        }
+
+        if (ScannedCode::shouldRunOnOrAbove($this->forbiddenNames[$contentLC]) === false) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Type keyword "%s" is not allowed as a class alias name since PHP %s.',
+            $firstNonEmpty,
+            'Found',
+            [$contentLC, $this->forbiddenNames[$contentLC]]
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Keywords/ForbiddenClassAliasUnitTest.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenClassAliasUnitTest.inc
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * OK, not our target.
+ * Safeguard against false positives on method calls and namespaced function calls.
+ */
+ClassName::class_alias('MyClass', 'bool');
+$obj->class_alias('MyClass', 'iterable');
+$obj?->class_alias('MyClass', 'parent');
+namespace\Sub\class_alias('MyClass', 'int');
+\Fully\Qualified\class_alias('MyClass', 'callable');
+Partially\Qualified\class_alias('MyClass', 'mixed');
+
+
+/*
+ * OK: cross-version compatible.
+ */
+class_alias('MyClass', 'NotReservedKeyword');
+class_alias(alias: 'MyClass', class: 'iterable'); // Error for other reasons (forbidden class name), but that's not the concern of this sniff.
+class_alias('MyClass', 'MyNamespace\null');
+
+// Invalid alias name due to the spaces, but PHP won't error on this and will just create an usuable class name, so not our concern.
+class_alias('MyClass', ' mixed ');
+
+// Safeguard against false positives when target param not found.
+class_alias();
+\class_alias($class, autoload: false);
+class_alias($class, aliass: 'string'); // Typo in param name, not our concern.
+
+// Ignore as undetermined.
+class_alias('MyClass', "$false");
+class_alias('MyClass', <<<EOD
+$float
+EOD
+);
+
+\class_alias('MyClass', $alias, $autoload);
+class_alias('MyClass', get_alias('void'));
+class_alias('MyClass', ClassName::MY_ALIAS);
+class_alias('MyClass', namespace\MY_ALIAS);
+
+class_alias('MyClass', __NAMESPACE__ . '\null');
+class_alias('MyClass', $something . 'false');
+
+
+/*
+ * Reserved names used as a class alias.
+ */
+
+// Forbidden since PHP 7.0.
+class_alias('MyClass', 'bool');
+class_alias('MyClass', 'FALSE');
+\class_alias('MyClass', "float");
+class_alias('MyClass', <<<'EOD'
+int
+EOD
+);
+\Class_Alias('MyClass', <<<"EOD"
+null
+EOD
+);
+class_alias(
+    'MyClass',
+    // Also testing case handling.
+    '\Parent' // phpcs:ignore Stnd.Cat.SniffName
+);
+
+class_alias(alias: 'self', class: 'MyClass');
+CLASS_ALIAS('MyClass', /*comment*/ 'static'/*comment*/);
+class_alias('MyClass', <<<EOD
+string
+EOD
+);
+class_alias('MyClass', "\True");
+
+// Forbidden since PHP 7.1.
+class_alias('MyClass', 'void');
+class_alias('MyClass', 'iterable');
+
+// Forbidden since PHP 7.2.
+\class_alias('\MyClass', '\object');
+
+// Forbidden since PHP 8.0.
+class_alias('MyClass', 'mixed');
+
+// Forbidden since PHP 8.1.
+class_alias('MyClass', 'never');
+
+// Forbidden since PHP 8.5.
+\class_alias('MyClass', 'Array');
+class_alias('MyClass', 'callable');

--- a/PHPCompatibility/Tests/Keywords/ForbiddenClassAliasUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenClassAliasUnitTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Keywords;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the ForbiddenClassAlias sniff.
+ *
+ * @group forbiddenClassAlias
+ * @group keywords
+ *
+ * @covers \PHPCompatibility\Sniffs\Keywords\ForbiddenClassAliasSniff
+ *
+ * @since 10.0.0
+ */
+final class ForbiddenClassAliasUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify that type keywords used as class alias names are detected correctly.
+     *
+     * @dataProvider dataForbiddenClassAlias
+     *
+     * @param int    $line         Line number where the error should occur.
+     * @param string $type         The type keyword to detect.
+     * @param string $okVersion    The last PHP version before this became an error.
+     * @param string $errorVersion The PHP version on which this became an error.
+     *
+     * @return void
+     */
+    public function testForbiddenClassAlias($line, $type, $okVersion, $errorVersion)
+    {
+        $file = $this->sniffFile(__FILE__, $okVersion);
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(__FILE__, $errorVersion);
+        $this->assertError($file, $line, "Type keyword \"{$type}\" is not allowed as a class alias name since PHP {$errorVersion}.");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenClassAlias()
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataForbiddenClassAlias()
+    {
+        return [
+            [51, 'bool', '5.6', '7.0'],
+            [52, 'false', '5.6', '7.0'],
+            [53, 'float', '5.6', '7.0'],
+            [54, 'int', '5.6', '7.0'],
+            [58, 'null', '5.6', '7.0'],
+            [65, 'parent', '5.6', '7.0'],
+            [68, 'self', '5.6', '7.0'],
+            [69, 'static', '5.6', '7.0'],
+            [70, 'string', '5.6', '7.0'],
+            [74, 'true', '5.6', '7.0'],
+
+            [77, 'void', '7.0', '7.1'],
+            [78, 'iterable', '7.0', '7.1'],
+            [81, 'object', '7.1', '7.2'],
+            [84, 'mixed', '7.4', '8.0'],
+            [87, 'never', '8.0', '8.1'],
+            [90, 'array', '8.4', '8.5'],
+            [91, 'callable', '8.4', '8.5'],
+        ];
+    }
+
+
+    /**
+     * Verify there are no false positives on valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '99.9'); // High version beyond that last change.
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $cases = [];
+
+        // No errors expected on the first 45 lines.
+        for ($line = 1; $line <= 45; $line++) {
+            $cases[] = [$line];
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '5.6'); // Low version before the first change.
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
Inspired by the following change in PHP 8.5:

> - Core:
>   . It is no longer possible to use "array" and "callable" as class alias names
>     in class_alias().

... I've done a deep-dive into type keywords versus the `class_alias()` function.

Turns out "normal" reserved keywords are allowed as class aliases: https://3v4l.org/jMsDd
Don't ask me why, as using these aliases would be complicated as "normal" usages like `new Name()` would be a parse error, but that's not our concern. It's not forbidden by PHP itself.

However, the "other" reserved keywords _are_ forbidden as class alias names since PHP 7.0, with new type keywords which were added in later PHP versions being forbidden as of that PHP version. https://3v4l.org/9Knt7

That is, with the exception of `array` and `callable`, which were forgotten in PHP 7.0, with that oversight being fixed now in PHP 8.5.
https://3v4l.org/P0sii#veol
https://3v4l.org/P0sii#vgit.master

This commit introduces a new sniff which detects calls to the `class_alias()` function with any of these forbidden names as the alias.

Includes tests.
Includes documentation.

Ref:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L22-L24
* https://github.com/php/php-src/blob/9b23fb29aba3bcd5ae5aee116fc35b103902a9fa/Zend/zend_compile.c#L202-L223
* Original commit from PHP 7.0: https://github.com/php/php-src/commit/53a40386bc81da824468ac3aa8b1962ab7029238
* php/php-src#16683
* https://github.com/php/php-src/commit/96d1cd00b7ee686143e0f66319a4ea5e324b723b

Related to #1849