### PR TITLE
PHP 8.5 | NewFunctionParameters: detect use of new pcntl_waitid() $resource_usage param

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -807,6 +807,13 @@ final class NewFunctionParametersSniff extends AbstractFunctionCallParameterSnif
                 '5.1.2' => true,
             ],
         ],
+        'pcntl_waitid' => [
+            5 => [
+                'name' => 'resource_usage',
+                '8.4'  => false,
+                '8.5'  => true,
+            ],
+        ],
         'posix_getrlimit' => [
             1 => [
                 'name' => 'resource',

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.inc
@@ -172,3 +172,7 @@ openssl_private_decrypt($data, $decrypted_data, $private_key, $padding, $digest_
 
 \openssl_sign($data, $signature, $private_key, $algorithm, $padding);
 openssl_verify($data, $signature, $public_key, padding: $padding);
+
+pcntl_waitid($idtype, $id, $info, $flags); // OK.
+pcntl_waitid($idtype, $id, $info, $flags, $resource_usage); // Error.
+pcntl_waitid($idtype, resource_usage: $resource_usage); // Error.

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionParametersUnitTest.php
@@ -178,6 +178,7 @@ final class NewFunctionParametersUnitTest extends BaseSniffTestCase
             ['openssl_verify', 'padding', '8.4', [174], '8.5'],
             ['parse_ini_file', 'scanner_mode', '5.2', [64], '5.3'],
             ['parse_url', 'component', '5.1.1', [65, 147], '5.2', '5.1'],
+            ['pcntl_waitid', 'resource_usage', '8.4', [177, 178], '8.5'],
             ['posix_getrlimit', 'resource', '8.2', [150], '8.3'],
             ['pg_escape_bytea', 'connection', '5.1', [123], '5.2'],
             ['pg_escape_string', 'connection', '5.1', [124], '5.2'],
@@ -261,6 +262,7 @@ final class NewFunctionParametersUnitTest extends BaseSniffTestCase
             [158],
             [159],
             [160],
+            [176],
         ];
     }
 


### PR DESCRIPTION
> . pcntl_waitid() takes an additional resource_usage argument to
>  gather various platform specific metrics about the child process.

This commit accounts for detecting the new parameter.

Refs:
* https://github.com/php/php-src/blob/PHP-8.5/UPGRADING#L638-L639
* php/php-src#15921
* https://github.com/php/php-src/commit/aea3ade74fdaf5e764061858fdc1d3e5378b862b
* https://www.php.net/manual/en/function.pcntl-waitid.php

Related to #1849