### PR TITLE
GH Actions: set permissions for each workflow/job

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -13,8 +13,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   checkcs:
+    permissions:
+      contents: read # To clone the repo.
+
     name: 'Basic CS and QA checks'
     runs-on: ubuntu-latest
 
@@ -104,6 +110,9 @@ jobs:
         run: vendor/bin/phpcs --generator=Text --standard=PHPCompatibility
 
   xml-cs:
+    permissions:
+      contents: read # To clone the repo.
+
     name: 'XML Code style'
     runs-on: ubuntu-latest
 
@@ -134,8 +143,12 @@ jobs:
         run: diff -B ./PHPCompatibility/ruleset.xml <(xmllint --format "./PHPCompatibility/ruleset.xml")
 
   verify-tests:
+    permissions:
+      contents: read # To clone the repo.
+
     name: 'Check test files are up to date'
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -159,20 +172,32 @@ jobs:
         run: git diff --exit-code
 
   markdownlint:
+    permissions:
+      contents: read # To clone the repo.
+
     name: 'Lint Markdown'
     uses: PHPCSStandards/.github/.github/workflows/reusable-markdownlint.yml@c535983699986d1c538d4e47f33e813fcfbcc8a0 # v1.2.2
 
   remark:
+    permissions:
+      contents: read # To clone the repo.
+
     name: 'QA Markdown'
     uses: PHPCSStandards/.github/.github/workflows/reusable-remark.yml@c535983699986d1c538d4e47f33e813fcfbcc8a0 # v1.2.2
 
   yamllint:
+    permissions:
+      contents: read # To clone the repo.
+
     name: 'Lint Yaml'
     uses: PHPCSStandards/.github/.github/workflows/reusable-yamllint.yml@c535983699986d1c538d4e47f33e813fcfbcc8a0 # v1.2.2
     with:
       strict: true
 
   find-token-properties:
+    permissions:
+      contents: read # To clone the repo.
+
     # The properties in the PHPCS Tokens class have been deprecated.
     # The code in this repository should always use the constants instead.
     name: 'Find use of Tokens properties'

--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -13,12 +13,18 @@ on:
       - synchronize
       - reopened
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   check-prs:
-    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # To add and remove PR labels.
+
     if: github.repository_owner == 'PHPCompatibility'
 
     name: Check PRs for merge conflicts
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check PRs for merge conflicts

--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -9,12 +9,18 @@ on:
     types:
       - closed
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   on-pr-merge:
-    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # To remove PR labels.
+
     if: github.repository_owner == 'PHPCompatibility' && github.event.pull_request.merged == true
 
     name: Clean up labels on PR merge
+    runs-on: ubuntu-latest
 
     steps:
       - uses: mondeja/remove-labels-gh-action@b7118e4ba5dca74acf1059b3cb7660378ff9ab1a # v2.0.0
@@ -28,10 +34,13 @@ jobs:
             Status: triage
 
   on-pr-close:
-    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # To remove PR labels.
+
     if: github.repository_owner == 'PHPCompatibility' && github.event_name == 'pull_request_target' && github.event.pull_request.merged == false
 
     name: Clean up labels on PR close
+    runs-on: ubuntu-latest
 
     steps:
       - uses: mondeja/remove-labels-gh-action@b7118e4ba5dca74acf1059b3cb7660378ff9ab1a # v2.0.0
@@ -44,10 +53,13 @@ jobs:
             Status: triage
 
   on-issue-close:
-    runs-on: ubuntu-latest
+    permissions:
+      issues: write # To remove issue labels.
+
     if: github.repository_owner == 'PHPCompatibility' && github.event.issue.state == 'closed'
 
     name: Clean up labels on issue close
+    runs-on: ubuntu-latest
 
     steps:
       - uses: mondeja/remove-labels-gh-action@b7118e4ba5dca74acf1059b3cb7660378ff9ab1a # v2.0.0

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   #### QUICK TEST STAGE ####
   # This is a much quicker test which only runs the unit tests and linting against the low/high
@@ -24,6 +27,9 @@ jobs:
   # These are basically the same builds as in the Test->Coverage workflow, but then without doing
   # the code-coverage.
   quicktest:
+    permissions:
+      contents: read # To clone the repo.
+
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,20 +20,28 @@ env:
   # - COMPOSER_ROOT_VERSION is needed to get round the recursive dependency when using CI.
   COMPOSER_ROOT_VERSION: '10.99.99'
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   #### PHP LINT STAGE ####
   # Linting against high/low of each PHP major should catch everything.
   # If needs be, we can always add interim versions back at a later point in time.
   lint:
+    permissions:
+      contents: read # To clone the repo.
+
     if: ${{ github.ref != 'refs/heads/develop' }}
+
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         php: ['7.2', '7.4', '8.0', '8.5', 'nightly']
 
-    name: "Lint: PHP ${{ matrix.php }}"
     continue-on-error: ${{ matrix.php == 'nightly' }}
+
+    name: "Lint: PHP ${{ matrix.php }}"
 
     steps:
       - name: Checkout code
@@ -75,9 +83,13 @@ jobs:
 
   #### TEST STAGE ####
   test:
-    if: ${{ github.ref != 'refs/heads/develop' }}
     # No use running the tests if there is a linting error somewhere as they would fail anyway.
     needs: lint
+
+    permissions:
+      contents: read # To clone the repo.
+
+    if: ${{ github.ref != 'refs/heads/develop' }}
 
     runs-on: ubuntu-latest
 
@@ -108,9 +120,9 @@ jobs:
           - php: '8.6' # Nightly.
             phpcs_version: '4.x-dev'
 
-    name: "Test: PHP ${{ matrix.php }}${{ matrix.custom_ini && ' (ini)' || '' }} - PHPCS ${{ matrix.phpcs_version }}"
-
     continue-on-error: ${{ matrix.php == '8.6' }}
+
+    name: "Test: PHP ${{ matrix.php }}${{ matrix.custom_ini && ' (ini)' || '' }} - PHPCS ${{ matrix.phpcs_version }}"
 
     steps:
       - name: Checkout code
@@ -201,6 +213,10 @@ jobs:
   coverage:
     # No use running the coverage builds if there are failing test builds.
     needs: test
+
+    permissions:
+      contents: read # To clone the repo.
+
     # The default condition is success(), but this is false when one of the previous jobs is skipped (but don't run on forks).
     if: always() && github.repository_owner == 'PHPCompatibility' && (needs.test.result == 'success' || needs.test.result == 'skipped')
 


### PR DESCRIPTION
> Users frequently over-scope their workflow and job permissions, or set broad workflow-level permissions without realizing that all jobs inherit those permissions.
>
> Furthermore, users often don't realize that the _default_ `GITHUB_TOKEN` permissions can be very broad, meaning that workflows that don't configure any permissions at all can _still_ provide excessive credentials to their individual jobs.
>
> **Remediation**
> In general, permissions should be declared as minimally as possible, and as close to their usage site as possible.
>
> In practice, this means that workflows should almost always set `permissions: {}` at the workflow level to disable all permissions by default, and then set specific job-level permissions as needed.

Refs:
* https://docs.zizmor.sh/audits/#excessive-permissions