### PR TITLE
PHP 8.5 | NewFunctions: detect new array functions (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5203,6 +5203,14 @@ final class NewFunctionsSniff extends Sniff
             'extension' => 'sodium',
         ],
 
+        'array_first' => [
+            '8.4' => false,
+            '8.5' => true,
+        ],
+        'array_last' => [
+            '8.4' => false,
+            '8.5' => true,
+        ],
         'get_error_handler' => [
             '8.4' => false,
             '8.5' => true,

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1101,3 +1101,5 @@ curl_share_init_persistent();
 grapheme_levenshtein();
 get_error_handler();
 get_exception_handler();
+array_first();
+array_last();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1157,6 +1157,8 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['grapheme_levenshtein', '8.4', 1101, '8.5'],
             ['get_error_handler', '8.4', 1102, '8.5'],
             ['get_exception_handler', '8.4', 1103, '8.5'],
+            ['array_first', '8.4', 1104, '8.5'],
+            ['array_last', '8.4', 1105, '8.5'],
         ];
     }
 


### PR DESCRIPTION
> - Standard:
>   . Added array_first() and array_last().
>     RFC: https://wiki.php.net/rfc/array_first_last

This commit accounts for detecting the new functions.

Refs:
* https://wiki.php.net/rfc/array_first_last
* https://github.com/php/php-src/blob/34721745833b4c9e69ed22f1b17c4c1c421f7179/UPGRADING#L798-L800
* php/php-src#18210
* https://github.com/php/php-src/commit/168343d2e811fe0f2152d39a8f88557cc0b35c86

Related to #1849