### PR TITLE
PHP 8.5: Deprecate NumberFormatter::TYPE_CURRENCY

### DIFF
--- a/PHPCompatibility/Sniffs/Constants/RemovedClassConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedClassConstantsSniff.php
@@ -137,7 +137,7 @@ final class RemovedClassConstantsSniff extends Sniff
 
         $this->addMessage(
             $phpcsFile,
-            $stackPtr,
+            $nextNonEmpty,
             $scannedClassConstant,
             $violation
         );

--- a/PHPCompatibility/Sniffs/Constants/RemovedClassConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedClassConstantsSniff.php
@@ -66,7 +66,8 @@ final class RemovedClassConstantsSniff extends Sniff
      *     softDeprecated?: string,
      *     deprecated?: string,
      *     removed?: string,
-     *     alternative?: string
+     *     alternative?: string,
+     *     extension?: string
      * }>
      */
     protected $classConstantCompatibilityMatrix = [
@@ -75,6 +76,7 @@ final class RemovedClassConstantsSniff extends Sniff
         // @link https://www.php.net/manual/en/class.numberformatter.php#numberformatter.constants.type-currency
         'NumberFormatter::TYPE_CURRENCY' => [
             self::DEPRECATED => '8.3',
+            'extension' => 'intl',
         ],
     ];
 
@@ -89,7 +91,6 @@ final class RemovedClassConstantsSniff extends Sniff
     {
         return [\T_DOUBLE_COLON];
     }
-
 
     /**
      * Processes this test when one of its tokens is encountered.

--- a/PHPCompatibility/Sniffs/Constants/RemovedClassConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedClassConstantsSniff.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\Constants;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Utils\MessageHelper;
+
+/**
+ * Detect the use of removed PHP class constants.
+ *
+ * PHP version All
+ *
+ * @since 10.0.0
+ */
+final class RemovedClassConstantsSniff extends Sniff
+{
+    const REMOVED         = 'removed';
+    const DEPRECATED      = 'deprecated';
+    const SOFT_DEPRECATED = 'softDeprecated';
+
+    /**
+     * List of all violation types and their semantic meaning.
+     *
+     * @var array<string, array{
+     *     type: string,
+     *     errorCode: string,
+     *     messageTemplate: string,
+     *     isError: bool,
+     * }>
+     */
+    private $violationTypes = [
+        self::REMOVED => [
+            'type' => self::REMOVED,
+            'errorCode' => 'Removed',
+            'messageTemplate' => 'Class constant %s is removed since PHP %s.',
+            'isError' => true,
+        ],
+        self::DEPRECATED => [
+            'type' => self::DEPRECATED,
+            'errorCode' => 'Deprecated',
+            'messageTemplate' => 'Class constant %s is deprecated since PHP %s.',
+            'isError' => false,
+        ],
+        self::SOFT_DEPRECATED => [
+            'type' => self::SOFT_DEPRECATED,
+            'errorCode' => 'SoftDeprecated',
+            'messageTemplate' => 'Class constant %s is maintained for backward compatibility since PHP %s.',
+            'isError' => false,
+        ],
+    ];
+
+    /**
+     * Class constants that will be scanned for compatibility.
+     *
+     * @var array<string, array{
+     *     softDeprecated?: string,
+     *     deprecated?: string,
+     *     removed?: string,
+     *     alternative?: string
+     * }>
+     */
+    protected $classConstantCompatibilityMatrix = [
+        // @link https://wiki.php.net/rfc/deprecations_php_8_3#the_numberformattertype_currency_constant
+        // @link https://www.php.net/manual/en/migration83.deprecated.php#migration83.deprecated.intl
+        // @link https://www.php.net/manual/en/class.numberformatter.php#numberformatter.constants.type-currency
+        'NumberFormatter::TYPE_CURRENCY' => [
+            self::DEPRECATED => '8.3',
+        ],
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_DOUBLE_COLON];
+    }
+
+
+    /**
+     * Processes this test when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // We can't know runtime values, so tokens on each side of the double colon can only be strings for this sniff.
+        $classNamePointer     = $phpcsFile->findPrevious([T_STRING], $stackPtr - 1);
+        $constantNamePointer  = $phpcsFile->findNext([T_STRING], $stackPtr + 1);
+        $scannedClassConstant = $phpcsFile->getTokensAsString($classNamePointer, $constantNamePointer - $classNamePointer + 1);
+
+        if (!isset($this->classConstantCompatibilityMatrix[$scannedClassConstant])) {
+            return;
+        }
+
+        $violation = $this->testOnTargetVersion(
+            $this->classConstantCompatibilityMatrix[$scannedClassConstant]
+        );
+        if ($violation === null) {
+            return;
+        }
+
+        $this->addMessage(
+            $phpcsFile,
+            $stackPtr,
+            $scannedClassConstant,
+            $violation
+        );
+    }
+
+    /**
+     * Get the compatibility violation with the target PHP version.
+     *
+     * @param array $compatibilityMatrix Compatibility matrix for a class constant.
+     *
+     * @return array|null Found violation on the target PHP version.
+     */
+    private function testOnTargetVersion(array $compatibilityMatrix)
+    {
+        $violationTypeIds = array_keys($this->violationTypes);
+
+        foreach ($violationTypeIds as $violationTypeId) {
+            if (!isset($compatibilityMatrix[$violationTypeId])) {
+                continue;
+            }
+            if (ScannedCode::shouldRunOnOrAbove($compatibilityMatrix[$violationTypeId])) {
+                return $this->violationTypes[$violationTypeId];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Assemble available information into a user-facing message.
+     *
+     * @param File   $phpcsFile      The file being scanned.
+     * @param int    $stackPtr       Stack pointer
+     * @param string $scannedMethod  Method for which the violation was found.
+     * @param array  $foundViolation Found violation.
+     *
+     * @return void
+     */
+    private function addMessage(File $phpcsFile, $stackPtr, $scannedMethod, array $foundViolation)
+    {
+        $compatibilityMatrix = $this->classConstantCompatibilityMatrix[$scannedMethod];
+        $version             = $compatibilityMatrix[$foundViolation['type']];
+        $hasAlternative      = isset($compatibilityMatrix['alternative']);
+
+        $message = sprintf(
+            $foundViolation['messageTemplate'],
+            $scannedMethod,
+            $version
+        );
+
+        if ($hasAlternative) {
+            $message .= sprintf(' Use %s instead.', $compatibilityMatrix['alternative']);
+        }
+
+        $messageData = [
+            $scannedMethod,
+            $version,
+        ];
+
+        MessageHelper::addMessage(
+            $phpcsFile,
+            $message,
+            $stackPtr,
+            $foundViolation['isError'],
+            $foundViolation['errorCode'],
+            $messageData
+        );
+    }
+}

--- a/PHPCompatibility/Sniffs/Constants/RemovedClassConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedClassConstantsSniff.php
@@ -107,21 +107,21 @@ final class RemovedClassConstantsSniff extends Sniff
     {
         // We can't know runtime values, so tokens on each side of the double colon can only be strings for this sniff.
         $previousNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        $nextNonEmpty     = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
         if (!$previousNonEmpty || !$nextNonEmpty) {
             return;
         }
 
-        $tokens = $phpcsFile->getTokens();
+        $tokens           = $phpcsFile->getTokens();
         $previousIsString = $tokens[$previousNonEmpty]['code'] === \T_STRING;
-        $nextIsString = $tokens[$nextNonEmpty]['code'] === \T_STRING;
+        $nextIsString     = $tokens[$nextNonEmpty]['code'] === \T_STRING;
 
         if (!$previousIsString || !$nextIsString) {
             return;
         }
 
-        $previous = $tokens[$previousNonEmpty]['content'];
-        $next = $tokens[$nextNonEmpty]['content'];
+        $previous             = $tokens[$previousNonEmpty]['content'];
+        $next                 = $tokens[$nextNonEmpty]['content'];
         $scannedClassConstant = sprintf('%s::%s', $previous, $next);
 
         if (!isset($this->classConstantCompatibilityMatrix[$scannedClassConstant])) {

--- a/PHPCompatibility/Sniffs/Constants/RemovedClassConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/RemovedClassConstantsSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\Constants;
 
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\MessageHelper;
@@ -105,9 +106,23 @@ final class RemovedClassConstantsSniff extends Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         // We can't know runtime values, so tokens on each side of the double colon can only be strings for this sniff.
-        $classNamePointer     = $phpcsFile->findPrevious([T_STRING], $stackPtr - 1);
-        $constantNamePointer  = $phpcsFile->findNext([T_STRING], $stackPtr + 1);
-        $scannedClassConstant = $phpcsFile->getTokensAsString($classNamePointer, $constantNamePointer - $classNamePointer + 1);
+        $previousNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        if (!$previousNonEmpty || !$nextNonEmpty) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $previousIsString = $tokens[$previousNonEmpty]['code'] === \T_STRING;
+        $nextIsString = $tokens[$nextNonEmpty]['code'] === \T_STRING;
+
+        if (!$previousIsString || !$nextIsString) {
+            return;
+        }
+
+        $previous = $tokens[$previousNonEmpty]['content'];
+        $next = $tokens[$nextNonEmpty]['content'];
+        $scannedClassConstant = sprintf('%s::%s', $previous, $next);
 
         if (!isset($this->classConstantCompatibilityMatrix[$scannedClassConstant])) {
             return;

--- a/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.inc
@@ -6,6 +6,11 @@
 [NumberFormatter::NOT_THE_TARGET_CONSTANT, TYPE_CURRENCY]; // TYPE_CURRENCY is not a class constant of NumberFormatter
 [OtherClass::TYPE_CURRENCY]; // TYPE_CURRENCY is a constant of a different class
 NumberFormatter::TYPE_CURRENCY_ADDITIONAL_TEXT // Additional text after TYPE_CURRENCY makes it a different constant name
+case $NumberFormatter: TYPE_CURRENCY; // syntax containing single colon
+NumberFormatter::${$TYPE_CURRENCY}; // fetch static property using dynamic name
+NumberFormatter::{$TYPE_CURRENCY}(); // call static method using dynamic name
+$NumberFormatter::$TYPE_CURRENCY; // fetch static property using dynamic name from object's class
+$NumberFormatter::$TYPE_CURRENCY(); // call static method on object's class using explicit method name
 
 // Sniff's target: deprecated
 // @see RemovedClassConstantsUnitTest::dataDeprecatedConstants

--- a/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.inc
@@ -1,4 +1,20 @@
 <?php
 
-if ($formatType === NumberFormatter:: TYPE_CURRENCY) {}; // deprecated since PHP 8.3
-[NumberFormatter:: NOT_THE_TARGET_CONSTANT, TYPE_CURRENCY]; // misleading syntax, but not a match
+// Not sniff's target (examples below focus on NumberFormatter::TYPE_CURRENCY)
+// @see RemovedClassConstantsUnitTest::dataNoFalsePositives
+
+[NumberFormatter::NOT_THE_TARGET_CONSTANT, TYPE_CURRENCY]; // TYPE_CURRENCY is not a class constant of NumberFormatter
+[OtherClass::TYPE_CURRENCY]; // TYPE_CURRENCY is a constant of a different class
+NumberFormatter::TYPE_CURRENCY_ADDITIONAL_TEXT // Additional text after TYPE_CURRENCY makes it a different constant name
+
+// Sniff's target: deprecated
+// @see RemovedClassConstantsUnitTest::dataDeprecatedConstants
+// @see RemovedClassConstantsUnitTest::dataNoViolationsOnValidVersion
+
+NumberFormatter::
+    /* newline and comment between tokens */ TYPE_CURRENCY; // deprecated since PHP 8.3
+
+// Parse error / live coding
+// @see RemovedClassConstantsUnitTest::dataNoFalsePositives
+
+NumberFormatter::

--- a/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+if ($formatType === NumberFormatter::TYPE_CURRENCY) {}; // deprecated since PHP 8.3
+[NumberFormatter:: NOT_THE_TARGET_CONSTANT, TYPE_CURRENCY]; // misleading syntax, but not a match

--- a/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.inc
+++ b/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.inc
@@ -1,4 +1,4 @@
 <?php
 
-if ($formatType === NumberFormatter::TYPE_CURRENCY) {}; // deprecated since PHP 8.3
+if ($formatType === NumberFormatter:: TYPE_CURRENCY) {}; // deprecated since PHP 8.3
 [NumberFormatter:: NOT_THE_TARGET_CONSTANT, TYPE_CURRENCY]; // misleading syntax, but not a match

--- a/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.php
@@ -52,7 +52,7 @@ final class RemovedClassConstantsUnitTest extends BaseSniffTestCase
     public static function dataDeprecatedConstants()
     {
         return [
-            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 15],
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 20],
         ];
     }
 
@@ -85,6 +85,11 @@ final class RemovedClassConstantsUnitTest extends BaseSniffTestCase
             ['8.3', 'NumberFormatter::TYPE_CURRENCY', 6],
             ['8.3', 'NumberFormatter::TYPE_CURRENCY', 7],
             ['8.3', 'NumberFormatter::TYPE_CURRENCY', 8],
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 9],
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 10],
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 11],
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 12],
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 13],
         ];
     }
 
@@ -114,9 +119,7 @@ final class RemovedClassConstantsUnitTest extends BaseSniffTestCase
     {
         // The constant name is here for test readability purposes
         return [
-            ['8.2', 'NumberFormatter::TYPE_CURRENCY', 6],
-            ['8.2', 'NumberFormatter::TYPE_CURRENCY', 7],
-            ['8.2', 'NumberFormatter::TYPE_CURRENCY', 8],
+            ['8.2', 'NumberFormatter::TYPE_CURRENCY', 25],
         ];
     }
 }

--- a/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.php
@@ -28,7 +28,7 @@ final class RemovedClassConstantsUnitTest extends BaseSniffTestCase
     /**
      * Ensure a warning message when found in versions that deprecated the class constant.
      *
-     * @dataProvider dataDeprecated
+     * @dataProvider dataDeprecatedConstants
      *
      * @param string $version    Target version
      * @param string $constant   Class constant
@@ -36,7 +36,7 @@ final class RemovedClassConstantsUnitTest extends BaseSniffTestCase
      *
      * @return void
      */
-    public function testDeprecated($version, $constant, $lineNumber)
+    public function testDeprecatedConstants($version, $constant, $lineNumber)
     {
         $file            = $this->sniffFile(__FILE__, $version);
         $expectedMessage = sprintf('Class constant %s is deprecated since PHP %s.', $constant, $version);
@@ -47,43 +47,76 @@ final class RemovedClassConstantsUnitTest extends BaseSniffTestCase
      * Data provider.
      *
      * @return array
-     * @see    testDeprecated()
+     * @see    testDeprecatedConstants()
      */
-    public static function dataDeprecated()
+    public static function dataDeprecatedConstants()
     {
         return [
-            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 3],
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 15],
         ];
     }
 
     /**
-     * Ensure NO messages when found in supported versions.
      * Ensure NO false positives due to misleading syntax
      *
-     * @dataProvider dataNoViolations
+     * @dataProvider dataNoFalsePositives
      *
      * @param string $version    Target version
      * @param int    $lineNumber The line number of the violation
      *
      * @return void
      */
-    public function testNoViolations($version, $lineNumber)
+    public function testNoFalsePositives($version, $lineNumber)
     {
         $file = $this->sniffFile(__FILE__, $version);
         $this->assertNoViolation($file, $lineNumber);
     }
 
     /**
-     * Data provider.
+     * All versions are _invalid_ for the associated constants, but the snippet should not be picked up by the sniff.
      *
      * @return array
-     * @see    testNoViolations()
+     * @see    testNoFalsePositives()
      */
-    public static function dataNoViolations()
+    public static function dataNoFalsePositives()
     {
+        // The constant name is here for test readability purposes
         return [
-            ['8.2', 3],
-            ['8.3', 4],
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 6],
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 7],
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 8],
+        ];
+    }
+
+    /**
+     * Ensure NO messages when found in supported versions.
+     *
+     * @dataProvider dataNoViolationsOnValidVersion
+     *
+     * @param string $version    Target version
+     * @param int    $lineNumber The line number of the violation
+     *
+     * @return void
+     */
+    public function testNoViolationsOnValidVersion($version, $lineNumber)
+    {
+        $file = $this->sniffFile(__FILE__, $version);
+        $this->assertNoViolation($file, $lineNumber);
+    }
+
+    /**
+     * All versions are _valid_ for the associated constants, and the sniff shouldn't flag warnings or errors
+     *
+     * @return array
+     * @see    testNoViolationsOnValidVersion()
+     */
+    public static function dataNoViolationsOnValidVersion()
+    {
+        // The constant name is here for test readability purposes
+        return [
+            ['8.2', 'NumberFormatter::TYPE_CURRENCY', 6],
+            ['8.2', 'NumberFormatter::TYPE_CURRENCY', 7],
+            ['8.2', 'NumberFormatter::TYPE_CURRENCY', 8],
         ];
     }
 }

--- a/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.php
@@ -18,7 +18,7 @@ use PHPCompatibility\Tests\BaseSniffTestCase;
  * @group removedClassConstants
  * @group constants
  *
- * @covers \PHPCompatibility\Sniffs\Constants\RemovedClassConstants
+ * @covers \PHPCompatibility\Sniffs\Constants\RemovedClassConstantsSniff
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.php
+++ b/PHPCompatibility/Tests/Constants/RemovedClassConstantsUnitTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Constants;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedClassConstants sniff.
+ *
+ * @group removedClassConstants
+ * @group constants
+ *
+ * @covers \PHPCompatibility\Sniffs\Constants\RemovedClassConstants
+ *
+ * @since 10.0.0
+ */
+final class RemovedClassConstantsUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Ensure a warning message when found in versions that deprecated the class constant.
+     *
+     * @dataProvider dataDeprecated
+     *
+     * @param string $version    Target version
+     * @param string $constant   Class constant
+     * @param int    $lineNumber The line number of the violation
+     *
+     * @return void
+     */
+    public function testDeprecated($version, $constant, $lineNumber)
+    {
+        $file            = $this->sniffFile(__FILE__, $version);
+        $expectedMessage = sprintf('Class constant %s is deprecated since PHP %s.', $constant, $version);
+        $this->assertWarning($file, $lineNumber, $expectedMessage);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     * @see    testDeprecated()
+     */
+    public static function dataDeprecated()
+    {
+        return [
+            ['8.3', 'NumberFormatter::TYPE_CURRENCY', 3],
+        ];
+    }
+
+    /**
+     * Ensure NO messages when found in supported versions.
+     * Ensure NO false positives due to misleading syntax
+     *
+     * @dataProvider dataNoViolations
+     *
+     * @param string $version    Target version
+     * @param int    $lineNumber The line number of the violation
+     *
+     * @return void
+     */
+    public function testNoViolations($version, $lineNumber)
+    {
+        $file = $this->sniffFile(__FILE__, $version);
+        $this->assertNoViolation($file, $lineNumber);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     * @see    testNoViolations()
+     */
+    public static function dataNoViolations()
+    {
+        return [
+            ['8.2', 3],
+            ['8.3', 4],
+        ];
+    }
+}


### PR DESCRIPTION
Part of this effort: https://github.com/PHPCompatibility/PHPCompatibility/issues/1849

Adding a sniff for removed/deprecated class constants `NumberFormatter::TYPE_CURRENCY`. This is different from bare constants like `MCRYPT_MODE_CFB`.

Implemented in a similar fashion to `RemovedMagicMethods`.

- Message depends on deprecation status: `Class constant NumberFormatter::TYPE_CURRENCY is deprecated since PHP 8.3.`.
- Message depends on deprecation status: `SoftDeprecated` , `Deprecated` and `Removed`.
- Added a test with potentially confusing syntax to ensure no false positives.
- Assumed 10.0.0 target release.
- Since we don't deal with runtime values, the check is a simple string on each side of the double colon, allowing of empty characters.