### PR TITLE
Composer: raise the minimum supported PHPCS to 4.0.2

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To start contributing, fork the repository, create a new branch in your fork, ma
 Please make sure that your pull request contains unit tests covering what's being addressed by it.
 
 * All new sniffs should be accompanied by an XML documentation file describing the change in PHP.
-* All code should be compatible with PHP_CodeSniffer >= 4.0.1 _(checked in CI)_.
+* All code should be compatible with PHP_CodeSniffer >= 4.0.2 _(checked in CI)_.
 * All code should be compatible with PHP 7.2 to PHP nightly _(checked in CI)_.
 * Try and avoid code duplication by using the utility functions from [PHPCSUtils] whenever relevant.
 * All code should comply with the PHPCompatibility coding standards _(checked in CI)_.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,12 +97,12 @@ jobs:
 
         include:
           - php: '7.2'
-            phpcs_version: '^4.0.1'
+            phpcs_version: '^4.0.2'
             custom_ini: true
             experimental: false
 
           - php: '8.4'
-            phpcs_version: '^4.0.1'
+            phpcs_version: '^4.0.2'
             custom_ini: true
             experimental: false
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ If you use PHPCompatibility, please fund this work by donating to the [PHP_CodeS
 ## Requirements
 
 * PHP 7.2+
-* PHP_CodeSniffer: 4.0.1+.
+* PHP_CodeSniffer: 4.0.2+.
 * PHPCSUtils: 1.1.2+
 
 The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP_CodeSniffer. You should get consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on a recent PHP version in combination with a recent PHP_CodeSniffer version.
 
 As of version 8.0.0, the PHPCompatibility standard can also be used with PHP_CodeSniffer 3.x.  
 As of version 9.0.0, support for PHP_CodeSniffer 1.5.x and low 2.x versions < 2.3.0 has been dropped.  
-As of version 10.0.0, support for PHP < 7.2 and PHP_CodeSniffer < 4.0.1 has been dropped (and support for PHP_CodeSniffer 4.x was added).
+As of version 10.0.0, support for PHP < 7.2 and PHP_CodeSniffer < 4.0.2 has been dropped (and support for PHP_CodeSniffer 4.x was added).
 
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require": {
     "php": ">=7.2",
-    "squizlabs/php_codesniffer": "^4.0.1",
+    "squizlabs/php_codesniffer": "^4.0.2",
     "phpcsstandards/phpcsutils": "^1.1.2"
   },
   "require-dev": {


### PR DESCRIPTION
PHP_CodeSniffer released security versions yesterday, so unless we actively ignore security advisories, all CI will fail on a failure to install for `lowest`.

As it would be prudent to encourage users to upgrade anyhow, let's raise the minimum supported PHPCS versions to get round this.

This will also allow us to benefit from tokenizer support for the new PHP 8.5 `(void)` cast.

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

Ref:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/4.0.2