### PR TITLE
PHP 8.5 | RemovedIniDirectives: detect use of disable_classes (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -746,6 +746,9 @@ final class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             'extension' => 'session',
         ],
 
+        'disable_classes' => [
+            '8.5' => true,
+        ],
         'register_argc_argv' => [
             '8.5' => false,
         ],

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -530,3 +530,5 @@ ini_set('report_memleaks', 1);
 $test = ini_get('report_memleaks');
 ini_set('register_argc_argv', 1);
 $test = ini_get('register_argc_argv');
+ini_set('disable_classes', 1);
+$test = ini_get('disable_classes');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -435,6 +435,8 @@ final class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
             ['oci8.prefetch_lob_size', '8.4', [509, 510], '8.3'],
             ['oci8.privileged_connect', '8.4', [512, 513], '8.3'],
             ['oci8.statement_cache_size', '8.4', [515, 516], '8.3'],
+
+            ['disable_classes', '8.5', [533, 534], '8.4'],
         ];
     }
 


### PR DESCRIPTION
> . The disable_classes INI setting has been removed as it causes various
>   engine assumptions to be broken.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_5#remove_disable_classes_ini_setting

This commit accounts for the removal of the ini setting.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#remove_disable_classes_ini_setting
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L52-L54
* php/php-src#12043
* https://github.com/php/php-src/commit/f4e2e91d4b6d28448104500819b68edf58bd263c

Related to #1849