### PR TITLE
ForbiddenNames: update error message

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -980,7 +980,7 @@ final class ForbiddenNamesSniff extends Sniff
         }
 
         if (isset($isError) === true) {
-            $error .= ' and should not be used to name a class, interface or trait or as part of a namespace (%s)';
+            $error .= ' and should not be used to name a class, interface, trait or enum or as part of a namespace (%s)';
             $data[] = $type;
 
             MessageHelper::addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -103,12 +103,12 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
         if (isset($this->testsForOtherInvalidNames[$usecase]) === true) {
             // The error message for "other" reserved keywords is slightly different.
             for ($i = ($fullReservedLineEnd + 1); $i <= $otherReservedLineEnd; $i++) {
-                $this->assertError($file, $i, ' and should not be used to name a class, interface or trait or as part of a namespace');
+                $this->assertError($file, $i, ' and should not be used to name a class, interface, trait or enum or as part of a namespace');
             }
 
             // Other "soft" reserved are a warning.
             for ($i = ($otherReservedLineEnd + 1); $i <= $lineCount; $i++) {
-                $this->assertWarning($file, $i, ' and should not be used to name a class, interface or trait or as part of a namespace');
+                $this->assertWarning($file, $i, ' and should not be used to name a class, interface, trait or enum or as part of a namespace');
             }
         }
     }
@@ -245,12 +245,12 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
 
         // The error message for "other" reserved keywords is slightly different.
         for ($i = ($fullReservedLineEnd + 1); $i <= $otherReservedLineEnd; $i++) {
-            $this->assertError($file, $i, ' and should not be used to name a class, interface or trait or as part of a namespace');
+            $this->assertError($file, $i, ' and should not be used to name a class, interface, trait or enum or as part of a namespace');
         }
 
         // Other "soft" reserved are a warning.
         for ($i = ($otherReservedLineEnd + 1); $i <= $lineCount; $i++) {
-            $this->assertWarning($file, $i, ' and should not be used to name a class, interface or trait or as part of a namespace');
+            $this->assertWarning($file, $i, ' and should not be used to name a class, interface, trait or enum or as part of a namespace');
         }
     }
 
@@ -359,7 +359,7 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
     public function testSpecificCodeSamplesOtherKeywords($line, $keyword)
     {
         $file = $this->sniffFile(__DIR__ . '/ForbiddenNamesUnitTest.3.inc', '0.0-');
-        $this->assertError($file, $line, 'and should not be used to name a class, interface or trait or as part of a namespace');
+        $this->assertError($file, $line, 'and should not be used to name a class, interface, trait or enum or as part of a namespace');
     }
 
     /**


### PR DESCRIPTION
The error message lists all OO constructs, but didn't list PHP 8.1 enums yet. Fixed now.

Related to #2054, but pulled separately as the change has a different impact, so is a different decision point.