### PR TITLE
Composer: update to PHPCSDevCS 1.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5 # Set to 0 to (temporarily) disable.
-    versioning-strategy: widen
-    commit-message:
-      prefix: "Composer:"
-      include: "scope"
-    labels:
-      - "chores/QA"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: 'Composer: adjust dependencies'
         run: |
-          # Using PHPCS `3.x` as an early detection system for bugs upstream.
-          # This should be changed to 4.x, but we'll need to wait for PHPCSDevCS to be compatible with 4.x.
-          composer require --no-update squizlabs/php_codesniffer:"3.x-dev" --no-interaction
+          # Using PHPCS `4.x` as an early detection system for bugs upstream.
+          composer require --no-update squizlabs/php_codesniffer:"4.x-dev" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -73,7 +73,7 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 
@@ -299,7 +299,7 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
 
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 

--- a/PHPCompatibility/Helpers/ComplexVersionDeprecatedRemovedFeatureTrait.php
+++ b/PHPCompatibility/Helpers/ComplexVersionDeprecatedRemovedFeatureTrait.php
@@ -62,7 +62,7 @@ trait ComplexVersionDeprecatedRemovedFeatureTrait
      *                  from the $itemArray or an empty string if the value for a key was unavailable
      *                  or could not be determined.
      */
-    protected function getVersionInfo(array $itemArray)
+    final protected function getVersionInfo(array $itemArray)
     {
         $versionInfo = [
             'deprecated'  => '',
@@ -100,7 +100,7 @@ trait ComplexVersionDeprecatedRemovedFeatureTrait
      *
      * @return array<string, string|array>
      */
-    protected function getMessageInfo($itemName, $itemBaseCode, array $versionInfo)
+    final protected function getMessageInfo($itemName, $itemBaseCode, array $versionInfo)
     {
         $message   = $this->msgTemplate;
         $errorCode = MessageHelper::stringToErrorCode($itemBaseCode, true);

--- a/PHPCompatibility/Helpers/ComplexVersionNewFeatureTrait.php
+++ b/PHPCompatibility/Helpers/ComplexVersionNewFeatureTrait.php
@@ -49,7 +49,7 @@ trait ComplexVersionNewFeatureTrait
      * @return string[] Array with a single key `'not_in_version'` with as the value, a PHP version number
      *                  as a string or an empty string if the version number could not be determined.
      */
-    protected function getVersionInfo(array $itemArray)
+    final protected function getVersionInfo(array $itemArray)
     {
         $versionInfo = [
             'not_in_version' => '',
@@ -79,7 +79,7 @@ trait ComplexVersionNewFeatureTrait
      *
      * @return array<string, string|array>
      */
-    protected function getMessageInfo($itemName, $itemBaseCode, array $versionInfo)
+    final protected function getMessageInfo($itemName, $itemBaseCode, array $versionInfo)
     {
         return [
             'message'   => $this->msgTemplate,

--- a/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
+++ b/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
@@ -83,7 +83,7 @@ trait HashAlgorithmsTrait
      * @return string|false The algorithm name without quotes if this was a relevant hash
      *                      function call or false if it was not.
      */
-    public function getHashAlgorithmParameter($functionName, array $parameters)
+    final public function getHashAlgorithmParameter($functionName, array $parameters)
     {
         // Get the parameter which should contain the algorithm name from the parameter stack.
         $functionNameLc = \strtolower($functionName);

--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -71,7 +71,7 @@ trait PCRERegexTrait
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the $paramInfo passed is invalid.
      */
-    public function getRegexPatternsFromParameter(File $phpcsFile, $functionName, array $paramInfo)
+    final public function getRegexPatternsFromParameter(File $phpcsFile, $functionName, array $paramInfo)
     {
         if (isset($paramInfo['start'], $paramInfo['end']) === false) {
             throw new RuntimeException(
@@ -148,7 +148,7 @@ trait PCRERegexTrait
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the $patternInfo passed is invalid.
      */
-    protected function getRegexModifiers(File $phpcsFile, array $patternInfo)
+    final protected function getRegexModifiers(File $phpcsFile, array $patternInfo)
     {
         if (isset($patternInfo['start'], $patternInfo['end']) === false) {
             throw new RuntimeException(

--- a/PHPCompatibility/Helpers/TokenGroup.php
+++ b/PHPCompatibility/Helpers/TokenGroup.php
@@ -242,12 +242,10 @@ final class TokenGroup
                 } else {
                     $content = (float) \trim($intMatch[0]);
                 }
+            } elseif ($intString !== 1 && $floatString !== 1) {
+                $content = 0.0;
             } else {
-                if ($intString !== 1 && $floatString !== 1) {
-                    $content = 0.0;
-                } else {
-                    $content = ($floatString === 1) ? (float) \trim($floatMatch[0]) : (float) \trim($intMatch[0]);
-                }
+                $content = ($floatString === 1) ? (float) \trim($floatMatch[0]) : (float) \trim($intMatch[0]);
             }
 
             // Allow for different behaviour for hex numeric strings between PHP 5 vs PHP 7.

--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1781,7 +1781,7 @@ final class NewClassesSniff extends Sniff
      */
     private function processUseToken(File $phpcsFile, $stackPtr)
     {
-        if (!UseStatements::isImportUse($phpcsFile, $stackPtr)) {
+        if (UseStatements::isImportUse($phpcsFile, $stackPtr) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -361,7 +361,7 @@ final class NewTypedPropertiesSniff extends Sniff
     }
 
 
-   /**
+    /**
      * Handle the retrieval of relevant information and - if necessary - throwing of an
      * error for a matched item.
      *

--- a/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedClassesSniff.php
@@ -618,7 +618,7 @@ final class RemovedClassesSniff extends Sniff
      */
     private function processUseToken(File $phpcsFile, $stackPtr)
     {
-        if (!UseStatements::isImportUse($phpcsFile, $stackPtr)) {
+        if (UseStatements::isImportUse($phpcsFile, $stackPtr) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -145,7 +145,7 @@ final class InternalInterfacesSniff extends Sniff
         foreach ($interfaces as $interface) {
             $interface   = \ltrim($interface, '\\');
             $interfaceLc = \strtolower($interface);
-            if (isset($targets[$interfaceLc]) && ! isset($this->importedDeclarations[$interfaceLc])) {
+            if (isset($targets[$interfaceLc]) && isset($this->importedDeclarations[$interfaceLc]) === false) {
                 $error     = 'The interface %s %s';
                 $errorCode = MessageHelper::stringToErrorCode($interfaceLc) . 'Found';
                 $data      = [
@@ -174,7 +174,7 @@ final class InternalInterfacesSniff extends Sniff
      */
     private function processUseToken(File $phpcsFile, $stackPtr)
     {
-        if (!UseStatements::isImportUse($phpcsFile, $stackPtr)) {
+        if (UseStatements::isImportUse($phpcsFile, $stackPtr) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/NewInterfacesSniff.php
@@ -617,7 +617,7 @@ final class NewInterfacesSniff extends Sniff
      */
     private function processUseToken(File $phpcsFile, $stackPtr)
     {
-        if (!UseStatements::isImportUse($phpcsFile, $stackPtr)) {
+        if (UseStatements::isImportUse($phpcsFile, $stackPtr) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -488,11 +488,9 @@ final class ForbiddenNamesSniff extends Sniff
                         $this->checkOtherName($phpcsFile, $i, $part, 'namespace declaration');
                     }
                 }
-            } else {
-                if ($this->isKeywordReservedPriorToPHP8($tokens[$i]['content']) === true) {
-                    $this->checkName($phpcsFile, $i, $tokens[$i]['content']);
-                    $this->checkOtherName($phpcsFile, $i, $tokens[$i]['content'], 'namespace declaration');
-                }
+            } elseif ($this->isKeywordReservedPriorToPHP8($tokens[$i]['content']) === true) {
+                $this->checkName($phpcsFile, $i, $tokens[$i]['content']);
+                $this->checkOtherName($phpcsFile, $i, $tokens[$i]['content'], 'namespace declaration');
             }
         }
     }

--- a/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
@@ -171,8 +171,8 @@ final class ValidIntegersSniff extends Sniff
     {
         // For invalid explicit octal, we need to also check the next token.
         if (($numberInfo['content'] === '0'
-             && \strtolower($tokens[($stackPtr + 1)]['content'][0]) === 'o')
-             || \stripos($numberInfo['content'], '0o') === 0
+            && \strtolower($tokens[($stackPtr + 1)]['content'][0]) === 'o')
+            || \stripos($numberInfo['content'], '0o') === 0
         ) {
             if (\preg_match('`^(?:[o_][0-7_]*)?[8-9]+[_0-9]*$`iD', $tokens[($stackPtr + 1)]['content']) === 1) {
                 return $tokens[$stackPtr]['content'] . $tokens[($stackPtr + 1)]['content'];

--- a/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
+++ b/PHPCompatibility/Tests/InitialValue/NewConstantScalarExpressionsUnitTest.php
@@ -229,7 +229,7 @@ final class NewConstantScalarExpressionsUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
-        if (PHP_VERSION_ID < 50500 || PHP_VERSION_ID >= 50600) {
+        if (\PHP_VERSION_ID < 50500 || \PHP_VERSION_ID >= 50600) {
             // Skip one particular test on PHP 5.5 as it just keeps being problematic.
             for ($line = 79; $line <= 87; $line++) {
                 $data[] = [$line];

--- a/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
+++ b/PHPCompatibility/Tests/TypeCasts/RemovedTypeCastsUnitTest.php
@@ -70,7 +70,7 @@ final class RemovedTypeCastsUnitTest extends BaseSniffTestCase
     }
 
 
-   /**
+    /**
      * testDeprecatedRemovedTypeCastWithAlternative
      *
      * @dataProvider dataDeprecatedRemovedTypeCastWithAlternative

--- a/PHPCompatibility/Util/Tests/Helpers/DisableSniffMsgUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/DisableSniffMsgUnitTest.php
@@ -35,7 +35,7 @@ final class DisableSniffMsgUnitTest extends TestCase
         $expectedPattern = '`' . \PHP_EOL . \PHP_EOL
             . 'To disable this notice, add --exclude=Stnd\.Cat\.Sniff to your command or'
             . ' add <exclude name="Stnd\.Cat\.Sniff\.Code"/> to your custom ruleset\.'
-             . \PHP_EOL . \PHP_EOL
+            . \PHP_EOL . \PHP_EOL
             . 'Thank you for using PHPCompatibility!`';
 
         $result = DisableSniffMsg::create('Stnd.Cat.Sniff', 'Code');

--- a/PHPCompatibility/Util/Tests/Helpers/TokenGroup/IsNumberUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/TokenGroup/IsNumberUnitTest.php
@@ -131,6 +131,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
      */
     public static function dataIsNumber()
     {
+        // phpcs:disable Universal.WhiteSpace.PrecisionAlignment.Found -- to allow for a few array entries with really long names.
         return [
             'Not a number - array'                                             => ['/* test 1 */', true, false, false, false],
             'Not a number - variable'                                          => ['/* test 2 */', true, false, false, false],
@@ -268,6 +269,7 @@ final class IsNumberUnitTest extends UtilityMethodTestCase
             'Evals to float, incl floats: + sign with text string'             => ['/* test F11 */', true, 0.123, true, false],
             'Evals to float, incl floats: PHP 7.4+ underscore number'          => ['/* test F12 */', true, 0.123, true, false],
         ];
+        // phpcs:enable
     }
 
     /**

--- a/bin/generate-forbidden-names-test-files
+++ b/bin/generate-forbidden-names-test-files
@@ -115,7 +115,7 @@ $otherInvalidNames = [
     // Soft reserved.
     'resource' => '7.0',
     'numeric'  => '7.0',
-    'enum'     => '8.1'
+    'enum'     => '8.1',
 ];
 
 // The "other" reserved names are fine to use for function or constant names, so should only be injected in select tests.
@@ -289,7 +289,7 @@ $tests = [
         return "use My\NS\{ const FOOBAR as $name, };\n";
     },
     'class-use-trait-alias-method'           => function ($name) {
-        if (in_array($name, array('public', 'protected', 'private', 'final'), true) === true) {
+        if (in_array($name, ['public', 'protected', 'private', 'final'], true) === true) {
             return '';
         } else {
             return "class Foobar { use BazTrait { oldfunction as $name; } }\n";
@@ -297,11 +297,7 @@ $tests = [
     },
 ];
 
-$path = realpath(dirname(__DIR__))
-    . DIRECTORY_SEPARATOR . 'PHPCompatibility'
-    . DIRECTORY_SEPARATOR . 'Tests'
-    . DIRECTORY_SEPARATOR . 'Keywords'
-    . DIRECTORY_SEPARATOR . 'ForbiddenNames';
+$path = realpath(dirname(__DIR__) . '/PHPCompatibility/Tests/Keywords/ForbiddenNames');
 
 foreach ($tests as $name => $callback) {
     $filename = $path . DIRECTORY_SEPARATOR . $name . '.inc';

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "php-parallel-lint/php-parallel-lint": "^1.4.0",
     "php-parallel-lint/php-console-highlighter": "^1.0.0",
     "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.5.32 || ^11.3.3",
-    "phpcsstandards/phpcsdevcs": "^1.1.6",
+    "phpcsstandards/phpcsdevcs": "^1.2.0",
     "phpcsstandards/phpcsdevtools": "^1.2.3",
     "yoast/phpunit-polyfills": "^1.1.5 || ^2.0.5 || ^3.1.0"
   },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,6 +11,8 @@
     -->
 
     <file>.</file>
+    <!-- Files without extension need to be explicitly requested for scan. -->
+    <file>./bin/generate-forbidden-names-test-files</file>
 
     <!-- Exclude Composer vendor directory. -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
@@ -54,11 +56,7 @@
         <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
         <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
 
-        <!-- Allow for the file docblock on the line directly following the PHP open tag.
-             As the sniff in PHPCS does not use modular error codes (yet - see upstream PR #2729),
-             the complete error code needs to be disabled, not just the bit involving
-             the file docblocks.
-        -->
+        <!-- Only needed for PHPCS 3.x. This exclusion can be removed when PHPCSDevCS drops support for PHPCS 3.x. -->
         <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
 
         <!-- All nice and good, but too much of a fuss for the outer array of nested arrays. -->
@@ -86,6 +84,11 @@
 
     <rule ref="PHPCompatibility.Attributes.NewAttributes.PHPUnitAttributeFound">
         <exclude-pattern>*/PHPCompatibility/Tests/BaseSniffTestCase\.php$</exclude-pattern>
+    </rule>
+
+    <!-- Disregard this rule in code which doesn't need to be tested (or rather: generates test code). -->
+    <rule ref="Universal.FunctionDeclarations.NoLongClosures.ExceedsMaximum">
+        <exclude-pattern>/bin/generate-forbidden-names-test-files$</exclude-pattern>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
### Composer: update to PHPCSDevCS 1.2.0

PHPCSDevCS now allows for PHPCS 4.0 and includes PHPCompatibility 10.0.0-alpha1 and a range of sniffs from PHPCSExtra.

This also means that we can now scan files without a file extension (if explicitly requested), so the `bin` script can now be scanned.

Includes minor documentation update in the ruleset.
Includes adding one selective exclusion to the ruleset.
Includes various small CS fixes.

Refs:
* https://github.com/PHPCSStandards/PHPCSDevCS/releases/tag/1.2.0
* squizlabs/PHP_CodeSniffer#2916
* PHPCSStandards/PHP_CodeSniffer#1022

### GH Actions: run CS check against PHPCS 4.x dev 

### Dependabot: remove `composer` ecosystem

Dependabot has basically _never_ submitted any useful PRs updating the dependencies managed via Composer.

In most cases, it wouldn't be able to anyway as the "widen" strategy only really causes update PRs when a new major of a dependency is released and with a new major of a dependency, we'll generally need to do a managed update, so wouldn't be able to use the Dependabot PR anyhow.

On top of that, it appears to be completely impossible to set any environment variables for the running of Dependabot via GH Actions.

This is problematic as we will have a circular dependency via the `phpcsstandards/phpcsdevcs` package once this update to PHPCSDevCS 1.2.0 would be merged and the only way to get round that is to set a `COMPOSER_ROOT_VERSION` environment variable.

In practice, this means that updating to PHPCSDevCS 1.2.0 will cause the action runs for Dependabot to fail, which is not useful.

All in all, I see no upside to continue to have Dependabot enabled for the Composer packages.