### PR TITLE
NewConstantScalarExpressionsUnitTest: skip one particular test on PHP 5.5

### DIFF
--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -224,8 +224,20 @@ final class NewConstantScalarExpressionsUnitTest extends BaseSniffTestCase
     {
         $data = [];
 
-        // No errors expected on the first 120 lines.
-        for ($line = 1; $line <= 120; $line++) {
+        // No errors expected on the first 78 lines.
+        for ($line = 1; $line <= 78; $line++) {
+            $data[] = [$line];
+        }
+
+        if (PHP_VERSION_ID < 50500 || PHP_VERSION_ID >= 50600) {
+            // Skip one particular test on PHP 5.5 as it just keeps being problematic.
+            for ($line = 79; $line <= 87; $line++) {
+                $data[] = [$line];
+            }
+        }
+
+        // ... nor on line 88 - 120.
+        for ($line = 88; $line <= 120; $line++) {
             $data[] = [$line];
         }
 


### PR DESCRIPTION

... as it _should_ pass, but randomly fails and does so way too often, making it really annoying with how often we need to retrigger builds.

As support for PHP < 7.2 will be dropped in the near future anyway, I believe skipping this test should be fine.