### PR TITLE
PHP 8.5 | NewIniDirectives: detect new max_memory_limit ini directive + 2 more

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -1090,6 +1090,11 @@ final class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.4' => false,
             '8.5' => true,
         ],
+        'opcache.file_cache_read_only' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'opcache',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -1086,6 +1086,10 @@ final class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.4' => false,
             '8.5' => true,
         ],
+        'max_memory_limit' => [
+            '8.4' => false,
+            '8.5' => true,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -1095,6 +1095,11 @@ final class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.5'       => true,
             'extension' => 'opcache',
         ],
+        'openssl.libctx' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'openssl',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -642,3 +642,6 @@ $test = ini_get('max_memory_limit');
 
 ini_set('opcache.file_cache_read_only', 1);
 $test = ini_get('opcache.file_cache_read_only');
+
+ini_set('openssl.libctx', 1);
+$test = ini_get('openssl.libctx');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -636,3 +636,6 @@ Partially\Qualified\ini_set('soap.wsdl_cache_dir', 1);
 
 ini_set('fatal_error_backtraces', 1);
 $test = ini_get('fatal_error_backtraces');
+
+ini_set('max_memory_limit', 1);
+$test = ini_get('max_memory_limit');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -639,3 +639,6 @@ $test = ini_get('fatal_error_backtraces');
 
 ini_set('max_memory_limit', 1);
 $test = ini_get('max_memory_limit');
+
+ini_set('opcache.file_cache_read_only', 1);
+$test = ini_get('opcache.file_cache_read_only');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -301,6 +301,7 @@ final class NewIniDirectivesUnitTest extends BaseSniffTestCase
             ['fatal_error_backtraces', '8.5', [637, 638], '8.4'],
             ['max_memory_limit', '8.5', [640, 641], '8.4'],
             ['opcache.file_cache_read_only', '8.5', [643, 644], '8.4'],
+            ['openssl.libctx', '8.5', [646, 647], '8.4'],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -299,6 +299,7 @@ final class NewIniDirectivesUnitTest extends BaseSniffTestCase
             ['opcache.jit_max_trace_length', '8.3', [627, 628], '8.2'],
 
             ['fatal_error_backtraces', '8.5', [637, 638], '8.4'],
+            ['max_memory_limit', '8.5', [640, 641], '8.4'],
         ];
     }
 

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -300,6 +300,7 @@ final class NewIniDirectivesUnitTest extends BaseSniffTestCase
 
             ['fatal_error_backtraces', '8.5', [637, 638], '8.4'],
             ['max_memory_limit', '8.5', [640, 641], '8.4'],
+            ['opcache.file_cache_read_only', '8.5', [643, 644], '8.4'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.5 | NewIniDirectives: detect new max_memory_limit ini directive 

> . Added startup-only max_memory_limit INI setting to control the maximum
>   memory_limit that may be configured at startup or runtime. Exceeding this
>   value emits a warning, unless set to -1, and sets memory_limit to the
>   current max_memory_limit instead.
>   ML discussion: https://externals.io/message/127108

This commit accounts for detecting the ini setting.

Refs:
* https://externals.io/message/127108
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L949-L953
* php/php-src#18011
* php/php-src@4e21924

Related to #1849

### PHP 8.5 | NewIniDirectives: detect new opcache.file_cache_read_only ini directive

> - Opcache:
>   . Added opcache.file_cache_read_only to support a read-only
>     opcache.file_cache directory, for use with read-only file systems
>     (e.g. read-only Docker containers).
>     Best used with opcache.validate_timestamps=0,
>     opcache.enable_file_override=1,
>     and opcache.file_cache_consistency_checks=0.
>     Note: A cache generated with a different build of PHP, a different file
>     path, or different settings (including which extensions are loaded), may be
>     ignored.

This commit accounts for detecting the ini setting.

Note: all other ini settings mentioned in the changelog entry already existed prior to PHP 8.5 and are already handled by the `NewIniDirectives` sniff for the PHP version in which they were introduced.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L956-L964
* php/php-src#16551
* php/php-src@37995c0
* php/php-src@5191581

Related to #1849

### PHP 8.5 | NewIniDirectives: detect new openssl.libctx ini directive 

> - OpenSSL:
>   . Added openssl.libctx to select the OpenSSL library context type. Either
>     custom libctx for each thread can be used or a single global (default)
>     libctx is used.

This commit accounts for detecting the ini setting.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L972-L975
* php/php-src#18768
* php/php-src@d0c0a9a

Related to #1849