### PR TITLE
Composer: remove roave/security-advisories suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,9 +42,6 @@
   "replace": {
     "wimg/php-compatibility": "*"
   },
-  "suggest": {
-    "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-  },
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true


### PR DESCRIPTION
The `roave/security-advisories` package was an inventive method to block installation of known insecure versions of other dependencies (via a `conflict` annotation).

As of Composer 2.9, using the `roave/security-advisories` package for this purpose is no longer needed as Composer will now natively block installation of known insecure versions of dependencies.

Refs:
* https://blog.packagist.com/composer-2-9/
* https://github.com/composer/composer/releases/tag/2.9.0