### PR TITLE
PHP 8.5 | ✨ New `PHPCompatibility.ControlStructures.RemovedTerminatingCaseWithSemicolon` sniff (RFC)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To start contributing, fork the repository, create a new branch in your fork, ma
 Please make sure that your pull request contains unit tests covering what's being addressed by it.
 
 * All new sniffs should be accompanied by an XML documentation file describing the change in PHP.
-* All code should be compatible with PHP_CodeSniffer >= 4.0.0 _(checked in CI)_.
+* All code should be compatible with PHP_CodeSniffer >= 4.0.1 _(checked in CI)_.
 * All code should be compatible with PHP 7.2 to PHP nightly _(checked in CI)_.
 * Try and avoid code duplication by using the utility functions from [PHPCSUtils] whenever relevant.
 * All code should comply with the PHPCompatibility coding standards _(checked in CI)_.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,12 +97,12 @@ jobs:
 
         include:
           - php: '7.2'
-            phpcs_version: '^4.0.0'
+            phpcs_version: '^4.0.1'
             custom_ini: true
             experimental: false
 
           - php: '8.4'
-            phpcs_version: '^4.0.0'
+            phpcs_version: '^4.0.1'
             custom_ini: true
             experimental: false
 

--- a/PHPCompatibility/Docs/ControlStructures/RemovedTerminatingCaseWithSemicolonStandard.xml
+++ b/PHPCompatibility/Docs/ControlStructures/RemovedTerminatingCaseWithSemicolonStandard.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed Terminating Case With Semicolon"
+    >
+    <standard>
+    <![CDATA[
+    Terminating a switch `case`/`default` condition statement with a semicolon, instead of a colon, is deprecated since PHP 8.5.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: terminating a case/default statement with a colon.">
+        <![CDATA[
+switch ($value) {
+    case 'foo'<em>:</em>
+    case 'baz'<em>:</em>
+        echo 'foo or baz';
+        break;
+    default<em>:</em>
+        echo 'default';
+        break;
+}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.5: terminating a case/default statement with a semicolon.">
+        <![CDATA[
+switch ($value) {
+    case 'foo'<em>;</em>
+    case 'baz'<em>;</em>
+        echo 'foo or baz';
+        break;
+    default<em>;</em>
+        echo 'default';
+        break;
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ControlStructures/RemovedTerminatingCaseWithSemicolonSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/RemovedTerminatingCaseWithSemicolonSniff.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ControlStructures;
+
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Detect use of a semicolon to terminate a switch case/default statement.
+ *
+ * This has been deprecated in PHP 8.5.
+ *
+ * PHP version 8.5
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_semicolon_after_case_in_switch_statement
+ * @link https://www.php.net/manual/en/control-structures.switch.php
+ *
+ * @since 10.0.0
+ */
+final class RemovedTerminatingCaseWithSemicolonSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            \T_CASE,
+            \T_DEFAULT,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrAbove('8.5') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            return;
+        }
+
+        $scopeOpener = $tokens[$stackPtr]['scope_opener'];
+        if ($tokens[$scopeOpener]['code'] === \T_COLON) {
+            // All good, nothing to do.
+            return;
+        }
+
+        /*
+         * If a case body is wrapped within curly braces, PHPCS sets the open brace as the scope opener,
+         * so we need to walk back to check for the _real_ opener.
+         */
+        if ($tokens[$scopeOpener]['code'] === \T_OPEN_CURLY_BRACKET) {
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($scopeOpener - 1), null, true);
+            if ($tokens[$prevNonEmpty]['code'] === \T_COLON) {
+                // All good, nothing to do.
+                return;
+            }
+
+            // Override what we regard as the scope opener.
+            $scopeOpener = $prevNonEmpty;
+        }
+
+        /*
+         * The scope opener can now only be one of two tokens: either the semicolon or a PHP close tag with an implied semicolon.
+         * In both cases, this is deprecated.
+         */
+        $terminator = 'a semicolon';
+        if ($tokens[$scopeOpener]['code'] === \T_CLOSE_TAG) {
+            $terminator = 'an implied semicolon';
+        }
+
+        $fix = $phpcsFile->addFixableWarning(
+            'Terminating a switch case statement with %s is deprecated since PHP 8.5.',
+            $scopeOpener,
+            'Deprecated',
+            [$terminator]
+        );
+
+        if ($fix === true) {
+            if ($tokens[$scopeOpener]['code'] === \T_SEMICOLON) {
+                $phpcsFile->fixer->replaceToken($scopeOpener, ':');
+            } else {
+                // This is a PHP close tag. Figure out where to place the colon.
+                $prevNonEmpty = $phpcsFile->findPrevious(Tokens::EMPTY_TOKENS, ($scopeOpener - 1), null, true);
+                $phpcsFile->fixer->addContent($prevNonEmpty, ':');
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/RemovedTerminatingCaseWithSemicolonParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedTerminatingCaseWithSemicolonParseError1UnitTest.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+switch ($foo) {
+    case 10
+}

--- a/PHPCompatibility/Tests/ControlStructures/RemovedTerminatingCaseWithSemicolonParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedTerminatingCaseWithSemicolonParseError1UnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedTerminatingCaseWithSemicolon sniff.
+ *
+ * @group removedTerminatingCaseWithSemicolon
+ * @group controlStructures
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\RemovedTerminatingCaseWithSemicolonSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedTerminatingCaseWithSemicolonParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/RemovedTerminatingCaseWithSemicolonUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedTerminatingCaseWithSemicolonUnitTest.inc
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * OK, not our target.
+ */
+enum NotASwitchCase {
+    case TERMINATED_WITH_SEMICOLON_IS_OKAY;
+}
+
+enum NotASwitchCaseBacked: string
+{
+    case Hearts = 'H';
+}
+
+$match = match($foo) {
+    1 => 10,
+    default => 20,
+};
+
+
+/*
+ * Ok: cross-version compatible.
+ */
+switch ($foo) {
+    case 10:
+        switch ($nested) {
+            case 'nested' /*comment*/ :
+                break;
+            default:
+                break;
+        }
+        break;
+    case 20: {
+        echo $foo;
+        break;
+    }
+    default:
+        echo 'default';
+        break;
+}
+
+switch ($foo):
+    case 10:
+        switch ($nested):
+            case 'nested':
+                break;
+            default:
+                break;
+        endswitch;
+        break;
+    case 20: {
+        echo $foo;
+        break;
+    }
+    default:
+        echo 'default';
+        break;
+endswitch;
+
+switch ($foo):
+    case "bar": ?>
+        <div>Some html</div>
+        <?php break;
+    default: ?>
+        <div>Some html</div>
+<?php endswitch;
+
+
+/*
+ * PHP 8.5 deprecated.
+ */
+switch ($foo) {
+    case 10;
+    case 20   ; echo $foo; break;
+    case 'foo';
+        switch ($nested) {
+            case 'nested' /*comment*/ ;
+                break;
+            default;
+                break;
+        }
+        // Fall through.
+    case FOO; {
+        echo $foo;
+        break;
+    }
+    case $bar ? 10 : 20;
+        return;
+    default;
+        echo 'default';
+        break;
+}
+
+switch ($foo):
+    case 10;
+    case 20;
+        echo $foo;
+        break;
+    case 'foo';
+        echo $foo;
+        break;
+    case FOO; {
+        switch ($nested) :
+            case 'nested';
+                break;
+            default;
+                break;
+        endswitch;
+        // Fall through.
+    }
+    default;
+        echo 'default';
+        break;
+endswitch;
+
+switch ($foo):
+    case "foo"?>
+        <div>Some html</div>
+        <?php break;
+    case "bar" ; ?>
+        <div>Some html</div>
+        <?php break;
+    case "baz" ?>
+        <div>Some html</div>
+        <?php break;
+    case "balls" // Comment.
+    ?>
+        <div>Some html</div>
+        <?php break;
+    default ?>
+        <div>Some html</div>
+<?php endswitch ?>
+<?php
+
+switch ($foo):
+    default?>
+        <div>Some html</div><?php
+endswitch;
+
+switch ($foo):
+    default ; ?>
+        <div>Some html</div><?php
+endswitch;
+
+switch ($foo):
+    default     ?>
+        <div>Some html</div><?php
+endswitch;
+
+switch ($foo):
+    default  /* comment*/   ?>
+        <div>Some html</div><?php
+endswitch;

--- a/PHPCompatibility/Tests/ControlStructures/RemovedTerminatingCaseWithSemicolonUnitTest.inc.fixed
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedTerminatingCaseWithSemicolonUnitTest.inc.fixed
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * OK, not our target.
+ */
+enum NotASwitchCase {
+    case TERMINATED_WITH_SEMICOLON_IS_OKAY;
+}
+
+enum NotASwitchCaseBacked: string
+{
+    case Hearts = 'H';
+}
+
+$match = match($foo) {
+    1 => 10,
+    default => 20,
+};
+
+
+/*
+ * Ok: cross-version compatible.
+ */
+switch ($foo) {
+    case 10:
+        switch ($nested) {
+            case 'nested' /*comment*/ :
+                break;
+            default:
+                break;
+        }
+        break;
+    case 20: {
+        echo $foo;
+        break;
+    }
+    default:
+        echo 'default';
+        break;
+}
+
+switch ($foo):
+    case 10:
+        switch ($nested):
+            case 'nested':
+                break;
+            default:
+                break;
+        endswitch;
+        break;
+    case 20: {
+        echo $foo;
+        break;
+    }
+    default:
+        echo 'default';
+        break;
+endswitch;
+
+switch ($foo):
+    case "bar": ?>
+        <div>Some html</div>
+        <?php break;
+    default: ?>
+        <div>Some html</div>
+<?php endswitch;
+
+
+/*
+ * PHP 8.5 deprecated.
+ */
+switch ($foo) {
+    case 10:
+    case 20   : echo $foo; break;
+    case 'foo':
+        switch ($nested) {
+            case 'nested' /*comment*/ :
+                break;
+            default:
+                break;
+        }
+        // Fall through.
+    case FOO: {
+        echo $foo;
+        break;
+    }
+    case $bar ? 10 : 20:
+        return;
+    default:
+        echo 'default';
+        break;
+}
+
+switch ($foo):
+    case 10:
+    case 20:
+        echo $foo;
+        break;
+    case 'foo':
+        echo $foo;
+        break;
+    case FOO: {
+        switch ($nested) :
+            case 'nested':
+                break;
+            default:
+                break;
+        endswitch;
+        // Fall through.
+    }
+    default:
+        echo 'default';
+        break;
+endswitch;
+
+switch ($foo):
+    case "foo":?>
+        <div>Some html</div>
+        <?php break;
+    case "bar" : ?>
+        <div>Some html</div>
+        <?php break;
+    case "baz": ?>
+        <div>Some html</div>
+        <?php break;
+    case "balls": // Comment.
+    ?>
+        <div>Some html</div>
+        <?php break;
+    default: ?>
+        <div>Some html</div>
+<?php endswitch ?>
+<?php
+
+switch ($foo):
+    default:?>
+        <div>Some html</div><?php
+endswitch;
+
+switch ($foo):
+    default : ?>
+        <div>Some html</div><?php
+endswitch;
+
+switch ($foo):
+    default:     ?>
+        <div>Some html</div><?php
+endswitch;
+
+switch ($foo):
+    default:  /* comment*/   ?>
+        <div>Some html</div><?php
+endswitch;

--- a/PHPCompatibility/Tests/ControlStructures/RemovedTerminatingCaseWithSemicolonUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedTerminatingCaseWithSemicolonUnitTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedTerminatingCaseWithSemicolon sniff.
+ *
+ * @group removedTerminatingCaseWithSemicolon
+ * @group controlStructures
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\RemovedTerminatingCaseWithSemicolonSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedTerminatingCaseWithSemicolonUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the use of semicolon for a switch-case statement is flagged correctly.
+     *
+     * @dataProvider dataRemovedTerminatingCaseWithSemicolon
+     *
+     * @param int    $line   The line number.
+     * @param string $insert Optional. Text snippet to insert into the error message.
+     *
+     * @return void
+     */
+    public function testRemovedTerminatingCaseWithSemicolonn($line, $insert = '')
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertWarning($file, $line, "Terminating a switch case statement with a{$insert} semicolon is deprecated since PHP 8.5.");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedTerminatingCaseWithSemicolon()
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataRemovedTerminatingCaseWithSemicolon()
+    {
+        return [
+            [73],
+            [74],
+            [75],
+            [77],
+            [79],
+            [83],
+            [87],
+            [89],
+            [95],
+            [96],
+            [99],
+            [102],
+            [104],
+            [106],
+            [111],
+            [117, 'n implied'],
+            [120],
+            [123, 'n implied'],
+            [127, 'n implied'],
+            [130, 'n implied'],
+            [136, 'n implied'],
+            [141],
+            [146, 'n implied'],
+            [151, 'n implied'],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $cases = [];
+
+        // No errors expected on the first 68 lines.
+        for ($line = 1; $line <= 68; $line++) {
+            $cases[] = [$line];
+        }
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.4');
+        $this->assertNoViolation($file);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ If you use PHPCompatibility, please fund this work by donating to the [PHP_CodeS
 ## Requirements
 
 * PHP 7.2+
-* PHP_CodeSniffer: 4.0.0+.
+* PHP_CodeSniffer: 4.0.1+.
 * PHPCSUtils: 1.1.2+
 
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP_CodeSniffer. You should get consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on a recent PHP version in combination with a recent PHP_CodeSniffer version.
 
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP_CodeSniffer 3.x.  
 As of version 9.0.0, support for PHP_CodeSniffer 1.5.x and low 2.x versions < 2.3.0 has been dropped.  
-As of version 10.0.0, support for PHP < 7.2 and PHP_CodeSniffer < 4.0.0 has been dropped (and support for PHP_CodeSniffer 4.x was added).
+As of version 10.0.0, support for PHP < 7.2 and PHP_CodeSniffer < 4.0.1 has been dropped (and support for PHP_CodeSniffer 4.x was added).
 
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require": {
     "php": ">=7.2",
-    "squizlabs/php_codesniffer": "^4.0.0",
+    "squizlabs/php_codesniffer": "^4.0.1",
     "phpcsstandards/phpcsutils": "^1.1.2"
   },
   "require-dev": {


### PR DESCRIPTION
### Composer: raise the minimum supported PHPCS to 4.0.1 

... to benefit from a tokenizer bug fix where a PHP close tag would not be recognized as a statement closer for a `case`/`default` statement.

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

Ref:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/4.0.1

### PHP 8.5 | ✨ New `PHPCompatibility.ControlStructures.RemovedTerminatingCaseWithSemicolon` sniff (RFC)

> . Terminating case statements with a semicolon instead of a colon has
>   been deprecated.
>   RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_semicolon_after_case_in_switch_statement

This commit adds a new sniff to detect and auto-fix this issue.

Includes tests.
Includes fixer (manually tested as the test framework does not allow for testing this currently).
Includes documentation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_semicolon_after_case_in_switch_statement
* https://github.com/php/php-src/blob/1570ce9f551f7dff3f51690e5c03b0f5ae0e159f/UPGRADING#L370-L372
* php/php-src#19215
* php/php-src@5f8d648
* https://externals.io/message/128839
* php/php-src#20172
* php/php-src@c03215b

Related to #1849