### PR TITLE
Syntax/RemovedCurlyBraceArrayAccess: prevent false positive on PHP 8.4 property hook declarations

### DIFF
--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -17,6 +17,7 @@ use PHPCompatibility\Sniffs\Syntax\NewClassMemberAccessSniff;
 use PHPCompatibility\Sniffs\Syntax\NewFunctionArrayDereferencingSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Scopes;
 
 /**
  * Using the curly brace syntax to access array or string offsets has been deprecated in PHP 7.4
@@ -160,6 +161,11 @@ final class RemovedCurlyBraceArrayAccessSniff extends Sniff
 
         // Note: Overwriting braces in each `if` is fine as only one will match anyway.
         if ($tokens[$stackPtr]['code'] === \T_VARIABLE) {
+            if (Scopes::isOOProperty($phpcsFile, $stackPtr) === true) {
+                // This will be a PHP 8.4 property hook, not array access.
+                return;
+            }
+
             $braces = $this->isVariableArrayAccess($phpcsFile, $stackPtr);
         }
 

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc
@@ -147,3 +147,8 @@ Partially\Qualified\ClassName::FOO[1]{0};
 namespace\callMe(){0};
 \Fully\Qualified\callMe($input){0};
 Partially\Qualified\callMe($a, $b){0};
+
+// Safeguard against false positives for PHP 8.4 property hooks.
+interface Thing {
+    public string $id { get; }
+}

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.inc.fixed
@@ -147,3 +147,8 @@ Partially\Qualified\ClassName::FOO[1][0];
 namespace\callMe()[0];
 \Fully\Qualified\callMe($input)[0];
 Partially\Qualified\callMe($a, $b)[0];
+
+// Safeguard against false positives for PHP 8.4 property hooks.
+interface Thing {
+    public string $id { get; }
+}

--- a/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
+++ b/PHPCompatibility/Tests/Syntax/RemovedCurlyBraceArrayAccessUnitTest.php
@@ -111,18 +111,39 @@ final class RemovedCurlyBraceArrayAccessUnitTest extends BaseSniffTestCase
 
 
     /**
-     * testNoFalsePositives
+     * Test that there are no false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
      *
      * @return void
      */
-    public function testNoFalsePositives()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(__FILE__, '7.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
 
         // No errors expected on the first 49 lines.
         for ($line = 1; $line <= 49; $line++) {
-            $this->assertNoViolation($file, $line);
+            $data[] = [$line];
         }
+
+        $data[] = [153];
+
+        return $data;
     }
 
 


### PR DESCRIPTION
At this time, PHPCS does not (yet) support PHP 8.4 property hook syntax properly, however, we may still encounter the syntax in code under scan.

With this in mind, and as this issue has been reported elsewhere, let's prevent this sniff from throwing a false positive on OO properties declaring PHP 8.4 property hooks.

Includes test.