### PR TITLE
PHP 8.5 | RemovedIniDirectives: detect use of register_argc_argv (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -746,6 +746,9 @@ final class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             'extension' => 'session',
         ],
 
+        'register_argc_argv' => [
+            '8.5' => false,
+        ],
         'report_memleaks' => [
             '8.5' => false,
         ],

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -528,3 +528,5 @@ Partially\Qualified\ini_set('assert.bail', 0);
 
 ini_set('report_memleaks', 1);
 $test = ini_get('report_memleaks');
+ini_set('register_argc_argv', 1);
+$test = ini_get('register_argc_argv');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -167,6 +167,7 @@ final class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
             ['session.sid_bits_per_character', '8.4', [521, 522], '8.3'],
 
             ['report_memleaks', '8.5', [529, 530], '8.4'],
+            ['register_argc_argv', '8.5', [531, 532], '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . Deriving $_SERVER['argc'] and $_SERVER['argv'] from the query string for non-CLI
>   SAPIs has been deprecated. Configure register_argc_argv=0 and switch to either
>   $_GET or $_SERVER['QUERY_STRING'] to access the information, after verifying
>   that the usage is safe.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_register_argc_argv_ini_directive

This commit accounts for the deprecation of the ini setting.

Note - as per the RFC:
>  On the CLI, phpdbg and embed SAPIs it is forced to On.

... so this only affects non-CLI-related SAPIs.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_register_argc_argv_ini_directive
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L399-L403
* php/php-src#19473
* https://github.com/php/php-src/commit/b27d91993dd6b1c506c81ae1a49684d2cc3eb768
* php/php-src#19606
* https://github.com/php/php-src/commit/37bf0ec9610d7faf5d24bad58c8873f2452fcb4d

Related to #1849