### PR TITLE
ParameterValues/NewExitAsFunctionCall: minor fix to the docs

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/NewExitAsFunctionCallStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/NewExitAsFunctionCallStandard.xml
@@ -15,7 +15,7 @@
 <em>die</em>;
         ]]>
         </code>
-        <code title="PHP &lt; 8.4: using exit()/die() as a fully qualified function call.">
+        <code title="PHP &gt;= 8.4: using exit()/die() as a fully qualified function call.">
         <![CDATA[
 <em>\exit()</em>;
 <em>\die()</em>;


### PR DESCRIPTION
The "invalid" code is what's allowed on `PHP >= 8.4`, not on `PHP < 8.4`.