### PR TITLE
Modernize: use the new PHPCS 4.x Tokens class constants 

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -165,3 +165,21 @@ jobs:
     uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@main
     with:
       strict: true
+
+  find-token-properties:
+    # The properties in the PHPCS Tokens class have been deprecated.
+    # The code in this repository should always use the constants instead.
+    name: 'Find use of Tokens properties'
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Find uses
+        id: findprops
+        shell: cmd
+        run: |
+          findstr /S /N /C:"Tokens::$" *.php
+          IF %ERRORLEVEL% NEQ 1 (Echo Please use the Tokens constants instead of the properties &Exit /b 1)
+          IF %ERRORLEVEL% EQU 1 (Echo All good &Exit /b 0)

--- a/PHPCompatibility/AbstractFunctionCallParameterSniff.php
+++ b/PHPCompatibility/AbstractFunctionCallParameterSniff.php
@@ -113,7 +113,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
             return;
         }
 
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextToken === false
             || $tokens[$nextToken]['code'] !== \T_OPEN_PARENTHESIS
             || (isset($tokens[$nextToken]['parenthesis_owner']) === true
@@ -129,7 +129,7 @@ abstract class AbstractFunctionCallParameterSniff extends Sniff
         }
 
         if ($tokens[$stackPtr]['code'] === \T_STRING) {
-            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
             if ($this->isMethod === true) {
                 if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === false) {

--- a/PHPCompatibility/AbstractInitialValueSniff.php
+++ b/PHPCompatibility/AbstractInitialValueSniff.php
@@ -187,7 +187,7 @@ abstract class AbstractInitialValueSniff extends Sniff
 
         // Filter out late static binding, class properties, static closures and arrow function and static return types.
         if ($tokens[$stackPtr]['code'] === \T_STATIC) {
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, $start, null, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $start, null, true);
             if ($next === false || $tokens[$next]['code'] !== \T_VARIABLE) {
                 // Not a static variable declaration. Bow out.
                 return;
@@ -205,7 +205,7 @@ abstract class AbstractInitialValueSniff extends Sniff
         // Examine each variable/constant in multi-declarations.
         do {
             $end   = $this->findEndOfCurrentDeclaration($phpcsFile, $start, $endOfStatement);
-            $start = $phpcsFile->findNext(Tokens::$emptyTokens, $start, $end, true);
+            $start = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $start, $end, true);
             if ($start === false
                 || ($tokens[$stackPtr]['code'] === \T_CONST && $tokens[$start]['code'] !== \T_STRING)
                 || ($tokens[$stackPtr]['code'] === \T_STATIC && $tokens[$start]['code'] !== \T_VARIABLE)
@@ -291,7 +291,7 @@ abstract class AbstractInitialValueSniff extends Sniff
     protected function processSubStatement(File $phpcsFile, $stackPtr, $end, $type)
     {
         $tokens = $phpcsFile->getTokens();
-        $next   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), $end, true);
+        $next   = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), $end, true);
         if ($next === false || $tokens[$next]['code'] !== \T_EQUAL) {
             // No value assigned.
             return;

--- a/PHPCompatibility/Helpers/MiscHelper.php
+++ b/PHPCompatibility/Helpers/MiscHelper.php
@@ -84,7 +84,7 @@ final class MiscHelper
             return false;
         }
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($next !== false
             && ($tokens[$next]['code'] === \T_OPEN_PARENTHESIS
                 || $tokens[$next]['code'] === \T_DOUBLE_COLON
@@ -115,11 +115,11 @@ final class MiscHelper
             \T_TYPE_INTERSECTION     => true,
             \T_TYPE_OPEN_PARENTHESIS => true,
         ];
-        $tokensToIgnore += Tokens::$ooScopeTokens;
+        $tokensToIgnore += Tokens::OO_SCOPE_TOKENS;
         $tokensToIgnore += Collections::objectOperators();
-        $tokensToIgnore += Tokens::$scopeModifiers;
+        $tokensToIgnore += Tokens::SCOPE_MODIFIERS;
 
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if (isset($tokensToIgnore[$tokens[$prev]['code']]) === true) {
             // Not the use of a constant.
             return false;
@@ -135,7 +135,7 @@ final class MiscHelper
             }
 
             if ($tokens[$next]['code'] === \T_SEMICOLON) {
-                $prevPrev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+                $prevPrev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prev - 1), null, true);
                 if ($tokens[$prevPrev]['code'] === \T_CLOSE_PARENTHESIS
                     && isset($tokens[$prevPrev]['parenthesis_owner'])
                 ) {
@@ -157,10 +157,10 @@ final class MiscHelper
             \T_OPEN_PARENTHESIS,
         ];
         $endOfPreviousStatement = $phpcsFile->findPrevious($find, ($stackPtr - 1));
-        $startOfThisStatement   = $phpcsFile->findNext(Tokens::$emptyTokens, ($endOfPreviousStatement + 1), null, true);
+        $startOfThisStatement   = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($endOfPreviousStatement + 1), null, true);
 
         if ($tokens[$startOfThisStatement]['code'] === \T_USE) {
-            $nextOnLine = $phpcsFile->findNext(Tokens::$emptyTokens, ($startOfThisStatement + 1), null, true);
+            $nextOnLine = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($startOfThisStatement + 1), null, true);
             if ($nextOnLine !== false) {
                 if (($tokens[$nextOnLine]['code'] === \T_STRING && $tokens[$nextOnLine]['content'] === 'const')) {
                     $hasNsSep = $phpcsFile->findNext(\T_NS_SEPARATOR, ($nextOnLine + 1), $stackPtr);

--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -79,7 +79,7 @@ trait PCRERegexTrait
             );
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $paramInfo['start'], ($paramInfo['end'] + 1), true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $paramInfo['start'], ($paramInfo['end'] + 1), true);
         if ($nextNonEmpty === false) {
             // Shouldn't be possible.
             return [];

--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -56,7 +56,7 @@ final class ResolveHelper
             return '';
         }
 
-        $start = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        $start = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $stackPtr + 1, null, true);
         if ($start === false
             || $tokens[$start]['code'] === \T_VARIABLE
             || $tokens[$start]['code'] === \T_ANON_CLASS
@@ -151,7 +151,7 @@ final class ResolveHelper
 
         // Get the classname from the class declaration if self is used.
         if ($tokens[$stackPtr - 1]['code'] === \T_SELF) {
-            $classDeclarationPtr = Conditions::getLastCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
+            $classDeclarationPtr = Conditions::getLastCondition($phpcsFile, $stackPtr, Tokens::OO_SCOPE_TOKENS);
             if ($classDeclarationPtr === false
                 || $tokens[$classDeclarationPtr]['code'] === \T_ANON_CLASS
                 || $tokens[$classDeclarationPtr]['code'] === \T_TRAIT
@@ -163,7 +163,7 @@ final class ResolveHelper
         }
 
         $find  = Collections::namespacedNameTokens();
-        $find += Tokens::$emptyTokens;
+        $find += Tokens::EMPTY_TOKENS;
 
         $start     = $phpcsFile->findPrevious($find, $stackPtr - 1, null, true, null, true);
         $start     = ($start + 1);

--- a/PHPCompatibility/Helpers/TokenGroup.php
+++ b/PHPCompatibility/Helpers/TokenGroup.php
@@ -134,7 +134,7 @@ final class TokenGroup
      */
     public static function isNumber(File $phpcsFile, $start, $end, $allowFloats = false)
     {
-        $stringTokens = Tokens::$heredocTokens + Tokens::$stringTokens;
+        $stringTokens = Tokens::HEREDOC_TOKENS + Tokens::STRING_TOKENS;
 
         $validTokens             = [];
         $validTokens[\T_LNUMBER] = true;
@@ -156,7 +156,7 @@ final class TokenGroup
             return false;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $start, $searchEnd, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $start, $searchEnd, true);
         while ($nextNonEmpty !== false
             && ($tokens[$nextNonEmpty]['code'] === \T_PLUS
             || $tokens[$nextNonEmpty]['code'] === \T_MINUS)
@@ -165,7 +165,7 @@ final class TokenGroup
                 $negativeNumber = ($negativeNumber === false) ? true : false;
             }
 
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), $searchEnd, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextNonEmpty + 1), $searchEnd, true);
         }
 
         if ($nextNonEmpty === false || isset($maybeValidTokens[$tokens[$nextNonEmpty]['code']]) === false) {
@@ -264,7 +264,7 @@ final class TokenGroup
         }
 
         // OK, so we have a number, now is there still more code after it ?
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), $searchEnd, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextNonEmpty + 1), $searchEnd, true);
         if ($nextNonEmpty !== false) {
             return false;
         }
@@ -304,9 +304,9 @@ final class TokenGroup
      */
     public static function isNumericCalculation(File $phpcsFile, $start, $end)
     {
-        $arithmeticTokens = Tokens::$arithmeticTokens;
+        $arithmeticTokens = Tokens::ARITHMETIC_TOKENS;
 
-        $skipTokens   = Tokens::$emptyTokens;
+        $skipTokens   = Tokens::EMPTY_TOKENS;
         $skipTokens[] = \T_MINUS;
         $skipTokens[] = \T_PLUS;
 
@@ -377,12 +377,12 @@ final class TokenGroup
                 \T_OPEN_PARENTHESIS => \T_OPEN_PARENTHESIS,
                 \T_STRING_CONCAT    => \T_STRING_CONCAT,
             ];
-            $disallowedTokens += Tokens::$assignmentTokens;
-            $disallowedTokens += Tokens::$equalityTokens;
-            $disallowedTokens += Tokens::$comparisonTokens;
-            $disallowedTokens += Tokens::$operators;
-            $disallowedTokens += Tokens::$booleanOperators;
-            $disallowedTokens += Tokens::$castTokens;
+            $disallowedTokens += Tokens::ASSIGNMENT_TOKENS;
+            $disallowedTokens += Tokens::EQUALITY_TOKENS;
+            $disallowedTokens += Tokens::COMPARISON_TOKENS;
+            $disallowedTokens += Tokens::OPERATORS;
+            $disallowedTokens += Tokens::BOOLEAN_OPERATORS;
+            $disallowedTokens += Tokens::CAST_TOKENS;
 
             /*
              * List of brackets which can be part of a variable variable.

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 
 /**
  * Attributes as a form of structured, syntactic metadata to declarations of classes, properties,
@@ -387,7 +386,7 @@ final class NewAttributesSniff extends Sniff
                 continue;
             }
 
-            if (isset(Collections::nameTokens()[$tokens[$i]['code']])) {
+            if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']])) {
                 $currentName .= $tokens[$i]['content'];
 
                 if (isset($startsAt) === false) {

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -319,7 +319,7 @@ final class NewAttributesSniff extends Sniff
             );
         }
 
-        $nextAfter = $phpcsFile->findNext(Tokens::$emptyTokens, ($closer + 1), null, true);
+        $nextAfter = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($closer + 1), null, true);
         if ($nextAfter !== false
             && $tokens[$nextAfter]['code'] !== \T_ATTRIBUTE
             && $tokens[$closer]['line'] === $tokens[$nextAfter]['line']
@@ -356,7 +356,7 @@ final class NewAttributesSniff extends Sniff
         $startsAt       = null;
 
         for ($i = ($opener + 1); $i <= $closer; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']])) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/Classes/ForbiddenClassNameUnderscoreSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/ForbiddenClassNameUnderscoreSniff.php
@@ -39,7 +39,7 @@ final class ForbiddenClassNameUnderscoreSniff extends Sniff
      */
     public function register()
     {
-        $targets = Tokens::$ooScopeTokens;
+        $targets = Tokens::OO_SCOPE_TOKENS;
         unset($targets[\T_ANON_CLASS]);
 
         return $targets;

--- a/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
@@ -39,7 +39,7 @@ final class NewConstructorPropertyPromotionSniff extends Sniff
      */
     public function register()
     {
-        return Tokens::$ooScopeTokens;
+        return Tokens::OO_SCOPE_TOKENS;
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -64,13 +64,13 @@ final class NewLateStaticBindingSniff extends Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true, null, true);
         if ($nextNonEmpty === false) {
             return;
         }
 
         if ($tokens[$nextNonEmpty]['code'] !== \T_DOUBLE_COLON) {
-            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true, null, true);
             if ($tokens[$prevNonEmpty]['code'] !== \T_NEW
                 && $tokens[$prevNonEmpty]['code'] !== \T_INSTANCEOF
             ) {
@@ -78,7 +78,7 @@ final class NewLateStaticBindingSniff extends Sniff
             }
         }
 
-        $inClass = Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
+        $inClass = Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::OO_SCOPE_TOKENS);
 
         if ($inClass === true && ScannedCode::shouldRunOnOrBelow('5.2') === true) {
             $phpcsFile->addError(

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
@@ -84,7 +84,7 @@ final class NewReadonlyClassesSniff extends Sniff
                 return;
             }
 
-            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if ($tokens[$prevNonEmpty]['code'] === \T_READONLY) {
                 $phpcsFile->addError(
                     'Readonly anonymous classes are not supported in PHP 8.2 or earlier.',

--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -64,7 +64,7 @@ final class RemovedOrphanedParentSniff extends Sniff
         }
 
         $tokens   = $phpcsFile->getTokens();
-        $classPtr = Conditions::getLastCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
+        $classPtr = Conditions::getLastCondition($phpcsFile, $stackPtr, Tokens::OO_SCOPE_TOKENS);
         if ($classPtr === false || $tokens[$classPtr]['code'] === \T_TRAIT) {
             // Use outside of a class scope. Not our concern.
             return;

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -99,7 +99,7 @@ final class NewMagicClassConstantSniff extends Sniff
 
         $preSubjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($subjectPtr - 1), null, true);
         if (isset(Collections::ooHierarchyKeywords()[$tokens[$subjectPtr]['code']]) === true
-            || (isset(Collections::nameTokens()[$tokens[$subjectPtr]['code']]) === true
+            || (isset(Tokens::NAME_TOKENS[$tokens[$subjectPtr]['code']]) === true
                 && isset(Collections::objectOperators()[$tokens[$preSubjectPtr]['code']]) === false)
         ) {
             // This is a syntax which is supported on PHP 5.5 and higher.

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -80,24 +80,24 @@ final class NewMagicClassConstantSniff extends Sniff
             return;
         }
 
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextToken !== false && $tokens[$nextToken]['code'] === \T_OPEN_PARENTHESIS) {
             // Function call or declaration for a function called "class".
             return;
         }
 
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($tokens[$prevToken]['code'] !== \T_DOUBLE_COLON) {
             return;
         }
 
-        $subjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
+        $subjectPtr = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prevToken - 1), null, true);
         if ($subjectPtr === false) {
             // Shouldn't be possible.
             return; // @codeCoverageIgnore
         }
 
-        $preSubjectPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($subjectPtr - 1), null, true);
+        $preSubjectPtr = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($subjectPtr - 1), null, true);
         if (isset(Collections::ooHierarchyKeywords()[$tokens[$subjectPtr]['code']]) === true
             || (isset(Tokens::NAME_TOKENS[$tokens[$subjectPtr]['code']]) === true
                 && isset(Collections::objectOperators()[$tokens[$preSubjectPtr]['code']]) === false)

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -67,13 +67,11 @@ final class DiscouragedSwitchContinueSniff extends Sniff
     /**
      * Token codes which are accepted to determine the level for the continue.
      *
-     * This array is enriched with the arithmetic operators in the register() method.
-     *
      * @since 8.2.0
      *
      * @var array<int|string, int|string>
      */
-    protected $acceptedLevelTokens = [
+    protected $acceptedLevelTokens = Tokens::ARITHMETIC_TOKENS + Tokens::EMPTY_TOKENS + [
         \T_LNUMBER           => \T_LNUMBER,
         \T_OPEN_PARENTHESIS  => \T_OPEN_PARENTHESIS,
         \T_CLOSE_PARENTHESIS => \T_CLOSE_PARENTHESIS,
@@ -89,9 +87,6 @@ final class DiscouragedSwitchContinueSniff extends Sniff
      */
     public function register()
     {
-        $this->acceptedLevelTokens += Tokens::$arithmeticTokens;
-        $this->acceptedLevelTokens += Tokens::$emptyTokens;
-
         return [\T_SWITCH];
     }
 
@@ -191,7 +186,7 @@ final class DiscouragedSwitchContinueSniff extends Sniff
                         $i          = $numberInfo['last_token'];
                     }
 
-                    if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                    if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                         continue;
                     }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -100,7 +100,7 @@ final class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
             if (isset(Tokens::NAME_TOKENS[$tokens[$curToken]['code']]) === true) {
                 // If the next non-whitespace token after the (potentially namespaced) name
                 // is an opening parenthesis then it's a function call.
-                $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, $curToken + 1, null, true);
+                $openBracket = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $curToken + 1, null, true);
                 if ($tokens[$openBracket]['code'] === \T_OPEN_PARENTHESIS) {
                     $errorType = 'variableArgument';
                     break;

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Numbers;
 
 /**
@@ -98,7 +97,7 @@ final class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
         $nextSemicolonToken = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr), null, false);
         $errorType          = '';
         for ($curToken = $stackPtr + 1; $curToken < $nextSemicolonToken; $curToken++) {
-            if (isset(Collections::nameTokens()[$tokens[$curToken]['code']]) === true) {
+            if (isset(Tokens::NAME_TOKENS[$tokens[$curToken]['code']]) === true) {
                 // If the next non-whitespace token after the (potentially namespaced) name
                 // is an opening parenthesis then it's a function call.
                 $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, $curToken + 1, null, true);

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -81,7 +81,7 @@ final class NewExecutionDirectivesSniff extends Sniff
      *
      * @var array
      */
-    protected $ignoreTokens = [];
+    protected $ignoreTokens = Tokens::EMPTY_TOKENS + [\T_EQUAL => \T_EQUAL];
 
 
     /**
@@ -93,9 +93,6 @@ final class NewExecutionDirectivesSniff extends Sniff
      */
     public function register()
     {
-        $this->ignoreTokens           = Tokens::$emptyTokens;
-        $this->ignoreTokens[\T_EQUAL] = \T_EQUAL;
-
         return [\T_DECLARE];
     }
 
@@ -327,7 +324,7 @@ final class NewExecutionDirectivesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         $value = $tokens[$stackPtr]['content'];
-        if ($directive === 'encoding' && isset(Tokens::$stringTokens[$tokens[$stackPtr]['code']]) === true) {
+        if ($directive === 'encoding' && isset(Tokens::STRING_TOKENS[$tokens[$stackPtr]['code']]) === true) {
             $value = TextStrings::stripQuotes($value);
         }
 

--- a/PHPCompatibility/Sniffs/ControlStructures/NewNonCapturingCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewNonCapturingCatchSniff.php
@@ -66,7 +66,7 @@ final class NewNonCapturingCatchSniff extends Sniff
         }
 
         $lastNonEmptyToken = $phpcsFile->findPrevious(
-            Tokens::$emptyTokens,
+            Tokens::EMPTY_TOKENS,
             ($token['parenthesis_closer'] - 1),
             $token['parenthesis_opener'],
             true

--- a/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/Extensions/RemovedExtensionsSniff.php
@@ -242,7 +242,7 @@ final class RemovedExtensionsSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Find the next non-empty token.
-        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openBracket = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
 
         if ($tokens[$openBracket]['code'] !== \T_OPEN_PARENTHESIS) {
             // Not a function call.
@@ -255,7 +255,7 @@ final class RemovedExtensionsSniff extends Sniff
         }
 
         // Find the previous non-empty token.
-        $search   = Tokens::$emptyTokens;
+        $search   = Tokens::EMPTY_TOKENS;
         $search[] = \T_BITWISE_AND;
         $previous = $phpcsFile->findPrevious($search, ($stackPtr - 1), null, true);
         if ($tokens[$previous]['code'] === \T_FUNCTION) {

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
@@ -50,7 +50,7 @@ final class AbstractPrivateMethodsSniff extends Sniff
      */
     public function register()
     {
-        return Tokens::$ooScopeTokens;
+        return Tokens::OO_SCOPE_TOKENS;
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenFinalPrivateMethodsSniff.php
@@ -47,7 +47,7 @@ final class ForbiddenFinalPrivateMethodsSniff extends Sniff
      */
     public function register()
     {
-        return Tokens::$ooScopeTokens;
+        return Tokens::OO_SCOPE_TOKENS;
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -42,7 +42,7 @@ final class ForbiddenToStringParametersSniff extends Sniff
      */
     public function register()
     {
-        return Tokens::$ooScopeTokens;
+        return Tokens::OO_SCOPE_TOKENS;
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -89,7 +89,7 @@ final class ForbiddenVariableNamesInClosureUseSniff extends Sniff
          * UseStatements::isClosureUse() check.
          */
         $tokens        = $phpcsFile->getTokens();
-        $prevNonEmpty  = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty  = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         $closureParams = FunctionDeclarations::getParameters($phpcsFile, $tokens[$prevNonEmpty]['parenthesis_owner']);
 
         /*

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -166,7 +166,7 @@ final class NewClosureSniff extends Sniff
                 /*
                  * Closures only have access to $this if used within a class context.
                  */
-                elseif (Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens) === false) {
+                elseif (Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::OO_SCOPE_TOKENS) === false) {
                     $phpcsFile->addWarning(
                         'Closures / anonymous functions only have access to $this if used within a class or when bound to an object using bindTo(). Please verify.',
                         $thisFound,
@@ -195,7 +195,7 @@ final class NewClosureSniff extends Sniff
     protected function isClosureStatic(File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true, null, true);
 
         return ($prevToken !== false && $tokens[$prevToken]['code'] === \T_STATIC);
     }
@@ -303,7 +303,7 @@ final class NewClosureSniff extends Sniff
             }
 
             // T_STATIC, make sure it is used as a class reference.
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($found + 1), $endToken, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($found + 1), $endToken, true);
             if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_DOUBLE_COLON) {
                 return false;
             }

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -34,13 +34,11 @@ final class NewExceptionsFromToStringSniff extends Sniff
      * Tokens which should be ignored when they preface a function declaration
      * when trying to find the docblock (if any).
      *
-     * Array will be added to in the register() method.
-     *
      * @since 9.3.0
      *
      * @var array<int|string, int|string>
      */
-    private $docblockIgnoreTokens = [
+    private $docblockIgnoreTokens = Tokens::METHOD_MODIFIERS + Tokens::PHPCS_ANNOTATION_TOKENS + [
         \T_WHITESPACE => \T_WHITESPACE,
     ];
 
@@ -53,11 +51,7 @@ final class NewExceptionsFromToStringSniff extends Sniff
      */
     public function register()
     {
-        // Enhance the array of tokens to ignore for finding the docblock.
-        $this->docblockIgnoreTokens += Tokens::$methodPrefixes;
-        $this->docblockIgnoreTokens += Tokens::$phpcsCommentTokens;
-
-        return Tokens::$ooScopeTokens;
+        return Tokens::OO_SCOPE_TOKENS;
     }
 
     /**

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -89,7 +89,7 @@ final class NewNullableTypesSniff extends Sniff
          */
         $properties = FunctionDeclarations::getProperties($phpcsFile, $stackPtr);
         if ($properties['nullable_return_type'] === true) {
-            $nullPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($properties['return_type_token'] - 1), null, true);
+            $nullPtr = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($properties['return_type_token'] - 1), null, true);
             $phpcsFile->addError(
                 'Nullable return types are not supported in PHP 7.0 or earlier. Found: %s',
                 $nullPtr,

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -289,7 +289,7 @@ final class NewParamTypeDeclarationsSniff extends Sniff
                     // Only throw this error for PHP 5.2+ as before that the "type hint not supported" error
                     // will be thrown.
                     if (($type === 'self' || $type === 'parent')
-                        && (Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::$ooScopeTokens) === false
+                        && (Conditions::hasCondition($phpcsFile, $stackPtr, Tokens::OO_SCOPE_TOKENS) === false
                             || ($tokens[$stackPtr]['code'] === \T_FUNCTION
                             && Scopes::isOOMethod($phpcsFile, $stackPtr) === false))
                         && ScannedCode::shouldRunOnOrBelow('5.1') === false

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewTrailingCommaSniff.php
@@ -70,7 +70,7 @@ final class NewTrailingCommaSniff extends Sniff
         /*
          * Check for trailing commas in a function declaration parameter list.
          */
-        $lastInParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), null, true);
+        $lastInParenthesis = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($closer - 1), null, true);
 
         if ($tokens[$lastInParenthesis]['code'] === \T_COMMA) {
             $phpcsFile->addError(
@@ -89,7 +89,7 @@ final class NewTrailingCommaSniff extends Sniff
             return;
         }
 
-        $usePtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($closer + 1), null, true);
+        $usePtr = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($closer + 1), null, true);
         if ($usePtr === false
             || $tokens[$usePtr]['code'] !== \T_USE
             || isset($tokens[$usePtr]['parenthesis_closer']) === false
@@ -99,7 +99,7 @@ final class NewTrailingCommaSniff extends Sniff
         }
 
         $closer            = $tokens[$usePtr]['parenthesis_closer'];
-        $lastInParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), null, true);
+        $lastInParenthesis = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($closer - 1), null, true);
 
         if ($tokens[$lastInParenthesis]['code'] === \T_COMMA) {
             $phpcsFile->addError(

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -132,7 +132,7 @@ final class NonStaticMagicMethodsSniff extends Sniff
      */
     public function register()
     {
-        return Tokens::$ooScopeTokens;
+        return Tokens::OO_SCOPE_TOKENS;
     }
 
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedCallingDestructAfterConstructorExitSniff.php
@@ -91,7 +91,7 @@ final class RemovedCallingDestructAfterConstructorExitSniff extends Sniff
         $functionClose = $tokens[$constructPtr]['scope_closer'];
         $exits         = [];
         for ($current = ($functionOpen + 1); $current < $functionClose; $current++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$current]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$current]['code']]) === true) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
@@ -61,7 +61,7 @@ final class RemovedReturnByReferenceFromVoidSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_BITWISE_AND) {
             // Not a function declared to return by reference.
             return;

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -143,7 +143,7 @@ final class NewMagicMethodsSniff extends Sniff
             return;
         }
 
-        $scopePtr = Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
+        $scopePtr = Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::OO_SCOPE_TOKENS);
         if ($scopePtr === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -41,13 +41,11 @@ final class RemovedMagicAutoloadSniff extends Sniff
     /**
      * Scopes to look for when testing using validDirectScope.
      *
-     * {@internal More tokens are added on register().}
-     *
      * @since 8.1.0
      *
      * @var array<int|string, int|string>
      */
-    private $checkForScopes = [
+    private $checkForScopes = Tokens::OO_SCOPE_TOKENS + [
         \T_NAMESPACE => \T_NAMESPACE,
     ];
 
@@ -60,8 +58,6 @@ final class RemovedMagicAutoloadSniff extends Sniff
      */
     public function register()
     {
-        $this->checkForScopes += Tokens::$ooScopeTokens;
-
         return [\T_FUNCTION];
     }
 

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -79,7 +79,7 @@ final class ReservedFunctionNamesSniff implements Sniff
             return;
         }
 
-        $ooPtr = Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens);
+        $ooPtr = Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::OO_SCOPE_TOKENS);
 
         /*
          * Check functions declared in the global namespace or in a namespace.
@@ -139,8 +139,8 @@ final class ReservedFunctionNamesSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $ignore                = Tokens::$methodPrefixes;
-        $ignore               += Tokens::$phpcsCommentTokens;
+        $ignore                = Tokens::METHOD_MODIFIERS;
+        $ignore               += Tokens::PHPCS_ANNOTATION_TOKENS;
         $ignore[\T_WHITESPACE] = \T_WHITESPACE;
         $ignore[\T_COMMENT]    = \T_COMMENT;
 

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -145,7 +145,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
         $prevNonEmpty = $scopeOpener;
         for ($i = ($scopeOpener + 1);
             $i < $scopeCloser;
-            $prevNonEmpty = (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) ? $prevNonEmpty : $i), $i++
+            $prevNonEmpty = (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) ? $prevNonEmpty : $i), $i++
         ) {
             if ((isset(Collections::closedScopes()[$tokens[$i]['code']]) || $tokens[$i]['code'] === \T_FN)
                 && isset($tokens[$i]['scope_closer'])
@@ -171,7 +171,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
             /*
              * Ok, so is this really a function call to one of the PHP native functions ?
              */
-            $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+            $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
             if ($next === false || $tokens[$next]['code'] !== \T_OPEN_PARENTHESIS) {
                 // Live coding, parse error or not a function call.
                 continue;
@@ -188,9 +188,9 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
              * Allowed for the debug_*backtrace() functions, but please don't do this....
              */
             if (isset($tokens[$next]['parenthesis_closer'])) {
-                $hasEllipsis = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), null, true);
+                $hasEllipsis = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($next + 1), null, true);
                 if ($hasEllipsis !== false && $tokens[$hasEllipsis]['code'] === \T_ELLIPSIS) {
-                    $isFirstClassCallable = $phpcsFile->findNext(Tokens::$emptyTokens, ($hasEllipsis + 1), null, true);
+                    $isFirstClassCallable = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($hasEllipsis + 1), null, true);
                     if ($isFirstClassCallable !== false && $isFirstClassCallable === $tokens[$next]['parenthesis_closer']) {
                         if ($foundFunctionName === 'debug_backtrace' || $foundFunctionName === 'debug_print_backtrace') {
                             $error = 'Since PHP 7.0, functions inspecting arguments, like %1$s(), no longer report the original value as passed to a parameter, but will instead provide the current value. Using this function as a first class callable is a really bad idea.';
@@ -263,7 +263,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                 $lastParenthesesOpener = Parentheses::getLastOpener($phpcsFile, $i);
                 if ($lastParenthesesOpener !== false) {
 
-                    $maybeFunctionCall = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($lastParenthesesOpener - 1), null, true);
+                    $maybeFunctionCall = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($lastParenthesesOpener - 1), null, true);
                     if (($tokens[$maybeFunctionCall]['code'] === \T_STRING
                         || $tokens[$maybeFunctionCall]['code'] === \T_NAME_FULLY_QUALIFIED)
                         && $this->isCallToGlobalFunction($phpcsFile, $maybeFunctionCall) === true
@@ -318,7 +318,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
              */
             if ($foundFunctionName === 'debug_backtrace' && isset($tokens[$next]['parenthesis_closer'])) {
                 $afterParenthesis = $phpcsFile->findNext(
-                    Tokens::$emptyTokens,
+                    Tokens::EMPTY_TOKENS,
                     ($tokens[$next]['parenthesis_closer'] + 1),
                     null,
                     true
@@ -328,7 +328,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     && isset($tokens[$afterParenthesis]['bracket_closer'])
                 ) {
                     $afterStackFrame = $phpcsFile->findNext(
-                        Tokens::$emptyTokens,
+                        Tokens::EMPTY_TOKENS,
                         ($tokens[$afterParenthesis]['bracket_closer'] + 1),
                         null,
                         true
@@ -461,7 +461,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     }
                 }
 
-                $beforeVar                = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($j - 1), null, true);
+                $beforeVar                = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($j - 1), null, true);
                 $startOfVariableStatement = BCFile::findStartOfStatement(
                     $phpcsFile,
                     $j,
@@ -499,7 +499,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
 
                     $endOfVariableStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($j + 1));
                     $lastAssignmentOperator = $phpcsFile->findPrevious(
-                        Tokens::$assignmentTokens,
+                        Tokens::ASSIGNMENT_TOKENS,
                         ($endOfVariableStatement - 1),
                         $startOfVariableStatement
                     );
@@ -540,7 +540,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     break;
                 }
 
-                $afterVar              = $phpcsFile->findNext(Tokens::$emptyTokens, ($j + 1), null, true);
+                $afterVar              = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($j + 1), null, true);
                 $lastParenthesesOpener = Parentheses::getLastOpener($phpcsFile, $j);
                 if ($lastParenthesesOpener !== false
                     && isset($tokens[$lastParenthesesOpener]['parenthesis_closer']) === true
@@ -553,7 +553,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
 
                 // Check for $obj::class, which can be safely ignored.
                 if ($tokens[$afterVar]['code'] === \T_DOUBLE_COLON) {
-                    $nextAfterAfterVar = $phpcsFile->findNext(Tokens::$emptyTokens, ($afterVar + 1), null, true);
+                    $nextAfterAfterVar = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($afterVar + 1), null, true);
                     if ($tokens[$nextAfterAfterVar]['code'] === \T_STRING
                         && \strtolower($tokens[$nextAfterAfterVar]['content']) === 'class'
                     ) {
@@ -601,7 +601,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     && isset($tokens[$afterVar]['bracket_closer'])
                 ) {
                     // Skip past array access on the variable.
-                    while (($afterVar = $phpcsFile->findNext(Tokens::$emptyTokens, ($tokens[$afterVar]['bracket_closer'] + 1), null, true)) !== false) {
+                    while (($afterVar = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($tokens[$afterVar]['bracket_closer'] + 1), null, true)) !== false) {
                         if ($tokens[$afterVar]['code'] !== \T_OPEN_SQUARE_BRACKET
                             || isset($tokens[$afterVar]['bracket_closer']) === false
                         ) {
@@ -610,7 +610,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
                     }
                 }
 
-                if (isset(Tokens::$assignmentTokens[$tokens[$afterVar]['code']])
+                if (isset(Tokens::ASSIGNMENT_TOKENS[$tokens[$afterVar]['code']])
                     && $tokens[$afterVar]['code'] !== \T_COALESCE_EQUAL
                 ) {
                     // Variable is being assigned something.
@@ -667,7 +667,7 @@ final class ArgumentFunctionsReportCurrentValueSniff extends Sniff
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
         if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === true) {
             // Method call.

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -162,7 +162,7 @@ final class ArgumentFunctionsUsageSniff extends Sniff
         }
 
         $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
-        if (isset(Collections::nameTokens()[$tokens[$prevNonEmpty]['code']]) === false) {
+        if (isset(Tokens::NAME_TOKENS[$tokens[$prevNonEmpty]['code']]) === false) {
             // Not nested in a function call.
             return;
         }

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -102,7 +102,7 @@ final class ArgumentFunctionsUsageSniff extends Sniff
         }
 
         // Next non-empty token should be the open parenthesis.
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false
             || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
             || isset($tokens[$nextNonEmpty]['parenthesis_owner'])
@@ -120,7 +120,7 @@ final class ArgumentFunctionsUsageSniff extends Sniff
         ];
         $ignore += Collections::objectOperators();
 
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
             // Not a call to a PHP function.
             return;
@@ -161,7 +161,7 @@ final class ArgumentFunctionsUsageSniff extends Sniff
             return;
         }
 
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($opener - 1), null, true);
         if (isset(Tokens::NAME_TOKENS[$tokens[$prevNonEmpty]['code']]) === false) {
             // Not nested in a function call.
             return;

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -1168,7 +1168,7 @@ final class NewFunctionParametersSniff extends AbstractFunctionCallParameterSnif
             $targetParam = PassedParameters::getParameterFromStack($parameters, $offset, $parameterDetails['name']);
 
             if ($targetParam !== false && $targetParam['clean'] !== '') {
-                $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+                $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $targetParam['start'], ($targetParam['end'] + 1), true);
 
                 $itemInfo = [
                     'name'   => $functionName,

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5307,7 +5307,7 @@ final class NewFunctionsSniff extends Sniff
             return;
         }
 
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextToken === false
             || $tokens[$nextToken]['code'] !== \T_OPEN_PARENTHESIS
             || isset($tokens[$nextToken]['parenthesis_owner']) === true
@@ -5318,7 +5318,7 @@ final class NewFunctionsSniff extends Sniff
         $ignore  = [\T_NEW => true];
         $ignore += Collections::objectOperators();
 
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;

--- a/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewNamedParametersSniff.php
@@ -71,7 +71,7 @@ final class NewNamedParametersSniff extends Sniff
             return;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS
             || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
         ) {
@@ -85,7 +85,7 @@ final class NewNamedParametersSniff extends Sniff
                 \T_USE      => true,
             ];
 
-            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
                 // Not a function call.
                 return;

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -288,7 +288,7 @@ final class RemovedFunctionParametersSniff extends AbstractFunctionCallParameter
                     }
                 }
 
-                $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+                $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $targetParam['start'], ($targetParam['end'] + 1), true);
 
                 $itemInfo = [
                     'name'   => $functionName,

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5776,7 +5776,7 @@ final class RemovedFunctionsSniff extends Sniff
             return;
         }
 
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextToken === false
             || $tokens[$nextToken]['code'] !== \T_OPEN_PARENTHESIS
             || isset($tokens[$nextToken]['parenthesis_owner']) === true
@@ -5787,7 +5787,7 @@ final class RemovedFunctionsSniff extends Sniff
         $ignore  = [\T_NEW => true];
         $ignore += Collections::objectOperators();
 
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if (isset($ignore[$tokens[$prevToken]['code']]) === true) {
             // Not a call to a PHP function.
             return;

--- a/PHPCompatibility/Sniffs/Generators/NewYieldFromCommentSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewYieldFromCommentSniff.php
@@ -74,7 +74,7 @@ final class NewYieldFromCommentSniff extends Sniff
                     break;
                 }
 
-                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false && $tokens[$i]['code'] !== \T_YIELD_FROM) {
+                if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === false && $tokens[$i]['code'] !== \T_YIELD_FROM) {
                     // Shouldn't be possible. Just to be on the safe side.
                     return; // @codeCoverageIgnore
                 }

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -15,7 +15,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\MessageHelper;
@@ -101,7 +100,7 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
          * This can be neigh anything, but for any usage except constants,
          * the namespaced name will be combined with non-allowed tokens, so we should be good.
          */
-        $this->safeOperands += Collections::nameTokens();
+        $this->safeOperands += Tokens::NAME_TOKENS;
     }
 
     /**
@@ -204,7 +203,7 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
                     // No need to worry about parent/self, that's handled above and
                     // the double colon is skipped over in that case.
                     if ($prevNonEmpty === false
-                        || isset(Collections::nameTokens()[$tokens[$prevNonEmpty]['code']]) === false
+                        || isset(Tokens::NAME_TOKENS[$tokens[$prevNonEmpty]['code']]) === false
                     ) {
                         return false;
                     }

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -59,7 +59,7 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
      *
      * @var array<int|string, int|string>
      */
-    protected $safeOperands = [
+    protected $safeOperands = Tokens::HEREDOC_TOKENS + Tokens::MAGIC_CONSTANTS + Tokens::EMPTY_TOKENS + Tokens::NAME_TOKENS + [
         \T_LNUMBER                  => \T_LNUMBER,
         \T_DNUMBER                  => \T_DNUMBER,
         \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
@@ -78,29 +78,7 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
      */
     public function register()
     {
-        // Set the properties up only once.
-        $this->setProperties();
-
         return parent::register();
-    }
-
-    /**
-     * Make some adjustments to the $safeOperands property.
-     *
-     * @since 8.2.0
-     *
-     * @return void
-     */
-    public function setProperties()
-    {
-        $this->safeOperands += Tokens::$heredocTokens;
-        $this->safeOperands += Tokens::$magicConstants;
-        $this->safeOperands += Tokens::$emptyTokens;
-        /*
-         * This can be neigh anything, but for any usage except constants,
-         * the namespaced name will be combined with non-allowed tokens, so we should be good.
-         */
-        $this->safeOperands += Tokens::NAME_TOKENS;
     }
 
     /**
@@ -184,7 +162,7 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
             case \T_PARENT:
             case \T_SELF:
             case \T_DOUBLE_COLON:
-                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonSimple + 1), ($end + 1), true);
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextNonSimple + 1), ($end + 1), true);
 
                 if ($tokens[$nextNonSimple]['code'] === \T_PARENT
                     || $tokens[$nextNonSimple]['code'] === \T_SELF
@@ -199,7 +177,7 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
                         return false;
                     }
 
-                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nextNonSimple - 1), null, true);
+                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($nextNonSimple - 1), null, true);
                     // No need to worry about parent/self, that's handled above and
                     // the double colon is skipped over in that case.
                     if ($prevNonEmpty === false
@@ -253,7 +231,7 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
                 ) {
                     $closer = $tokens[$nextNonSimple]['bracket_closer'];
                 } else {
-                    $maybeOpener = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonSimple + 1), ($end + 1), true);
+                    $maybeOpener = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextNonSimple + 1), ($end + 1), true);
                     if ($tokens[$maybeOpener]['code'] === \T_OPEN_PARENTHESIS) {
                         $opener = $maybeOpener;
                         if (isset($tokens[$opener]['parenthesis_closer']) === true) {

--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
@@ -136,7 +136,7 @@ final class NewNewInInitializersSniff extends AbstractInitialValueSniff
 
         $data = [$phrase];
 
-        $allowedNameTokens            = Collections::nameTokens();
+        $allowedNameTokens            = Tokens::NAME_TOKENS;
         $allowedNameTokens[\T_SELF]   = \T_SELF;
         $allowedNameTokens[\T_PARENT] = \T_PARENT;
 

--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
@@ -167,7 +167,7 @@ final class NewNewInInitializersSniff extends AbstractInitialValueSniff
             }
 
             // Only throw an error if this is a non-dynamic object instantiation. Dynamic is still not supported.
-            $isNameInvalid     = $phpcsFile->findNext($allowedNameTokens + Tokens::$emptyTokens, ($hasNew + 1), $end, true);
+            $isNameInvalid     = $phpcsFile->findNext($allowedNameTokens + Tokens::EMPTY_TOKENS, ($hasNew + 1), $end, true);
             $hasValidNameToken = $phpcsFile->findNext($allowedNameTokens, ($hasNew + 1), $end);
 
             if ($hasValidNameToken !== false

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenClassAliasSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenClassAliasSniff.php
@@ -73,13 +73,13 @@ final class ForbiddenClassAliasSniff extends AbstractFunctionCallParameterSniff
     /**
      * Tokens which we are looking for in the parameter.
      *
-     * This property is set in the register() method.
+     * This property is updated from the register() method.
      *
      * @since 10.0.0
      *
      * @var array<int|string, int|string>
      */
-    private $targetTokens = [];
+    private $targetTokens = Tokens::EMPTY_TOKENS + Tokens::HEREDOC_TOKENS + Tokens::STRING_TOKENS;
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -90,10 +90,6 @@ final class ForbiddenClassAliasSniff extends AbstractFunctionCallParameterSniff
      */
     public function register()
     {
-        // Only set the $targetTokens property once.
-        $this->targetTokens  = Tokens::$emptyTokens;
-        $this->targetTokens += Tokens::$heredocTokens;
-        $this->targetTokens += Tokens::$stringTokens;
         unset($this->targetTokens[\T_DOUBLE_QUOTED_STRING]);
 
         return parent::register();
@@ -131,7 +127,7 @@ final class ForbiddenClassAliasSniff extends AbstractFunctionCallParameterSniff
             return;
         }
 
-        $firstNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, $param['start'], ($param['end'] + 1), true);
+        $firstNonEmpty   = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $param['start'], ($param['end'] + 1), true);
         $hasNonTextToken = $phpcsFile->findNext($this->targetTokens, $firstNonEmpty, ($param['end'] + 1), true);
         if ($hasNonTextToken !== false) {
             // Non text string token found.

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -450,7 +450,7 @@ final class ForbiddenNamesSniff extends Sniff
                 continue;
             }
 
-            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']]) === true
                 && $tokens[$i]['code'] !== \T_STRING
             ) {
                 /*

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -207,7 +207,7 @@ final class ForbiddenNamesSniff extends Sniff
      *
      * @var array<int|string, int|string>
      */
-    private $allowedModifiers = [];
+    private $allowedModifiers = Tokens::SCOPE_MODIFIERS + [\T_FINAL => \T_FINAL];
 
     /**
      * Targeted tokens.
@@ -239,9 +239,6 @@ final class ForbiddenNamesSniff extends Sniff
      */
     public function register()
     {
-        $this->allowedModifiers           = Tokens::$scopeModifiers;
-        $this->allowedModifiers[\T_FINAL] = \T_FINAL;
-
         // Do the "other reserved keywords" list merge only once.
         $this->allOtherForbiddenNames = \array_merge($this->otherForbiddenNames, $this->softReservedNames);
 
@@ -293,7 +290,7 @@ final class ForbiddenNamesSniff extends Sniff
                  * handle this.
                  */
                 if (\strtolower($tokens[$stackPtr]['content']) === 'enum') {
-                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
                     if ($tokens[$prevNonEmpty]['code'] === \T_DOUBLE_COLON
                         || $tokens[$prevNonEmpty]['code'] === \T_OBJECT_OPERATOR
                         || $tokens[$prevNonEmpty]['code'] === \T_NULLSAFE_OBJECT_OPERATOR
@@ -313,7 +310,7 @@ final class ForbiddenNamesSniff extends Sniff
                         return;
                     }
 
-                    $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+                    $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
                     if ($nextNonEmpty === false) {
                         return;
                     }
@@ -362,7 +359,7 @@ final class ForbiddenNamesSniff extends Sniff
                  * and the 'conditions' aren't always correctly set, so we need to do an additional check for
                  * the last condition potentially being a previous trait T_USE.
                  */
-                $traitScopes = Tokens::$ooScopeTokens;
+                $traitScopes = Tokens::OO_SCOPE_TOKENS;
                 unset($traitScopes[\T_INTERFACE]);
 
                 if (Conditions::hasCondition($phpcsFile, $stackPtr, $traitScopes) === false) {
@@ -388,13 +385,13 @@ final class ForbiddenNamesSniff extends Sniff
                  * Deal with anonymous classes - `class` before a reserved keyword is sometimes
                  * misidentified as `T_ANON_CLASS`.
                  */
-                $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+                $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
                 if ($prevNonEmpty !== false && $tokens[$prevNonEmpty]['code'] === \T_NEW) {
                     return;
                 }
 
                 // Ok, so this isn't really an anonymous class.
-                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
                 if ($nextNonEmpty === false) {
                     return;
                 }
@@ -424,7 +421,7 @@ final class ForbiddenNamesSniff extends Sniff
         }
 
         $tokens = $phpcsFile->getTokens();
-        $next   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), ($endOfStatement + 1), true);
+        $next   = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), ($endOfStatement + 1), true);
         if ($next === $endOfStatement) {
             // Declaration of global namespace. I.e.: namespace {}.
             return;
@@ -446,7 +443,7 @@ final class ForbiddenNamesSniff extends Sniff
         }
 
         for ($i = $next; $i < $endOfStatement; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                 continue;
             }
 
@@ -621,7 +618,7 @@ final class ForbiddenNamesSniff extends Sniff
 
         if ($isOOConstant === false) {
             // Non-class constant declared using the "const" keyword.
-            $namePtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $namePtr = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
             if ($namePtr === false) {
                 // Live coding or parse error.
                 return;
@@ -718,7 +715,7 @@ final class ForbiddenNamesSniff extends Sniff
         }
 
         $checkOther   = true;
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), $endOfStatement, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), $endOfStatement, true);
         if (isset($this->validUseNames[$tokens[$nextNonEmpty]['content']]) === true) {
             $checkOther = false;
         }
@@ -757,7 +754,7 @@ final class ForbiddenNamesSniff extends Sniff
 
                 $checkOtherLocal = true;
 
-                $nextPtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextPtr + 1), $endOfStatement, true);
+                $nextPtr = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextPtr + 1), $endOfStatement, true);
                 if ($nextPtr === false) {
                     // Group use with trailing comma.
                     break;
@@ -775,7 +772,7 @@ final class ForbiddenNamesSniff extends Sniff
             }
 
             // Ok, so this must be an T_AS token.
-            $nextPtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextPtr + 1), $endOfStatement, true);
+            $nextPtr = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextPtr + 1), $endOfStatement, true);
             if ($nextPtr === false) {
                 break;
             }
@@ -822,7 +819,7 @@ final class ForbiddenNamesSniff extends Sniff
                 break;
             }
 
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($asPtr + 1), $closer, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($asPtr + 1), $closer, true);
             if ($nextNonEmpty === false) {
                 break;
             }
@@ -833,7 +830,7 @@ final class ForbiddenNamesSniff extends Sniff
              * - `use HelloWorld { sayHello as private myPrivateHello; }` => move to the next token to verify.
              */
             if (isset($this->allowedModifiers[$tokens[$nextNonEmpty]['code']]) === true) {
-                $maybeUseNext = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), $closer, true);
+                $maybeUseNext = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextNonEmpty + 1), $closer, true);
                 if ($maybeUseNext === false) {
                     // Reached the end of the use statement.
                     break;

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -274,7 +274,7 @@ final class NewKeywordsSniff extends Sniff
                     break;
                 }
 
-                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === false && $tokens[$i]['code'] !== \T_YIELD_FROM) {
+                if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === false && $tokens[$i]['code'] !== \T_YIELD_FROM) {
                     // Shouldn't be possible. Just to be on the safe side.
                     break; // @codeCoverageIgnore
                 }
@@ -295,8 +295,8 @@ final class NewKeywordsSniff extends Sniff
             return;
         }
 
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true);
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
         if ($prevToken !== false
             && isset(Collections::objectOperators()[$tokens[$prevToken]['code']]) === true

--- a/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
@@ -64,7 +64,7 @@ final class ForbiddenToStringParametersSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_STRING) {
             /*
              * Not a method call.

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -65,7 +65,7 @@ final class NewDirectCallsToCloneSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_STRING) {
             /*
              * Not a method call.
@@ -83,13 +83,13 @@ final class NewDirectCallsToCloneSniff extends Sniff
             return;
         }
 
-        $nextNextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
+        $nextNextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextNonEmpty + 1), null, true);
         if ($nextNextNonEmpty === false || $tokens[$nextNextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
             // Not a method call.
             return;
         }
 
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($prevNonEmpty === false
             || isset(Collections::ooHierarchyKeywords()[$tokens[$prevNonEmpty]['code']])
         ) {

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -171,7 +171,7 @@ final class ReservedNamesSniff extends Sniff
             }
 
             // Throw the message on the first part of the namespace name.
-            $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
 
             // Special case "PHP" to a warning with a custom message.
             if ($firstPart === 'php') {
@@ -208,7 +208,7 @@ final class ReservedNamesSniff extends Sniff
             }
 
             // Throw the message on the first part of the namespace name.
-            $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
 
             $warning = 'The top-level namespace name "%s" is reserved for, and in use by, a PECL extension%s. Found: %s';
             $code    = MessageHelper::stringToErrorCode($firstPart, true) . 'PeclReserved';

--- a/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/RemovedHexadecimalNumericStringsSniff.php
@@ -141,7 +141,7 @@ final class RemovedHexadecimalNumericStringsSniff extends Sniff
          */
         $nested = Parentheses::getLastOpener($phpcsFile, $stackPtr);
         if ($nested !== false) {
-            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($nested - 1), null, true);
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($nested - 1), null, true);
             if ($tokens[$prevNonEmpty]['code'] === \T_STRING
                 || $tokens[$prevNonEmpty]['code'] === \T_NAME_FULLY_QUALIFIED
             ) {
@@ -204,7 +204,7 @@ final class RemovedHexadecimalNumericStringsSniff extends Sniff
     private function isCallToGlobalFunction(File $phpcsFile, $stackPtr)
     {
         $tokens       = $phpcsFile->getTokens();
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
         if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === true) {
             // Method call.

--- a/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
@@ -174,8 +174,8 @@ final class ChangedConcatOperatorPrecedenceSniff extends Sniff
             }
 
             // Check for chain being broken by a token with a lower precedence.
-            if (isset(Tokens::$booleanOperators[$tokens[$i]['code']]) === true
-                || isset(Tokens::$assignmentTokens[$tokens[$i]['code']]) === true
+            if (isset(Tokens::BOOLEAN_OPERATORS[$tokens[$i]['code']]) === true
+                || isset(Tokens::ASSIGNMENT_TOKENS[$tokens[$i]['code']]) === true
             ) {
                 return;
             }

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -89,7 +89,7 @@ final class ForbiddenNegativeBitshiftSniff extends Sniff
 
         // Determine the start and end of the part of the statement we need to examine.
         $start = ($stackPtr + 1);
-        $next  = $phpcsFile->findNext(Tokens::$emptyTokens, $start, null, true);
+        $next  = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $start, null, true);
         if ($next !== false && $tokens[$next]['code'] === \T_OPEN_PARENTHESIS) {
             $start = ($next + 1);
         }

--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -118,7 +118,7 @@ final class RemovedTernaryAssociativitySniff extends Sniff
             }
 
             // Check for operators with lower operator precedence.
-            if (isset(Tokens::$assignmentTokens[$tokens[$i]['code']])
+            if (isset(Tokens::ASSIGNMENT_TOKENS[$tokens[$i]['code']])
                 || isset($this->tokensWithLowerPrecedence[$tokens[$i]['code']])
             ) {
                 break;

--- a/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ChangedIntToBoolParamTypeSniff.php
@@ -105,8 +105,8 @@ final class ChangedIntToBoolParamTypeSniff extends AbstractFunctionCallParameter
                 \T_LNUMBER => \T_LNUMBER,
                 \T_DNUMBER => \T_DNUMBER,
             ];
-            $search += Tokens::$arithmeticTokens;
-            $search += Tokens::$emptyTokens;
+            $search += Tokens::ARITHMETIC_TOKENS;
+            $search += Tokens::EMPTY_TOKENS;
         }
 
         $functionLC   = \strtolower($functionName);

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
@@ -46,31 +46,11 @@ final class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallPara
     /**
      * Tokens which we are looking for in the parameter.
      *
-     * This property is set in the register() method.
-     *
      * @since 10.0.0
      *
      * @var array<int|string, int|string>
      */
-    private $targetTokens = [];
-
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @since 10.0.0
-     *
-     * @return array<int|string>
-     */
-    public function register()
-    {
-        // Only set the $targetTokens property once.
-        $this->targetTokens  = Tokens::$emptyTokens;
-        $this->targetTokens += Tokens::$heredocTokens;
-        $this->targetTokens += Tokens::$stringTokens;
-
-        return parent::register();
-    }
-
+    private $targetTokens = Tokens::EMPTY_TOKENS + Tokens::HEREDOC_TOKENS + Tokens::STRING_TOKENS;
 
     /**
      * Do a version check to determine if this sniff needs to run at all.
@@ -105,7 +85,7 @@ final class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallPara
             return;
         }
 
-        $firstNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, $param['start'], ($param['end'] + 1), true);
+        $firstNonEmpty   = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $param['start'], ($param['end'] + 1), true);
         $hasNonTextToken = $phpcsFile->findNext($this->targetTokens, $firstNonEmpty, ($param['end'] + 1), true);
         if ($hasNonTextToken !== false) {
             // Non text string token found.

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -77,7 +76,7 @@ final class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCall
 
         $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLSniff.php
@@ -83,7 +83,7 @@ final class ForbiddenStripTagsSelfClosingXHTMLSniff extends AbstractFunctionCall
                 return;
             }
 
-            if (isset(Tokens::$textStringTokens[$tokens[$i]['code']]) === true
+            if (isset(Tokens::TEXT_STRING_TOKENS[$tokens[$i]['code']]) === true
                 && \strpos($tokens[$i]['content'], '/>') !== false
             ) {
                 $phpcsFile->addError(

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarSniff.php
@@ -76,7 +76,7 @@ final class NewArrayMergeRecursiveWithGlobalsVarSniff extends AbstractFunctionCa
             $hasNonVarToken = false;
 
             for ($i = $param['start']; $i <= $param['end']; $i++) {
-                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
+                if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']])) {
                     continue;
                 }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -14,6 +14,7 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -68,7 +69,7 @@ final class NewArrayReduceInitialTypeSniff extends AbstractFunctionCallParameter
     public function register()
     {
         // Enrich the variable value tokens array only once.
-        $this->variableValueTokens += Collections::nameTokens();
+        $this->variableValueTokens += Tokens::NAME_TOKENS;
         $this->variableValueTokens += Collections::ooHierarchyKeywords();
 
         return parent::register();

--- a/PHPCompatibility/Sniffs/ParameterValues/NewClassAliasInternalClassSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewClassAliasInternalClassSniff.php
@@ -64,13 +64,13 @@ final class NewClassAliasInternalClassSniff extends AbstractFunctionCallParamete
     /**
      * Tokens which we are looking for in the parameter.
      *
-     * This property is set in the register() method.
+     * This property is updated from the register() method.
      *
      * @since 10.0.0
      *
      * @var array<int|string, int|string>
      */
-    private $targetTokens = [];
+    private $targetTokens = Tokens::EMPTY_TOKENS + Tokens::HEREDOC_TOKENS + Tokens::STRING_TOKENS;
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -95,10 +95,6 @@ final class NewClassAliasInternalClassSniff extends AbstractFunctionCallParamete
 
         $this->declaredOONamesLC = \array_change_key_case($allOONames, \CASE_LOWER);
 
-        // Only set the $targetTokens property once.
-        $this->targetTokens  = Tokens::$emptyTokens;
-        $this->targetTokens += Tokens::$heredocTokens;
-        $this->targetTokens += Tokens::$stringTokens;
         unset($this->targetTokens[\T_DOUBLE_QUOTED_STRING]);
 
         return parent::register();
@@ -136,7 +132,7 @@ final class NewClassAliasInternalClassSniff extends AbstractFunctionCallParamete
             return;
         }
 
-        $firstNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, $param['start'], ($param['end'] + 1), true);
+        $firstNonEmpty   = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $param['start'], ($param['end'] + 1), true);
         $hasNonTextToken = $phpcsFile->findNext($this->targetTokens, $firstNonEmpty, ($param['end'] + 1), true);
         if ($hasNonTextToken !== false) {
             // Non text string token found.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewExitAsFunctionCallSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewExitAsFunctionCallSniff.php
@@ -226,7 +226,7 @@ final class NewExitAsFunctionCallSniff extends AbstractFunctionCallParameterSnif
         $total   = 0;
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']])) {
                 continue;
             }
 
@@ -307,13 +307,13 @@ final class NewExitAsFunctionCallSniff extends AbstractFunctionCallParameterSnif
                 continue;
             }
 
-            if (isset(Tokens::$arithmeticTokens[$tokens[$i]['code']])) {
+            if (isset(Tokens::ARITHMETIC_TOKENS[$tokens[$i]['code']])) {
                 ++$arithm;
                 continue;
             }
 
-            if (isset(Tokens::$textStringTokens[$tokens[$i]['code']])
-                || isset(Tokens::$heredocTokens[$tokens[$i]['code']])
+            if (isset(Tokens::TEXT_STRING_TOKENS[$tokens[$i]['code']])
+                || isset(Tokens::HEREDOC_TOKENS[$tokens[$i]['code']])
             ) {
                 ++$string;
                 continue;

--- a/PHPCompatibility/Sniffs/ParameterValues/NewExitAsFunctionCallSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewExitAsFunctionCallSniff.php
@@ -15,7 +15,6 @@ use PHPCompatibility\Helpers\MiscHelper;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -285,7 +284,7 @@ final class NewExitAsFunctionCallSniff extends AbstractFunctionCallParameterSnif
                 continue;
             }
 
-            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, non-PHP-native constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -13,7 +13,7 @@ namespace PHPCompatibility\Sniffs\ParameterValues;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
-use PHPCSUtils\Tokens\Collections;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -80,7 +80,7 @@ final class NewFopenModesSniff extends AbstractFunctionCallParameterSniff
         $errors = [];
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -253,7 +253,7 @@ final class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallPara
         }
 
         $tokens        = $phpcsFile->getTokens();
-        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $targetParam['start'], ($targetParam['end'] + 1), true);
         if ($firstNonEmpty === false) {
             // Parse error or live coding, but preferences is definitely not set, so throw the error.
             $phpcsFile->addError($errorMsg, $stackPtr, 'PreferencesNotSet', $data);
@@ -274,7 +274,7 @@ final class NewIconvMbstringCharsetDefaultSniff extends AbstractFunctionCallPara
                 $hasInputCharset  += \preg_match('`^\s*([\'"])input-charset\1\s*=>`', $item['clean']);
                 $hasOutputCharset += \preg_match('`^\s*([\'"])output-charset\1\s*=>`', $item['clean']);
 
-                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $item['start'], ($item['end'] + 1), true);
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $item['start'], ($item['end'] + 1), true);
                 if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_ELLIPSIS) {
                     ++$hasSpreadInArray;
                 }

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
@@ -46,31 +46,11 @@ final class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCall
     /**
      * Tokens which we are looking for in the parameter.
      *
-     * This property is set in the register() method.
-     *
      * @since 10.0.0
      *
      * @var array<int|string, int|string>
      */
-    private $targetTokens = [];
-
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @since 10.0.0
-     *
-     * @return array<int|string>
-     */
-    public function register()
-    {
-        // Only set the $targetTokens property once.
-        $this->targetTokens  = Tokens::$emptyTokens;
-        $this->targetTokens += Tokens::$heredocTokens;
-        $this->targetTokens += Tokens::$stringTokens;
-
-        return parent::register();
-    }
-
+    private $targetTokens = Tokens::EMPTY_TOKENS + Tokens::HEREDOC_TOKENS + Tokens::STRING_TOKENS;
 
     /**
      * Do a version check to determine if this sniff needs to run at all.
@@ -124,7 +104,7 @@ final class NewNumberFormatMultibyteSeparatorsSniff extends AbstractFunctionCall
      */
     protected function examineParameter(File $phpcsFile, $param, $paramName)
     {
-        $firstNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, $param['start'], ($param['end'] + 1), true);
+        $firstNonEmpty   = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $param['start'], ($param['end'] + 1), true);
         $hasNonTextToken = $phpcsFile->findNext($this->targetTokens, $firstNonEmpty, ($param['end'] + 1), true);
         if ($hasNonTextToken !== false) {
             // Non text string token found.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -101,7 +100,7 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
         $tokens = $phpcsFile->getTokens();
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -107,7 +107,7 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
                 return;
             }
 
-            if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === false) {
+            if (isset(Tokens::STRING_TOKENS[$tokens[$i]['code']]) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -112,7 +112,7 @@ final class NewPasswordAlgoConstantValuesSniff extends AbstractFunctionCallParam
 
         $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']]) === true) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -79,7 +79,7 @@ final class NewProcOpenCmdArraySniff extends AbstractFunctionCallParameterSniff
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], $targetParam['end'], true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $targetParam['start'], $targetParam['end'], true);
 
         if ($nextNonEmpty === false) {
             // Shouldn't be possible.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -113,7 +112,7 @@ final class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallPara
 
             foreach ($items as $item) {
                 for ($i = $item['start']; $i <= $item['end']; $i++) {
-                    if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
+                    if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']]) === true
                         || $tokens[$i]['code'] === \T_VARIABLE
                     ) {
                         // Variable, constant, function call. Ignore complete item as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -76,7 +76,7 @@ final class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallPara
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], $targetParam['end'], true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $targetParam['start'], $targetParam['end'], true);
 
         if ($nextNonEmpty === false) {
             // Shouldn't be possible.
@@ -119,7 +119,7 @@ final class NewStripTagsAllowableTagsArraySniff extends AbstractFunctionCallPara
                         break;
                     }
 
-                    if (isset(Tokens::$textStringTokens[$tokens[$i]['code']]) === true
+                    if (isset(Tokens::TEXT_STRING_TOKENS[$tokens[$i]['code']]) === true
                         && \strpos($tokens[$i]['content'], '>') !== false
                     ) {
                         $phpcsFile->addWarning(

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
@@ -59,24 +59,7 @@ final class RemovedAssertStringAssertionSniff extends AbstractFunctionCallParame
      *
      * @var array<int|string, int|string>
      */
-    private $targetTokens = [];
-
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @since 10.0.0
-     *
-     * @return array<int|string>
-     */
-    public function register()
-    {
-        // Set $targetTokens only once.
-        $this->targetTokens                   = Tokens::$emptyTokens;
-        $this->targetTokens                  += Tokens::$stringTokens + Tokens::$heredocTokens;
-        $this->targetTokens[\T_STRING_CONCAT] = \T_STRING_CONCAT;
-
-        return parent::register();
-    }
+    private $targetTokens = Tokens::EMPTY_TOKENS + Tokens::STRING_TOKENS + Tokens::HEREDOC_TOKENS + [\T_STRING_CONCAT => \T_STRING_CONCAT];
 
     /**
      * Do a version check to determine if this sniff needs to run at all.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedDbaKeySplitNullFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedDbaKeySplitNullFalseSniff.php
@@ -82,7 +82,7 @@ final class RemovedDbaKeySplitNullFalseSniff extends AbstractFunctionCallParamet
         $firstNonEmpty                = null;
 
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']])) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -276,7 +276,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                 return;
             }
 
-            if (isset(Collections::nameTokens()[$tokenCode]) || $tokenCode === \T_VARIABLE) {
+            if (isset(Tokens::NAME_TOKENS[$tokenCode]) || $tokenCode === \T_VARIABLE) {
                 // Function call, constant or variable encountered.
                 // No matter what this is combined with, we won't be able to reliably determine the value.
                 return;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -142,7 +142,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
         $end         = ($targetParam['end'] + 1);
         $isOnlyText  = true;
 
-        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $start, $end, true);
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $start, $end, true);
         if ($firstNonEmpty === false) {
             // Parse error. Shouldn't be possible.
             return;
@@ -164,7 +164,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
         for ($i = $start; $i < $end; $i++) {
             $tokenCode = $tokens[$i]['code'];
 
-            if (isset(Tokens::$emptyTokens[$tokenCode])) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokenCode])) {
                 continue;
             }
 
@@ -178,7 +178,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                 continue;
             }
 
-            if (isset(Tokens::$stringTokens[$tokenCode]) === false) {
+            if (isset(Tokens::STRING_TOKENS[$tokenCode]) === false) {
                 $isOnlyText = false;
             }
 
@@ -191,7 +191,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                 /*
                  * Check for specific functions which return an array (i.e. $pieces).
                  */
-                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), $end, true);
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), $end, true);
                 if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
                     continue;
                 }
@@ -210,7 +210,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
 
                 if ($tokenCode === \T_STRING) {
                     // Now make sure it's the PHP native function being called.
-                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($i - 1), $start, true);
+                    $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($i - 1), $start, true);
                     if (isset(Collections::objectOperators()[$tokens[$prevNonEmpty]['code']]) === true) {
                         // Method call, not a call to the PHP native function.
                         continue;
@@ -237,7 +237,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
         $start       = $targetParam['start'];
         $end         = ($targetParam['end'] + 1);
 
-        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $start, $end, true);
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $start, $end, true);
         if ($firstNonEmpty === false) {
             // Parse error. Shouldn't be possible.
             return;
@@ -259,7 +259,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
         for ($i = $start; $i < $end; $i++) {
             $tokenCode = $tokens[$i]['code'];
 
-            if (isset(Tokens::$emptyTokens[$tokenCode])) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokenCode])) {
                 continue;
             }
 
@@ -282,7 +282,7 @@ final class RemovedImplodeFlexibleParamOrderSniff extends AbstractFunctionCallPa
                 return;
             }
 
-            if (isset(Tokens::$textStringTokens[$tokenCode]) === true) {
+            if (isset(Tokens::TEXT_STRING_TOKENS[$tokenCode]) === true) {
                 $this->throwNotice($phpcsFile, $stackPtr, $functionName);
                 return;
             }

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrimWidthNegativeWidthSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrimWidthNegativeWidthSniff.php
@@ -82,7 +82,7 @@ final class RemovedMbStrimWidthNegativeWidthSniff extends AbstractFunctionCallPa
             return;
         }
 
-        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $targetParam['start'], ($targetParam['end'] + 1), true);
 
         $phpcsFile->addWarning(
             'Passing a negative $width to mb_strimwidth() is deprecated since PHP 8.3. Found: %s',

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -110,7 +110,7 @@ final class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCall
             return;
         }
 
-        $targets   = $this->numberTokens + Tokens::$emptyTokens;
+        $targets   = $this->numberTokens + Tokens::EMPTY_TOKENS;
         $nonNumber = $phpcsFile->findNext($targets, $targetParam['start'], ($targetParam['end'] + 1), true);
         if ($nonNumber === false) {
             return;
@@ -123,7 +123,7 @@ final class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCall
         $tokens         = $phpcsFile->getTokens();
         $probablyString = false;
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
+            if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']])) {
                 continue;
             }
 
@@ -151,7 +151,7 @@ final class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCall
                 continue;
             }
 
-            if (isset(Tokens::$textStringTokens[$tokens[$i]['code']])
+            if (isset(Tokens::TEXT_STRING_TOKENS[$tokens[$i]['code']])
                 || $tokens[$i]['code'] === \T_STRING_CAST
                 || $tokens[$i]['code'] === \T_STRING_CONCAT
             ) {
@@ -167,7 +167,7 @@ final class RemovedMbStrrposEncodingThirdParamSniff extends AbstractFunctionCall
         $error     = 'Passing the encoding to mb_strrpos() as third parameter is soft deprecated since PHP 5.2';
         $isError   = false;
         $code      = 'Deprecated';
-        $realStart = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+        $realStart = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $targetParam['start'], ($targetParam['end'] + 1), true);
 
         if (ScannedCode::shouldRunOnOrAbove('8.0') === true) {
             $error  .= ', hard deprecated since PHP 7.4 and removed since PHP 8.0';

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -104,7 +103,7 @@ final class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterS
          * Get the content of any string tokens in the options parameter and remove the quotes and variables.
          */
         for ($i = $optionsParam['start']; $i <= $optionsParam['end']; $i++) {
-            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -110,7 +110,7 @@ final class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterS
                 return;
             }
 
-            if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === false) {
+            if (isset(Tokens::STRING_TOKENS[$tokens[$i]['code']]) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedProprietaryCSVEscapingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedProprietaryCSVEscapingSniff.php
@@ -141,7 +141,7 @@ final class RemovedProprietaryCSVEscapingSniff extends AbstractFunctionCallParam
             return;
         }
 
-        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $targetParam['start'], ($targetParam['end'] + 1), true);
 
         // Special case the changed behaviour for str_getcsv().
         if ($functionLC === 'str_getcsv') {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -89,7 +89,7 @@ final class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSni
                 return;
             }
 
-            if (isset(Tokens::$stringTokens[$tokens[$i]['code']]) === false) {
+            if (isset(Tokens::STRING_TOKENS[$tokens[$i]['code']]) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -83,7 +82,7 @@ final class RemovedSetlocaleStringSniff extends AbstractFunctionCallParameterSni
 
         $tokens = $phpcsFile->getTokens();
         for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-            if (isset(Collections::nameTokens()[$tokens[$i]['code']]) === true
+            if (isset(Tokens::NAME_TOKENS[$tokens[$i]['code']]) === true
                 || $tokens[$i]['code'] === \T_VARIABLE
             ) {
                 // Variable, constant, function call. Ignore as undetermined.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedTriggerErrorLevelSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedTriggerErrorLevelSniff.php
@@ -79,7 +79,7 @@ final class RemovedTriggerErrorLevelSniff extends AbstractFunctionCallParameterS
             return;
         }
 
-        $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+        $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $targetParam['start'], ($targetParam['end'] + 1), true);
 
         $phpcsFile->addWarning(
             'Passing E_USER_ERROR to trigger_error() is deprecated since 8.4. Throw an exception or call exit with a string message instead.',

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedVersionCompareOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedVersionCompareOperatorsSniff.php
@@ -96,11 +96,11 @@ final class RemovedVersionCompareOperatorsSniff extends AbstractFunctionCallPara
 
         $tokens = $phpcsFile->getTokens();
 
-        $textStartTokens  = Tokens::$stringTokens;
-        $textStartTokens += Tokens::$heredocTokens;
+        $textStartTokens  = Tokens::STRING_TOKENS;
+        $textStartTokens += Tokens::HEREDOC_TOKENS;
 
         $accepted  = $textStartTokens;
-        $accepted += Tokens::$emptyTokens;
+        $accepted += Tokens::EMPTY_TOKENS;
 
         $hasNonText = $phpcsFile->findNext($accepted, $targetParam['start'], ($targetParam['end'] + 1), true);
         if ($hasNonText !== false) {

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedXmlSetHandlerCallbackUnsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedXmlSetHandlerCallbackUnsetSniff.php
@@ -106,7 +106,7 @@ final class RemovedXmlSetHandlerCallbackUnsetSniff extends AbstractFunctionCallP
 
             $callback = '';
             for ($i = $targetParam['start']; $i <= $targetParam['end']; $i++) {
-                if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
+                if (isset(Tokens::EMPTY_TOKENS[$tokens[$i]['code']])) {
                     continue;
                 }
 
@@ -141,7 +141,7 @@ final class RemovedXmlSetHandlerCallbackUnsetSniff extends AbstractFunctionCallP
                 continue;
             }
 
-            $firstNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $targetParam['start'], ($targetParam['end'] + 1), true);
+            $firstNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $targetParam['start'], ($targetParam['end'] + 1), true);
 
             $msg  = 'Passing an empty string to reset the $%s for %s() is deprecated since PHP 8.4. Pass `null` instead.';
             $code = 'Deprecated';

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -39,13 +39,11 @@ final class ForbiddenCallTimePassByReferenceSniff extends Sniff
     /**
      * Tokens that represent assignments or equality comparisons.
      *
-     * Tokens are set via register(). Combines Tokens::$assignmentTokens + Tokens::$equalityTokens.
-     *
      * @since 8.1.0
      *
      * @var array<int|string, int|string>
      */
-    private $assignOrCompare = [];
+    private $assignOrCompare = Tokens::ASSIGNMENT_TOKENS + Tokens::EQUALITY_TOKENS;
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -56,8 +54,6 @@ final class ForbiddenCallTimePassByReferenceSniff extends Sniff
      */
     public function register()
     {
-        $this->assignOrCompare = Tokens::$assignmentTokens + Tokens::$equalityTokens;
-
         return Collections::functionCallTokens();
     }
 
@@ -84,7 +80,7 @@ final class ForbiddenCallTimePassByReferenceSniff extends Sniff
         // within their definitions. For example: function myFunction...
         // "myFunction" is T_STRING but we should skip because it is not a
         // function or method *call*.
-        $findTokens   = Tokens::$emptyTokens;
+        $findTokens   = Tokens::EMPTY_TOKENS;
         $findTokens[] = \T_BITWISE_AND;
 
         $prevNonEmpty = $phpcsFile->findPrevious(
@@ -100,7 +96,7 @@ final class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
         // If the next non-whitespace token after the function or method call
         // is not an opening parenthesis then it can't really be a *call*.
-        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openBracket = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
 
         if ($openBracket === false || $tokens[$openBracket]['code'] !== \T_OPEN_PARENTHESIS
             || isset($tokens[$openBracket]['parenthesis_closer']) === false
@@ -210,7 +206,7 @@ final class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
             // Checking this: $value = my_function(...[*]$arg...).
             $tokenBefore = $phpcsFile->findPrevious(
-                Tokens::$emptyTokens,
+                Tokens::EMPTY_TOKENS,
                 ($nextVariable - 1),
                 $searchStartToken,
                 true
@@ -227,7 +223,7 @@ final class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
             // Checking this: $value = my_function(...[*]&$arg...).
             $tokenBefore = $phpcsFile->findPrevious(
-                Tokens::$emptyTokens,
+                Tokens::EMPTY_TOKENS,
                 ($tokenBefore - 1),
                 $searchStartToken,
                 true

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -160,7 +160,7 @@ final class NewArrayStringDereferencingSniff extends Sniff
         $braces = [];
 
         do {
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true, null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true, null, true);
             if ($nextNonEmpty === false) {
                 break;
             }

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -122,7 +122,7 @@ final class NewArrayUnpackingSniff extends Sniff
             }
 
             // Ok, found one.
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
             $snippet      = GetTokensAsString::compact($phpcsFile, $i, $nextNonEmpty, true);
             $phpcsFile->addError(
                 'Array unpacking within array declarations using the spread operator is not supported in PHP 7.3 or earlier. Found: %s',

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -149,7 +149,7 @@ final class NewClassMemberAccessSniff extends Sniff
 
         $parenthesisCloser = $tokens[$parenthesisOpener]['parenthesis_closer'];
 
-        $prevBeforeParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($parenthesisOpener - 1), null, true);
+        $prevBeforeParenthesis = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($parenthesisOpener - 1), null, true);
         if ($prevBeforeParenthesis !== false
             && isset(Tokens::NAME_TOKENS[$tokens[$prevBeforeParenthesis]['code']]) === true
         ) {
@@ -161,7 +161,7 @@ final class NewClassMemberAccessSniff extends Sniff
         $end    = $parenthesisCloser;
 
         do {
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($end + 1), null, true, null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($end + 1), null, true, null, true);
             if ($nextNonEmpty === false) {
                 break;
             }

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Parentheses;
 
 /**
@@ -152,7 +151,7 @@ final class NewClassMemberAccessSniff extends Sniff
 
         $prevBeforeParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($parenthesisOpener - 1), null, true);
         if ($prevBeforeParenthesis !== false
-            && isset(Collections::nameTokens()[$tokens[$prevBeforeParenthesis]['code']]) === true
+            && isset(Tokens::NAME_TOKENS[$tokens[$prevBeforeParenthesis]['code']]) === true
         ) {
             // This is most likely a function call with the new/cloned object as a parameter.
             return [];

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessWithoutParenthesesSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessWithoutParenthesesSniff.php
@@ -65,7 +65,7 @@ final class NewClassMemberAccessWithoutParenthesesSniff extends Sniff
             return;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             // Live coding/parse error.
             return;
@@ -87,7 +87,7 @@ final class NewClassMemberAccessWithoutParenthesesSniff extends Sniff
 
         $endOfStatement = $phpcsFile->findEndOfStatement($stackPtr);
 
-        $ignore              = Tokens::$emptyTokens;
+        $ignore              = Tokens::EMPTY_TOKENS;
         $ignore             += Collections::namespacedNameTokens();
         $ignore[\T_READONLY] = \T_READONLY; // PHP 8.3 readonly anonymous classes.
         $ignore[\T_VARIABLE] = \T_VARIABLE;

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -14,7 +14,6 @@ use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 
 /**
  * Detect dynamic access to static methods and properties, as well as class constants.
@@ -85,7 +84,7 @@ final class NewDynamicAccessToStaticSniff extends Sniff
             }
         }
 
-        if (isset(Collections::nameTokens()[$tokens[$prevNonEmpty]['code']]) === true
+        if (isset(Tokens::NAME_TOKENS[$tokens[$prevNonEmpty]['code']]) === true
             && $tokens[$prevNonEmpty]['code'] !== \T_STRING
         ) {
             return;

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicAccessToStaticSniff.php
@@ -64,7 +64,7 @@ final class NewDynamicAccessToStaticSniff extends Sniff
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
         // Disregard `static::` as well. Late static binding is reported by another sniff.
         if ($tokens[$prevNonEmpty]['code'] === \T_SELF
@@ -75,7 +75,7 @@ final class NewDynamicAccessToStaticSniff extends Sniff
         }
 
         if ($tokens[$prevNonEmpty]['code'] === \T_STRING) {
-            $prevPrevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+            $prevPrevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prevNonEmpty - 1), null, true);
 
             if ($tokens[$prevPrevNonEmpty]['code'] !== \T_OBJECT_OPERATOR
                 && $tokens[$prevPrevNonEmpty]['code'] !== \T_NULLSAFE_OBJECT_OPERATOR

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -60,7 +60,7 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $stackPtr + 1, null, true);
         if ($nextNonEmpty === false) {
             return;
         }
@@ -77,13 +77,13 @@ final class NewDynamicClassConstantFetchSniff extends Sniff
         }
 
         $bracketCloser = $tokens[$bracketOpener]['bracket_closer'];
-        $nextNonEmpty  = $phpcsFile->findNext(Tokens::$emptyTokens, $bracketCloser + 1, null, true);
+        $nextNonEmpty  = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $bracketCloser + 1, null, true);
         // Prevent false positive for syntax which has been supported since PHP 5.4: `Foo::{$bar}()`.
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS) {
             return;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, $bracketOpener + 1, $bracketCloser, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $bracketOpener + 1, $bracketCloser, true);
         // Example: `Foo::{{$bar->name}()}` is a parse error that might seem like a valid constant fetch due to `Foo::{...}`.
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_CURLY_BRACKET) {
             return;

--- a/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
@@ -63,12 +63,12 @@ final class NewFirstClassCallablesSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($tokens[$prev]['code'] !== \T_OPEN_PARENTHESIS) {
             return;
         }
 
-        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($next === false || $tokens[$next]['code'] !== \T_CLOSE_PARENTHESIS) {
             return;
         }

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -122,7 +122,7 @@ final class NewFunctionArrayDereferencingSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Next non-empty token should be the open parenthesis.
-        $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $openParenthesis = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true, null, true);
         if ($openParenthesis === false || $tokens[$openParenthesis]['code'] !== \T_OPEN_PARENTHESIS) {
             return [];
         }
@@ -134,13 +134,13 @@ final class NewFunctionArrayDereferencingSniff extends Sniff
 
         // Is this token really a function or method call ?
         if ($tokens[$stackPtr]['code'] === \T_STRING) {
-            $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if ($prevToken !== false
                 && isset(Collections::objectOperators()[$tokens[$prevToken]['code']]) === false
             ) {
                 if ($tokens[$prevToken]['code'] === \T_BITWISE_AND) {
                     // This may be a function declared by reference.
-                    $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevToken - 1), null, true);
+                    $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prevToken - 1), null, true);
                 }
 
                 $ignore = [
@@ -163,7 +163,7 @@ final class NewFunctionArrayDereferencingSniff extends Sniff
         $braces  = [];
 
         do {
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), null, true, null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($current + 1), null, true, null, true);
             if ($nextNonEmpty === false) {
                 break;
             }

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -51,7 +51,7 @@ final class NewFunctionArrayDereferencingSniff extends Sniff
      */
     public function register()
     {
-        return Collections::nameTokens();
+        return Tokens::NAME_TOKENS;
     }
 
     /**

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -81,7 +81,7 @@ final class NewFunctionCallTrailingCommaSniff extends Sniff
         if (isset($tokens[$stackPtr]['parenthesis_opener']) === true) {
             $opener = $tokens[$stackPtr]['parenthesis_opener'];
         } else {
-            $opener = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $opener = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
             if ($tokens[$opener]['code'] !== \T_OPEN_PARENTHESIS
                 || isset($tokens[$opener]['parenthesis_closer']) === false
             ) {
@@ -98,7 +98,7 @@ final class NewFunctionCallTrailingCommaSniff extends Sniff
         }
 
         $closer            = $tokens[$opener]['parenthesis_closer'];
-        $lastInParenthesis = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), $opener, true);
+        $lastInParenthesis = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($closer - 1), $opener, true);
 
         if ($tokens[$lastInParenthesis]['code'] !== \T_COMMA) {
             return;

--- a/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
@@ -74,7 +74,7 @@ final class NewInterpolatedStringDereferencingSniff extends Sniff
         }
 
         // Check whether the string is being dereferenced.
-        $nextNonEmpty     = $phpcsFile->findNext(Tokens::$emptyTokens, $nextAfter, null, true);
+        $nextNonEmpty     = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $nextAfter, null, true);
         $nextNonEmptyCode = $tokens[$nextNonEmpty]['code'];
         if ($nextNonEmptyCode !== \T_OPEN_SQUARE_BRACKET
             && $nextNonEmptyCode !== \T_OBJECT_OPERATOR

--- a/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewMagicConstantDereferencingSniff.php
@@ -36,7 +36,7 @@ final class NewMagicConstantDereferencingSniff extends Sniff
      */
     public function register()
     {
-        return Tokens::$magicConstants;
+        return Tokens::MAGIC_CONSTANTS;
     }
 
     /**
@@ -57,7 +57,7 @@ final class NewMagicConstantDereferencingSniff extends Sniff
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             return;
         }
@@ -72,7 +72,7 @@ final class NewMagicConstantDereferencingSniff extends Sniff
         }
 
         $hasContent = $phpcsFile->findNext(
-            Tokens::$emptyTokens,
+            Tokens::EMPTY_TOKENS,
             ($nextNonEmpty + 1),
             $tokens[$nextNonEmpty]['bracket_closer'],
             true
@@ -89,13 +89,13 @@ final class NewMagicConstantDereferencingSniff extends Sniff
         // Make sure this isn't an array assignment. That would be illegal, i.e. a parse error.
         $nextNext = $tokens[$nextNonEmpty]['bracket_closer'];
         do {
-            $nextNext = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNext + 1), null, true);
+            $nextNext = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextNext + 1), null, true);
             if ($nextNext === false) {
                 break;
             }
 
             // If the next token is an assignment, that's all we need to know.
-            if (isset(Tokens::$assignmentTokens[$tokens[$nextNext]['code']]) === true) {
+            if (isset(Tokens::ASSIGNMENT_TOKENS[$tokens[$nextNext]['code']]) === true) {
                 return;
             }
 

--- a/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewNestedStaticAccessSniff.php
@@ -69,7 +69,7 @@ final class NewNestedStaticAccessSniff extends Sniff
         $prevOperator = false;
 
         do {
-            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+            $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prev - 1), null, true);
 
             if ($prev === false) {
                 return;
@@ -106,7 +106,7 @@ final class NewNestedStaticAccessSniff extends Sniff
             }
 
             // OK, we have the start of the access, let see if it's nested.
-            $prevOperator = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prev - 1), null, true);
+            $prevOperator = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($prev - 1), null, true);
             break;
 
         } while (true);

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -17,7 +17,6 @@ use PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff;
 use PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
-use PHPCSUtils\Tokens\Collections;
 
 /**
  * Using the curly brace syntax to access array or string offsets has been deprecated in PHP 7.4
@@ -118,7 +117,7 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
             ],
         ];
 
-        $targets[] = Collections::nameTokens(); // Constants.
+        $targets[] = Tokens::NAME_TOKENS; // Constants.
 
         // Registers T_ARRAY, T_OPEN_SHORT_ARRAY and T_CONSTANT_ENCAPSED_STRING.
         $additionalTargets                        = $this->newArrayStringDereferencing->register();
@@ -130,7 +129,7 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
         $this->newClassMemberAccessTargets = \array_flip($additionalTargets);
         $targets[]                         = $additionalTargets;
 
-        // Registers Collections::nameTokens().
+        // Registers Tokens::NAME_TOKENS.
         $additionalTargets = $this->newFunctionArrayDereferencing->register();
         $this->newFunctionArrayDereferencingTargets = \array_flip($additionalTargets);
         $targets[] = $additionalTargets;
@@ -179,7 +178,7 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
             $braces = $this->newFunctionArrayDereferencing->isFunctionArrayDereferencing($phpcsFile, $stackPtr);
         }
 
-        if (empty($braces) && isset(Collections::nameTokens()[$tokens[$stackPtr]['code']])) {
+        if (empty($braces) && isset(Tokens::NAME_TOKENS[$tokens[$stackPtr]['code']])) {
             $braces = $this->isConstantArrayAccess($phpcsFile, $stackPtr);
         }
 

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -203,7 +203,7 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
             }
 
             // Make sure there is something between the braces, otherwise it's still not curly brace array access.
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($open + 1), $close, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($open + 1), $close, true);
             if ($nextNonEmpty === false) {
                 // Nothing between the brackets. Parse error. Ignore.
                 continue;
@@ -248,7 +248,7 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
         $braces  = [];
 
         do {
-            $current = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), null, true);
+            $current = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($current + 1), null, true);
             if ($current === false) {
                 break;
             }
@@ -266,7 +266,7 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
             if ($tokens[$current]['code'] === \T_OBJECT_OPERATOR
                 || $tokens[$current]['code'] === \T_NULLSAFE_OBJECT_OPERATOR
             ) {
-                $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), null, true);
+                $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($current + 1), null, true);
                 if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_STRING) {
                     // Live coding or parse error.
                     break;
@@ -318,9 +318,9 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
     protected function isConstantArrayAccess(File $phpcsFile, $stackPtr)
     {
         $tokens       = $phpcsFile->getTokens();
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             return [];
         }
@@ -336,7 +336,7 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
         $braces  = [];
 
         do {
-            $current = $phpcsFile->findNext(Tokens::$emptyTokens, ($current + 1), null, true);
+            $current = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($current + 1), null, true);
             if ($current === false) {
                 break;
             }

--- a/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedNewReferenceSniff.php
@@ -63,7 +63,7 @@ final class RemovedNewReferenceSniff extends Sniff
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== \T_BITWISE_AND) {
             return;
         }

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -84,7 +84,7 @@ final class NewGroupUseDeclarationsSniff extends Sniff
         }
 
         if ($tokens[$stackPtr]['code'] === \T_CLOSE_USE_GROUP) {
-            $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
             if ($tokens[$prevToken]['code'] === \T_COMMA) {
                 $phpcsFile->addError(
                     'Trailing commas are not allowed in group use statements in PHP 7.1 or earlier',

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -84,14 +84,14 @@ final class NewUseConstFunctionSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Note: $nextNonEmpty will never be `false` as otherwise `isImportUse()` would have returned `false`.
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if (isset($this->validUseNames[\strtolower($tokens[$nextNonEmpty]['content'])]) === false) {
             // Not a `use const` or `use function` statement.
             return;
         }
 
         // `use const` and `use function` have to be followed by the function/constant name.
-        $functionOrConstName = $phpcsFile->findNext(Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
+        $functionOrConstName = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($nextNonEmpty + 1), null, true);
         if ($functionOrConstName === false
             || ($tokens[$functionOrConstName]['code'] === \T_AS
             || $tokens[$functionOrConstName]['code'] === \T_COMMA)

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenGlobalVariableVariableSniff.php
@@ -76,10 +76,10 @@ final class ForbiddenGlobalVariableVariableSniff extends Sniff
 
             if ($variable !== false) {
 
-                $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($variable - 1), $ptr, true);
+                $prev = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($variable - 1), $ptr, true);
                 if ($tokens[$prev]['code'] === \T_DOLLAR) {
 
-                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($variable + 1), $varEnd, true);
+                    $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($variable + 1), $varEnd, true);
                     if ($next !== false
                         && (isset(Collections::objectOperators()[$tokens[$next]['code']]) === true
                             || $tokens[$next]['code'] === \T_OPEN_SQUARE_BRACKET)
@@ -106,7 +106,7 @@ final class ForbiddenGlobalVariableVariableSniff extends Sniff
             if ($errorThrown === false) {
                 $dollar = $phpcsFile->findNext(\T_DOLLAR, $ptr, $varEnd);
                 if ($dollar !== false) {
-                    $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($dollar + 1), $varEnd, true);
+                    $next = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($dollar + 1), $varEnd, true);
                     if ($tokens[$next]['code'] === \T_OPEN_CURLY_BRACKET) {
                         $phpcsFile->addWarning(
                             'Global with anything other than bare variables is discouraged since PHP 7.0. Found %s',

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -62,7 +62,7 @@ final class ForbiddenThisUseContextsSniff extends Sniff
      *
      * @var array<int|string, true>
      */
-    private $skipOverScopes = [
+    private $skipOverScopes = Tokens::OO_SCOPE_TOKENS + [
         \T_FUNCTION => true,
         \T_CLOSURE  => true,
     ];
@@ -88,8 +88,6 @@ final class ForbiddenThisUseContextsSniff extends Sniff
      */
     public function register()
     {
-        $this->skipOverScopes += Tokens::$ooScopeTokens;
-
         return [
             \T_FUNCTION,
             \T_CLOSURE,
@@ -210,7 +208,7 @@ final class ForbiddenThisUseContextsSniff extends Sniff
                 }
 
                 $afterThis = $phpcsFile->findNext(
-                    Tokens::$emptyTokens,
+                    Tokens::EMPTY_TOKENS,
                     ($valueVarPtr + 1),
                     $tokens[$stackPtr]['parenthesis_closer'],
                     true
@@ -252,7 +250,7 @@ final class ForbiddenThisUseContextsSniff extends Sniff
                         continue;
                     }
 
-                    $afterThis = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), $closeParenthesis, true);
+                    $afterThis = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), $closeParenthesis, true);
                     if ($afterThis !== false
                         && (isset(Collections::objectOperators()[$tokens[$afterThis]['code']]) === true
                             || $tokens[$afterThis]['code'] === \T_OPEN_SQUARE_BRACKET)
@@ -288,7 +286,7 @@ final class ForbiddenThisUseContextsSniff extends Sniff
      */
     protected function isThisUsedAsParameter(File $phpcsFile, $stackPtr)
     {
-        if (Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens) !== false) {
+        if (Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::OO_SCOPE_TOKENS) !== false) {
             return;
         }
 
@@ -346,7 +344,7 @@ final class ForbiddenThisUseContextsSniff extends Sniff
             return;
         }
 
-        if (Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::$ooScopeTokens) !== false) {
+        if (Scopes::validDirectScope($phpcsFile, $stackPtr, Tokens::OO_SCOPE_TOKENS) !== false) {
             $methodProps = $phpcsFile->getMethodProperties($stackPtr);
             if ($methodProps['is_static'] === false) {
                 return;
@@ -384,7 +382,7 @@ final class ForbiddenThisUseContextsSniff extends Sniff
                 $lastOpenParenthesis   = \array_pop($nestedOpenParenthesis);
 
                 $previousNonEmpty = $phpcsFile->findPrevious(
-                    Tokens::$emptyTokens,
+                    Tokens::EMPTY_TOKENS,
                     ($lastOpenParenthesis - 1),
                     null,
                     true,

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -63,7 +63,7 @@ final class NewUniformVariableSyntaxSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Verify that the next token is a square open bracket. If not, bow out.
-        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextToken = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextToken === false
             || $tokens[$nextToken]['code'] !== \T_OPEN_SQUARE_BRACKET
             || isset($tokens[$nextToken]['bracket_closer']) === false
@@ -72,7 +72,7 @@ final class NewUniformVariableSyntaxSniff extends Sniff
         }
 
         // The previous non-empty token has to be a $, -> or ::.
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if (isset(Collections::objectOperators()[$tokens[$prevToken]['code']]) === false
             && $tokens[$prevToken]['code'] !== \T_DOLLAR
         ) {
@@ -82,7 +82,7 @@ final class NewUniformVariableSyntaxSniff extends Sniff
         // For static object calls, it only applies when this is a function call.
         if ($tokens[$prevToken]['code'] === \T_DOUBLE_COLON) {
             $hasBrackets = $tokens[$nextToken]['bracket_closer'];
-            while (($hasBrackets = $phpcsFile->findNext(Tokens::$emptyTokens, ($hasBrackets + 1), null, true)) !== false) {
+            while (($hasBrackets = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($hasBrackets + 1), null, true)) !== false) {
                 if ($tokens[$hasBrackets]['code'] === \T_OPEN_SQUARE_BRACKET) {
                     if (isset($tokens[$hasBrackets]['bracket_closer'])) {
                         $hasBrackets = $tokens[$hasBrackets]['bracket_closer'];

--- a/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
@@ -94,7 +94,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
             return;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             // Live coding or parse error.
             return;
@@ -109,7 +109,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
             $searchStart = ($nextNonEmpty + 1);
             $searchEnd   = $tokens[$nextNonEmpty]['bracket_closer'];
 
-            $hasNonEmptyTokens = $phpcsFile->findNext(Tokens::$emptyTokens, $searchStart, $searchEnd, true);
+            $hasNonEmptyTokens = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, $searchStart, $searchEnd, true);
             if ($hasNonEmptyTokens === false) {
                 // Assigning to a new array key.
                 $phpcsFile->addError(
@@ -120,7 +120,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
                 return;
             }
 
-            $allowedNumeric             = Tokens::$emptyTokens;
+            $allowedNumeric             = Tokens::EMPTY_TOKENS;
             $allowedNumeric[\T_LNUMBER] = \T_LNUMBER;
             $allowedNumeric[\T_DNUMBER] = \T_DNUMBER;
 
@@ -142,7 +142,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
              * Also doesn't allow for T_DOUBLE_QUOTED_STRING as that means there is variable interpolation
              * and that would never result in a match anyway.
              */
-            $allowedText = Tokens::$emptyTokens;
+            $allowedText = Tokens::EMPTY_TOKENS;
             $allowedText[\T_CONSTANT_ENCAPSED_STRING] = \T_CONSTANT_ENCAPSED_STRING;
 
             $hasNonText = $phpcsFile->findNext($allowedText, $searchStart, $searchEnd, true);
@@ -198,7 +198,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
             }
         }
 
-        if (isset(Tokens::$assignmentTokens[$tokens[$nextNonEmpty]['code']]) === true) {
+        if (isset(Tokens::ASSIGNMENT_TOKENS[$tokens[$nextNonEmpty]['code']]) === true) {
             $phpcsFile->addError(
                 \sprintf(self::WRITE_ERROR, 'assignment to $GLOBALS'),
                 $stackPtr,
@@ -207,7 +207,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
             return;
         }
 
-        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true);
         if ($tokens[$prevNonEmpty]['code'] === \T_BITWISE_AND
             && Operators::isReference($phpcsFile, $prevNonEmpty) === true
         ) {
@@ -269,7 +269,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
             return false;
         }
 
-        $maybeLabel = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($lastOpenParens - 1), null, true);
+        $maybeLabel = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($lastOpenParens - 1), null, true);
         if ($maybeLabel === false
             || ($tokens[$maybeLabel]['code'] !== \T_STRING
             && $tokens[$maybeLabel]['code'] !== \T_NAME_FULLY_QUALIFIED)
@@ -295,7 +295,7 @@ final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
             return false;
         }
 
-        $beforeLabel = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($maybeLabel - 1), null, true);
+        $beforeLabel = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($maybeLabel - 1), null, true);
         if ($beforeLabel !== false
             && (isset(Collections::objectOperators()[$tokens[$beforeLabel]['code']]) === true
             || $tokens[$beforeLabel]['code'] === \T_NEW)

--- a/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedPredefinedGlobalVariablesSniff.php
@@ -150,7 +150,7 @@ final class RemovedPredefinedGlobalVariablesSniff extends Sniff
         }
 
         // Check for static usage of class properties shadowing the removed global variables.
-        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $prevToken = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($stackPtr - 1), null, true, null, true);
         if ($prevToken !== false && $tokens[$prevToken]['code'] === \T_DOUBLE_COLON) {
             return;
         }
@@ -212,7 +212,7 @@ final class RemovedPredefinedGlobalVariablesSniff extends Sniff
         /*
          * Now, let's do some additional checks.
          */
-        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($stackPtr + 1), null, true);
 
         // Is the variable being used as an array ?
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_OPEN_SQUARE_BRACKET) {
@@ -223,7 +223,7 @@ final class RemovedPredefinedGlobalVariablesSniff extends Sniff
 
         // Is this a variable assignment ?
         if ($nextNonEmpty !== false
-            && isset(Tokens::$assignmentTokens[$tokens[$nextNonEmpty]['code']]) === true
+            && isset(Tokens::ASSIGNMENT_TOKENS[$tokens[$nextNonEmpty]['code']]) === true
         ) {
             return false;
         }
@@ -244,7 +244,7 @@ final class RemovedPredefinedGlobalVariablesSniff extends Sniff
                 && isset($tokens[$function]['parenthesis_closer'])
             ) {
                 $hasUse = $phpcsFile->findNext(
-                    Tokens::$emptyTokens,
+                    Tokens::EMPTY_TOKENS,
                     ($tokens[$function]['parenthesis_closer'] + 1),
                     null,
                     true
@@ -287,10 +287,10 @@ final class RemovedPredefinedGlobalVariablesSniff extends Sniff
                 continue;
             }
 
-            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
 
             if ($nextNonEmpty !== false
-                && isset(Tokens::$assignmentTokens[$tokens[$nextNonEmpty]['code']]) === true
+                && isset(Tokens::ASSIGNMENT_TOKENS[$tokens[$nextNonEmpty]['code']]) === true
             ) {
                 return false;
             }

--- a/PHPCompatibility/Util/Tests/Helpers/MiscHelper/IsUseOfGlobalConstantUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/MiscHelper/IsUseOfGlobalConstantUnitTest.php
@@ -10,9 +10,9 @@
 
 namespace PHPCompatibility\Util\Tests\Helpers\MiscHelper;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\MiscHelper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
-use PHPCSUtils\Tokens\Collections;
 
 /**
  * Tests for the `isUseOfGlobalConstant()` utility function.
@@ -63,7 +63,7 @@ final class IsUseOfGlobalConstantUnitTest extends UtilityMethodTestCase
      */
     public function testIsUseOfGlobalConstant($commentString, $expected, $targetContent = 'PHP_VERSION_ID')
     {
-        $stackPtr = $this->getTargetToken($commentString, Collections::nameTokens(), $targetContent);
+        $stackPtr = $this->getTargetToken($commentString, Tokens::NAME_TOKENS, $targetContent);
         $result   = MiscHelper::isUseOfGlobalConstant(self::$phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }


### PR DESCRIPTION
### Modernize: prefer Tokens::NAME_TOKENS over Collections::nameTokens() 

These token arrays contain the same tokens, but the `Tokens::NAME_TOKENS` array is only available in PHPCS 4.x, which is why we previously couldn't use it.

### Modernize: use the new PHPCS 4.x Tokens class constants 

... instead of the properties to reference token arrays.

This also allows for some simplifications when these token arrays are used to fill the value of a class property.

### GH Actions: add automated check for usage of Tokens::$... properties 

Now support for PHPCS 3.x has been dropped, only the `Tokens::...` constants should be used. The use of the properties from the `Tokens` class is deprecated.

This workflow job is intended to catch any accidental/force-of-habit usages of the `Tokens` properties.