### PR TITLE
PHP 8.5 | NewClasses/Functions: handle curl_share_init_persistent() addition (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1080,6 +1080,12 @@ final class NewClassesSniff extends Sniff
             '8.4'       => true,
             'extension' => 'streams',
         ],
+
+        'CurlSharePersistentHandle' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'curl',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5202,6 +5202,12 @@ final class NewFunctionsSniff extends Sniff
             '8.4'       => true,
             'extension' => 'sodium',
         ],
+
+        'curl_share_init_persistent' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'curl',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -628,3 +628,5 @@ try {
 try {
 } catch (\Filter\FilterFailedException $e ) {
 } catch (Filter\FilterException) {}
+
+function doSomethingWithCurl(CurlSharePersistentHandle $curlHandle) {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -273,6 +273,8 @@ final class NewClassesUnitTest extends BaseSniffTestCase
             ['BcMath\Number', '8.3', [561], '8.4'],
             ['ReflectionConstant', '8.3', [562, 577], '8.4'],
 
+            ['CurlSharePersistentHandle', '8.4', [632], '8.5'],
+
             ['DATETIME', '5.1', [146], '5.2'],
             ['datetime', '5.1', [147, 320], '5.2'],
             ['dATeTiMe', '5.1', [148], '5.2'],

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1096,3 +1096,5 @@ opcache_jit_blacklist();
 // Safeguard against false positives on namespaced function calls.
 namespace\intltz_get_id();
 \Fully\Qualified\array_is_list();
+
+curl_share_init_persistent();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1153,6 +1153,7 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['openssl_password_verify', '8.3', 1092, '8.4'],
             ['bcdivmod', '8.3', 1093, '8.4'],
             ['opcache_jit_blacklist', '8.3', 1094, '8.4'],
+            ['curl_share_init_persistent', '8.4', 1100, '8.5'],
         ];
     }
 


### PR DESCRIPTION
> - Curl:
>   . Added support for share handles that are persisted across multiple PHP
>     requests, safely allowing for more effective connection reuse.
>     RFC: https://wiki.php.net/rfc/curl_share_persistence_improvement
>
> - Curl:
>   . curl_share_init_persistent() allows creating a share handle that is
>     persisted across multiple PHP requests.
>     RFC: https://wiki.php.net/rfc/curl_share_persistence_improvement
>
> - Curl:
>   . CurlSharePersistentHandle representing a share handle that is persisted
>     across multiple PHP requests.
>     RFC: https://wiki.php.net/rfc/curl_share_persistence_improvement

This commit adds detection for all aspects of this new functionality:
* The new function
* The new class

Refs:
* https://wiki.php.net/rfc/curl_share_persistence_improvement supersedes https://wiki.php.net/rfc/curl_share_persistence
* https://github.com/php/php-src/blob/34721745833b4c9e69ed22f1b17c4c1c421f7179/UPGRADING#L214-L216
* https://github.com/php/php-src/blob/34721745833b4c9e69ed22f1b17c4c1c421f7179/UPGRADING#L752-L754
* https://github.com/php/php-src/blob/34721745833b4c9e69ed22f1b17c4c1c421f7179/UPGRADING#L812-L815
* php/php-src#16937
* https://github.com/php/php-src/commit/d20880ce3b14e2be02961e0ea63efc514987eca4

Related to #1849