### PR TITLE
PHP 8.5 | NewFunctions: detect new grapheme_levenshtein() function (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5208,6 +5208,11 @@ final class NewFunctionsSniff extends Sniff
             '8.5'       => true,
             'extension' => 'curl',
         ],
+        'grapheme_levenshtein' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'intl',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1098,3 +1098,4 @@ namespace\intltz_get_id();
 \Fully\Qualified\array_is_list();
 
 curl_share_init_persistent();
+grapheme_levenshtein();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1154,6 +1154,7 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['bcdivmod', '8.3', 1093, '8.4'],
             ['opcache_jit_blacklist', '8.3', 1094, '8.4'],
             ['curl_share_init_persistent', '8.4', 1100, '8.5'],
+            ['grapheme_levenshtein', '8.4', 1101, '8.5'],
         ];
     }
 


### PR DESCRIPTION
> . Added grapheme_levenshtein() function.
>   RFC: https://wiki.php.net/rfc/grapheme_levenshtein

This commit accounts for detecting the new function.

Refs:
* https://wiki.php.net/rfc/grapheme_levenshtein
* https://github.com/php/php-src/blob/34721745833b4c9e69ed22f1b17c4c1c421f7179/UPGRADING#L769-L770
* php/php-src#18087
* https://github.com/php/php-src/commit/bdcea111f30fee395d5830505df5de58598abb5e

Related to #1849