### PR TITLE
Modernize: use ::class resolution

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -16,6 +16,7 @@ use PHPCompatibility\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Scopes;
 
 /**
  * Detect use of new PHP keywords.
@@ -75,7 +76,7 @@ final class NewKeywordsSniff extends Sniff
             '5.2'         => false,
             '5.3'         => true,
             'description' => '"const" keyword',
-            'callback'    => '\PHPCSUtils\Utils\Scopes::isOOConstant', // Keyword is only new when not in class context.
+            'callback'    => [Scopes::class, 'isOOConstant'], // Keyword is only new when not in class context.
         ],
         'T_CALLABLE' => [
             '5.3'         => false,
@@ -126,7 +127,7 @@ final class NewKeywordsSniff extends Sniff
             '5.2'         => false,
             '5.3'         => true,
             'description' => '(Double) quoted Heredoc identifier',
-            'callback'    => [__CLASS__, 'isNotQuoted'], // Heredoc is only new with quoted identifier.
+            'callback'    => [self::class, 'isNotQuoted'], // Heredoc is only new with quoted identifier.
         ],
         'T_TRAIT' => [
             '5.3'         => false,

--- a/PHPCompatibility/Tests/BaseSniffTestCase.php
+++ b/PHPCompatibility/Tests/BaseSniffTestCase.php
@@ -117,7 +117,7 @@ abstract class BaseSniffTestCase extends TestCase
      */
     protected function getSniffCode()
     {
-        $className = \get_class($this);
+        $className = static::class;
         $className = \preg_replace('`ParseError[0-9]*UnitTest$`i', 'UnitTest', $className);
 
         return Common::getSniffCode($className);

--- a/PHPCompatibility/Util/Tests/Exceptions/InvalidTestVersionRangeUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Exceptions/InvalidTestVersionRangeUnitTest.php
@@ -30,7 +30,7 @@ final class InvalidTestVersionRangeUnitTest extends TestCase
      */
     public function testCreate()
     {
-        $this->expectException('PHPCompatibility\Exceptions\InvalidTestVersionRange');
+        $this->expectException(InvalidTestVersionRange::class);
         $this->expectExceptionMessage('Invalid range in provided PHPCompatibility testVersion: \'7.0-5.6\'');
 
         throw InvalidTestVersionRange::create('7.0-5.6');

--- a/PHPCompatibility/Util/Tests/Exceptions/InvalidTestVersionUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Exceptions/InvalidTestVersionUnitTest.php
@@ -30,7 +30,7 @@ final class InvalidTestVersionUnitTest extends TestCase
      */
     public function testCreate()
     {
-        $this->expectException('PHPCompatibility\Exceptions\InvalidTestVersion');
+        $this->expectException(InvalidTestVersion::class);
         $this->expectExceptionMessage('Invalid PHPCompatibility testVersion provided: \'invalid\'');
 
         throw InvalidTestVersion::create('invalid');

--- a/PHPCompatibility/Util/Tests/Helpers/ComplexVersionDeprecatedRemovedFeatureTraitUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ComplexVersionDeprecatedRemovedFeatureTraitUnitTest.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Util\Tests\Helpers;
 
-use PHPUnit\Framework\TestCase;
 use PHPCompatibility\Helpers\ComplexVersionDeprecatedRemovedFeatureTrait;
+use PHPUnit\Framework\TestCase;
+use TypeError;
 
 /**
  * Tests for the ComplexVersionDeprecatedRemovedFeatureTrait sniff helper.
@@ -33,7 +34,7 @@ final class ComplexVersionDeprecatedRemovedFeatureTraitUnitTest extends TestCase
      */
     public function testGetVersionInfoInvalidParamType()
     {
-        $this->expectException('TypeError');
+        $this->expectException(TypeError::class);
 
         $this->getVersionInfo(null);
     }
@@ -228,7 +229,7 @@ final class ComplexVersionDeprecatedRemovedFeatureTraitUnitTest extends TestCase
      */
     public function testGetMessageInvalidParamType()
     {
-        $this->expectException('TypeError');
+        $this->expectException(TypeError::class);
 
         $this->getMessageInfo(null, null, null);
     }

--- a/PHPCompatibility/Util/Tests/Helpers/ComplexVersionNewFeatureTraitUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ComplexVersionNewFeatureTraitUnitTest.php
@@ -10,8 +10,9 @@
 
 namespace PHPCompatibility\Util\Tests\Helpers;
 
-use PHPUnit\Framework\TestCase;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
+use PHPUnit\Framework\TestCase;
+use TypeError;
 
 /**
  * Tests for the ComplexVersionNewFeatureTrait sniff helper.
@@ -33,7 +34,7 @@ final class ComplexVersionNewFeatureTraitUnitTest extends TestCase
      */
     public function testGetVersionInfoInvalidParamType()
     {
-        $this->expectException('TypeError');
+        $this->expectException(TypeError::class);
 
         $this->getVersionInfo(null);
     }
@@ -138,7 +139,7 @@ final class ComplexVersionNewFeatureTraitUnitTest extends TestCase
      */
     public function testGetMessageInvalidParamType()
     {
-        $this->expectException('TypeError');
+        $this->expectException(TypeError::class);
 
         $this->getMessageInfo(null, null, null);
     }

--- a/PHPCompatibility/Util/Tests/Helpers/ScannedCodeUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ScannedCodeUnitTest.php
@@ -10,6 +10,8 @@
 
 namespace PHPCompatibility\Util\Tests\Helpers;
 
+use PHPCompatibility\Exceptions\InvalidTestVersion;
+use PHPCompatibility\Exceptions\InvalidTestVersionRange;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\ConfigDouble;
@@ -51,7 +53,7 @@ final class ScannedCodeUnitTest extends TestCase
     {
         self::$config = new ConfigDouble();
 
-        self::$reflMethod = new ReflectionMethod('PHPCompatibility\Helpers\ScannedCode', 'getTestVersion');
+        self::$reflMethod = new ReflectionMethod(ScannedCode::class, 'getTestVersion');
         (\PHP_VERSION_ID < 80100) && self::$reflMethod->setAccessible(true);
     }
 
@@ -182,7 +184,7 @@ final class ScannedCodeUnitTest extends TestCase
     {
         $message = \sprintf('Invalid range in provided PHPCompatibility testVersion: \'%s\'', $testVersion);
 
-        $this->expectException('PHPCompatibility\Exceptions\InvalidTestVersionRange');
+        $this->expectException(InvalidTestVersionRange::class);
         $this->expectExceptionMessage($message);
 
         $this->testGetTestVersion($testVersion, [null, null]);
@@ -220,7 +222,7 @@ final class ScannedCodeUnitTest extends TestCase
     {
         $message = \sprintf('Invalid PHPCompatibility testVersion provided: \'%s\'', \trim($testVersion));
 
-        $this->expectException('PHPCompatibility\Exceptions\InvalidTestVersion');
+        $this->expectException(InvalidTestVersion::class);
         $this->expectExceptionMessage($message);
 
         $this->testGetTestVersion($testVersion, [null, null]);


### PR DESCRIPTION
... which is a PHP 5.5+ syntax and can now be used what with support for PHP < 7.2 having been dropped.