### PR TITLE
ParameterValues/NewPackFormat: new formats also apply to `unpack`

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -18,11 +18,12 @@ use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
- * Check for valid values for the `$format` passed to `pack()`.
+ * Check for valid values for the `$format` passed to `(un)pack()`.
  *
  * PHP version 5.4+
  *
  * @link https://www.php.net/manual/en/function.pack.php#refsect1-function.pack-changelog
+ * @link https://www.php.net/manual/en/function.unpack.php
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.
@@ -38,7 +39,8 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
      * @var array<string, true>
      */
     protected $targetFunctions = [
-        'pack' => true,
+        'pack'   => true,
+        'unpack' => true,
     ];
 
     /**
@@ -123,11 +125,12 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
                 foreach ($versionArray as $version => $present) {
                     if ($present === false && ScannedCode::shouldRunOnOrBelow($version) === true) {
                         $phpcsFile->addError(
-                            'Passing the $format(s) "%s" to pack() is not supported in PHP %s or lower. Found: %s',
+                            'Passing the $format(s) "%s" to %s() is not supported in PHP %s or lower. Found: %s',
                             $targetParam['start'],
                             'NewFormatFound',
                             [
                                 $matches[1],
+                                \strtolower($functionName),
                                 $version,
                                 $targetParam['clean'],
                             ]

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
@@ -2,39 +2,39 @@
 
 // OK.
 $binarydata = pack("nvc*", 0x1234, 0x5678, 65, 66);
-$binarydata = \pack("n{$e}vc*", 0x1234, 0x5678, 65, 66);
+$binarydata = \unpack("n{$e}vc*", 0x1234, 0x5678, 65, 66);
 
 // Not OK.
-$binarydata = pack("nZc*", 0x1234, 0x5678, 65, 66);
+$binarydata = unpack("nZc*", 0x1234, 0x5678, 65, 66);
 $binarydata = pack("nvq*", 0x1234, 0x5678, 65, 66);
 $binarydata = \pack("Qnvc*", 0x1234, 0x5678, 65, 66);
-$binarydata = pack("nJc*", 0x1234, 0x5678, 65, 66);
+$binarydata = unpack("nJc*", 0x1234, 0x5678, 65, 66);
 $binarydata = pack('nvPc*', 0x1234, 0x5678, 65, 66);
-$binarydata = pack("nec*", 0x1234, 0x5678, 65, 66);
+$binarydata = unpack("nec*", 0x1234, 0x5678, 65, 66);
 $binarydata = PACK("Envc*", 0x1234, 0x5678, 65, 66);
 $binarydata = pack('nvcgG*', 0x1234, 0x5678, 65, 66);
-$binarydata = \pack("n{$s}vGc*", 0x1234, 0x5678, 65, 66);
+$binarydata = \unpack("n{$s}vGc*", 0x1234, 0x5678, 65, 66);
 
 $binarydata = pack("ZJE*", 0x1234, 0x5678, 65, 66); // Error x 3.
 
-$binarydata = pack('nv' . /*comment*/ 'Pc*', 0x1234, 0x5678, 65, 66); // Testing multi-token.
+$binarydata = unpack('nv' . /*comment*/ 'Pc*', 0x1234, 0x5678, 65, 66); // Testing multi-token.
 
 // Issue #1043 - OK, text in brackets, not the actual format.
 $binarydata = pack($foo['test'], 0x1234, 0x5678, 65, 66);
-$binarydata = pack($obj->getModes('type'), 0x1234, 0x5678, 65, 66);
+$binarydata = unpack($obj->getModes('type'), 0x1234, 0x5678, 65, 66);
 
 // Test handling of more complex embedded variables and expressions.
 $binarydata = pack("n${(eq)}vc*", 0x1234, 0x5678, 65, 66); // OK.
 
 // More tests related to issue #1043 - all OK.
 pack(namespace\setFormat('type'));
-pack(\Fully\Qualified\setFormat('type'));
+unpack(\Fully\Qualified\setFormat('type'));
 \pack(Partially\Qualified\setFormat('type'));
 
 // Safeguard against false positives. Not our target.
 $obj->pack("nZc*", 0x1234, 0x5678, 65, 66);
-$obj?->pack("nZc*", 0x1234, 0x5678, 65, 66);
+$obj?->unpack("nZc*", 0x1234, 0x5678, 65, 66);
 MyClass::pack("nZc*", 0x1234, 0x5678, 65, 66);
-\Fully\Qualified\pack("nZc*", 0x1234, 0x5678, 65, 66);
+\Fully\Qualified\unpack("nZc*", 0x1234, 0x5678, 65, 66);
 Partially\Qualified\pack("nZc*", 0x1234, 0x5678, 65, 66);
-namespace\pack("nZc*", 0x1234, 0x5678, 65, 66);
+namespace\unpack("nZc*", 0x1234, 0x5678, 65, 66);

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -32,6 +32,7 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
      *
      * @param int    $line           Line number where the error should occur.
      * @param string $code           Format code which should be detected.
+     * @param string $functionName   Name of the function found.
      * @param string $errorVersion   The PHP version to use to test for the error.
      * @param string $okVersion      A PHP version in which the code is valid.
      * @param string $displayVersion Optional PHP version which is shown in the error message
@@ -39,12 +40,13 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
      *
      * @return void
      */
-    public function testNewPackFormat($line, $code, $errorVersion, $okVersion, $displayVersion = null)
+    public function testNewPackFormat($line, $code, $functionName, $errorVersion, $okVersion, $displayVersion = null)
     {
         $file  = $this->sniffFile(__FILE__, $errorVersion);
         $error = \sprintf(
-            'Passing the $format(s) "%s" to pack() is not supported in PHP %s or lower.',
+            'Passing the $format(s) "%s" to %s() is not supported in PHP %s or lower.',
             $code,
+            $functionName,
             isset($displayVersion) ? $displayVersion : $errorVersion
         );
         $this->assertError($file, $line, $error);
@@ -63,19 +65,19 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
     public static function dataNewPackFormat()
     {
         return [
-            [8, 'Z', '5.4', '5.5'],
-            [9, 'q', '5.6', '7.0', '5.6.2'],
-            [10, 'Q', '5.6', '7.0', '5.6.2'],
-            [11, 'J', '5.6', '7.0', '5.6.2'],
-            [12, 'P', '5.6', '7.0', '5.6.2'],
-            [13, 'e', '7.0', '7.1', '7.0.14'],
-            [14, 'E', '7.0', '7.1', '7.0.14'],
-            [15, 'g', '7.0', '7.1', '7.0.14'],
-            [16, 'G', '7.0', '7.1', '7.0.14'],
-            [18, 'Z', '5.4', '7.1'], // OK version set to beyond last error.
-            [18, 'J', '5.6', '7.1', '5.6.2'], // OK version set to beyond last error.
-            [18, 'E', '7.0', '7.1', '7.0.14'],
-            [20, 'P', '5.6', '7.0', '5.6.2'],
+            [8, 'Z', 'unpack', '5.4', '5.5'],
+            [9, 'q', 'pack', '5.6', '7.0', '5.6.2'],
+            [10, 'Q', 'pack', '5.6', '7.0', '5.6.2'],
+            [11, 'J', 'unpack', '5.6', '7.0', '5.6.2'],
+            [12, 'P', 'pack', '5.6', '7.0', '5.6.2'],
+            [13, 'e', 'unpack', '7.0', '7.1', '7.0.14'],
+            [14, 'E', 'pack', '7.0', '7.1', '7.0.14'],
+            [15, 'g', 'pack', '7.0', '7.1', '7.0.14'],
+            [16, 'G', 'unpack', '7.0', '7.1', '7.0.14'],
+            [18, 'Z', 'pack', '5.4', '7.1'], // OK version set to beyond last error.
+            [18, 'J', 'pack', '5.6', '7.1', '5.6.2'], // OK version set to beyond last error.
+            [18, 'E', 'pack', '7.0', '7.1', '7.0.14'],
+            [20, 'P', 'unpack', '5.6', '7.0', '5.6.2'],
         ];
     }
 


### PR DESCRIPTION
The `unpack()` manual page does not list the supported format codes. Instead it defers to the `pack()` manual, which leads me to believe that any format code supported by `pack()` is also supported by `unpack()`, so the `NewPackFormat` sniff should not only search for function calls to `pack()`, but also `unpack()`.

Fixed now.

Includes updates to the tests to cover the change and allow for it.

Ref: https://www.php.net/manual/en/function.unpack.php