### PR TITLE
PHP 8.5 | RemovedFunctions: detect use of mysqli_execute() (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5718,6 +5718,11 @@ final class RemovedFunctionsSniff extends Sniff
             '8.5'       => false,
             'extension' => 'gd',
         ],
+        'mysqli_execute' => [
+            '8.5'         => false,
+            'alternative' => 'mysqli_stmt_execute()',
+            'extension'   => 'mysqli',
+        ],
         'socket_set_timeout' => [
             '8.5'         => false,
             'alternative' => 'stream_set_timeout()',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1401,3 +1401,4 @@ xml_parser_free();
 curl_close();
 curl_share_close();
 imagedestroy();
+mysqli_execute();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -176,6 +176,7 @@ final class RemovedFunctionsUnitTest extends BaseSniffTestCase
             ['lcg_value', '8.4', 'Random\Randomizer::getFloat()', 1395, '8.3'],
 
             ['socket_set_timeout', '8.5', 'stream_set_timeout()', 1398, '8.4'],
+            ['mysqli_execute', '8.5', 'mysqli_stmt_execute()', 1404, '8.4'],
         ];
     }
 


### PR DESCRIPTION
> - MySQLi:
>   . The mysqli_execute() alias function has been deprecated.
>     Use mysqli_stmt_execute() instead.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#formally_deprecate_mysqli_execute

This commit accounts for the function deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#formally_deprecate_mysqli_execute
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L463-L466
* php/php-src#19286
* https://github.com/php/php-src/commit/5d865157725344ef5be0acb90ab128c850142963
* https://www.php.net/mysqli_execute
* https://www.php.net/manual/en/mysqli-stmt.execute.php

Related to #1849