### PR TITLE
PHP 8.5 | RemovedIniDirectives: detect use of intl.error_level (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -755,6 +755,11 @@ final class RemovedIniDirectivesSniff extends AbstractFunctionCallParameterSniff
         'report_memleaks' => [
             '8.5' => false,
         ],
+        'intl.error_level' => [
+            '8.5'         => false,
+            'extension'   => 'intl',
+            'alternative' => 'intl.use_exceptions',
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.inc
@@ -532,3 +532,5 @@ ini_set('register_argc_argv', 1);
 $test = ini_get('register_argc_argv');
 ini_set('disable_classes', 1);
 $test = ini_get('disable_classes');
+ini_set('intl.error_level', 1);
+$test = ini_get('intl.error_level');

--- a/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/RemovedIniDirectivesUnitTest.php
@@ -217,6 +217,7 @@ final class RemovedIniDirectivesUnitTest extends BaseSniffTestCase
             ['assert.callback', '8.3', 'zend.assertions', [476, 477], '8.2'],
             ['assert.exception', '8.3', 'zend.assertions', [479, 480], '8.2'],
             ['assert.warning', '8.3', 'zend.assertions', [482, 483], '8.2'],
+            ['intl.error_level', '8.5', 'intl.use_exceptions', [535, 536], '8.4'],
         ];
     }
 


### PR DESCRIPTION
> - Intl:
>   . The intl.error_level INI setting has been deprecated.
>     Errors should either be checked manually or exceptions should be enabled
>     by using the intl.use_exceptions INI setting.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_intlerror_level_ini_setting

This commit accounts for the deprecation of the ini setting.

In the RFC (and the implementation), the deprecation is conditional on the value:

> we propose deprecating this INI setting, meaning setting it to any value different than `0` will raise an `E_DEPRECATED` diagnostic.

However, for the purpose of PHPCompatibility, I believe checking the value for a call to `ini_set()` is a little over the top. If anyone would report false positives because of this, we can always consider adding such a check later.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_intlerror_level_ini_setting
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L446-L450
* php/php-src#19430
* https://github.com/php/php-src/commit/69f67f990dd3b2eeed9e2687a528b7a00fc2671a

Related to #1849