### PR TITLE
GH Actions: fail "setup-php" if requested tooling could not be installed

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -148,6 +148,8 @@ jobs:
           php-version: 'latest'
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, display_startup_errors=On
           coverage: none
+        env:
+          fail-fast: true
 
       - name: Regenerate the test files for the forbidden names test
         run: php "./bin/generate-forbidden-names-test-files"

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -62,6 +62,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
+        env:
+          fail-fast: true
 
       # Remove PHPCSDevCS as it could potentially prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
           ini-values: error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1
           coverage: none
           tools: cs2pr
+        env:
+          fail-fast: true
 
       - name: 'Composer: adjust dependencies'
         # Remove PHPUnit requirement to save some bandwidth.
@@ -149,6 +151,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
+        env:
+          fail-fast: true
 
       # Remove PHPCSDevCS as it could potentially prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'
@@ -261,6 +265,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
+        env:
+          fail-fast: true
 
       # Remove PHPCSDevCS as it could potentially prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'


### PR DESCRIPTION
Setup-PHP will normally "gracefully" show a warning and not fail the build when an extension or tool failed to install.

In most cases, this is not particularly useful as that means that either there will be a failure later on in the build due to the extension or tool missing, or the build will not be representative of what is supposed to be tested.

This commit changes this behaviour to fail select builds at the `setup-php` step, which also makes debugging these type of build failures much more straight-forward.

Ref: https://github.com/shivammathur/setup-php?tab=readme-ov-file#fail-fast-optional
