### PR TITLE
PHP 8.5 | RemovedFunctionParameters: detect use of finfo_buffer() $context (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -69,6 +69,12 @@ final class RemovedFunctionParametersSniff extends AbstractFunctionCallParameter
                 '8.0'  => true,
             ],
         ],
+        'finfo_buffer' => [
+            4 => [
+                'name' => 'context',
+                '8.5'  => false,
+            ],
+        ],
         /*
          * Closely related to the `PHPCompatibility.ParameterValues.RemovedGetDefinedFunctionsExcludeDisabledFalse` sniff.
          * That sniff detects the change in PHP 8.0, this sniff detect the follow-up step of deprecating the parameter

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.inc
@@ -82,3 +82,6 @@ get_defined_functions($exclude_disabled); // Warning.
 
 openssl_pkey_derive($public_key, $private_key); // OK.
 openssl_pkey_derive($public_key, $private_key, key_length: $key_length); // Warning.
+
+finfo_buffer($finfo, $string); // OK.
+finfo_buffer($finfo, $string, $flags, $context); // Warning.

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionParametersUnitTest.php
@@ -189,6 +189,7 @@ final class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             ['mysqli_store_result', 'mode', '8.4', [71], '8.3'],
             ['get_defined_functions', 'exclude_disabled', '8.5', [81], '8.4'],
             ['openssl_pkey_derive', 'key_length', '8.5', [84], '8.4'],
+            ['finfo_buffer', 'context', '8.5', [87], '8.4'],
         ];
     }
 
@@ -237,6 +238,7 @@ final class RemovedFunctionParametersUnitTest extends BaseSniffTestCase
             [78],
             [80],
             [83],
+            [86],
         ];
     }
 


### PR DESCRIPTION
> . The $context parameter of the finfo_buffer() function has been deprecated
>   as it is ignored.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_context_parameter_for_finfo_buffer

This commit accounts for the parameter deprecation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_context_parameter_for_finfo_buffer
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L432-L434
* php/php-src#19378
* https://github.com/php/php-src/commit/ba21ab4ea012f35091694b8b03a79dcab1de6742
* https://www.php.net/manual/en/function.finfo-buffer.php

Related to #1849