### PR TITLE
Modernize: add constant visibility

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedOptionalBeforeRequiredParamSniff.php
@@ -54,35 +54,35 @@ final class RemovedOptionalBeforeRequiredParamSniff extends Sniff
      *
      * @var string
      */
-    const PHP80_MSG = 'Declaring an optional parameter before a required parameter is deprecated since PHP 8.0.';
+    private const PHP80_MSG = 'Declaring an optional parameter before a required parameter is deprecated since PHP 8.0.';
 
     /**
      * Base message for the PHP 8.1 deprecation.
      *
      * @var string
      */
-    const PHP81_MSG = 'Declaring an optional parameter with a nullable type before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.1';
+    private const PHP81_MSG = 'Declaring an optional parameter with a nullable type before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.1';
 
     /**
      * Base message for the PHP 8.3 deprecation.
      *
      * @var string
      */
-    const PHP83_MSG = 'Declaring an optional parameter with a null stand-alone type or a union type including null before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.3';
+    private const PHP83_MSG = 'Declaring an optional parameter with a null stand-alone type or a union type including null before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.3';
 
     /**
      * Base message for the PHP 8.4 deprecation.
      *
      * @var string
      */
-    const PHP84_MSG = 'Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4';
+    private const PHP84_MSG = 'Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4';
 
     /**
      * Message template for detailed information about the deprecation.
      *
      * @var string
      */
-    const MSG_DETAILS = ' Parameter %1$s is optional, while parameter %2$s is required. The %1$s parameter is implicitly treated as a required parameter.';
+    private const MSG_DETAILS = ' Parameter %1$s is optional, while parameter %2$s is required. The %1$s parameter is implicitly treated as a required parameter.';
 
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -49,7 +49,7 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
      *
      * @var string
      */
-    const ERROR_PHRASE = 'Constant scalar expressions are not allowed %s in PHP 5.5 or earlier.';
+    private const ERROR_PHRASE = 'Constant scalar expressions are not allowed %s in PHP 5.5 or earlier.';
 
     /**
      * Tokens which were allowed to be used in these declarations prior to PHP 5.6.

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -49,7 +49,7 @@ final class NewHeredocSniff extends AbstractInitialValueSniff
      *
      * @var string
      */
-    const ERROR_PHRASE = 'Initializing %s using the Heredoc syntax was not supported in PHP 5.2 or earlier. Found: %s';
+    private const ERROR_PHRASE = 'Initializing %s using the Heredoc syntax was not supported in PHP 5.2 or earlier. Found: %s';
 
     /**
      * Partial error phrases to be used in combination with the error message constant.

--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
@@ -46,7 +46,7 @@ final class NewNewInInitializersSniff extends AbstractInitialValueSniff
      *
      * @var string
      */
-    const ERROR_PHRASE = 'New in initializers is not supported in PHP 8.0 or earlier for %s.';
+    private const ERROR_PHRASE = 'New in initializers is not supported in PHP 8.0 or earlier for %s.';
 
     /**
      * Partial error phrases to be used in combination with the error message constant.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedGetClassNoArgsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedGetClassNoArgsSniff.php
@@ -38,7 +38,7 @@ final class RemovedGetClassNoArgsSniff extends AbstractFunctionCallParameterSnif
      *
      * @var string
      */
-    const ERROR_MSG = 'Calling %s() without the $%s argument is deprecated since PHP 8.3.';
+    private const ERROR_MSG = 'Calling %s() without the $%s argument is deprecated since PHP 8.3.';
 
     /**
      * Functions to check for.

--- a/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
@@ -48,7 +48,7 @@ use ReflectionFunction;
 final class RemovedIndirectModificationOfGlobalsSniff extends Sniff
 {
 
-    const WRITE_ERROR = 'Only individual keys in the $GLOBALS variable can be modified. The top-level $GLOBALS variable is read-only since PHP 8.1. Detected: %s';
+    private const WRITE_ERROR = 'Only individual keys in the $GLOBALS variable can be modified. The top-level $GLOBALS variable is read-only since PHP 8.1. Detected: %s';
 
     /**
      * List of PHP native functions.

--- a/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
+++ b/PHPCompatibility/Tests/Attributes/NewAttributesUnitTest.php
@@ -30,14 +30,14 @@ final class NewAttributesUnitTest extends BaseSniffTestCase
      *
      * @var string
      */
-    const TEST_FILE = 'NewAttributesUnitTest.1.inc';
+    private const TEST_FILE = 'NewAttributesUnitTest.1.inc';
 
     /**
      * The name of a secondary test case file containing tests with a PHP close tag in a text string.
      *
      * @var string
      */
-    const TEST_CLOSE_TAG = 'NewAttributesUnitTest.2.inc';
+    private const TEST_CLOSE_TAG = 'NewAttributesUnitTest.2.inc';
 
     /**
      * Verify that multi-line attributes are identified and flagged correctly.

--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -50,7 +50,7 @@ abstract class BaseSniffTestCase extends TestCase
      *
      * @var string
      */
-    const STANDARD_NAME = 'PHPCompatibility';
+    private const STANDARD_NAME = 'PHPCompatibility';
 
     /**
      * An array of PHPCS results by filename and PHP version.

--- a/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/ForbiddenBreakContinueVariableArgumentsUnitTest.php
@@ -30,14 +30,14 @@ final class ForbiddenBreakContinueVariableArgumentsUnitTest extends BaseSniffTes
      *
      * @var string
      */
-    const ERROR_TYPE_VARIABLE = 'a variable argument';
+    private const ERROR_TYPE_VARIABLE = 'a variable argument';
 
     /**
      * Error message snippet for the zero argument error.
      *
      * @var string
      */
-    const ERROR_TYPE_ZERO = '0 as an argument';
+    private const ERROR_TYPE_ZERO = '0 as an argument';
 
     /**
      * testBreakAndContinueVariableArgument

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedOptionalBeforeRequiredParamUnitTest.php
@@ -30,28 +30,28 @@ final class RemovedOptionalBeforeRequiredParamUnitTest extends BaseSniffTestCase
      *
      * @var string
      */
-    const PHP80_MSG = 'Declaring an optional parameter before a required parameter is deprecated since PHP 8.0.';
+    private const PHP80_MSG = 'Declaring an optional parameter before a required parameter is deprecated since PHP 8.0.';
 
     /**
      * Base message for the PHP 8.1 deprecation.
      *
      * @var string
      */
-    const PHP81_MSG = 'Declaring an optional parameter with a nullable type before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.1';
+    private const PHP81_MSG = 'Declaring an optional parameter with a nullable type before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.1';
 
     /**
      * Base message for the PHP 8.3 deprecation.
      *
      * @var string
      */
-    const PHP83_MSG = 'Declaring an optional parameter with a null stand-alone type or a union type including null before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.3';
+    private const PHP83_MSG = 'Declaring an optional parameter with a null stand-alone type or a union type including null before a required parameter is soft deprecated since PHP 8.0 and hard deprecated since PHP 8.3';
 
     /**
      * Base message for the PHP 8.4 deprecation.
      *
      * @var string
      */
-    const PHP84_MSG = 'Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4';
+    private const PHP84_MSG = 'Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4';
 
     /**
      * Verify that the sniff throws a warning for optional parameters before required.

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedMagicAutoloadUnitTest.php
@@ -30,7 +30,7 @@ final class RemovedMagicAutoloadUnitTest extends BaseSniffTestCase
      *
      * @var string
      */
-    const TEST_FILE = 'RemovedMagicAutoloadUnitTest.1.inc';
+    private const TEST_FILE = 'RemovedMagicAutoloadUnitTest.1.inc';
 
     /**
      * The name of a secondary test case file to test against false positives
@@ -38,7 +38,7 @@ final class RemovedMagicAutoloadUnitTest extends BaseSniffTestCase
      *
      * @var string
      */
-    const TEST_FILE_NAMESPACED = 'RemovedMagicAutoloadUnitTest.2.inc';
+    private const TEST_FILE_NAMESPACED = 'RemovedMagicAutoloadUnitTest.2.inc';
 
     /**
      * Test __autoload deprecation not causing issue in 7.1.

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/RemovedNamespacedAssertUnitTest.php
@@ -30,14 +30,14 @@ final class RemovedNamespacedAssertUnitTest extends BaseSniffTestCase
      *
      * @var string
      */
-    const TEST_FILE = 'RemovedNamespacedAssertUnitTest.1.inc';
+    private const TEST_FILE = 'RemovedNamespacedAssertUnitTest.1.inc';
 
     /**
      * The name of a secondary test case file containing code in a unscoped namespace.
      *
      * @var string
      */
-    const TEST_FILE_NAMESPACED = 'RemovedNamespacedAssertUnitTest.2.inc';
+    private const TEST_FILE_NAMESPACED = 'RemovedNamespacedAssertUnitTest.2.inc';
 
     /**
      * Test deprecation of namespaced free-standing assert() function declaration.

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -32,7 +32,7 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
      *
      * @var int
      */
-    const OTHER_KEYWORD_COUNT = 17;
+    private const OTHER_KEYWORD_COUNT = 17;
 
     /**
      * Count of "soft" reserved keywords.
@@ -41,7 +41,7 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
      *
      * @var int
      */
-    const SOFT_KEYWORD_COUNT = 3;
+    private const SOFT_KEYWORD_COUNT = 3;
 
     /**
      * Test case files containing tests for the "other" reserved keywords.

--- a/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
+++ b/PHPCompatibility/Tests/Miscellaneous/NewPHPOpenTagEOFUnitTest.php
@@ -30,7 +30,7 @@ final class NewPHPOpenTagEOFUnitTest extends BaseSniffTestCase
      *
      * @var string
      */
-    const TEST_FILE = 'NewPHPOpenTagEOFUnitTest.%d.inc';
+    private const TEST_FILE = 'NewPHPOpenTagEOFUnitTest.%d.inc';
 
     /**
      * Test detection of stand alone PHP open tag at end of file.

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenSessionModuleNameUserUnitTest.php
@@ -30,14 +30,14 @@ final class ForbiddenSessionModuleNameUserUnitTest extends BaseSniffTestCase
      *
      * @var string
      */
-    const TEST_FILE = 'ForbiddenSessionModuleNameUserUnitTest.1.inc';
+    private const TEST_FILE = 'ForbiddenSessionModuleNameUserUnitTest.1.inc';
 
     /**
      * The name of a secondary test case file containing PHP 7.3+ indented heredocs.
      *
      * @var string
      */
-    const TEST_FILE_PHP73HEREDOCS = 'ForbiddenSessionModuleNameUserUnitTest.2.inc';
+    private const TEST_FILE_PHP73HEREDOCS = 'ForbiddenSessionModuleNameUserUnitTest.2.inc';
 
     /**
      * Verify detection of the issue.

--- a/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/ForbiddenStripTagsSelfClosingXHTMLUnitTest.php
@@ -30,14 +30,14 @@ final class ForbiddenStripTagsSelfClosingXHTMLUnitTest extends BaseSniffTestCase
      *
      * @var string
      */
-    const TEST_FILE = 'ForbiddenStripTagsSelfClosingXHTMLUnitTest.1.inc';
+    private const TEST_FILE = 'ForbiddenStripTagsSelfClosingXHTMLUnitTest.1.inc';
 
     /**
      * The name of a secondary test case file containing PHP 7.3+ indented heredocs.
      *
      * @var string
      */
-    const TEST_FILE_PHP73HEREDOCS = 'ForbiddenStripTagsSelfClosingXHTMLUnitTest.2.inc';
+    private const TEST_FILE_PHP73HEREDOCS = 'ForbiddenStripTagsSelfClosingXHTMLUnitTest.2.inc';
 
     /**
      * Verify detection of the issue.

--- a/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/NewFlexibleHeredocNowdocUnitTest.php
@@ -30,7 +30,7 @@ final class NewFlexibleHeredocNowdocUnitTest extends BaseSniffTestCase
      *
      * @var string
      */
-    const TEST_FILE = 'NewFlexibleHeredocNowdocUnitTest.%d.inc';
+    private const TEST_FILE = 'NewFlexibleHeredocNowdocUnitTest.%d.inc';
 
     /**
      * Whether PHP 7.3+ is used.

--- a/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.php
+++ b/PHPCompatibility/Tests/TextStrings/RemovedDollarBraceStringEmbedsUnitTest.php
@@ -30,17 +30,17 @@ final class RemovedDollarBraceStringEmbedsUnitTest extends BaseSniffTestCase
      *
      * @var string
      */
-    const TEST_FILE = 'RemovedDollarBraceStringEmbedsUnitTest.1.inc';
+    private const TEST_FILE = 'RemovedDollarBraceStringEmbedsUnitTest.1.inc';
 
     /**
      * The name of a secondary test case file containing PHP 7.3+ indented heredocs.
      *
      * @var string
      */
-    const TEST_FILE_PHP73HEREDOCS = 'RemovedDollarBraceStringEmbedsUnitTest.2.inc';
+    private const TEST_FILE_PHP73HEREDOCS = 'RemovedDollarBraceStringEmbedsUnitTest.2.inc';
 
     /**
-     * Test that variable embeds of "type 3" - Braces after the dollar sign (“${foo}”) -
+     * Test that variable embeds of "type 3" - Braces after the dollar sign (`${foo}`) -
      * are correctly detected.
      *
      * @dataProvider dataRemovedDollarBraceStringEmbedsType3
@@ -77,7 +77,7 @@ final class RemovedDollarBraceStringEmbedsUnitTest extends BaseSniffTestCase
 
 
     /**
-     * Test that variable embeds of "type 4" - Variable variables (“${expr}”, equivalent to
+     * Test that variable embeds of "type 4" - Variable variables (`${expr}`, equivalent to
      * (string) ${expr}) - are correctly detected.
      *
      * @dataProvider dataRemovedDollarBraceStringEmbedsType4
@@ -123,7 +123,7 @@ final class RemovedDollarBraceStringEmbedsUnitTest extends BaseSniffTestCase
 
 
     /**
-     * Test that variable embeds of "type 3" - Braces after the dollar sign (“${foo}”) -
+     * Test that variable embeds of "type 3" - Braces after the dollar sign (`${foo}`) -
      * are correctly detected in PHP 7.3+ indented heredocs.
      *
      * @dataProvider dataRemovedDollarBraceStringEmbedsType3InIndentedHeredoc
@@ -159,7 +159,7 @@ final class RemovedDollarBraceStringEmbedsUnitTest extends BaseSniffTestCase
 
 
     /**
-     * Test that variable embeds of "type 4" - Variable variables (“${expr}”, equivalent to
+     * Test that variable embeds of "type 4" - Variable variables (`${expr}`, equivalent to
      * (string) ${expr}) - are correctly detected in PHP 7.3+ indented heredocs.
      *
      * @dataProvider dataRemovedDollarBraceStringEmbedsType4InIndentedHeredoc

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -60,6 +60,12 @@
         <exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/>
     </rule>
 
+    <!-- Enforce constant visibility.
+          This directive can be removed once PHPCSDevCS drops support for PHPCS 3.x. -->
+    <rule ref="PSR12.Properties.ConstantVisibility">
+        <severity>5</severity>
+    </rule>
+
 
     <!--
     #############################################################################


### PR DESCRIPTION
This commit makes all pre-existing OO constants `private` as none of them were ever intended to be overwritten or accessed from outside and the classes are all `final` now anyway.

:point_right: This should still be annotated as a BC-break as access from outside the class will now no longer be possible (though the chances of anyone doing that for these constants are slim to none anyway).
