### PR TITLE
PHP 8.5 | RemovedFunctions: detect use of deprecated no-op functions (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5702,10 +5702,30 @@ final class RemovedFunctionsSniff extends Sniff
             'extension'   => 'xml',
         ],
 
+        'curl_close' => [
+            '8.5'       => false,
+            'extension' => 'curl',
+        ],
+        'curl_share_close' => [
+            '8.5'       => false,
+            'extension' => 'curl',
+        ],
+        'finfo_close' => [
+            '8.5'       => false,
+            'extension' => 'fileinfo',
+        ],
+        'imagedestroy' => [
+            '8.5'       => false,
+            'extension' => 'gd',
+        ],
         'socket_set_timeout' => [
             '8.5'         => false,
             'alternative' => 'stream_set_timeout()',
             'extension'   => 'streams',
+        ],
+        'xml_parser_free' => [
+            '8.5'       => false,
+            'extension' => 'xml',
         ],
     ];
 

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1396,3 +1396,8 @@ lcg_value();
 
 // PHP 8.5.
 \socket_set_timeout();
+finfo_close();
+xml_parser_free();
+curl_close();
+curl_share_close();
+imagedestroy();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -70,6 +70,11 @@ final class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['openssl_free_key', '8.0', 1218, '7.4'],
             ['odbc_result_all', '8.1', 1229, '8.0'],
             ['assert_options', '8.3', 1237, '8.2'],
+            ['finfo_close', '8.5', 1399, '8.4'],
+            ['xml_parser_free', '8.5', 1400, '8.4'],
+            ['curl_close', '8.5', 1401, '8.4'],
+            ['curl_share_close', '8.5', 1402, '8.4'],
+            ['imagedestroy', '8.5', 1403, '8.4'],
         ];
     }
 


### PR DESCRIPTION


This handles the deprecation of a number of functions which became no-op after an earlier (PHP 8.0/8.1) resource to object migration.

> - Curl:
>   . The curl_close() function has been deprecated, as CurlHandle objects are
>     freed automatically.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_curl_close
>   . The curl_share_close() function has been deprecated, as CurlShareHandle
>     objects are freed automatically.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_curl_share_close
> - FileInfo:
>   . The finfo_close() function has been deprecated.
>     As finfo objects are freed automatically.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_finfo_close
> - GD:
>   . The imagedestroy() function has been deprecated, as GdImage objects are
>     freed automatically.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_imagedestroy
> - XML:
>   . The xml_parser_free() function has been deprecated, as XMLParser objects
>     are freed automatically.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_xml_parser_free

This commit accounts for the function deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_no-op_functions_from_the_resource_to_object_conversion

Curl:
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L411-L416
* php/php-src#19451
* https://github.com/php/php-src/commit/9b13bb1ae45f2e8abf6a702b64fd2333a23fc341
* https://www.php.net/manual/en/function.curl-close.php
* php/php-src#19452
* https://github.com/php/php-src/commit/699e5632b1c1b77055b5ace8f062ac54da04a458
* https://www.php.net/manual/en/function.curl-share-close.php

Fileinfo:
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L429-L431
* php/php-src#18396
* https://github.com/php/php-src/commit/ccb716dcadf60d989db48e4d2963e14d7dc63df3
* https://www.php.net/manual/en/function.finfo-close.php

GD:
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L437-L439
* php/php-src#19454
* https://github.com/php/php-src/commit/a68f3d6374db409bec284824631f79e7fa209acc
* https://www.php.net/manual/en/function.imagedestroy.php

XML:
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L588-L590
* php/php-src#19449
* https://github.com/php/php-src/commit/4de2ec3895e904478df891cb31ca9f425a98dff5
* https://www.php.net/manual/en/function.xml-parser-free.php

Related to #1849