### PR TITLE
Drop support for PHPCS < 4.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To start contributing, fork the repository, create a new branch in your fork, ma
 Please make sure that your pull request contains unit tests covering what's being addressed by it.
 
 * All new sniffs should be accompanied by an XML documentation file describing the change in PHP.
-* All code should be compatible with PHP_CodeSniffer >= 3.13.3 _(checked in CI)_.
+* All code should be compatible with PHP_CodeSniffer >= 4.0.0 _(checked in CI)_.
 * All code should be compatible with PHP 7.2 to PHP nightly _(checked in CI)_.
 * Try and avoid code duplication by using the utility functions from [PHPCSUtils] whenever relevant.
 * All code should comply with the PHPCompatibility coding standards _(checked in CI)_.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -33,9 +33,9 @@ jobs:
     strategy:
       matrix:
         php: ['7.2', 'latest']
-        phpcs_version: ['lowest', '3.x-dev', '4.0.0', '4.x-dev']
+        phpcs_version: ['lowest', '4.x-dev']
 
-    name: "QTest${{ matrix.phpcs_version == '3.x-dev' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
+    name: "QTest${{ matrix.phpcs_version == '4.x-dev' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
     steps:
       - name: Checkout code
@@ -63,7 +63,7 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS "lowest".
+      # Remove PHPCSDevCS as it could potentially prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 
@@ -88,7 +88,7 @@ jobs:
         run: composer update squizlabs/php_codesniffer phpcsstandards/phpcsutils --prefer-lowest --no-scripts --no-interaction
 
       - name: Lint against parse errors
-        if: ${{ matrix.phpcs_version == '3.x-dev' }}
+        if: ${{ matrix.phpcs_version == '4.x-dev' }}
         run: composer lint
 
       - name: Grab PHPUnit version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,12 +92,12 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        phpcs_version: ['lowest', '3.x-dev', '4.0.0', '4.x-dev']
+        phpcs_version: ['lowest', '4.x-dev']
         experimental: [false]
 
         include:
           - php: '7.2'
-            phpcs_version: '^3.13.3'
+            phpcs_version: '^4.0.0'
             custom_ini: true
             experimental: false
 
@@ -107,10 +107,6 @@ jobs:
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-          - php: '8.6' # Nightly.
-            phpcs_version: '3.x-dev'
-            experimental: true
-
           - php: '8.6' # Nightly.
             phpcs_version: '4.x-dev'
             experimental: true
@@ -154,7 +150,7 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS "lowest".
+      # Remove PHPCSDevCS as it could potentially prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 
@@ -220,23 +216,14 @@ jobs:
           - php: '8.5'
             phpcs_version: '4.x-dev'
           - php: '8.5'
-            phpcs_version: '4.0.0'
-          - php: '8.5'
-            phpcs_version: '3.x-dev'
-            custom_ini: true
-          - php: '8.5'
             phpcs_version: 'lowest'
+            custom_ini: true
 
           - php: '7.2'
             phpcs_version: '4.x-dev'
             custom_ini: true
           - php: '7.2'
-            phpcs_version: '4.0.0'
-          - php: '7.2'
-            phpcs_version: '3.x-dev'
-          - php: '7.2'
             phpcs_version: 'lowest'
-            custom_ini: true
 
     name: "Coverage: PHP ${{ matrix.php }}${{ matrix.custom_ini && ' (ini)' || '' }} - PHPCS ${{ matrix.phpcs_version }}"
 
@@ -275,7 +262,7 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
 
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS "lowest".
+      # Remove PHPCSDevCS as it could potentially prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 

--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -13,10 +13,8 @@
  */
 
 /*
- * Alias a number of PHPCS 3.x classes to their PHPCS 2.x equivalents.
- *
- * This file is auto-loaded by PHPCS 3.x before any sniffs are loaded
- * through the PHPCS 3.x `<autoload>` ruleset directive.
+ * This file is auto-loaded by PHPCS before any sniffs are loaded
+ * through the PHPCS `<autoload>` ruleset directive.
  */
 if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
     define('PHPCOMPATIBILITY_PHPCS_ALIASES_SET', true);

--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -136,21 +136,9 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
                     // Not a call to a PHP method.
                     return;
                 }
-            } else {
-                if (isset($this->ignoreTokens[$tokens[$prevNonEmpty]['code']]) === true) {
-                    // Not a call to a PHP function.
-                    return;
-                }
-
-                if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
-                    $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
-                    if ($tokens[$prevPrevToken]['code'] === \T_STRING
-                        || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
-                    ) {
-                        // Namespaced function.
-                        return;
-                    }
-                }
+            } elseif (isset($this->ignoreTokens[$tokens[$prevNonEmpty]['code']]) === true) {
+                // Not a call to a PHP function.
+                return;
             }
         }
 

--- a/PHPCompatibility/Helpers/MiscHelper.php
+++ b/PHPCompatibility/Helpers/MiscHelper.php
@@ -98,20 +98,6 @@ final class MiscHelper
             return false;
         }
 
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-        if ($tokens[$prev]['code'] === \T_NS_SEPARATOR) {
-            $prevPrev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
-            if ($tokens[$prevPrev]['code'] === \T_STRING
-                || $tokens[$prevPrev]['code'] === \T_NAMESPACE
-            ) {
-                // Namespaced constant on PHPCS 3.x.
-                return false;
-            }
-
-            // If not a namespaced constant, skip over the NS separator when looking at the "previous" token.
-            $prev = $prevPrev;
-        }
-
         // Array of tokens which if found preceding the $stackPtr indicate that a T_STRING is not a global constant.
         $tokensToIgnore  = [
             \T_NAMESPACE             => true,
@@ -133,6 +119,7 @@ final class MiscHelper
         $tokensToIgnore += Collections::objectOperators();
         $tokensToIgnore += Tokens::$scopeModifiers;
 
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if (isset($tokensToIgnore[$tokens[$prev]['code']]) === true) {
             // Not the use of a constant.
             return false;

--- a/PHPCompatibility/Helpers/TokenGroup.php
+++ b/PHPCompatibility/Helpers/TokenGroup.php
@@ -156,9 +156,7 @@ final class TokenGroup
             return false;
         }
 
-        $skipOver                  = Tokens::$emptyTokens;
-        $skipOver[\T_NS_SEPARATOR] = \T_NS_SEPARATOR;
-        $nextNonEmpty              = $phpcsFile->findNext($skipOver, $start, $searchEnd, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $start, $searchEnd, true);
         while ($nextNonEmpty !== false
             && ($tokens[$nextNonEmpty]['code'] === \T_PLUS
             || $tokens[$nextNonEmpty]['code'] === \T_MINUS)
@@ -167,7 +165,7 @@ final class TokenGroup
                 $negativeNumber = ($negativeNumber === false) ? true : false;
             }
 
-            $nextNonEmpty = $phpcsFile->findNext($skipOver, ($nextNonEmpty + 1), $searchEnd, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), $searchEnd, true);
         }
 
         if ($nextNonEmpty === false || isset($maybeValidTokens[$tokens[$nextNonEmpty]['code']]) === false) {

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -387,7 +387,7 @@ final class NewAttributesSniff extends Sniff
                 continue;
             }
 
-            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']])) {
+            if (isset(Collections::nameTokens()[$tokens[$i]['code']])) {
                 $currentName .= $tokens[$i]['content'];
 
                 if (isset($startsAt) === false) {

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -39,16 +39,12 @@ final class NewLateStaticBindingSniff extends Sniff
      * Returns an array of tokens this test wants to listen for.
      *
      * @since 7.0.3
-     * @since 10.0.0 Now also sniffs for `T_STRING`.
      *
      * @return array<int|string>
      */
     public function register()
     {
-        return [
-            \T_STATIC,
-            \T_STRING,
-        ];
+        return [\T_STATIC];
     }
 
 
@@ -68,38 +64,18 @@ final class NewLateStaticBindingSniff extends Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        switch ($tokens[$stackPtr]['code']) {
-            case \T_STRING:
-                // PHPCS 3.x changes T_STATIC to T_STRING when used with instanceof.
-                if ($tokens[$stackPtr]['content'] !== 'static') {
-                    return;
-                }
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        if ($nextNonEmpty === false) {
+            return;
+        }
 
-                $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-                if ($prevNonEmpty === false
-                    || $tokens[$prevNonEmpty]['code'] !== \T_INSTANCEOF
-                ) {
-                    return;
-                }
-
-                break;
-
-            case \T_STATIC:
-                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
-                if ($nextNonEmpty === false) {
-                    return;
-                }
-
-                if ($tokens[$nextNonEmpty]['code'] !== \T_DOUBLE_COLON) {
-                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
-                    if ($tokens[$prevNonEmpty]['code'] !== \T_NEW
-                        && $tokens[$prevNonEmpty]['code'] !== \T_INSTANCEOF // PHPCS 4.x.
-                    ) {
-                        return;
-                    }
-                }
-
-                break;
+        if ($tokens[$nextNonEmpty]['code'] !== \T_DOUBLE_COLON) {
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+            if ($tokens[$prevNonEmpty]['code'] !== \T_NEW
+                && $tokens[$prevNonEmpty]['code'] !== \T_INSTANCEOF
+            ) {
+                return;
+            }
         }
 
         $inClass = Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -99,7 +99,7 @@ final class NewMagicClassConstantSniff extends Sniff
 
         $preSubjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($subjectPtr - 1), null, true);
         if (isset(Collections::ooHierarchyKeywords()[$tokens[$subjectPtr]['code']]) === true
-            || (isset(Collections::namespacedNameTokens()[$tokens[$subjectPtr]['code']]) === true
+            || (isset(Collections::nameTokens()[$tokens[$subjectPtr]['code']]) === true
                 && isset(Collections::objectOperators()[$tokens[$preSubjectPtr]['code']]) === false)
         ) {
             // This is a syntax which is supported on PHP 5.5 and higher.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
@@ -90,21 +90,15 @@ final class NewTrailingCommaSniff extends Sniff
         }
 
         $usePtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($closer + 1), null, true);
-        if ($usePtr === false || $tokens[$usePtr]['code'] !== \T_USE) {
+        if ($usePtr === false
+            || $tokens[$usePtr]['code'] !== \T_USE
+            || isset($tokens[$usePtr]['parenthesis_closer']) === false
+        ) {
             // Closure without use list or live coding/parse error.
             return;
         }
 
-        $openParens = $phpcsFile->findNext(Tokens::$emptyTokens, ($usePtr + 1), null, true);
-        if ($openParens === false
-            || $tokens[$openParens]['code'] !== \T_OPEN_PARENTHESIS
-            || isset($tokens[$openParens]['parenthesis_closer']) === false
-        ) {
-            // Live coding/parse error.
-            return;
-        }
-
-        $closer            = $tokens[$openParens]['parenthesis_closer'];
+        $closer            = $tokens[$usePtr]['parenthesis_closer'];
         $lastInParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), null, true);
 
         if ($tokens[$lastInParenthesis]['code'] === \T_COMMA) {

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -386,16 +386,12 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 }
 
                 // Ignore use of any of the passed parameters in isset() or empty().
-                if ($tokens[$j]['code'] === \T_ISSET
-                    || $tokens[$j]['code'] === \T_EMPTY
+                if (($tokens[$j]['code'] === \T_ISSET
+                    || $tokens[$j]['code'] === \T_EMPTY)
+                    && isset($tokens[$j]['parenthesis_closer'])
                 ) {
-                    $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($j + 1), null, true);
-                    if ($nextNonEmpty !== false
-                        && isset($tokens[$nextNonEmpty]['parenthesis_closer'])
-                    ) {
-                        $j = $tokens[$nextNonEmpty]['parenthesis_closer'];
-                        continue;
-                    }
+                    $j = $tokens[$j]['parenthesis_closer'];
+                    continue;
                 }
 
                 // Keep track of the long/short lists structures seen.

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -680,16 +680,6 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
             return false;
         }
 
-        if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
-            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
-            if ($tokens[$prevPrevToken]['code'] === \T_STRING
-                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
-            ) {
-                // Namespaced function.
-                return false;
-            }
-        }
-
         return true;
     }
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -124,14 +124,6 @@ final class ArgumentFunctionsUsageSniff extends Sniff
         if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
             // Not a call to a PHP function.
             return;
-        } elseif ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
-            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
-            if ($tokens[$prevPrevToken]['code'] === \T_STRING
-                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
-            ) {
-                // Namespaced function on PHPCS 3.x.
-                return;
-            }
         }
 
         $data = [$tokens[$stackPtr]['content']];

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5323,16 +5323,6 @@ final class NewFunctionsSniff extends Sniff
             // Not a call to a PHP function.
             return;
 
-        } elseif ($tokens[$stackPtr]['code'] === \T_STRING
-            && $tokens[$prevToken]['code'] === \T_NS_SEPARATOR
-        ) {
-            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
-            if ($tokens[$prevPrevToken]['code'] === \T_STRING
-                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
-            ) {
-                // Namespaced function.
-                return;
-            }
         }
 
         $itemInfo = [

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5792,16 +5792,6 @@ final class RemovedFunctionsSniff extends Sniff
             // Not a call to a PHP function.
             return;
 
-        } elseif ($tokens[$stackPtr]['code'] === \T_STRING
-            && $tokens[$prevToken]['code'] === \T_NS_SEPARATOR
-        ) {
-            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
-            if ($tokens[$prevPrevToken]['code'] === \T_STRING
-                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
-            ) {
-                // Namespaced function.
-                return;
-            }
         }
 
         $itemInfo = [

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -67,9 +67,6 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
         \T_TRUE                     => \T_TRUE,
         \T_FALSE                    => \T_FALSE,
         \T_NULL                     => \T_NULL,
-
-        // Special cases:
-        \T_NS_SEPARATOR             => \T_NS_SEPARATOR,
     ];
 
 
@@ -185,18 +182,12 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
 
                 return false;
 
-            case \T_NAMESPACE:
             case \T_PARENT:
             case \T_SELF:
             case \T_DOUBLE_COLON:
                 $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonSimple + 1), ($end + 1), true);
 
-                if ($tokens[$nextNonSimple]['code'] === \T_NAMESPACE) {
-                    // Allow only `namespace\...`.
-                    if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_NS_SEPARATOR) {
-                        return false;
-                    }
-                } elseif ($tokens[$nextNonSimple]['code'] === \T_PARENT
+                if ($tokens[$nextNonSimple]['code'] === \T_PARENT
                     || $tokens[$nextNonSimple]['code'] === \T_SELF
                 ) {
                     // Allow only `parent::` and `self::`.

--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
@@ -136,7 +136,7 @@ final class NewNewInInitializersSniff extends AbstractInitialValueSniff
 
         $data = [$phrase];
 
-        $allowedNameTokens            = Collections::namespacedNameTokens();
+        $allowedNameTokens            = Collections::nameTokens();
         $allowedNameTokens[\T_SELF]   = \T_SELF;
         $allowedNameTokens[\T_PARENT] = \T_PARENT;
 

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -19,7 +19,6 @@ use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\Constants;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\MessageHelper;
-use PHPCSUtils\Utils\Namespaces;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\Scopes;
@@ -303,7 +302,6 @@ final class ForbiddenNamesSniff extends Sniff
                         || $tokens[$prevNonEmpty]['code'] === \T_TRAIT
                         || $tokens[$prevNonEmpty]['code'] === \T_EXTENDS
                         || $tokens[$prevNonEmpty]['code'] === \T_IMPLEMENTS
-                        || $tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR
                     ) {
                         // Use of a construct named `enum`, not an enum declaration.
                         return;
@@ -419,18 +417,6 @@ final class ForbiddenNamesSniff extends Sniff
      */
     protected function processNamespaceDeclaration(File $phpcsFile, $stackPtr)
     {
-        /*
-         * Note: explicitly only excluding use of the keyword as an operator, not the "undetermined"
-         * type, as the "undetermined" cases are often exactly the type of errors this sniff is trying to detect.
-         *
-         * Also note: that is also the reason to determine the namespace name within this method and
-         * not to use the `Namespaces::getDeclaredName()` method.
-         */
-        $type = Namespaces::getType($phpcsFile, $stackPtr);
-        if ($type === 'operator') {
-            return;
-        }
-
         $endOfStatement = $phpcsFile->findNext(Collections::namespaceDeclarationClosers(), ($stackPtr + 1));
         if ($endOfStatement === false) {
             // Live coding or parse error.
@@ -439,8 +425,8 @@ final class ForbiddenNamesSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
         $next   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), ($endOfStatement + 1), true);
-        if ($next === $endOfStatement || $tokens[$next]['code'] === \T_NS_SEPARATOR) {
-            // Declaration of global namespace. I.e.: namespace {} or use as non-scoped operator.
+        if ($next === $endOfStatement) {
+            // Declaration of global namespace. I.e.: namespace {}.
             return;
         }
 
@@ -454,16 +440,13 @@ final class ForbiddenNamesSniff extends Sniff
          */
         $nextContentLC = \strtolower($tokens[$next]['content']);
         if (ScannedCode::shouldRunOnOrBelow('7.4') === false
-            && $nextContentLC !== 'namespace'
-            && \strpos($nextContentLC, 'namespace\\') !== 0 // PHPCS 4.x.
+            && \strpos($nextContentLC, 'namespace\\') !== 0
         ) {
             return;
         }
 
         for ($i = $next; $i < $endOfStatement; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true
-                || $tokens[$i]['code'] === \T_NS_SEPARATOR
-            ) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
                 continue;
             }
 
@@ -489,6 +472,7 @@ final class ForbiddenNamesSniff extends Sniff
                     }
                 }
             } elseif ($this->isKeywordReservedPriorToPHP8($tokens[$i]['content']) === true) {
+                // Namespace name interlaced with whitespace/comments, not supported on PHP >= 8.0.
                 $this->checkName($phpcsFile, $i, $tokens[$i]['content']);
                 $this->checkOtherName($phpcsFile, $i, $tokens[$i]['content'], 'namespace declaration');
             }

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Verify that nothing but variables are passed to empty().
@@ -66,15 +65,12 @@ final class NewEmptyNonVariableSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $open = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
-        if ($open === false
-            || $tokens[$open]['code'] !== \T_OPEN_PARENTHESIS
-            || isset($tokens[$open]['parenthesis_closer']) === false
-        ) {
+        if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {
             return;
         }
 
-        $close = $tokens[$open]['parenthesis_closer'];
+        $open  = $tokens[$stackPtr]['parenthesis_opener'];
+        $close = $tokens[$stackPtr]['parenthesis_closer'];
 
         $nestingLevel = 0;
         if ($close !== ($open + 1) && isset($tokens[$open + 1]['nested_parenthesis'])) {

--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -101,14 +101,14 @@ final class NewPHPOpenTagEOFSniff extends Sniff
                 break;
 
             case \T_OPEN_TAG_WITH_ECHO:
-                // PHP 5.4+.
+                // PHP 7.2+.
                 if (\rtrim($contents) === '<?=') {
                     $error = true;
                 }
                 break;
 
             case \T_OPEN_TAG:
-                // PHP 5.4+ on PHPCS 3.12.2 or higher.
+                // PHP 7.2+ on PHPCS 3.12.2 or higher.
                 if ($contents === '<?php') {
                     $error = true;
                 }

--- a/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
@@ -217,16 +217,6 @@ final class RemovedHexadecimalNumericStringsSniff extends Sniff
             return false;
         }
 
-        if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR) {
-            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
-            if ($tokens[$prevPrevToken]['code'] === \T_STRING
-                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
-            ) {
-                // Namespaced function.
-                return false;
-            }
-        }
-
         return true;
     }
 }

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -77,7 +77,7 @@ final class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCall
 
         $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -68,7 +68,7 @@ final class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameter
     public function register()
     {
         // Enrich the variable value tokens array only once.
-        $this->variableValueTokens += Collections::namespacedNameTokens();
+        $this->variableValueTokens += Collections::nameTokens();
         $this->variableValueTokens += Collections::ooHierarchyKeywords();
 
         return parent::register();

--- a/PHPCompatibility/Sniffs/ParameterValues/NewExitAsFunctionCallSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewExitAsFunctionCallSniff.php
@@ -170,19 +170,7 @@ final class NewExitAsFunctionCallSniff extends AbstractFunctionCallParameterSnif
         }
 
         // Check if this is exit/die used as a fully qualified function call.
-        $isFullyQualified = false;
         if ($tokens[$stackPtr]['content'][0] === '\\') {
-            // PHPCS 4.x.
-            $isFullyQualified = true;
-        } else {
-            // PHPCS 3.x.
-            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
-            if ($tokens[$prev]['code'] === \T_NS_SEPARATOR) {
-                $isFullyQualified = true;
-            }
-        }
-
-        if ($isFullyQualified === true) {
             $phpcsFile->addError(
                 'Using "%s" as a fully qualified function call is not allowed in PHP 8.3 or earlier.',
                 $stackPtr,
@@ -239,7 +227,7 @@ final class NewExitAsFunctionCallSniff extends AbstractFunctionCallParameterSnif
         $total   = 0;
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) || $tokens[$i]['code'] === \T_NS_SEPARATOR) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -80,7 +80,7 @@ final class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
         $errors = [];
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -101,7 +101,7 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
         $tokens = $phpcsFile->getTokens();
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -112,9 +112,7 @@ final class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParam
 
         $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true
-                || $tokens[$i]['code'] === \T_NS_SEPARATOR
-            ) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -113,7 +113,7 @@ final class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallPara
 
             foreach ($items as $item) {
                 for ($i = $item['start']; $i <= $item['end']; $i++) {
-                    if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
+                    if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
                         || $tokens[$i]['code'] === \T_VARIABLE
                     ) {
                         // Variable, constant, function call. Ignore complete item as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -168,8 +168,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                 continue;
             }
 
-            if ($tokenCode === \T_NS_SEPARATOR
-                || ($tokenCode === \T_STRING && isset($this->constantStrings[$tokens[$i]['content']]))
+            if (($tokenCode === \T_STRING && isset($this->constantStrings[$tokens[$i]['content']]))
                 || ($tokenCode === \T_NAME_FULLY_QUALIFIED && isset($this->constantStrings[\ltrim($tokens[$i]['content'], '\\')]))
             ) {
                 continue;
@@ -216,13 +215,6 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                         // Method call, not a call to the PHP native function.
                         continue;
                     }
-
-                    if ($tokens[$prevNonEmpty]['code'] === \T_NS_SEPARATOR
-                        && $tokens[$prevNonEmpty - 1]['code'] === \T_STRING
-                    ) {
-                        // Namespaced function.
-                        continue;
-                    }
                 }
 
                 // Ok, so we know that there is an array function in the first param.
@@ -267,7 +259,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
         for ($i = $start; $i < $end; $i++) {
             $tokenCode = $tokens[$i]['code'];
 
-            if (isset(Tokens::$emptyTokens[$tokenCode]) || $tokenCode === \T_NS_SEPARATOR) {
+            if (isset(Tokens::$emptyTokens[$tokenCode])) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -104,7 +104,7 @@ final class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterS
          * Get the content of any string tokens in the options parameter and remove the quotes and variables.
          */
         for ($i = $optionsParam['start']; $i <= $optionsParam['end']; $i++) {
-            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -83,7 +83,7 @@ final class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSni
 
         $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Collections::namespacedNameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
@@ -73,8 +73,9 @@ final class NewFirstClassCallablesSniff extends Sniff
             return;
         }
 
-        $beforeParens = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
-        if ($tokens[$beforeParens]['code'] === \T_EXIT) {
+        if (isset($tokens[$prev]['parenthesis_owner']) === true
+            && $tokens[$tokens[$prev]['parenthesis_owner']]['code'] === \T_EXIT
+        ) {
             $phpcsFile->addError(
                 'Using exit/die as a first class callable is not supported in PHP 8.3 or earlier.',
                 $stackPtr,

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -78,23 +78,27 @@ final class NewFunctionCallTrailingCommaSniff extends Sniff
             return;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-        if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
-            || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
-        ) {
-            return;
+        if (isset($tokens[$stackPtr]['parenthesis_opener']) === true) {
+            $opener = $tokens[$stackPtr]['parenthesis_opener'];
+        } else {
+            $opener = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($tokens[$opener]['code'] !== \T_OPEN_PARENTHESIS
+                || isset($tokens[$opener]['parenthesis_closer']) === false
+            ) {
+                return;
+            }
         }
 
         if (($tokens[$stackPtr]['code'] === \T_STRING
             || isset(Collections::ooHierarchyKeywords()[$tokens[$stackPtr]['code']]))
-                && isset($tokens[$nextNonEmpty]['parenthesis_owner']) === true
+                && isset($tokens[$opener]['parenthesis_owner']) === true
         ) {
             // Function declaration, not a function call.
             return;
         }
 
-        $closer            = $tokens[$nextNonEmpty]['parenthesis_closer'];
-        $lastInParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), $nextNonEmpty, true);
+        $closer            = $tokens[$opener]['parenthesis_closer'];
+        $lastInParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), $opener, true);
 
         if ($tokens[$lastInParenthesis]['code'] !== \T_COMMA) {
             return;

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -234,15 +234,14 @@ final class ForbiddenThisUseContextsSniff extends Sniff
                 /*
                  * $this can no longer be unset.
                  */
-                $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-                if ($openParenthesis === false
-                    || $tokens[$openParenthesis]['code'] !== \T_OPEN_PARENTHESIS
-                    || isset($tokens[$openParenthesis]['parenthesis_closer']) === false
-                ) {
+                if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {
                     return;
                 }
 
-                for ($i = ($openParenthesis + 1); $i < $tokens[$openParenthesis]['parenthesis_closer']; $i++) {
+                $openParenthesis  = $tokens[$stackPtr]['parenthesis_opener'];
+                $closeParenthesis = $tokens[$stackPtr]['parenthesis_closer'];
+
+                for ($i = ($openParenthesis + 1); $i < $closeParenthesis; $i++) {
                     // Ignore anything within square brackets (array access keys).
                     if (isset($tokens[$i]['bracket_closer'])) {
                         $i = $tokens[$i]['bracket_closer'];
@@ -253,13 +252,7 @@ final class ForbiddenThisUseContextsSniff extends Sniff
                         continue;
                     }
 
-                    $afterThis = $phpcsFile->findNext(
-                        Tokens::$emptyTokens,
-                        ($i + 1),
-                        $tokens[$openParenthesis]['parenthesis_closer'],
-                        true
-                    );
-
+                    $afterThis = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), $closeParenthesis, true);
                     if ($afterThis !== false
                         && (isset(Collections::objectOperators()[$tokens[$afterThis]['code']]) === true
                             || $tokens[$afterThis]['code'] === \T_OPEN_SQUARE_BRACKET)

--- a/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
@@ -304,16 +304,6 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
             return false;
         }
 
-        if ($tokens[$beforeLabel]['code'] === \T_NS_SEPARATOR) {
-            $prevPrevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($beforeLabel - 1), null, true);
-            if ($tokens[$prevPrevToken]['code'] === \T_STRING
-                || $tokens[$prevPrevToken]['code'] === \T_NAMESPACE
-            ) {
-                // Namespaced function call.
-                return false;
-            }
-        }
-
         return $maybeLabel;
     }
 

--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -154,7 +154,6 @@ abstract class BaseSniffTestCase extends TestCase
         // Set up the Config and tokenize the test case file only once.
         if (isset(self::$sniffFiles[$pathToFile]['only_parsed']) === false) {
             try {
-                // PHPCS 3.x, 4.x.
                 $config            = new Config();
                 $config->cache     = false;
                 $config->standards = [self::STANDARD_NAME];

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -247,7 +247,7 @@ restore_include_path();
 
 // These calls should *not* trigger an error.
 $myobject -> php_check_syntax (); // Method, not the native PHP function.
-myNamespace \ /*comment*/ php_check_syntax(); // Namespaced function, not the native PHP function.
+myNamespace\php_check_syntax(); // Namespaced function, not the native PHP function.
 namespace\php_check_syntax(); // Namespaced function, not the native PHP function.
 $obj = new php_check_syntax /*comment*/ (); // Class not method.
 

--- a/PHPCompatibility/Util/Tests/Helpers/MiscHelper/IsUseOfGlobalConstantUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/MiscHelper/IsUseOfGlobalConstantUnitTest.php
@@ -61,16 +61,10 @@ final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase
      *
      * @return void
      */
-    public function testIsUseOfGlobalConstant($commentString, $expected, $targetContent = null)
+    public function testIsUseOfGlobalConstant($commentString, $expected, $targetContent = 'PHP_VERSION_ID')
     {
-        // Work around tokenization difference between PHPCS 3.x/4.x.
-        if (self::usesPhp8NameTokens() === true && $targetContent !== null) {
-            $stackPtr = $this->getTargetToken($commentString, Collections::nameTokens(), $targetContent);
-        } else {
-            $stackPtr = $this->getTargetToken($commentString, \T_STRING, 'PHP_VERSION_ID');
-        }
-
-        $result = MiscHelper::isUseOfGlobalConstant(self::$phpcsFile, $stackPtr);
+        $stackPtr = $this->getTargetToken($commentString, Collections::nameTokens(), $targetContent);
+        $result   = MiscHelper::isUseOfGlobalConstant(self::$phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ If you use PHPCompatibility, please fund this work by donating to the [PHP_CodeS
 ## Requirements
 
 * PHP 7.2+
-* PHP_CodeSniffer: 3.13.3+ / 4.0.0+.
+* PHP_CodeSniffer: 4.0.0+.
 * PHPCSUtils: 1.1.2+
 
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP_CodeSniffer. You should get consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on a recent PHP version in combination with a recent PHP_CodeSniffer version.
 
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP_CodeSniffer 3.x.  
 As of version 9.0.0, support for PHP_CodeSniffer 1.5.x and low 2.x versions < 2.3.0 has been dropped.  
-As of version 10.0.0, support for PHP < 7.2 and PHP_CodeSniffer < 3.13.3 has been dropped and support for PHP_CodeSniffer 4.x has been added.
+As of version 10.0.0, support for PHP < 7.2 and PHP_CodeSniffer < 4.0.0 has been dropped (and support for PHP_CodeSniffer 4.x was added).
 
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require": {
     "php": ">=7.2",
-    "squizlabs/php_codesniffer": "^3.13.3 || ^4.0",
+    "squizlabs/php_codesniffer": "^4.0.0",
     "phpcsstandards/phpcsutils": "^1.1.2"
   },
   "require-dev": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -56,9 +56,6 @@
         <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
         <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
 
-        <!-- Only needed for PHPCS 3.x. This exclusion can be removed when PHPCSDevCS drops support for PHPCS 3.x. -->
-        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
-
         <!-- All nice and good, but too much of a fuss for the outer array of nested arrays. -->
         <exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/>
     </rule>

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -16,7 +16,7 @@ if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
     define('PHP_CODESNIFFER_IN_TESTS', true);
 }
 
-// The below two defines are needed for PHPCS 3.x.
+// The below two defines are needed for PHPCS > 2.x.
 if (defined('PHP_CODESNIFFER_CBF') === false) {
     define('PHP_CODESNIFFER_CBF', false);
 }
@@ -61,7 +61,6 @@ if ($phpcsUtilsDir !== false) {
 
 // Try and load the PHPCS autoloader.
 if ($phpcsDir !== false && file_exists($phpcsDir . '/autoload.php')) {
-    // PHPCS 3.x.
     require_once $phpcsDir . '/autoload.php';
 
     /*


### PR DESCRIPTION
## Context

PHP 8.5 contains various new syntaxes for which support will only be added to PHP_CodeSniffer 4.0. To detect these with PHPCompatibility, we need to drop support for PHPCS 3.x.

Note: this PR is a best effort to remove PHPCS 3.x specific code, but there may well be additional simplifications which can be made.

Also see:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Version-4.0-Developer-Upgrade-Guide
* https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/4.x/CHANGELOG-4.x.md


## Changes

### Composer: drop support for PHPCS < 4.0

### 4.x does not retokenize `static` to `T_STRING` after `instanceof`

#### Classes/NewLateStaticBinding: remove PHPCS 3.x compat code 

The `static` keyword is generally tokenized as `T_STATIC`. However, in PHPCS 3.x, there was one exception - when `static` was used in an `instanceof static` expression, the `static` keyword was tokenized as `T_STRING`.

As of PHPCS 4.0, this exception has been removed and `static` in `instanceof static` will now also be tokenized as `T_STATIC`.

This commit removes the code handling the PHPCS 3.x exception.

### More tokens are parenthesis owners in PHPCS 4.x

As of PHPCS 4.0, `T_USE` (for closures), `T_ISSET`, `T_UNSET`, `T_EMPTY`, `T_EVAL`, `T_EXIT` are parenthesis owners, so we don't need to token walk to search for the parenthesis opener/closer anymore, we can just access the token stream array indexes directly.

#### FunctionDeclarations/NewTrailingComma: more tokens are parenthesis owners
#### FunctionUse/ArgumentFunctionsReportCurrentValue: more tokens are parenthesis owners
#### LanguageConstructs/NewEmptyNonVariable: more tokens are parenthesis owners
#### Syntax/NewFirstClassCallables: more tokens are parenthesis owners 
#### Syntax/NewFunctionCallTrailingComma: more tokens are parenthesis owners 
#### Variables/ForbiddenThisUseContexts: more tokens are parenthesis owners 

### Namespaces names are now tokenized as per PHP 8.0+

As of PHPCS, namespaced names use the tokenization as per PHP 8.0. This also means that we no longer need to check if a `T_STRING` token is a namespaced name, as if it were, it would be tokenized differently.

This also means we can remove some code which is no longer needed as, for instance, a namespace relative name `namespace\something` will no longer use the `T_NAMESPACE` token.

#### AbstractFunctionCallParameterSniff: minor simplification 
#### MiscHelper::isUseOfGlobalConstant(): minor simplification 
#### TokenGroup::isNumber(): minor simplification 
#### FunctionUse/ArgumentFunctionsReportCurrentValue: minor simplification 
#### FunctionUse/ArgumentFunctionsUsage: minor simplification 
#### FunctionUse/NewFunctions: minor simplification 
#### FunctionUse/RemovedFunctions: minor simplification 
#### InitialValue/NewConstantScalarExpressions: minor simplification 
#### Keywords/ForbiddenNames: minor simplification 
#### Numbers/RemovedHexadecimalNumericStrings: minor simplification 
#### ParameterValues/NewPasswordAlgoConstantValues: minor simplification 
#### Variables/RemovedIndirectModificationOfGlobals: minor simplification 
#### Variables/RemovedImplodeFlexibleParamOrder: minor simplification 

### T_EXIT now includes the namespace separator (where applicable)

#### ParameterValues/NewExitAsFunctionCall: minor simplification 

As of PHPCS 4.0, namespaced names use the tokenization as per PHP 8.0. This also means that we no longer need to check for a `T_NS_SEPARATOR` token for a fully qualified call to exit/die, as that will be tokenized as part of the `T_EXIT` token as of PHPCS 4.0.

### Various sniffs: minor simplification 

As of PHPCS, namespaced names use the tokenization as per PHP 8.0. This also means that we no longer need to check for `T_NS_SEPARATOR` or `T_NAMESPACE` tokens when examining names.

The `Collections::namespacedNameTokens()` token array contains the PHPCS cross-version compatible tokens, while the `Collections::nameTokens()` token array contains only the tokens we need to take into account for PHPCS 4.x.

### Various documentation updates for PHPCS < 4 version drop