### PR TITLE
Classes/NewClasses: fix case of a classname

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1030,7 +1030,7 @@ final class NewClassesSniff extends Sniff
             '8.4'       => true,
             'extension' => 'odbc',
         ],
-        'Pdo\DbLib' => [
+        'Pdo\Dblib' => [
             '8.3'       => false,
             '8.4'       => true,
             'extension' => 'pdo',


### PR DESCRIPTION
Class names in PHP are case-insensitive and the sniff handles them as such as well.

However, there's been some discussion to change that, so better to make sure the classes listed use the correct case.

Note: I've not gone through the whole list. This was just one I came across while doing something else.