### PR TITLE
PHP 8.5 | NewFunctions: detect various new functions

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5229,6 +5229,11 @@ final class NewFunctionsSniff extends Sniff
             '8.5'       => true,
             'extension' => 'curl',
         ],
+        'enchant_dict_remove' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'enchant',
+        ],
         'enchant_dict_remove_from_session' => [
             '8.4'       => false,
             '8.5'       => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5249,6 +5249,11 @@ final class NewFunctionsSniff extends Sniff
             '8.5'       => true,
             'extension' => 'intl',
         ],
+        'opcache_is_script_cached_in_file_cache' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'opcache',
+        ],
     ];
 
 

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5219,6 +5219,11 @@ final class NewFunctionsSniff extends Sniff
             '8.4' => false,
             '8.5' => true,
         ],
+        'curl_multi_get_handles' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'curl',
+        ],
         'curl_share_init_persistent' => [
             '8.4'       => false,
             '8.5'       => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5229,6 +5229,11 @@ final class NewFunctionsSniff extends Sniff
             '8.5'       => true,
             'extension' => 'curl',
         ],
+        'enchant_dict_remove_from_session' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'enchant',
+        ],
         'grapheme_levenshtein' => [
             '8.4'       => false,
             '8.5'       => true,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5259,6 +5259,11 @@ final class NewFunctionsSniff extends Sniff
             '8.5'       => true,
             'extension' => 'pgsql',
         ],
+        'pg_service' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'pgsql',
+        ],
     ];
 
 

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5244,6 +5244,11 @@ final class NewFunctionsSniff extends Sniff
             '8.5'       => true,
             'extension' => 'intl',
         ],
+        'locale_is_right_to_left' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'intl',
+        ],
     ];
 
 

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5254,6 +5254,11 @@ final class NewFunctionsSniff extends Sniff
             '8.5'       => true,
             'extension' => 'opcache',
         ],
+        'pg_close_stmt' => [
+            '8.4'       => false,
+            '8.5'       => true,
+            'extension' => 'pgsql',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1106,3 +1106,4 @@ array_last();
 curl_multi_get_handles();
 enchant_dict_remove_from_session();
 enchant_dict_remove();
+locale_is_right_to_left();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1108,3 +1108,4 @@ enchant_dict_remove_from_session();
 enchant_dict_remove();
 locale_is_right_to_left();
 opcache_is_script_cached_in_file_cache();
+pg_close_stmt();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1104,3 +1104,4 @@ get_exception_handler();
 array_first();
 array_last();
 curl_multi_get_handles();
+enchant_dict_remove_from_session();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1105,3 +1105,4 @@ array_first();
 array_last();
 curl_multi_get_handles();
 enchant_dict_remove_from_session();
+enchant_dict_remove();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1109,3 +1109,4 @@ enchant_dict_remove();
 locale_is_right_to_left();
 opcache_is_script_cached_in_file_cache();
 pg_close_stmt();
+pg_service();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1107,3 +1107,4 @@ curl_multi_get_handles();
 enchant_dict_remove_from_session();
 enchant_dict_remove();
 locale_is_right_to_left();
+opcache_is_script_cached_in_file_cache();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1103,3 +1103,4 @@ get_error_handler();
 get_exception_handler();
 array_first();
 array_last();
+curl_multi_get_handles();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1163,6 +1163,7 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['enchant_dict_remove_from_session', '8.4', 1107, '8.5'],
             ['enchant_dict_remove', '8.4', 1108, '8.5'],
             ['locale_is_right_to_left', '8.4', 1109, '8.5'],
+            ['opcache_is_script_cached_in_file_cache', '8.4', 1110, '8.5'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1162,6 +1162,7 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['curl_multi_get_handles', '8.4', 1106, '8.5'],
             ['enchant_dict_remove_from_session', '8.4', 1107, '8.5'],
             ['enchant_dict_remove', '8.4', 1108, '8.5'],
+            ['locale_is_right_to_left', '8.4', 1109, '8.5'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1165,6 +1165,7 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['locale_is_right_to_left', '8.4', 1109, '8.5'],
             ['opcache_is_script_cached_in_file_cache', '8.4', 1110, '8.5'],
             ['pg_close_stmt', '8.4', 1111, '8.5'],
+            ['pg_service', '8.4', 1112, '8.5'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1164,6 +1164,7 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['enchant_dict_remove', '8.4', 1108, '8.5'],
             ['locale_is_right_to_left', '8.4', 1109, '8.5'],
             ['opcache_is_script_cached_in_file_cache', '8.4', 1110, '8.5'],
+            ['pg_close_stmt', '8.4', 1111, '8.5'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1160,6 +1160,7 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['array_first', '8.4', 1104, '8.5'],
             ['array_last', '8.4', 1105, '8.5'],
             ['curl_multi_get_handles', '8.4', 1106, '8.5'],
+            ['enchant_dict_remove_from_session', '8.4', 1107, '8.5'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1159,6 +1159,7 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['get_exception_handler', '8.4', 1103, '8.5'],
             ['array_first', '8.4', 1104, '8.5'],
             ['array_last', '8.4', 1105, '8.5'],
+            ['curl_multi_get_handles', '8.4', 1106, '8.5'],
         ];
     }
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1161,6 +1161,7 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['array_last', '8.4', 1105, '8.5'],
             ['curl_multi_get_handles', '8.4', 1106, '8.5'],
             ['enchant_dict_remove_from_session', '8.4', 1107, '8.5'],
+            ['enchant_dict_remove', '8.4', 1108, '8.5'],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.5 | NewFunctions: detect new curl_multi_get_handles() 

> - Curl:
>   . curl_multi_get_handles() allows retrieving all CurlHandles currently
>     attached to a CurlMultiHandle. This includes both handles added using
>     curl_multi_add_handle() and handles accepted by CURLMOPT_PUSHFUNCTION.

This commit accounts for detecting the new function.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L749-L751
* php/php-src#16363
* php/php-src@cb6025c

### PHP 8.5 | NewFunctions: detect new enchant_dict_remove_from_session() 

> - Enchant:
>   . Added enchant_dict_remove_from_session() to remove a word added to the
>     spellcheck session via enchant_dict_add_to_session().

This commit accounts for detecting the new function.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L760-L762
* php/php-src#17393
* php/php-src@3a039e3

### PHP 8.5 | NewFunctions: detect new enchant_dict_remove_from_session() 

> - Enchant:
>   . Added enchant_dict_remove() to put a word on the exclusion list and
>     remove it from the session dictionary.

This commit accounts for detecting the new function.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L763-L764
* php/php-src#17507
* php/php-src@ff80ec7

### PHP 8.5 | NewFunctions: detect new locale_is_right_to_left() 

> - Intl:
>  . Added locale_is_right_to_left/Locale::isRightToLeft, returns true if
>    the locale is written right to left (after its enrichment with likely subtags).

This commit accounts for detecting the new function.

Refs:
* https://github.com/php/php-src/blob/PHP-8.5/UPGRADING#L766-L768
* php/php-src#18351
* php/php-src@fcd0f72

### PHP 8.5 | NewFunctions: detect new opcache_is_script_cached_in_file_cache()

> - Opcache:
>  . Added opcache_is_script_cached_in_file_cache().

This commit accounts for detecting the new function.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L772-L773
* php/php-src#16979
* php/php-src@6f1501a

### PHP 8.5 | NewFunctions: detect new pg_close_stmt() 

> - PGSQL:
>   . pg_close_stmt offers an alternative way to close a prepared
>     statement from the DEALLOCATE sql command in that we can reuse
>     its name afterwards.

This commit accounts for detecting the new function.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L781-L783
* php/php-src#14584
* php/php-src@1da352c
* php/php-src#18194
* php/php-src@07470c3

### PHP 8.5 | NewFunctions: detect new pg_service() 

> - PGSQL:
>   . pg_service returns the ongoing service name of the connection.

This commit accounts for detecting the new function.

Refs:
* https://github.com/php/php-src/blob/18687e4f394f7efb1fc84ad5a7a6721f2774a764/UPGRADING#L784
* php/php-src#18198
* php/php-src@334d9bb

Related to #1849