### PR TITLE
PHP 8.5: Soft deprecate __sleep / __wakeup

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -75,15 +75,15 @@ final class RemovedMagicMethodsSniff extends Sniff
      * }>
      */
     protected $methodCompatibilityMatrix = [
-        // @see https://wiki.php.net/rfc/soft-deprecate-sleep-wakeup#proposal
-        // @see https://www.php.net/manual/en/language.oop5.magic.php#object.serialize
+        // @link https://wiki.php.net/rfc/soft-deprecate-sleep-wakeup#proposal
+        // @link https://www.php.net/manual/language.oop5.magic.php#object.serialize
         '__sleep' => [
             self::SOFT_DEPRECATED => '8.5',
             'mutuallyExclusiveWith' => '__serialize',
             'alternative' => '__serialize',
         ],
-        // @see https://wiki.php.net/rfc/soft-deprecate-sleep-wakeup#proposal
-        // @see https://www.php.net/manual/en/language.oop5.magic.php#object.unserialize
+        // @link https://wiki.php.net/rfc/soft-deprecate-sleep-wakeup#proposal
+        // @link https://www.php.net/manual/language.oop5.magic.php#object.unserialize
         '__wakeup' => [
             self::SOFT_DEPRECATED => '8.5',
             'mutuallyExclusiveWith' => '__unserialize',

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -11,7 +11,6 @@
 namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
 
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\FunctionDeclarations;

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -16,6 +16,7 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
+use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;
 
 /**
@@ -106,16 +107,17 @@ final class RemovedMagicMethodsSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in the
+     *                        stack passed in $tokens.
      *
      * @return void
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-
-        if (!Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens)) {
+        $magicMethodScopes = [T_CLASS, T_ANON_CLASS, T_TRAIT];
+        $parentScope       = Scopes::validDirectScope($phpcsFile, $stackPtr, $magicMethodScopes);
+        if (!$parentScope) {
             return;
         }
 
@@ -130,8 +132,14 @@ final class RemovedMagicMethodsSniff extends Sniff
         $violation = $this->testOnTargetVersion(
             $this->methodCompatibilityMatrix[$scannedMethod]
         );
-
         if ($violation === null) {
+            return;
+        }
+
+        $allMethodsInClass          = ObjectDeclarations::getDeclaredMethods($phpcsFile, $parentScope);
+        $mutuallyExclusiveMethod    = $this->methodCompatibilityMatrix[$scannedMethod]['mutuallyExclusiveWith'];
+        $hasMutuallyExclusiveMethod = array_key_exists($mutuallyExclusiveMethod, $allMethodsInClass);
+        if ($hasMutuallyExclusiveMethod) {
             return;
         }
 
@@ -180,15 +188,15 @@ final class RemovedMagicMethodsSniff extends Sniff
     private function addMessage(File $phpcsFile, $stackPtr, $scannedMethod, array $foundViolation)
     {
         $compatibilityMatrix = $this->methodCompatibilityMatrix[$scannedMethod];
-
-        $version        = $compatibilityMatrix[$foundViolation['type']];
-        $hasAlternative = isset($compatibilityMatrix['alternative']);
+        $version             = $compatibilityMatrix[$foundViolation['type']];
+        $hasAlternative      = isset($compatibilityMatrix['alternative']);
 
         $message = sprintf(
             $foundViolation['messageTemplate'],
             $scannedMethod,
             $version
         );
+
         if ($hasAlternative) {
             $message .= sprintf(' Use %s instead.', $compatibilityMatrix['alternative']);
         }

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -119,14 +119,13 @@ final class RemovedMagicMethodsSniff extends Sniff
     {
         $magicMethodScopes = [T_CLASS, T_ANON_CLASS, T_TRAIT];
         $parentScope       = Scopes::validDirectScope($phpcsFile, $stackPtr, $magicMethodScopes);
-        if (!$parentScope) {
+        if ($parentScope === false) {
             return;
         }
 
         $scannedMethod = \strtolower(
             FunctionDeclarations::getName($phpcsFile, $stackPtr)
         );
-
         if (!isset($this->methodCompatibilityMatrix[$scannedMethod])) {
             return;
         }
@@ -138,10 +137,9 @@ final class RemovedMagicMethodsSniff extends Sniff
             return;
         }
 
-        $allMethodsInClass          = ObjectDeclarations::getDeclaredMethods($phpcsFile, $parentScope);
-        $mutuallyExclusiveMethod    = $this->methodCompatibilityMatrix[$scannedMethod]['mutuallyExclusiveWith'];
-        $hasMutuallyExclusiveMethod = array_key_exists($mutuallyExclusiveMethod, $allMethodsInClass);
-        if ($hasMutuallyExclusiveMethod) {
+        $allMethodsInClass       = ObjectDeclarations::getDeclaredMethods($phpcsFile, $parentScope);
+        $mutuallyExclusiveMethod = $this->methodCompatibilityMatrix[$scannedMethod]['mutuallyExclusiveWith'];
+        if (array_key_exists($mutuallyExclusiveMethod, $allMethodsInClass)) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -37,7 +37,9 @@ final class RemovedMagicMethodsSniff extends Sniff
      * List of all violation types and their semantic meaning.
      *
      * @var array<string, array{
+     *     type: string,
      *     errorCode: string,
+     *     messageTemplate: string,
      *     isError: bool,
      * }>
      */

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -167,7 +167,7 @@ final class RemovedMagicMethodsSniff extends Sniff
             if (!isset($compatibilityMatrix[$violationTypeId])) {
                 continue;
             }
-            if (ScannedCode::shouldRunOnOrAbove($compatibilityMatrix[$violationTypeId])) {
+            if (ScannedCode::shouldRunOnOrAbove($compatibilityMatrix[$violationTypeId]) === true) {
                 return $this->violationTypes[$violationTypeId];
             }
         }

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -29,9 +29,9 @@ use PHPCSUtils\Utils\Scopes;
  */
 final class RemovedMagicMethodsSniff extends Sniff
 {
-    const REMOVED         = 'removed';
-    const DEPRECATED      = 'deprecated';
-    const SOFT_DEPRECATED = 'softDeprecated';
+    private const REMOVED         = 'removed';
+    private const DEPRECATED      = 'deprecated';
+    private const SOFT_DEPRECATED = 'softDeprecated';
 
     /**
      * List of all violation types and their semantic meaning.
@@ -126,7 +126,7 @@ final class RemovedMagicMethodsSniff extends Sniff
         $scannedMethod = \strtolower(
             FunctionDeclarations::getName($phpcsFile, $stackPtr)
         );
-        if (!isset($this->methodCompatibilityMatrix[$scannedMethod])) {
+        if (isset($this->methodCompatibilityMatrix[$scannedMethod]) === false) {
             return;
         }
 
@@ -164,7 +164,7 @@ final class RemovedMagicMethodsSniff extends Sniff
         $violationTypeIds = array_keys($this->violationTypes);
 
         foreach ($violationTypeIds as $violationTypeId) {
-            if (!isset($compatibilityMatrix[$violationTypeId])) {
+            if (isset($compatibilityMatrix[$violationTypeId]) === false) {
                 continue;
             }
             if (ScannedCode::shouldRunOnOrAbove($compatibilityMatrix[$violationTypeId]) === true) {

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -29,9 +29,9 @@ use PHPCSUtils\Utils\Scopes;
  */
 final class RemovedMagicMethodsSniff extends Sniff
 {
-    private const REMOVED         = 'removed';
-    private const DEPRECATED      = 'deprecated';
-    private const SOFT_DEPRECATED = 'softDeprecated';
+    const REMOVED         = 'removed';
+    const DEPRECATED      = 'deprecated';
+    const SOFT_DEPRECATED = 'softDeprecated';
 
     /**
      * List of all violation types and their semantic meaning.

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -71,6 +71,7 @@ final class RemovedMagicMethodsSniff extends Sniff
      *     softDeprecated?: string,
      *     deprecated?: string,
      *     removed?: string,
+     *     mutuallyExclusiveWith?: string,
      *     alternative?: string
      * }>
      */

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -29,9 +29,9 @@ use PHPCSUtils\Utils\Scopes;
  */
 final class RemovedMagicMethodsSniff extends Sniff
 {
-    const REMOVED         = 'removed';
-    const DEPRECATED      = 'deprecated';
-    const SOFT_DEPRECATED = 'softDeprecated';
+    private const REMOVED         = 'removed';
+    private const DEPRECATED      = 'deprecated';
+    private const SOFT_DEPRECATED = 'softDeprecated';
 
     /**
      * List of all violation types and their semantic meaning.

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -57,7 +57,7 @@ final class RemovedMagicMethodsSniff extends Sniff
         self::SOFT_DEPRECATED => [
             'type' => self::SOFT_DEPRECATED,
             'errorCode' => 'SoftDeprecated',
-            'messageTemplate' => 'Magic method %s() is soft-deprecated since PHP %s.',
+            'messageTemplate' => 'Magic method %s() is maintained for backward compatibility since PHP %s.',
             'isError' => false,
         ],
     ];
@@ -73,11 +73,15 @@ final class RemovedMagicMethodsSniff extends Sniff
      * }>
      */
     protected $methodCompatibilityMatrix = [
+        // @see https://wiki.php.net/rfc/soft-deprecate-sleep-wakeup#proposal
+        // @see https://www.php.net/manual/en/language.oop5.magic.php#object.serialize
         '__sleep' => [
             self::SOFT_DEPRECATED => '8.5',
             'mutuallyExclusiveWith' => '__serialize',
             'alternative' => '__serialize',
         ],
+        // @see https://wiki.php.net/rfc/soft-deprecate-sleep-wakeup#proposal
+        // @see https://www.php.net/manual/en/language.oop5.magic.php#object.unserialize
         '__wakeup' => [
             self::SOFT_DEPRECATED => '8.5',
             'mutuallyExclusiveWith' => '__unserialize',

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicMethodsSniff.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\MessageHelper;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Detect declarations of deprecated/removed magic methods.
+ *
+ * Suggests alternative if available.
+ *
+ * PHP version All
+ *
+ * @since 10.0.0
+ */
+final class RemovedMagicMethodsSniff extends Sniff
+{
+    const REMOVED         = 'removed';
+    const DEPRECATED      = 'deprecated';
+    const SOFT_DEPRECATED = 'softDeprecated';
+
+    /**
+     * List of all violation types and their semantic meaning.
+     *
+     * @var array<string, array{
+     *     errorCode: string,
+     *     isError: bool,
+     * }>
+     */
+    private $violationTypes = [
+        self::REMOVED => [
+            'type' => self::REMOVED,
+            'errorCode' => 'Removed',
+            'messageTemplate' => 'Magic method %s() is removed since PHP %s.',
+            'isError' => true,
+        ],
+        self::DEPRECATED => [
+            'type' => self::DEPRECATED,
+            'errorCode' => 'Deprecated',
+            'messageTemplate' => 'Magic method %s() is deprecated since PHP %s.',
+            'isError' => false,
+        ],
+        self::SOFT_DEPRECATED => [
+            'type' => self::SOFT_DEPRECATED,
+            'errorCode' => 'SoftDeprecated',
+            'messageTemplate' => 'Magic method %s() is soft-deprecated since PHP %s.',
+            'isError' => false,
+        ],
+    ];
+
+    /**
+     * Methods that will be scanned for compatibility.
+     *
+     * @var array<string, array{
+     *     softDeprecated?: string,
+     *     deprecated?: string,
+     *     removed?: string,
+     *     alternative?: string
+     * }>
+     */
+    protected $methodCompatibilityMatrix = [
+        '__sleep' => [
+            self::SOFT_DEPRECATED => '8.5',
+            'mutuallyExclusiveWith' => '__serialize',
+            'alternative' => '__serialize',
+        ],
+        '__wakeup' => [
+            self::SOFT_DEPRECATED => '8.5',
+            'mutuallyExclusiveWith' => '__unserialize',
+            'alternative' => '__unserialize',
+        ],
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_FUNCTION];
+    }
+
+    /**
+     * Processes this test when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+
+        if (!Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens)) {
+            return;
+        }
+
+        $scannedMethod = \strtolower(
+            FunctionDeclarations::getName($phpcsFile, $stackPtr)
+        );
+
+        if (!isset($this->methodCompatibilityMatrix[$scannedMethod])) {
+            return;
+        }
+
+        $violation = $this->testOnTargetVersion(
+            $this->methodCompatibilityMatrix[$scannedMethod]
+        );
+
+        if ($violation === null) {
+            return;
+        }
+
+        $this->addMessage(
+            $phpcsFile,
+            $stackPtr,
+            $scannedMethod,
+            $violation
+        );
+    }
+
+
+    /**
+     * Get the compatibility violation with the target PHP version.
+     *
+     * @param array $compatibilityMatrix Compatibility matrix for a method.
+     *
+     * @return array|null Found violation on the target PHP version.
+     */
+    private function testOnTargetVersion(array $compatibilityMatrix)
+    {
+        $violationTypeIds = array_keys($this->violationTypes);
+
+        foreach ($violationTypeIds as $violationTypeId) {
+            if (!isset($compatibilityMatrix[$violationTypeId])) {
+                continue;
+            }
+            if (ScannedCode::shouldRunOnOrAbove($compatibilityMatrix[$violationTypeId])) {
+                return $this->violationTypes[$violationTypeId];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Assemble available information into a user-facing message.
+     *
+     * @param File   $phpcsFile      The file being scanned.
+     * @param int    $stackPtr       Stack pointer
+     * @param string $scannedMethod  Method for which the violation was found.
+     * @param array  $foundViolation Found violation.
+     *
+     * @return void
+     */
+    private function addMessage(File $phpcsFile, $stackPtr, $scannedMethod, array $foundViolation)
+    {
+        $compatibilityMatrix = $this->methodCompatibilityMatrix[$scannedMethod];
+
+        $version        = $compatibilityMatrix[$foundViolation['type']];
+        $hasAlternative = isset($compatibilityMatrix['alternative']);
+
+        $message = sprintf(
+            $foundViolation['messageTemplate'],
+            $scannedMethod,
+            $version
+        );
+        if ($hasAlternative) {
+            $message .= sprintf(' Use %s instead.', $compatibilityMatrix['alternative']);
+        }
+
+        $messageData = [
+            $scannedMethod,
+            $version,
+        ];
+
+        MessageHelper::addMessage(
+            $phpcsFile,
+            $message,
+            $stackPtr,
+            $foundViolation['isError'],
+            $foundViolation['errorCode'],
+            $messageData
+        );
+    }
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsParseError1UnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+class Foo
+{
+    function __sleep(
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionNameRestrictions;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedMagicMethodsSniff sniff.
+ *
+ * @group removedMagicMethods
+ * @group functionNameRestrictions
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedMagicMethodsSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedMagicMethodsParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.inc
@@ -1,7 +1,46 @@
 <?php
 
-class DeprecatedOnlyMethods
+class MutuallyExclusiveMethods
 {
-    function __sleep() {}
-    function __wakeup() {}
+    function __sleep() {} // no violation because __serialize is present, so __sleep is already not called
+    function __wakeup() {} // no violation because __unserialize is present, so __wakeup is already not called
+    function __serialize() {}
+    function __unserialize(array $data) {}
+}
+
+class DeclaredInClass
+{
+    function __sleep() {} // violation
+    function __wakeup() {} // violation
+}
+
+trait DeclaredInTrait
+{
+    function __sleep() {} // violation
+    function __wakeup() {} // violation
+}
+
+interface DeclaredInInterface
+{
+    function __sleep(); // no violation
+    function __wakeup(); // no violation
+}
+
+$DeclaredInAnonymousClass = new class {
+    function __sleep() {} // violation
+    function __wakeup() {} // violation
+};
+
+class DeclaredInNested
+{
+    function nested()
+    {
+        function __sleep() {} // no violation because not a valid magic method in this context
+        function __wakeup() {} // no violation because not a valid magic method in this context
+    }
+}
+
+enum DeclaredInEnum {
+    public function __sleep() {} // no violation because not a valid magic method in this context
+    public function __wakeup() {} // no violation because not a valid magic method in this context
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+class DeprecatedOnlyMethods
+{
+    function __sleep() {}
+    function __wakeup() {}
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.inc
@@ -1,46 +1,57 @@
 <?php
 
-class MutuallyExclusiveMethods
+// Not sniff's target: using similar tokens or syntax
+
+// Not sniff's target: excluded from certain contexts
+interface DeclaredInInterface // only implementations are impacted
 {
-    function __sleep() {} // no violation because __serialize is present, so __sleep is already not called
-    function __wakeup() {} // no violation because __unserialize is present, so __wakeup is already not called
+    function __sleep();
+    function __wakeup();
+}
+
+class MutuallyExclusiveMethods // disregarded when another method is already overriding our target method
+{
+    function __sleep() {} // __serialize is already present
+    function __wakeup() {} // __unserialize is already present
     function __serialize() {}
     function __unserialize(array $data) {}
 }
 
+class DeclaredInNested // don't act like magic methods when nested in functions/methods
+{
+    function nested()
+    {
+        function __sleep() {}
+        function __wakeup() {}
+    }
+}
+
+enum DeclaredInEnum { // don't act like magic methods in enums
+    public function __sleep() {}
+    public function __wakeup() {}
+}
+
+// Sniff's target: deprecated/removed in specific versions
+// @see RemovedMagicMethodsUnitTest::testSoftDeprecations
 class DeclaredInClass
 {
-    function __sleep() {} // violation
-    function __wakeup() {} // violation
+    function __sleep() {} // soft-deprecated since PHP 8.5
+    function __wakeup() {} // soft-deprecated since PHP 8.5
+}
+
+abstract class DeclaredInAbstractClass
+{
+    function __sleep() {} // soft-deprecated since PHP 8.5
+    function __wakeup() {} // soft-deprecated since PHP 8.5
 }
 
 trait DeclaredInTrait
 {
-    function __sleep() {} // violation
-    function __wakeup() {} // violation
-}
-
-interface DeclaredInInterface
-{
-    function __sleep(); // no violation
-    function __wakeup(); // no violation
+    function __sleep() {} // soft-deprecated since PHP 8.5
+    function __wakeup() {} // soft-deprecated since PHP 8.5
 }
 
 $DeclaredInAnonymousClass = new class {
-    function __sleep() {} // violation
-    function __wakeup() {} // violation
+    function __sleep() {} // soft-deprecated since PHP 8.5
+    function __wakeup() {} // soft-deprecated since PHP 8.5
 };
-
-class DeclaredInNested
-{
-    function nested()
-    {
-        function __sleep() {} // no violation because not a valid magic method in this context
-        function __wakeup() {} // no violation because not a valid magic method in this context
-    }
-}
-
-enum DeclaredInEnum {
-    public function __sleep() {} // no violation because not a valid magic method in this context
-    public function __wakeup() {} // no violation because not a valid magic method in this context
-}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.inc
@@ -1,8 +1,17 @@
 <?php
 
 // Not sniff's target: using similar tokens or syntax
+// @see RemovedMagicMethodsUnitTest::dataNoFalsePositives
+$function = __sleep();
+function foo($__sleep) {};
+function() use ($__sleep) {};
 
 // Not sniff's target: excluded from certain contexts
+// @see RemovedMagicMethodsUnitTest::dataSoftDeprecations
+// @see RemovedMagicMethodsUnitTest::dataNoViolationsOnValidVersion
+function __sleep() {} // bare functions are not magic methods
+function __wakeup() {} // bare functions are not magic methods
+
 interface DeclaredInInterface // only implementations are impacted
 {
     function __sleep();
@@ -55,3 +64,10 @@ $DeclaredInAnonymousClass = new class {
     function __sleep() {} // soft-deprecated since PHP 8.5
     function __wakeup() {} // soft-deprecated since PHP 8.5
 };
+
+// Parse error / live coding
+// @see RemovedMagicMethodsUnitTest::dataNoFalsePositives
+class Foo
+{
+    function __sleep(
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.inc
@@ -64,10 +64,3 @@ $DeclaredInAnonymousClass = new class {
     function __sleep() {} // soft-deprecated since PHP 8.5
     function __wakeup() {} // soft-deprecated since PHP 8.5
 };
-
-// Parse error / live coding
-// @see RemovedMagicMethodsUnitTest::dataNoFalsePositives
-class Foo
-{
-    function __sleep(
-}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
@@ -28,38 +28,79 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     /**
      * testViolation
      *
-     * @dataProvider dataViolation
+     * @dataProvider dataSoftDeprecations
      *
-     * @param int $lineNumber The line number of the violation
-     * @param string $method
-     * @param string $alternative
+     * @param string $version     Target version
+     * @param string $method      Method name
+     * @param string $alternative Alternative proposed
+     * @param int[]  $lineNumbers The line numbers of the violation
      *
      * @return void
      */
-    public function testViolation($lineNumber, $method, $alternative)
+    public function testSoftDeprecations($version, $method, $alternative, $lineNumbers)
     {
-        $file = $this->sniffFile(__FILE__, '8.5');
-
+        $file            = $this->sniffFile(__FILE__, $version);
         $expectedMessage = sprintf(
-            'Magic method %s is soft-deprecated since PHP 8.5. Use %s instead.',
+            'Magic method %s is maintained for backward compatibility since PHP %s. Use %s instead.',
             $method,
+            $version,
             $alternative
         );
-        $this->assertWarning($file, $lineNumber, $expectedMessage);
+        foreach ($lineNumbers as $lineNumber) {
+            $this->assertWarning($file, $lineNumber, $expectedMessage);
+        }
     }
 
     /**
      * Data provider.
      *
-     * @see testViolation()
+     * @see testSoftDeprecations()
      *
      * @return array
      */
-    public static function dataViolation()
+    public static function dataSoftDeprecations()
     {
         return [
-            [5, '__sleep()', '__serialize'],
-            [6, '__wakeup()', '__unserialize'],
+            ['8.5', '__sleep()', '__serialize', [13, 19, 30]],
+            ['8.5', '__wakeup()', '__unserialize', [14, 20, 31]],
+        ];
+    }
+
+    /**
+     * testViolation
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param string $version     Target version
+     * @param string $method      Method name
+     * @param int[]  $lineNumbers The line numbers of the violation
+     *
+     * @return void
+     */
+    public function testNoViolation($version, $method, $lineNumbers)
+    {
+        $file = $this->sniffFile(__FILE__, $version);
+        foreach ($lineNumbers as $lineNumber) {
+            $this->assertNoViolation($file, $lineNumber);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testSoftDeprecations()
+     *
+     * @return array
+     */
+    public static function dataNoViolation()
+    {
+        return [
+            // Pre-deprecation/removal
+            ['8.4', '__sleep()', [13]],
+            ['8.4', '__wakeup()', [14]],
+            // Post-deprecation/removal
+            ['8.5', '__sleep()', [5, 25, 38, 44]],
+            ['8.5', '__wakeup()', [6, 26, 39, 45]],
         ];
     }
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
@@ -26,7 +26,7 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
 {
 
     /**
-     * testViolation
+     * Ensure a warning message when found in versions that sof-deprecated the magic method.
      *
      * @dataProvider dataSoftDeprecations
      *
@@ -61,15 +61,15 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     public static function dataSoftDeprecations()
     {
         return [
-            ['8.5', '__sleep()', '__serialize', [13, 19, 30]],
-            ['8.5', '__wakeup()', '__unserialize', [14, 20, 31]],
+            ['8.5', '__sleep()', '__serialize', [38, 44, 50, 55]],
+            ['8.5', '__wakeup()', '__unserialize', [39, 45, 51, 56]],
         ];
     }
 
     /**
-     * testViolation
+     * Ensure NO false positives due to misleading syntax out excluded scopes.
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param string $version     Target version
      * @param string $method      Method name
@@ -77,7 +77,7 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
      *
      * @return void
      */
-    public function testNoViolation($version, $method, $lineNumbers)
+    public function testNoFalsePositives($version, $method, $lineNumbers)
     {
         $file = $this->sniffFile(__FILE__, $version);
         foreach ($lineNumbers as $lineNumber) {
@@ -86,21 +86,51 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * Data provider.
+     * All versions are _invalid_ for the associated constants, but the snippet should not be picked up by the sniff.
      *
-     * @see testSoftDeprecations()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public static function dataNoViolation()
+    public static function dataNoFalsePositives()
     {
         return [
-            // Pre-deprecation/removal
-            ['8.4', '__sleep()', [13]],
-            ['8.4', '__wakeup()', [14]],
-            // Post-deprecation/removal
-            ['8.5', '__sleep()', [5, 25, 38, 44]],
-            ['8.5', '__wakeup()', [6, 26, 39, 45]],
+            ['8.4', '__sleep()', [8, 14, 24, 30]],
+            ['8.4', '__wakeup()', [9, 15, 25, 31]],
+        ];
+    }
+
+    /**
+     * Ensure NO messages when found in supported versions.
+     *
+     * @dataProvider dataNoViolationsOnValidVersion
+     *
+     * @param string $version     Target version
+     * @param string $method      Method name
+     * @param int[]  $lineNumbers The line numbers of the violation
+     *
+     * @return void
+     */
+    public function testNoViolationsOnValidVersion($version, $method, $lineNumbers)
+    {
+        $file = $this->sniffFile(__FILE__, $version);
+        foreach ($lineNumbers as $lineNumber) {
+            $this->assertNoViolation($file, $lineNumber);
+        }
+    }
+
+    /**
+     * All versions are _valid_ for the associated magic methods, and the sniff shouldn't flag warnings or errors
+     *
+     * @see testNoViolationsOnValidVersion()
+     *
+     * @return array
+     */
+    public static function dataNoViolationsOnValidVersion()
+    {
+        return [
+            ['8.4', '__sleep()', [38, 44, 50, 55]],
+            ['8.4', '__wakeup()', [39, 45, 51, 56]],
         ];
     }
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
@@ -67,7 +67,7 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * Ensure NO false positives due to misleading syntax out excluded scopes.
+     * Ensure no false positives due to misleading syntax out excluded scopes.
      *
      * @dataProvider dataNoFalsePositives
      *
@@ -86,7 +86,7 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * All versions are _invalid_ for the associated constants, but the snippet should not be picked up by the sniff.
+     * All versions are invalid for the associated constants, but the snippet should not be picked up by the sniff.
      *
      * @see testNoFalsePositives()
      *
@@ -101,7 +101,7 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * Ensure NO messages when found in supported versions.
+     * Ensure no messages when found in supported versions.
      *
      * @dataProvider dataNoViolationsOnValidVersion
      *
@@ -120,7 +120,7 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * All versions are _valid_ for the associated magic methods, and the sniff shouldn't flag warnings or errors
+     * All versions are valid for the associated magic methods, and the sniff shouldn't flag warnings or errors
      *
      * @see testNoViolationsOnValidVersion()
      *

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionNameRestrictions;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedMagicMethodsSniff sniff.
+ *
+ * @group removedMagicMethods
+ * @group functionNameRestrictions
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\RemovedMagicMethodsSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * testViolation
+     *
+     * @dataProvider dataViolation
+     *
+     * @param int $lineNumber The line number of the violation
+     * @param string $method
+     * @param string $alternative
+     *
+     * @return void
+     */
+    public function testViolation($lineNumber, $method, $alternative)
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+
+        $expectedMessage = sprintf(
+            'Magic method %s is soft-deprecated since PHP 8.5. Use %s instead.',
+            $method,
+            $alternative
+        );
+        $this->assertWarning($file, $lineNumber, $expectedMessage);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testViolation()
+     *
+     * @return array
+     */
+    public static function dataViolation()
+    {
+        return [
+            [5, '__sleep()', '__serialize'],
+            [6, '__wakeup()', '__unserialize'],
+        ];
+    }
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
@@ -30,20 +30,18 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataSoftDeprecations
      *
-     * @param string $version     Target version
      * @param string $method      Method name
      * @param string $alternative Alternative proposed
      * @param int[]  $lineNumbers The line numbers of the violation
      *
      * @return void
      */
-    public function testSoftDeprecations($version, $method, $alternative, $lineNumbers)
+    public function testSoftDeprecations($method, $alternative, $lineNumbers)
     {
-        $file            = $this->sniffFile(__FILE__, $version);
+        $file            = $this->sniffFile(__FILE__, '8.5');
         $expectedMessage = sprintf(
-            'Magic method %s is maintained for backward compatibility since PHP %s. Use %s instead.',
+            'Magic method %s is maintained for backward compatibility since PHP 8.5. Use %s instead.',
             $method,
-            $version,
             $alternative
         );
         foreach ($lineNumbers as $lineNumber) {
@@ -61,32 +59,31 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     public static function dataSoftDeprecations()
     {
         return [
-            ['8.5', '__sleep()', '__serialize', [47, 53, 59, 64]],
-            ['8.5', '__wakeup()', '__unserialize', [48, 54, 60, 65]],
+            ['__sleep()', '__serialize', [47, 53, 59, 64]],
+            ['__wakeup()', '__unserialize', [48, 54, 60, 65]],
         ];
     }
 
     /**
-     * Ensure no false positives due to misleading syntax out excluded scopes.
+     * Verify there are no false positives on valid code.
      *
      * @dataProvider dataNoFalsePositives
      *
-     * @param string $version     Target version
      * @param string $method      Method name
      * @param int[]  $lineNumbers The line numbers of the violation
      *
      * @return void
      */
-    public function testNoFalsePositives($version, $method, $lineNumbers)
+    public function testNoFalsePositives($method, $lineNumbers)
     {
-        $file = $this->sniffFile(__FILE__, $version);
+        $file = $this->sniffFile(__FILE__, '8.5');
         foreach ($lineNumbers as $lineNumber) {
             $this->assertNoViolation($file, $lineNumber);
         }
     }
 
     /**
-     * All versions are invalid for the associated constants, but the snippet should not be picked up by the sniff.
+     * Data provider.
      *
      * @see testNoFalsePositives()
      *
@@ -96,48 +93,22 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     {
         return [
             // misleading syntax
-            ['8.4', '__sleep()', [5, 6, 7]],
+            ['__sleep()', [5, 6, 7]],
 
             // inapplicable contexts
-            ['8.4', '__sleep()', [12, 17, 23, 33, 39]],
-            ['8.4', '__wakeup()', [13, 18, 24, 33, 40]],
-
-            // parse error
-            ['8.4', '__sleep()', [72]],
+            ['__sleep()', [12, 17, 23, 33, 39]],
+            ['__wakeup()', [13, 18, 24, 34, 40]],
         ];
     }
 
     /**
-     * Ensure no messages when found in supported versions.
-     *
-     * @dataProvider dataNoViolationsOnValidVersion
-     *
-     * @param string $version     Target version
-     * @param string $method      Method name
-     * @param int[]  $lineNumbers The line numbers of the violation
+     * Verify no notices are thrown at all on PHP versions on which the syntax is supported.
      *
      * @return void
      */
-    public function testNoViolationsOnValidVersion($version, $method, $lineNumbers)
+    public function testNoViolationsOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, $version);
-        foreach ($lineNumbers as $lineNumber) {
-            $this->assertNoViolation($file, $lineNumber);
-        }
-    }
-
-    /**
-     * All versions are valid for the associated magic methods, and the sniff shouldn't flag warnings or errors
-     *
-     * @see testNoViolationsOnValidVersion()
-     *
-     * @return array
-     */
-    public static function dataNoViolationsOnValidVersion()
-    {
-        return [
-            ['8.4', '__sleep()', [47, 53, 59, 64]],
-            ['8.4', '__wakeup()', [48, 54, 60, 65]],
-        ];
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
     }
 }

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicMethodsUnitTest.php
@@ -61,8 +61,8 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     public static function dataSoftDeprecations()
     {
         return [
-            ['8.5', '__sleep()', '__serialize', [38, 44, 50, 55]],
-            ['8.5', '__wakeup()', '__unserialize', [39, 45, 51, 56]],
+            ['8.5', '__sleep()', '__serialize', [47, 53, 59, 64]],
+            ['8.5', '__wakeup()', '__unserialize', [48, 54, 60, 65]],
         ];
     }
 
@@ -95,8 +95,15 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     public static function dataNoFalsePositives()
     {
         return [
-            ['8.4', '__sleep()', [8, 14, 24, 30]],
-            ['8.4', '__wakeup()', [9, 15, 25, 31]],
+            // misleading syntax
+            ['8.4', '__sleep()', [5, 6, 7]],
+
+            // inapplicable contexts
+            ['8.4', '__sleep()', [12, 17, 23, 33, 39]],
+            ['8.4', '__wakeup()', [13, 18, 24, 33, 40]],
+
+            // parse error
+            ['8.4', '__sleep()', [72]],
         ];
     }
 
@@ -129,8 +136,8 @@ final class RemovedMagicMethodsUnitTest extends BaseSniffTestCase
     public static function dataNoViolationsOnValidVersion()
     {
         return [
-            ['8.4', '__sleep()', [38, 44, 50, 55]],
-            ['8.4', '__wakeup()', [39, 45, 51, 56]],
+            ['8.4', '__sleep()', [47, 53, 59, 64]],
+            ['8.4', '__wakeup()', [48, 54, 60, 65]],
         ];
     }
 }


### PR DESCRIPTION
Part of this effort: https://github.com/PHPCompatibility/PHPCompatibility/issues/1849

Adding a new sniff for deprecated/removed magic methods, currently used for `__sleep` and `__wakeup` soft deprecation.

- Message for soft deprecation adapted from RFC. Example: `Magic method __wakeup() is maintained for backward compatibility since PHP 8.5. Use __unserialize instead.`
- Using `SoftDeprecated` error code. Other codes are `Deprecated` and `Removed`.
- Applies to classes, anonymous classes, and traits.
- Interfaces were excluded because the value is debatable, since no behavior change will occur.
- Assumed 10.0.0 target release
- Included references in the sniff above each magic method entry. It seemed useful.