### PR TITLE
PHP 8.5 | RemovedFunctionParameters: detect use of openssl_pkey_derive() $key_length (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -184,6 +184,12 @@ final class RemovedFunctionParametersSniff extends AbstractFunctionCallParameter
                 '8.0'  => true,
             ],
         ],
+        'openssl_pkey_derive' => [
+            3 => [
+                'name' => 'key_length',
+                '8.5'  => false,
+            ],
+        ],
         'pg_connect' => [
             // These were already deprecated before, but version in which deprecation took place is unclear.
             3 => [

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -79,3 +79,6 @@ Partially\Qualified\mysqli_store_result($mysql, $mode);
 
 get_defined_functions(); // OK.
 get_defined_functions($exclude_disabled); // Warning.
+
+openssl_pkey_derive($public_key, $private_key); // OK.
+openssl_pkey_derive($public_key, $private_key, key_length: $key_length); // Warning.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -188,6 +188,7 @@ final class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             ['session_set_save_handler', 'update_timestamp', '8.4', [68], '8.3'],
             ['mysqli_store_result', 'mode', '8.4', [71], '8.3'],
             ['get_defined_functions', 'exclude_disabled', '8.5', [81], '8.4'],
+            ['openssl_pkey_derive', 'key_length', '8.5', [84], '8.4'],
         ];
     }
 
@@ -235,6 +236,7 @@ final class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             [77],
             [78],
             [80],
+            [83],
         ];
     }
 


### PR DESCRIPTION
> - OpenSSL:
>   . The $key_length parameter for openssl_pkey_derive() has been deprecated.
>     This is because it is either ignored, or truncates the key, which can be
>     a vulnerability.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_key_length_parameter_of_openssl_pkey_derive

This commit accounts for the parameter deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_key_length_parameter_of_openssl_pkey_derive
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L468-L472
* php/php-src#19421
* https://github.com/php/php-src/commit/284e622506f47fab4aa96d458cf3a517acf8e099
* https://www.php.net/manual/en/function.openssl-pkey-derive.php

Related to #1849