### PR TITLE
PHP 8.5 | NewFunctions: detect new error handler functions (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5203,6 +5203,14 @@ final class NewFunctionsSniff extends Sniff
             'extension' => 'sodium',
         ],
 
+        'get_error_handler' => [
+            '8.4' => false,
+            '8.5' => true,
+        ],
+        'get_exception_handler' => [
+            '8.4' => false,
+            '8.5' => true,
+        ],
         'curl_share_init_persistent' => [
             '8.4'       => false,
             '8.5'       => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1099,3 +1099,5 @@ namespace\intltz_get_id();
 
 curl_share_init_persistent();
 grapheme_levenshtein();
+get_error_handler();
+get_exception_handler();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1155,6 +1155,8 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['opcache_jit_blacklist', '8.3', 1094, '8.4'],
             ['curl_share_init_persistent', '8.4', 1100, '8.5'],
             ['grapheme_levenshtein', '8.4', 1101, '8.5'],
+            ['get_error_handler', '8.4', 1102, '8.5'],
+            ['get_exception_handler', '8.4', 1103, '8.5'],
         ];
     }
 


### PR DESCRIPTION
> . get_error_handler() allows retrieving the current user-defined error handler
>   function.
>   RFC: https://wiki.php.net/rfc/get-error-exception-handler
> . get_exception_handler() allows retrieving the current user-defined exception
>   handler function.
>   RFC: https://wiki.php.net/rfc/get-error-exception-handler

This commit accounts for detecting the new functions.

Refs:
* https://wiki.php.net/rfc/get-error-exception-handler
* https://github.com/php/php-src/blob/34721745833b4c9e69ed22f1b17c4c1c421f7179/UPGRADING#L737-L742
* php/php-src#17693
* https://github.com/php/php-src/commit/14fc50e73224cd01d3abb7b2181c2f23b33e5fef

Related to #1849