### PR TITLE
PHP 8.5 | NewFunctionParameters: detect use of new openssl_*() params

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -774,11 +774,23 @@ final class NewFunctionParametersSniff extends AbstractFunctionCallParameterSnif
                 '7.0'  => true,
             ],
         ],
+        'openssl_sign' => [
+            5 => [
+                'name' => 'padding',
+                '8.4'  => false,
+                '8.5'  => true,
+            ],
+        ],
         'openssl_verify' => [
             4 => [
                 'name' => 'algorithm',
                 '5.1'  => false,
                 '5.2'  => true,
+            ],
+            5 => [
+                'name' => 'padding',
+                '8.4'  => false,
+                '8.5'  => true,
             ],
         ],
         'parse_ini_file' => [

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -748,6 +748,20 @@ final class NewFunctionParametersSniff extends AbstractFunctionCallParameterSnif
                 '7.2'  => true,
             ],
         ],
+        'openssl_private_decrypt' => [
+            5 => [
+                'name' => 'digest_algo',
+                '8.4'  => false,
+                '8.5'  => true,
+            ],
+        ],
+        'openssl_public_encrypt' => [
+            5 => [
+                'name' => 'digest_algo',
+                '8.4'  => false,
+                '8.5'  => true,
+            ],
+        ],
         'openssl_seal' => [
             5 => [
                 'name' => 'cipher_algo',

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
@@ -169,3 +169,6 @@ grapheme_stristr( $haystack, $needle, $beforeNeedle, $locale );
 
 openssl_private_decrypt($data, $decrypted_data, $private_key, $padding, $digest_algo);
 \openssl_public_encrypt($data, $encrypted_data, $public_key, digest_algo: $digest_algo);
+
+\openssl_sign($data, $signature, $private_key, $algorithm, $padding);
+openssl_verify($data, $signature, $public_key, padding: $padding);

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
@@ -166,3 +166,6 @@ grapheme_strripos($haystack, $needle, locale: $locale);
 grapheme_substr($string, $offset, $length, $locale);
 \grapheme_strstr($haystack, $needle, locale: $locale);
 grapheme_stristr( $haystack, $needle, $beforeNeedle, $locale );
+
+openssl_private_decrypt($data, $decrypted_data, $private_key, $padding, $digest_algo);
+\openssl_public_encrypt($data, $encrypted_data, $public_key, digest_algo: $digest_algo);

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -173,7 +173,9 @@ final class NewFunctionParametersUnitTest extends BaseSniffTestCase
             ['openssl_public_encrypt', 'digest_algo', '8.4', [171], '8.5'],
             ['openssl_seal', 'cipher_algo', '5.2', [62], '7.0'], // OK version > version in which last parameter was added to the function.
             ['openssl_seal', 'iv', '5.6', [62], '7.0'],
+            ['openssl_sign', 'padding', '8.4', [173], '8.5'],
             ['openssl_verify', 'algorithm', '5.1', [63], '5.2'],
+            ['openssl_verify', 'padding', '8.4', [174], '8.5'],
             ['parse_ini_file', 'scanner_mode', '5.2', [64], '5.3'],
             ['parse_url', 'component', '5.1.1', [65, 147], '5.2', '5.1'],
             ['posix_getrlimit', 'resource', '8.2', [150], '8.3'],

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -169,6 +169,8 @@ final class NewFunctionParametersUnitTest extends BaseSniffTestCase
             ['openssl_open', 'iv', '5.6', [103], '7.0'],
             ['openssl_pkcs7_verify', 'content', '5.0', [61], '7.2'], // OK version > version in which last parameter was added to the function.
             ['openssl_pkcs7_verify', 'output_filename', '7.1', [61], '7.2'],
+            ['openssl_private_decrypt', 'digest_algo', '8.4', [170], '8.5'],
+            ['openssl_public_encrypt', 'digest_algo', '8.4', [171], '8.5'],
             ['openssl_seal', 'cipher_algo', '5.2', [62], '7.0'], // OK version > version in which last parameter was added to the function.
             ['openssl_seal', 'iv', '5.6', [62], '7.0'],
             ['openssl_verify', 'algorithm', '5.1', [63], '5.2'],


### PR DESCRIPTION
### PHP 8.5 | NewFunctionParameters: detect use of new openssl_*() $digest_algo param

> - OpenSSL:
>  . openssl_public_encrypt() and openssl_private_decrypt() have a new parameter
>    $digest_algo that allows specifying the hash digest algorithm for OAEP padding.

This commit accounts for detecting the new parameters.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L627-L629
* php/php-src#19223
* php/php-src@b1fce8a
* https://www.php.net/manual/en/function.openssl-public-encrypt.php
* https://www.php.net/manual/en/function.openssl-private-decrypt.php

Related to #1849

### PHP 8.5 | NewFunctionParameters: detect use of new openssl_*() $padding param

> - OpenSSL:
>    . openssl_sign() and openssl_verify() have a new parameter $padding to allow
>     using more secure RSA PSS padding.

This commit accounts for detecting the new parameters.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L630-L631
* php/php-src#19432
* php/php-src@702d18d
* https://www.php.net/manual/en/function.openssl-sign.php
* https://www.php.net/manual/en/function.openssl-verify.php

Related to #1849