### PR TITLE
PHP 8.3: New sniff to detect dynamic class constant fetch

### DIFF
--- a/PHPCompatibility/Docs/Syntax/NewDynamicClassConstantFetchStandard.xml
+++ b/PHPCompatibility/Docs/Syntax/NewDynamicClassConstantFetchStandard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Dynamic Class Constant Fetch"
+    >
+    <standard>
+    <![CDATA[
+    PHP 8.3 introduced the dynamic fetching of class constants. The new syntax is not compatible with previous versions and would emit a parse error in PHP 8.2 and earlier.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: using the constant() function.">
+            <![CDATA[
+<em>constant</em>(Foo::class . '::' . $bar);
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.3: dynamic class constant fetch.">
+        <![CDATA[
+Foo<em>::{</em>$bar<em>}</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Docs/Syntax/NewDynamicClassConstantFetchStandard.xml
+++ b/PHPCompatibility/Docs/Syntax/NewDynamicClassConstantFetchStandard.xml
@@ -10,7 +10,7 @@
     </standard>
     <code_comparison>
         <code title="Cross-version compatible: using the constant() function.">
-            <![CDATA[
+        <![CDATA[
 <em>constant</em>(Foo::class . '::' . $bar);
         ]]>
         </code>

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -63,8 +63,15 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
         if ($nextNonEmpty === false) {
             return;
         }
-
+        // Example: Foo::{$bar}
         if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_CURLY_BRACKET) {
+            return;
+        }
+
+        $closingBracket = $phpcsFile->findNext(\T_CLOSE_CURLY_BRACKET, $nextNonEmpty + 1);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $closingBracket + 1, null, true);
+        // Example: Foo::{$bar}() is a false positive
+        if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -70,7 +70,7 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
 
         $phpcsFile->addError(
             'Dynamic class constant fetch is not available in PHP 8.2 or earlier.',
-            $stackPtr,
+            $nextNonEmpty,
             'Found'
         );
     }

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Syntax;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+
+/**
+ * Class constants can be accessed dynamically using the C::{$name} syntax.
+ *
+ * PHP version 8.3
+ *
+ * @link https://www.php.net/releases/8.3/en.php#dynamic_class_constant_fetch
+ * @link https://wiki.php.net/rfc/dynamic_class_constant_fetch
+ *
+ * @since 10.0.0
+ */
+final class NewDynamicClassConstantFetchSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            \T_DOUBLE_COLON,
+        ];
+    }
+
+    /**
+     * Processes this test when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (!ScannedCode::shouldRunOnOrBelow('8.2')) {
+            return;
+        }
+
+        $tokens       = $phpcsFile->getTokens();
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        if (!$nextNonEmpty) {
+            return;
+        }
+
+        $isNextNonEmptyAnOpenCurlyBracket = $tokens[$nextNonEmpty]['code'] === \T_OPEN_CURLY_BRACKET;
+        if (!$isNextNonEmptyAnOpenCurlyBracket) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Dynamic class constant fetch is not available in PHP 8.2 or earlier.',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -68,10 +68,22 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
             return;
         }
 
-        $closingBracket = $phpcsFile->findNext(\T_CLOSE_CURLY_BRACKET, $nextNonEmpty + 1);
-        $nextNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, $closingBracket + 1, null, true);
+        $bracketOpener = $nextNonEmpty;
+        // Example: Foo::{ is a live coding or parse error
+        if (isset($tokens[$bracketOpener]['bracket_closer']) === false) {
+            return;
+        }
+
+        $bracketCloser = $tokens[$bracketOpener]['bracket_closer'];
+        $nextNonEmpty  = $phpcsFile->findNext(Tokens::$emptyTokens, $bracketCloser + 1, null, true);
         // Example: Foo::{$bar}() is a false positive
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $bracketOpener + 1, $bracketCloser, true);
+        // Example: Foo::{{$bar->name}()} is a parse error that might seem like a valid constant fetch due to Foo::{...}
+        if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_CURLY_BRACKET) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -54,7 +54,7 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if (!ScannedCode::shouldRunOnOrBelow('8.2')) {
+        if (ScannedCode::shouldRunOnOrBelow('8.2') === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -59,7 +59,7 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $stackPtr + 1, null, true);
         if ($nextNonEmpty === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -69,7 +69,7 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
         }
 
         $closingBracket = $phpcsFile->findNext(\T_CLOSE_CURLY_BRACKET, $nextNonEmpty + 1);
-        $nextNonEmpty   = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $closingBracket + 1, null, true);
+        $nextNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, $closingBracket + 1, null, true);
         // Example: Foo::{$bar}() is a false positive
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
             return;

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -69,7 +69,7 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
         }
 
         $closingBracket = $phpcsFile->findNext(\T_CLOSE_CURLY_BRACKET, $nextNonEmpty + 1);
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $closingBracket + 1, null, true);
+        $nextNonEmpty   = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $closingBracket + 1, null, true);
         // Example: Foo::{$bar}() is a false positive
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
             return;

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -59,7 +59,7 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $stackPtr + 1, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
         if ($nextNonEmpty === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -60,12 +60,11 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
 
         $tokens       = $phpcsFile->getTokens();
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
-        if (!$nextNonEmpty) {
+        if ($nextNonEmpty === false) {
             return;
         }
 
-        $isNextNonEmptyAnOpenCurlyBracket = $tokens[$nextNonEmpty]['code'] === \T_OPEN_CURLY_BRACKET;
-        if (!$isNextNonEmptyAnOpenCurlyBracket) {
+        if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_CURLY_BRACKET) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -47,8 +47,9 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
      *
      * @since 10.0.0
      *
-     * @param File $phpcsFile The file being scanned.
-     * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
      *
      * @return void
      */
@@ -63,26 +64,27 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
         if ($nextNonEmpty === false) {
             return;
         }
-        // Example: Foo::{$bar}
+
+        // We're looking for `Foo::{$bar}`.
         if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_CURLY_BRACKET) {
             return;
         }
 
         $bracketOpener = $nextNonEmpty;
-        // Example: Foo::{ is a live coding or parse error
+        // Example: `Foo::{` is a live coding or parse error.
         if (isset($tokens[$bracketOpener]['bracket_closer']) === false) {
             return;
         }
 
         $bracketCloser = $tokens[$bracketOpener]['bracket_closer'];
         $nextNonEmpty  = $phpcsFile->findNext(Tokens::$emptyTokens, $bracketCloser + 1, null, true);
-        // Example: Foo::{$bar}() is a false positive
+        // Prevent false positive for syntax which has been supported since PHP 5.4: `Foo::{$bar}()`.
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
             return;
         }
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $bracketOpener + 1, $bracketCloser, true);
-        // Example: Foo::{{$bar->name}()} is a parse error that might seem like a valid constant fetch due to Foo::{...}
+        // Example: `Foo::{{$bar->name}()}` is a parse error that might seem like a valid constant fetch due to `Foo::{...}`.
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_CURLY_BRACKET) {
             return;
         }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError1UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+Foo::

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewDynamicClassConstantFetch sniff.
+ *
+ * @group newDynamicClassConstantFetch
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewDynamicClassConstantFetchSniff
+ *
+ * @since 10.0.0
+ */
+final class NewDynamicClassConstantFetchParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError2UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError2UnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+Foo::{

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError2UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError2UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewDynamicClassConstantFetch sniff.
+ *
+ * @group newDynamicClassConstantFetch
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewDynamicClassConstantFetchSniff
+ *
+ * @since 10.0.0
+ */
+final class NewDynamicClassConstantFetchParseError2UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError3UnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError3UnitTest.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+// Sample contains extra curly brackets to make sure we match the correct closer, and skip it as a parse error.
+Foo::{{$bar->name}()};

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError3UnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchParseError3UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewDynamicClassConstantFetch sniff.
+ *
+ * @group newDynamicClassConstantFetch
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewDynamicClassConstantFetchSniff
+ *
+ * @since 10.0.0
+ */
+final class NewDynamicClassConstantFetchParseError3UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
@@ -1,0 +1,3 @@
+<?php
+
+ClassWithConstant:: {$obj->getConstantName()}; // valid syntax only since PHP 8.3

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
@@ -1,6 +1,25 @@
 <?php
 
-A:: {$obj->getConstantName('param')}; // valid syntax only since PHP 8.3
-self::{$name}; // valid syntax only since PHP 8.3
-static::{$array['key']}; // valid syntax only since PHP 8.3
-static::{B::class}; // make sure double colon `::` on the inner expression doesn't confuse the sniff
+// Not sniff's target, using similar tokens or syntax
+$$foo; // fetch variable using dynamic name
+$foo->$bar; // fetch object property using dynamic name
+Foo::${$bar}; // explicit class name, fetch static property using dynamic name
+$foo->{$bar}(); // call object method using dynamic name
+Foo::{$bar}(); // explicit class name, call static method using dynamic name
+$foo::$bar; // fetch static property using dynamic name from object’s class
+$foo::bar(); // call static method on object’s class using explicit method name
+$array{'index'}; // curly brace array access, string index
+$array{10}; // curly brace array access, numeric index
+$className::class; // fetch static constant
+MyClass::class; // explicit class name, fetch static constant
+
+// Sniff's target: invalid syntax on <=8.2
+Foo::{$bar->get('index')}; // complex expression as constant name
+self::{$bar}; // class is self
+static::{$array['index']}; // class is static
+static::{Foo::class}; // inner expression double colon `::` shouldn't interfere
+Foo::
+    /* multiline, comment between relevant tokens */
+    {$bar}
+
+MyClass:: // parse error / live coding

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
@@ -26,6 +26,3 @@ static::{Foo::class}; // inner expression double colon `::` shouldn't interfere
 Foo::
     /* multiline, comment between relevant tokens */
     {$bar};
-
-Foo::{ // parse error / live coding
-Foo::{{$bar->name}()}; // extra curly brackets to make sure we match the correct closer, and skip it as a parse error

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
@@ -1,3 +1,6 @@
 <?php
 
-ClassWithConstant:: {$obj->getConstantName()}; // valid syntax only since PHP 8.3
+A:: {$obj->getConstantName('param')}; // valid syntax only since PHP 8.3
+self::{$name}; // valid syntax only since PHP 8.3
+static::{$array['key']}; // valid syntax only since PHP 8.3
+static::{B::class}; // make sure double colon `::` on the inner expression doesn't confuse the sniff

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
@@ -20,6 +20,6 @@ static::{$array['index']}; // class is static
 static::{Foo::class}; // inner expression double colon `::` shouldn't interfere
 Foo::
     /* multiline, comment between relevant tokens */
-    {$bar}
+    {$bar};
 
 MyClass:: // parse error / live coding

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
@@ -14,6 +14,11 @@ $className::class; // fetch static constant
 MyClass::class; // explicit class name, fetch static constant
 
 // Sniff's target: invalid syntax on <=8.2
+Foo::{$bar}->prop;
+Foo::{$bar}->method();
+Foo::{$bar}?->prop;
+Foo::{$bar}?->method();
+Foo::{$bar}::CONSTANT_NAME;
 Foo::{$bar->get('index')}; // complex expression as constant name
 self::{$bar}; // class is self
 static::{$array['index']}; // class is static

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
@@ -26,3 +26,4 @@ static::{Foo::class}; // inner expression double colon `::` shouldn't interfere
 Foo::
     /* multiline, comment between relevant tokens */
     {$bar};
+Foo::{$bar}['key'];

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.inc
@@ -11,7 +11,7 @@ $foo::bar(); // call static method on object’s class using explicit method nam
 $array{'index'}; // curly brace array access, string index
 $array{10}; // curly brace array access, numeric index
 $className::class; // fetch static constant
-MyClass::class; // explicit class name, fetch static constant
+Foo::class; // explicit class name, fetch static constant
 
 // Sniff's target: invalid syntax on <=8.2
 Foo::{$bar}->prop;
@@ -27,4 +27,5 @@ Foo::
     /* multiline, comment between relevant tokens */
     {$bar};
 
-MyClass:: // parse error / live coding
+Foo::{ // parse error / live coding
+Foo::{{$bar->name}()}; // extra curly brackets to make sure we match the correct closer, and skip it as a parse error

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -120,7 +120,7 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
             [12],
             [13],
             [14],
-            [23], // last because parse error
+            [25], // last because parse error
         ];
     }
 }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -116,7 +116,7 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
         }
 
         // Parse error test.
-        $cases[] = [25];
+        $cases[] = [30];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -50,6 +50,38 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
     {
         return [
             [3],
+            [4],
+            [5],
+        ];
+    }
+
+    /**
+     * Ensure a warning message in NOT found syntax on supported versions.
+     *
+     * @dataProvider dataSupportedVersion
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testSupportedVersion($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     * @see    testSupportedVersion()
+     */
+    public static function dataSupportedVersion()
+    {
+        return [
+            [3],
+            [4],
+            [5],
         ];
     }
 }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -96,7 +96,7 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
      */
     public function testNoFalsePositives($line)
     {
-        $file = $this->sniffFile(__FILE__, '8.3');
+        $file = $this->sniffFile(__FILE__, '8.2');
         $this->assertNoViolation($file, $line);
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -26,7 +26,7 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
 {
 
     /**
-     * Ensure a warning message when found syntax on earlier versions.
+     * Ensure an error is thrown when the new syntax is used.
      *
      * @dataProvider dataDynamicClassConstantFetch
      *

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Syntax;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewDynamicClassConstantFetch sniff.
+ *
+ * @group newDynamicClassConstantFetch
+ * @group syntax
+ *
+ * @covers \PHPCompatibility\Sniffs\Syntax\NewDynamicClassConstantFetchSniff
+ *
+ * @since 10.0.0
+ */
+final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Ensure a warning message when found syntax on earlier versions.
+     *
+     * @dataProvider dataUnsupportedVersion
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testUnsupportedVersion($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.2');
+        $this->assertError($file, $line, 'Dynamic class constant fetch is not available in PHP 8.2 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     * @see    testUnsupportedVersion()
+     */
+    public static function dataUnsupportedVersion()
+    {
+        return [
+            [3],
+        ];
+    }
+}

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -117,6 +117,7 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
 
         // Parse error test.
         $cases[] = [30];
+        $cases[] = [31];
 
         return $cases;
     }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -115,10 +115,6 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
             $cases[] = [$line];
         }
 
-        // Parse error test.
-        $cases[] = [30];
-        $cases[] = [31];
-
         return $cases;
     }
 }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -58,34 +58,6 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * Verify no notices are thrown at all on PHP versions on which the syntax is supported.
-     *
-     * @return void
-     */
-    public function testNoViolationsOnValidVersion()
-    {
-        $file = $this->sniffFile(__FILE__, '8.3');
-        $this->assertNoViolation($file);
-    }
-
-    /**
-     * Data provider.
-     *
-     * @return array<array<int>>
-     * @see    testNoViolationsOnValidVersion()
-     */
-    public static function dataNoViolationsOnValidVersion()
-    {
-        return [
-            [17],
-            [18],
-            [19],
-            [20],
-            [23],
-        ];
-    }
-
-    /**
      * Verify there are no false positives on valid code.
      *
      * @dataProvider dataNoFalsePositives
@@ -116,5 +88,16 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
         }
 
         return $cases;
+    }
+
+    /**
+     * Verify no notices are thrown at all on PHP versions on which the syntax is supported.
+     *
+     * @return void
+     */
+    public function testNoViolationsOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file);
     }
 }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -43,7 +43,7 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
     /**
      * Data provider.
      *
-     * @return array
+     * @return array<array<int>>
      * @see    testDynamicClassConstantFetch()
      */
     public static function dataDynamicClassConstantFetch()

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -28,13 +28,13 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
     /**
      * Ensure a warning message when found syntax on earlier versions.
      *
-     * @dataProvider dataUnsupportedVersion
+     * @dataProvider dataDynamicClassConstantFetch
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testUnsupportedVersion($line)
+    public function testDynamicClassConstantFetch($line)
     {
         $file = $this->sniffFile(__FILE__, '8.2');
         $this->assertError($file, $line, 'Dynamic class constant fetch is not available in PHP 8.2 or earlier.');
@@ -44,27 +44,29 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
      * Data provider.
      *
      * @return array
-     * @see    testUnsupportedVersion()
+     * @see    testDynamicClassConstantFetch()
      */
-    public static function dataUnsupportedVersion()
+    public static function dataDynamicClassConstantFetch()
     {
         return [
-            [3],
-            [4],
-            [5],
+            [17],
+            [18],
+            [19],
+            [20],
+            [23],
         ];
     }
 
     /**
      * Ensure a warning message in NOT found syntax on supported versions.
      *
-     * @dataProvider dataSupportedVersion
+     * @dataProvider dataNoViolationsOnValidVersion
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testSupportedVersion($line)
+    public function testNoViolationsOnValidVersion($line)
     {
         $file = $this->sniffFile(__FILE__, '8.3');
         $this->assertNoViolation($file, $line);
@@ -74,15 +76,55 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
      * Data provider.
      *
      * @return array
-     * @see    testSupportedVersion()
+     * @see    testNoViolationsOnValidVersion()
      */
-    public static function dataSupportedVersion()
+    public static function dataNoViolationsOnValidVersion()
     {
         return [
-            [3],
+            [17],
+            [18],
+            [19],
+            [20],
+            [23],
+        ];
+    }
+
+    /**
+     * Ensure a warning message in NOT found in syntax that is not explicitly targeted by this sniff.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     * @see    testNoFalsePositives()
+     */
+    public static function dataNoFalsePositives()
+    {
+        return [
             [4],
             [5],
             [6],
+            [7],
+            [8],
+            [9],
+            [10],
+            [11],
+            [12],
+            [13],
+            [14],
+            [23], // last because parse error
         ];
     }
 }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -71,7 +71,7 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
     /**
      * Data provider.
      *
-     * @return array
+     * @return array<array<int>>
      * @see    testNoViolationsOnValidVersion()
      */
     public static function dataNoViolationsOnValidVersion()

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -58,18 +58,14 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * Ensure a warning message in NOT found syntax on supported versions.
-     *
-     * @dataProvider dataNoViolationsOnValidVersion
-     *
-     * @param int $line The line number.
+     * Verify no notices are thrown at all on PHP versions on which the syntax is supported.
      *
      * @return void
      */
-    public function testNoViolationsOnValidVersion($line)
+    public function testNoViolationsOnValidVersion()
     {
         $file = $this->sniffFile(__FILE__, '8.3');
-        $this->assertNoViolation($file, $line);
+        $this->assertNoViolation($file);
     }
 
     /**

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -43,8 +43,9 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
     /**
      * Data provider.
      *
+     * @see testDynamicClassConstantFetch()
+     *
      * @return array<array<int>>
-     * @see    testDynamicClassConstantFetch()
      */
     public static function dataDynamicClassConstantFetch()
     {
@@ -81,8 +82,9 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
     /**
      * Data provider.
      *
+     * @see testNoFalsePositives()
+     *
      * @return array<array<int>>
-     * @see    testNoFalsePositives()
      */
     public static function dataNoFalsePositives()
     {

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -82,6 +82,7 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
             [3],
             [4],
             [5],
+            [6],
         ];
     }
 }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -53,7 +53,13 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
             [18],
             [19],
             [20],
+            [21],
+            [22],
             [23],
+            [24],
+            [25],
+            [28],
+            [29],
         ];
     }
 

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -108,19 +108,16 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
      */
     public static function dataNoFalsePositives()
     {
-        return [
-            [4],
-            [5],
-            [6],
-            [7],
-            [8],
-            [9],
-            [10],
-            [11],
-            [12],
-            [13],
-            [14],
-            [25], // last because parse error
-        ];
+        $cases = [];
+
+        // No errors expected on the first 15 lines.
+        for ($line = 1; $line <= 15; $line++) {
+            $cases[] = [$line];
+        }
+
+        // Parse error test.
+        $cases[] = [25];
+
+        return $cases;
     }
 }

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -86,7 +86,7 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * Ensure a warning message in NOT found in syntax that is not explicitly targeted by this sniff.
+     * Verify there are no false positives on valid code.
      *
      * @dataProvider dataNoFalsePositives
      *

--- a/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewDynamicClassConstantFetchUnitTest.php
@@ -103,7 +103,7 @@ final class NewDynamicClassConstantFetchUnitTest extends BaseSniffTestCase
     /**
      * Data provider.
      *
-     * @return array
+     * @return array<array<int>>
      * @see    testNoFalsePositives()
      */
     public static function dataNoFalsePositives()


### PR DESCRIPTION
Part of this effort: https://github.com/PHPCompatibility/PHPCompatibility/issues/1589

Adding a sniff for new syntax to dynamically fetch class constants `C::{$name}`. Existing sniffs were not fit for this purpose, and adding things there would have made them unnecessarily hard to maintain.

Implemented in a similar fashion to other new syntax sniffs.

- Will flag any use of this syntax before it was introduced in PHP 8.3,
- Message: `Dynamic class constant fetch is not available in PHP 8.2 or earlier.`
- Using `Found` error code.
- Added complex expressions in the curly brackets, including one with :: to ensure sniff doesn't get confused.
- Assumed 10.0.0 target release.
- Out of scope: checking for corresponding closing curly bracket. This seemed unnecessary, as it will do nothing but lint in exchange for extra overhead.

Edit: we ended up checking the corresponding closing bracket. It was needed to weed out some false positives.