### PR TITLE
Classes/RemovedOrphanedParent: remove redundant code snippet

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -83,20 +83,6 @@ final class RemovedOrphanedParentSniff extends Sniff
             }
         }
 
-        /*
-         * Work round a tokenizer issue in PHPCS < 3.8.0 (?) where a call to a global
-         * `parent()` function would tokenize the `parent` function call label as `T_PARENT`.
-         * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3797
-         */
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($tokens[$prev]['code'] !== \T_NEW
-            && $next !== false
-            && $tokens[$next]['code'] === \T_OPEN_PARENTHESIS
-        ) {
-            return;
-        }
-
         $error = 'Using "parent" inside %s is deprecated since PHP 7.4';
         $data  = ['a class without parent'];
 


### PR DESCRIPTION
Support for PHPCS < 3.8.0 was dropped quite a while ago, so this work-around is moot.
