### PR TITLE
Docs: use language agnostic links to PHP manual

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Related to ### (PHPCompatibility meta ticket for that PHP version)
 * The [PHP RFC wiki][php-wiki-rfc]
 * The [UPGRADING](https://github.com/php/php-src/blob/master/UPGRADING) document of each release
 * The [NEWS](https://github.com/php/php-src/blob/master/NEWS) document of each release
-* The [Migrating from PHP x.x.x to PHP x.x.x section](https://www.php.net/manual/en/appendices.php) in the manual for each release (once published)
+* The [Migrating from PHP x.x.x to PHP x.x.x section](https://www.php.net/appendices) in the manual for each release (once published)
 * The [Changelog](https://www.php.net/doc.changelog) in the manual
 * The official [PHP manual][php-manual] in general
 * The legacy [PHP 5 manual](https://php-legacy-docs.zend.com/manual/php5/en/index)

--- a/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
+++ b/PHPCompatibility/Helpers/HashAlgorithmsTrait.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\TextStrings;
  * This also means that it has no promise of backward compatibility. Use at your own risk.
  * ---------------------------------------------------------------------------------------------
  *
- * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
+ * @link https://www.php.net/hash-algos#refsect1-function.hash-algos-changelog
  *
  * @since 5.5
  * @since 7.0.7  Logic moved from the `RemovedHashAlgorithms` sniff to the generic `Sniff` class.

--- a/PHPCompatibility/Helpers/TokenGroup.php
+++ b/PHPCompatibility/Helpers/TokenGroup.php
@@ -220,7 +220,7 @@ final class TokenGroup
 
             /*
              * Regexes based on the formats outlined in the manual, created by JRF.
-             * @link https://www.php.net/manual/en/language.types.float.php
+             * @link https://www.php.net/types.float
              */
             $regexInt   = '`^\s*[0-9]+`';
             $regexFloat = '`^\s*(?:[+-]?(?:(?:(?P<LNUM>[0-9]+)|(?P<DNUM>([0-9]*\.(?P>LNUM)|(?P>LNUM)\.[0-9]*)))[eE][+-]?(?P>LNUM))|(?P>DNUM))`';

--- a/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
+++ b/PHPCompatibility/Sniffs/Attributes/NewAttributesSniff.php
@@ -40,7 +40,7 @@ use PHPCompatibility\Sniff;
  * @link https://wiki.php.net/rfc/attribute_amendments
  * @link https://wiki.php.net/rfc/shorter_attribute_syntax
  * @link https://wiki.php.net/rfc/shorter_attribute_syntax_change
- * @link https://www.php.net/manual/en/language.attributes.php
+ * @link https://www.php.net/attributes
  *
  * @since 10.0.0
  */
@@ -66,7 +66,7 @@ final class NewAttributesSniff extends Sniff
      *
      * These attributes will be bundled into one error code to allow for easily selectively ignoring them.
      *
-     * Source of the attributes list: https://www.php.net/manual/en/reserved.attributes.php
+     * Source of the attributes list: https://www.php.net/reserved.attributes
      *
      * @since 10.0.0
      *

--- a/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewAnonymousClassesSniff.php
@@ -19,7 +19,7 @@ use PHPCompatibility\Sniff;
  *
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/language.oop5.anonymous.php
+ * @link https://www.php.net/oop5.anonymous
  * @link https://wiki.php.net/rfc/anonymous_classes
  *
  * @since 7.0.0

--- a/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstVisibilitySniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Constants;
  * PHP version 7.1
  *
  * @link https://wiki.php.net/rfc/class_const_visibility
- * @link https://www.php.net/manual/en/language.oop5.constants.php#language.oop5.basic.class.this
+ * @link https://www.php.net/oop5.constants#language.oop5.basic.class.this
  *
  * @since 7.0.7
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewConstructorPropertyPromotionSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion
+ * @link https://www.php.net/oop5.decon#language.oop5.decon.constructor.promotion
  * @link https://wiki.php.net/rfc/constructor_promotion
  *
  * @since 10.0.0

--- a/PHPCompatibility/Sniffs/Classes/NewFinalConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewFinalConstantsSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Constants;
  * PHP version 8.1
  *
  * @link https://wiki.php.net/rfc/final_class_const
- * @link https://www.php.net/manual/en/language.oop5.final.php#language.oop5.final.example.php81
+ * @link https://www.php.net/oop5.final#language.oop5.final.example.php81
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewLateStaticBindingSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Conditions;
  *
  * PHP version 5.3
  *
- * @link https://www.php.net/manual/en/language.oop5.late-static-bindings.php
+ * @link https://www.php.net/oop5.late-static-bindings
  * @link https://wiki.php.net/rfc/lsb_parentself_forwarding
  *
  * @since 7.0.3

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyClassesSniff.php
@@ -23,9 +23,9 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * PHP version 8.3
  *
  * @link https://wiki.php.net/rfc/readonly_classes
- * @link https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.readonly-classes
- * @link https://www.php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.readonly
- * @link https://www.php.net/manual/en/migration83.new-features.php#migration83.new-features.core.readonly-modifier-improvements
+ * @link https://www.php.net/migration82.new-features#migration82.new-features.core.readonly-classes
+ * @link https://www.php.net/oop5.basic#language.oop5.basic.class.readonly
+ * @link https://www.php.net/migration83.new-features#migration83.new-features.core.readonly-modifier-improvements
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewReadonlyPropertiesSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Variables;
  *
  * PHP version 8.1
  *
- * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.readonly
+ * @link https://www.php.net/migration81.new-features#migration81.new-features.core.readonly
  * @link https://wiki.php.net/rfc/readonly_properties_v2
  *
  * @since 10.0.0

--- a/PHPCompatibility/Sniffs/Classes/NewTypedConstantsSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedConstantsSniff.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\TypeString;
  *
  * PHP version 8.3+
  *
- * @link https://www.php.net/manual/en/migration83.new-features.php#migration83.new-features.core.typed-class-constants
+ * @link https://www.php.net/migration83.new-features#migration83.new-features.core.typed-class-constants
  * @link https://wiki.php.net/rfc/typed_class_constants
  *
  * @since 10.0.0

--- a/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewTypedPropertiesSniff.php
@@ -35,7 +35,7 @@ use PHPCSUtils\Utils\Variables;
  *
  * PHP version 7.4+
  *
- * @link https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.typed-properties
+ * @link https://www.php.net/migration74.new-features#migration74.new-features.core.typed-properties
  * @link https://wiki.php.net/rfc/typed_properties_v2
  * @link https://wiki.php.net/rfc/mixed_type_v2
  * @link https://wiki.php.net/rfc/union_types_v2

--- a/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/RemovedOrphanedParentSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\MessageHelper;
  * PHP version 7.4
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.parent
+ * @link https://www.php.net/migration74.deprecated#migration74.deprecated.core.parent
  *
  * @since 9.2.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Constants/NewConstantsInTraitsSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewConstantsInTraitsSniff.php
@@ -21,8 +21,8 @@ use PHPCSUtils\Utils\Scopes;
  * PHP version 8.2
  *
  * @link https://wiki.php.net/rfc/constants_in_traits
- * @link https://www.php.net/manual/en/migration82.new-features.php#migration82.new-features.core.constant-in-traits
- * @link https://www.php.net/manual/en/language.oop5.traits.php#language.oop5.traits.constants
+ * @link https://www.php.net/migration82.new-features#migration82.new-features.core.constant-in-traits
+ * @link https://www.php.net/oop5.traits#language.oop5.traits.constants
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/Constants/NewMagicClassConstantSniff.php
@@ -29,7 +29,7 @@ use PHPCSUtils\Utils\Context;
  * PHP version 8.0
  *
  * @link https://wiki.php.net/rfc/class_name_scalars
- * @link https://www.php.net/manual/en/language.oop5.constants.php#example-186
+ * @link https://www.php.net/oop5.constants#example-186
  * @link https://wiki.php.net/rfc/class_name_literal_on_object
  *
  * @since 7.1.4

--- a/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/DiscouragedSwitchContinueSniff.php
@@ -25,11 +25,11 @@ use PHPCSUtils\Utils\Numbers;
  *
  * PHP version 7.3
  *
- * @link https://www.php.net/manual/en/migration73.incompatible.php#migration73.incompatible.core.continue-targeting-switch
+ * @link https://www.php.net/migration73.incompatible#migration73.incompatible.core.continue-targeting-switch
  * @link https://wiki.php.net/rfc/continue_on_switch_deprecation
  * @link https://github.com/php/php-src/commit/04e3523b7d095341f65ed5e71a3cac82fca690e4
  *       (actual implementation which is different from the RFC).
- * @link https://www.php.net/manual/en/control-structures.switch.php
+ * @link https://www.php.net/control-structures.switch
  *
  * @since 8.2.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -21,9 +21,9 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.break-continue
- * @link https://www.php.net/manual/en/control-structures.break.php
- * @link https://www.php.net/manual/en/control-structures.continue.php
+ * @link https://www.php.net/migration70.incompatible#migration70.incompatible.other.break-continue
+ * @link https://www.php.net/control-structures.break
+ * @link https://www.php.net/control-structures.continue
  *
  * @since 7.0.7
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -26,8 +26,8 @@ use PHPCSUtils\Utils\Numbers;
  * PHP version 5.4
  *
  * @link https://php-legacy-docs.zend.com/manual/php5/en/migration54.incompatible
- * @link https://www.php.net/manual/en/control-structures.break.php
- * @link https://www.php.net/manual/en/control-structures.continue.php
+ * @link https://www.php.net/control-structures.break
+ * @link https://www.php.net/control-structures.continue
  *
  * @since 5.5
  * @since 5.6    Now extends the base `Sniff` class.

--- a/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -20,7 +20,7 @@ use PHPCompatibility\Sniff;
  * PHP version 7.0
  *
  * @link https://wiki.php.net/rfc/switch.default.multiple
- * @link https://www.php.net/manual/en/control-structures.switch.php
+ * @link https://www.php.net/control-structures.switch
  *
  * @since 7.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewExecutionDirectivesSniff.php
@@ -32,7 +32,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/control-structures.declare.php
+ * @link https://www.php.net/control-structures.declare
  * @link https://wiki.php.net/rfc/scalar_type_hints_v5#strict_types_declare_directive
  *
  * @since 7.0.3

--- a/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewForeachExpressionReferencingSniff.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Sniff;
  *
  * PHP version 5.5
  *
- * @link https://www.php.net/manual/en/control-structures.foreach.php
+ * @link https://www.php.net/control-structures.foreach
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewListInForeachSniff.php
@@ -19,9 +19,9 @@ use PHPCompatibility\Sniff;
  *
  * PHP version 5.5
  *
- * @link https://www.php.net/manual/en/migration55.new-features.php#migration55.new-features.foreach-list
+ * @link https://www.php.net/migration55.new-features#migration55.new-features.foreach-list
  * @link https://wiki.php.net/rfc/foreachlist
- * @link https://www.php.net/manual/en/control-structures.foreach.php#control-structures.foreach.list
+ * @link https://www.php.net/control-structures.foreach#control-structures.foreach.list
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewMultiCatchSniff.php
@@ -19,9 +19,9 @@ use PHPCompatibility\Sniff;
  *
  * PHP version 7.1
  *
- * @link https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.mulit-catch-exception-handling
+ * @link https://www.php.net/migration71.new-features#migration71.new-features.mulit-catch-exception-handling
  * @link https://wiki.php.net/rfc/multiple-catch
- * @link https://www.php.net/manual/en/language.exceptions.php#language.exceptions.catch
+ * @link https://www.php.net/exceptions#language.exceptions.catch
  *
  * @since 7.0.7
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ControlStructures/NewNonCapturingCatchSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/NewNonCapturingCatchSniff.php
@@ -21,7 +21,7 @@ use PHPCompatibility\Sniff;
  * PHP version 8.0
  *
  * @link https://wiki.php.net/rfc/non-capturing_catches
- * @link https://www.php.net/manual/en/language.exceptions.php#language.exceptions.catch
+ * @link https://www.php.net/exceptions#language.exceptions.catch
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/ControlStructures/RemovedTerminatingCaseWithSemicolonSniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/RemovedTerminatingCaseWithSemicolonSniff.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Sniff;
  * PHP version 8.5
  *
  * @link https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_semicolon_after_case_in_switch_statement
- * @link https://www.php.net/manual/en/control-structures.switch.php
+ * @link https://www.php.net/control-structures.switch
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/AbstractPrivateMethodsSniff.php
@@ -29,7 +29,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * PHP version 5.1
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/migration51.oop.php#migration51.oop-methods
+ * @link https://www.php.net/migration51.oop#migration51.oop-methods
  * @link https://wiki.php.net/rfc/abstract_trait_method_validation
  *
  * @since 9.2.0

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenParametersWithSameNameSniff.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.func-parameters
+ * @link https://www.php.net/migration70.incompatible#migration70.incompatible.other.func-parameters
  *
  * @since 7.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenToStringParametersSniff.php
@@ -24,8 +24,8 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * PHP version 5.3
  *
- * @link https://www.php.net/manual/en/migration53.incompatible.php
- * @link https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
+ * @link https://www.php.net/migration53.incompatible
+ * @link https://www.php.net/oop5.magic#object.tostring
  *
  * @since 9.2.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/ForbiddenVariableNamesInClosureUseSniff.php
@@ -27,8 +27,8 @@ use PHPCSUtils\Utils\Variables;
  *
  * PHP version 7.1
  *
- * @link https://www.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.lexical-names
- * @link https://www.php.net/manual/en/functions.anonymous.php
+ * @link https://www.php.net/migration71.incompatible#migration71.incompatible.lexical-names
+ * @link https://www.php.net/functions.anonymous
  *
  * @since 7.1.4
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewClosureSniff.php
@@ -34,7 +34,7 @@ use PHPCSUtils\Utils\Conditions;
  * PHP version 5.3
  * PHP version 5.4
  *
- * @link https://www.php.net/manual/en/functions.anonymous.php
+ * @link https://www.php.net/functions.anonymous
  * @link https://wiki.php.net/rfc/closures
  * @link https://wiki.php.net/rfc/closures/object-extension
  *

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewExceptionsFromToStringSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * PHP version 7.4
  *
  * @link https://wiki.php.net/rfc/tostring_exceptions
- * @link https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
+ * @link https://www.php.net/oop5.magic#object.tostring
  *
  * @since 9.2.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php
@@ -22,9 +22,9 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * PHP version 7.1
  *
- * @link https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.nullable-types
+ * @link https://www.php.net/migration71.new-features#migration71.new-features.nullable-types
  * @link https://wiki.php.net/rfc/nullable_types
- * @link https://www.php.net/manual/en/functions.arguments.php#example-146
+ * @link https://www.php.net/functions.arguments#example-146
  *
  * @since 7.0.7
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewParamTypeDeclarationsSniff.php
@@ -47,7 +47,7 @@ use PHPCSUtils\Utils\TypeString;
  *
  * PHP version 5.0+
  *
- * @link https://www.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration
+ * @link https://www.php.net/functions.arguments#functions.arguments.type-declaration
  * @link https://wiki.php.net/rfc/callable
  * @link https://wiki.php.net/rfc/scalar_type_hints_v5
  * @link https://wiki.php.net/rfc/iterable

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NewReturnTypeDeclarationsSniff.php
@@ -35,8 +35,8 @@ use PHPCSUtils\Utils\TypeString;
  *
  * PHP version 7.0+
  *
- * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.return-type-declarations
- * @link https://www.php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
+ * @link https://www.php.net/migration70.new-features#migration70.new-features.return-type-declarations
+ * @link https://www.php.net/functions.returning-values#functions.returning-values.type-declaration
  * @link https://wiki.php.net/rfc/return_types
  * @link https://wiki.php.net/rfc/iterable
  * @link https://wiki.php.net/rfc/void_return_type

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/NonStaticMagicMethodsSniff.php
@@ -29,7 +29,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * PHP version 5.3
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/language.oop5.magic.php
+ * @link https://www.php.net/oop5.magic
  *
  * @since 5.5
  * @since 5.6    Now extends the base `Sniff` class.

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnByReferenceFromVoidSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * PHP version 8.1
  *
  * @link https://wiki.php.net/rfc/deprecations_php_8_1#return_by_reference_with_void_type
- * @link https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.void-by-ref
+ * @link https://www.php.net/migration81.deprecated#migration81.deprecated.core.void-by-ref
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewMagicMethodsSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Scopes;
  *
  * PHP version 5.0+
  *
- * @link https://www.php.net/manual/en/language.oop5.magic.php
+ * @link https://www.php.net/oop5.magic
  * @link https://wiki.php.net/rfc/closures#additional_goodyinvoke
  * @link https://wiki.php.net/rfc/debug-info
  * @link https://wiki.php.net/rfc/phase_out_serializable Special casing of the __[un]serialize methods.

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedMagicAutoloadSniff.php
@@ -27,9 +27,9 @@ use PHPCSUtils\Utils\Scopes;
  * PHP version 7.2
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/migration72.deprecated.php#migration72.deprecated.__autoload-method
+ * @link https://www.php.net/migration72.deprecated#migration72.deprecated.__autoload-method
  * @link https://wiki.php.net/rfc/deprecations_php_7_2#autoload
- * @link https://www.php.net/manual/en/function.autoload.php
+ * @link https://www.php.net/autoload
  *
  * @since 8.1.0
  * @since 9.0.0  Renamed from `DeprecatedMagicAutoloadSniff` to `RemovedMagicAutoloadSniff`.

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedNamespacedAssertSniff.php
@@ -31,9 +31,9 @@ use PHPCSUtils\Utils\Scopes;
  * PHP version 7.3
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/migration73.deprecated.php#migration73.deprecated.core.assert
+ * @link https://www.php.net/migration73.deprecated#migration73.deprecated.core.assert
  * @link https://wiki.php.net/rfc/deprecations_php_7_3#defining_a_free-standing_assert_function
- * @link https://www.php.net/manual/en/function.assert.php
+ * @link https://www.php.net/assert
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/RemovedPHP4StyleConstructorsSniff.php
@@ -33,9 +33,9 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * PHP version 7.0
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors
+ * @link https://www.php.net/migration70.deprecated#migration70.deprecated.php4-constructors
  * @link https://wiki.php.net/rfc/remove_php4_constructors
- * @link https://www.php.net/manual/en/language.oop5.decon.php
+ * @link https://www.php.net/oop5.decon
  *
  * @since 7.0.0
  * @since 7.0.8  This sniff now throws a warning instead of an error as the functionality is

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/ReservedFunctionNamesSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Scopes;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/language.oop5.magic.php
+ * @link https://www.php.net/oop5.magic
  *
  * @since 8.2.0  This was previously, since 7.0.3, checked by the upstream sniff.
  * @since 9.3.2  The sniff will now ignore functions marked as `@deprecated` by design.

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsReportCurrentValueSniff.php
@@ -36,7 +36,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.func-parameter-modified
+ * @link https://www.php.net/migration70.incompatible#migration70.incompatible.other.func-parameter-modified
  *
  * @since 9.1.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/ArgumentFunctionsUsageSniff.php
@@ -33,7 +33,7 @@ use PHPCSUtils\Utils\Parentheses;
  *
  * PHP version 5.3
  *
- * @link https://www.php.net/manual/en/migration53.incompatible.php
+ * @link https://www.php.net/migration53.incompatible
  *
  * @since 8.2.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionParametersSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/doc.changelog.php
+ * @link https://www.php.net/doc.changelog
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..

--- a/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/OptionalToRequiredFunctionParametersSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/doc.changelog.php
+ * @link https://www.php.net/doc.changelog
  *
  * @since 8.1.0
  * @since 9.0.0  Renamed from `OptionalRequiredFunctionParametersSniff` to `OptionalToRequiredFunctionParametersSniff`.

--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionParametersSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/doc.changelog.php
+ * @link https://www.php.net/doc.changelog
  *
  * @since 7.0.0
  * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.

--- a/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RequiredToOptionalFunctionParametersSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/doc.changelog.php
+ * @link https://www.php.net/doc.changelog
  *
  * @since 7.0.3
  * @since 7.1.0  Now extends the `AbstractComplexVersionSniff` instead of the base `Sniff` class.

--- a/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewGeneratorReturnSniff.php
@@ -21,9 +21,9 @@ use PHPCSUtils\Utils\Conditions;
  *
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.generator-return-expressions
+ * @link https://www.php.net/migration70.new-features#migration70.new-features.generator-return-expressions
  * @link https://wiki.php.net/rfc/generator-return-expressions
- * @link https://www.php.net/manual/en/language.generators.syntax.php
+ * @link https://www.php.net/generators.syntax
  *
  * @since 8.2.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -23,8 +23,8 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/ini.list.php
- * @link https://www.php.net/manual/en/ini.core.php
+ * @link https://www.php.net/ini.list
+ * @link https://www.php.net/ini.core
  *
  * @since 5.5
  * @since 7.0.7  When a new directive is used with `ini_set()`, the sniff will now throw an error

--- a/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/RemovedIniDirectivesSniff.php
@@ -23,8 +23,8 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/ini.list.php
- * @link https://www.php.net/manual/en/ini.core.php
+ * @link https://www.php.net/ini.list
+ * @link https://www.php.net/ini.core
  *
  * @since 5.5
  * @since 7.0.0  This sniff now throws a warning (deprecated) or an error (removed) depending

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingConstSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\Arrays;
  * PHP version 5.6
  *
  * @link https://wiki.php.net/rfc/const_scalar_exprs
- * @link https://www.php.net/manual/en/language.constants.syntax.php
+ * @link https://www.php.net/constants.syntax
  *
  * @since 7.1.4
  * @since 9.0.0  Renamed from `ConstantArraysUsingConstSniff` to `NewConstantArraysUsingConstSniff`.

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantArraysUsingDefineSniff.php
@@ -23,8 +23,8 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.define-array
- * @link https://www.php.net/manual/en/language.constants.syntax.php
+ * @link https://www.php.net/migration70.new-features#migration70.new-features.define-array
+ * @link https://www.php.net/constants.syntax
  *
  * @since 7.0.0
  * @since 9.0.0  Renamed from `ConstantArraysUsingDefineSniff` to `NewConstantArraysUsingDefineSniff`.

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -30,7 +30,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 5.6
  *
- * @link https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.const-scalar-exprs
+ * @link https://www.php.net/migration56.new-features#migration56.new-features.const-scalar-exprs
  * @link https://wiki.php.net/rfc/const_scalar_exprs
  *
  * @since 8.2.0

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -29,8 +29,8 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * PHP version 5.3
  *
- * @link https://www.php.net/manual/en/migration53.new-features.php
- * @link https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc
+ * @link https://www.php.net/migration53.new-features
+ * @link https://www.php.net/types.string#language.types.string.syntax.heredoc
  *
  * @since 7.1.4
  * @since 8.2.0  Now extends the NewConstantScalarExpressionsSniff instead of the base Sniff class.

--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInDefineSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInDefineSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 8.1
  *
- * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.new-in-initializer
+ * @link https://www.php.net/migration81.new-features#migration81.new-features.core.new-in-initializer
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewNewInInitializersSniff.php
@@ -32,7 +32,7 @@ use PHPCSUtils\Utils\Scopes;
  * PHP version 8.1
  *
  * @link https://wiki.php.net/rfc/new_in_initializers
- * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.new-in-initializer
+ * @link https://www.php.net/migration81.new-features#migration81.new-features.core.new-in-initializer
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/InternalInterfacesSniff.php
@@ -22,9 +22,9 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * PHP version 5.0+
  *
- * @link https://www.php.net/manual/en/class.traversable.php
- * @link https://www.php.net/manual/en/class.throwable.php
- * @link https://www.php.net/manual/en/class.datetimeinterface.php
+ * @link https://www.php.net/traversable
+ * @link https://www.php.net/throwable
+ * @link https://www.php.net/datetimeinterface
  *
  * @since 7.0.3
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
+++ b/PHPCompatibility/Sniffs/Interfaces/RemovedSerializableSniff.php
@@ -35,10 +35,10 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * PHP version 8.1
  * PHP version 9.0
  *
- * @link https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.serialize-interface
+ * @link https://www.php.net/migration81.deprecated#migration81.deprecated.core.serialize-interface
  * @link https://wiki.php.net/rfc/phase_out_serializable
- * @link https://www.php.net/manual/en/class.serializable.php
- * @link https://www.php.net/manual/en/language.oop5.magic.php#object.serialize
+ * @link https://www.php.net/serializable
+ * @link https://www.php.net/oop5.magic#object.serialize
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenClassAliasSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenClassAliasSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/function.class-alias.php
+ * @link https://www.php.net/class-alias
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -30,7 +30,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/reserved.keywords.php
+ * @link https://www.php.net/reserved.keywords
  *
  * @since 5.5
  * @since 10.0.0 - Strictly checks declarations and aliases only.

--- a/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/LanguageConstructs/NewEmptyNonVariableSniff.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Sniff;
  * PHP version 5.5
  *
  * @link https://wiki.php.net/rfc/empty_isset_exprs
- * @link https://www.php.net/manual/en/function.empty.php
+ * @link https://www.php.net/empty
  *
  * @since 7.0.4
  * @since 9.0.0  The "is the parameter a variable" determination has been abstracted out

--- a/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/AssignmentOrderSniff.php
@@ -25,9 +25,9 @@ use PHPCSUtils\Utils\Lists;
  *
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.list.order
+ * @link https://www.php.net/migration70.incompatible#migration70.incompatible.variable-handling.list.order
  * @link https://wiki.php.net/rfc/abstract_syntax_tree#changes_to_list
- * @link https://www.php.net/manual/en/function.list.php
+ * @link https://www.php.net/list
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/ForbiddenEmptyListAssignmentSniff.php
@@ -22,9 +22,9 @@ use PHPCSUtils\Utils\Lists;
  *
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.list.empty
+ * @link https://www.php.net/migration70.incompatible#migration70.incompatible.variable-handling.list.empty
  * @link https://wiki.php.net/rfc/abstract_syntax_tree#changes_to_list
- * @link https://www.php.net/manual/en/function.list.php
+ * @link https://www.php.net/list
  *
  * @since 7.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewKeyedListSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\Lists;
  * PHP version 7.1
  *
  * @link https://wiki.php.net/rfc/list_keys
- * @link https://www.php.net/manual/en/function.list.php
+ * @link https://www.php.net/list
  *
  * @since 9.0.0
  * @since 10.0.0 - Complete rewrite.

--- a/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewListReferenceAssignmentSniff.php
@@ -22,9 +22,9 @@ use PHPCSUtils\Utils\Lists;
  *
  * PHP version 7.3
  *
- * @link https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.destruct-reference
+ * @link https://www.php.net/migration73.new-features#migration73.new-features.core.destruct-reference
  * @link https://wiki.php.net/rfc/list_reference_assignment
- * @link https://www.php.net/manual/en/function.list.php
+ * @link https://www.php.net/list
  *
  * @since 9.0.0
  * @since 10.0.0 - Complete rewrite. No longer extends the `NewKeyedListSniff`.

--- a/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
+++ b/PHPCompatibility/Sniffs/Lists/NewShortListSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * PHP version 7.1
  *
- * @link https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.symmetric-array-destructuring
+ * @link https://www.php.net/migration71.new-features#migration71.new-features.symmetric-array-destructuring
  * @link https://wiki.php.net/rfc/short_list_syntax
  *
  * @since 9.0.0

--- a/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/ForbiddenToStringParametersSniff.php
@@ -24,8 +24,8 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 5.3
  *
- * @link https://www.php.net/manual/en/migration53.incompatible.php
- * @link https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
+ * @link https://www.php.net/migration53.incompatible
+ * @link https://www.php.net/oop5.magic#object.tostring
  *
  * @since 9.2.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
+++ b/PHPCompatibility/Sniffs/MethodUse/NewDirectCallsToCloneSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Tokens\Collections;
  * PHP version 7.0
  *
  * @link https://wiki.php.net/rfc/abstract_syntax_tree#directly_calling_clone_is_allowed
- * @link https://www.php.net/manual/en/language.oop5.cloning.php
+ * @link https://www.php.net/oop5.cloning
  *
  * @since 9.1.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -24,7 +24,7 @@ use PHPCompatibility\Sniff;
  *
  * PHP version 7.4
  *
- * @link https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.php-tag
+ * @link https://www.php.net/migration74.incompatible#migration74.incompatible.core.php-tag
  * @link https://github.com/php/php-src/blob/30de357fa14480468132bbc22a272aeb91789ba8/UPGRADING#L37-L40
  *
  * @since 9.3.0

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Tokens\Collections;
  * PHP version 7.0
  *
  * @link https://wiki.php.net/rfc/remove_alternative_php_tags
- * @link https://www.php.net/manual/en/language.basic-syntax.phptags.php
+ * @link https://www.php.net/basic-syntax.phptags
  *
  * @since 7.0.4
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\Namespaces;
  *
  * PHP version 5.3+
  *
- * @link https://www.php.net/manual/en/language.namespaces.rationale.php
+ * @link https://www.php.net/namespaces.rationale
  * @link https://wiki.php.net/rfc/namespaces_in_bundled_extensions
  *
  * @since 10.0.0

--- a/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/NewExplicitOctalNotationSniff.php
@@ -20,7 +20,7 @@ use PHPCSUtils\Utils\Numbers;
  *
  * PHP version 8.1
  *
- * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.octal-literal-prefix
+ * @link https://www.php.net/migration81.new-features#migration81.new-features.core.octal-literal-prefix
  * @link https://wiki.php.net/rfc/explicit_octal_notation
  *
  * @since 10.0.0

--- a/PHPCompatibility/Sniffs/Numbers/NewNumericLiteralSeparatorSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/NewNumericLiteralSeparatorSniff.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Utils\Numbers;
  *
  * PHP version 7.4
  *
- * @link https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.numeric-literal-separator
+ * @link https://www.php.net/migration74.new-features#migration74.new-features.core.numeric-literal-separator
  * @link https://wiki.php.net/rfc/numeric_literal_separator
  *
  * @since 10.0.0

--- a/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/Numbers/ValidIntegersSniff.php
@@ -28,7 +28,7 @@ use PHPCSUtils\Utils\Numbers;
  * PHP version 5.4+
  *
  * @link https://wiki.php.net/rfc/binnotation4ints
- * @link https://www.php.net/manual/en/language.types.integer.php
+ * @link https://www.php.net/types.integer
  *
  * @since 7.0.3
  * @since 7.0.8  This sniff now throws a warning instead of an error for invalid binary integers.

--- a/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ChangedConcatOperatorPrecedenceSniff.php
@@ -32,7 +32,7 @@ use PHPCSUtils\Utils\Operators;
  * PHP version 8.0
  *
  * @link https://wiki.php.net/rfc/concatenation_precedence
- * @link https://www.php.net/manual/en/language.operators.precedence.php
+ * @link https://www.php.net/operators.precedence
  *
  * @since 9.2.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/Operators/ForbiddenNegativeBitshiftSniff.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  * PHP version 7.0
  *
  * @link https://wiki.php.net/rfc/integer_semantics
- * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.integers.negative-bitshift
+ * @link https://www.php.net/migration70.incompatible#migration70.incompatible.integers.negative-bitshift
  *
  * @since 7.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/NewShortTernarySniff.php
@@ -23,8 +23,8 @@ use PHPCSUtils\Utils\Operators;
  *
  * PHP version 5.3
  *
- * @link https://www.php.net/manual/en/migration53.new-features.php
- * @link https://www.php.net/manual/en/language.operators.comparison.php#language.operators.comparison.ternary
+ * @link https://www.php.net/migration53.new-features
+ * @link https://www.php.net/operators.comparison#language.operators.comparison.ternary
  *
  * @since 7.0.0
  * @since 7.0.8  This sniff now throws an error instead of a warning.

--- a/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
+++ b/PHPCompatibility/Sniffs/Operators/RemovedTernaryAssociativitySniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Operators;
  * PHP version 7.4
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.nested-ternary
+ * @link https://www.php.net/migration74.deprecated#migration74.deprecated.core.nested-ternary
  * @link https://wiki.php.net/rfc/ternary_associativity
  * @link https://github.com/php/php-src/pull/4017
  *

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNoArgsOutsideOOSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNoArgsOutsideOOSniff.php
@@ -23,8 +23,8 @@ use PHPCSUtils\Utils\Scopes;
  *
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/function.get-class.php#refsect1-function.get-class-changelog
- * @link https://www.php.net/manual/en/function.get-called-class.php#refsect1-function.get-called-class-changelog
+ * @link https://www.php.net/get-class#refsect1-function.get-class-changelog
+ * @link https://www.php.net/get-called-class#refsect1-function.get-called-class-changelog
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenGetClassNullSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\PassedParameters;
  * PHP version 7.2
  *
  * @link https://wiki.php.net/rfc/get_class_disallow_null_parameter
- * @link https://www.php.net/manual/en/function.get-class.php#refsect1-function.get-class-changelog
+ * @link https://www.php.net/get-class#refsect1-function.get-class-changelog
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * PHP version 7.2
  *
- * @link https://www.php.net/manual/en/function.session-module-name.php#refsect1-function.session-module-name-changelog
+ * @link https://www.php.net/session-module-name#refsect1-function.session-module-name-changelog
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayMergeRecursiveWithGlobalsVarSniff.php
@@ -20,7 +20,7 @@ use PHPCompatibility\Helpers\ScannedCode;
  *
  * PHP version 8.1
  *
- * @link https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.globals-access
+ * @link https://www.php.net/migration81.incompatible#migration81.incompatible.core.globals-access
  * @link https://wiki.php.net/rfc/restrict_globals_usage
  *
  * @since 10.0.0

--- a/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewArrayReduceInitialTypeSniff.php
@@ -23,8 +23,8 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 5.3
  *
- * @link https://www.php.net/manual/en/migration53.other.php#migration53.other
- * @link https://www.php.net/manual/en/function.array-reduce.php#refsect1-function.array-reduce-changelog
+ * @link https://www.php.net/migration53.other#migration53.other
+ * @link https://www.php.net/array-reduce#refsect1-function.array-reduce-changelog
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewAssertCustomExceptionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewAssertCustomExceptionSniff.php
@@ -24,7 +24,7 @@ use PHPCompatibility\Helpers\ScannedCode;
  * PHP version 7.0
  *
  * @link https://wiki.php.net/rfc/expectations
- * @link https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-changelog
+ * @link https://www.php.net/assert#refsect1-function.assert-changelog
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/NewClassAliasInternalClassSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewClassAliasInternalClassSniff.php
@@ -29,7 +29,7 @@ use ReflectionClass;
  *
  * PHP version 8.3
  *
- * @link https://www.php.net/manual/en/function.class-alias.php
+ * @link https://www.php.net/class-alias
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewFopenModesSniff.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 5.2+
  *
- * @link https://www.php.net/manual/en/function.fopen.php#refsect1-function.fopen-changelog
+ * @link https://www.php.net/fopen#refsect1-function.fopen-changelog
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesEncodingDefaultSniff.php
@@ -21,10 +21,10 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 5.4
  *
- * @link https://www.php.net/manual/en/migration54.other.php
- * @link https://www.php.net/manual/en/function.html-entity-decode.php#refsect1-function.html-entity-decode-changelog
- * @link https://www.php.net/manual/en/function.htmlentities.php#refsect1-function.htmlentities-changelog
- * @link https://www.php.net/manual/en/function.htmlspecialchars.php#refsect1-function.htmlspecialchars-changelog
+ * @link https://www.php.net/migration54.other
+ * @link https://www.php.net/html-entity-decode#refsect1-function.html-entity-decode-changelog
+ * @link https://www.php.net/htmlentities#refsect1-function.htmlentities-changelog
+ * @link https://www.php.net/htmlspecialchars#refsect1-function.htmlspecialchars-changelog
  *
  * @since 9.3.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesFlagsDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHTMLEntitiesFlagsDefaultSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 8.1
  *
- * @link https://www.php.net/manual/en/function.html-entity-decode#refsect1-function.html-entity-decode-changelog
+ * @link https://www.php.net/html-entity-decode#refsect1-function.html-entity-decode-changelog
  * @link https://github.com/php/php-src/commit/50eca61f68815005f3b0f808578cc1ce3b4297f0
  *
  * @since 10.0.0

--- a/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewHashAlgorithmsSniff.php
@@ -21,7 +21,7 @@ use PHPCompatibility\Helpers\ScannedCode;
  *
  * PHP version 5.2+
  *
- * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
+ * @link https://www.php.net/hash-algos#refsect1-function.hash-algos-changelog
  *
  * @since 7.0.7
  * @since 7.1.0  Now extends the `AbstractNewFeatureSniff` instead of the base `Sniff` class..

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIDNVariantDefaultSniff.php
@@ -21,10 +21,10 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 7.4
  *
- * @link https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.intl
+ * @link https://www.php.net/migration74.incompatible#migration74.incompatible.intl
  * @link https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003
- * @link https://www.php.net/manual/en/function.idn-to-ascii.php
- * @link https://www.php.net/manual/en/function.idn-to-utf8.php
+ * @link https://www.php.net/idn-to-ascii
+ * @link https://www.php.net/idn-to-utf8
  *
  * @since 9.3.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewIconvMbstringCharsetDefaultSniff.php
@@ -31,8 +31,8 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 5.6
  *
- * @link https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.default-encoding
- * @link https://www.php.net/manual/en/migration56.deprecated.php#migration56.deprecated.iconv-mbstring-encoding
+ * @link https://www.php.net/migration56.new-features#migration56.new-features.default-encoding
+ * @link https://www.php.net/migration56.deprecated#migration56.deprecated.iconv-mbstring-encoding
  * @link https://wiki.php.net/rfc/default_encoding
  *
  * @since 9.3.0

--- a/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewNumberFormatMultibyteSeparatorsSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * PHP version 5.4
  *
- * @link https://www.php.net/manual/en/function.number-format.php#refsect1-function.number-format-changelog
+ * @link https://www.php.net/number-format#refsect1-function.number-format-changelog
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPCREModifiersSniff.php
@@ -24,8 +24,8 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 7.2+
  *
- * @link https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
- * @link https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.pcre
+ * @link https://www.php.net/reference.pcre.pattern.modifiers
+ * @link https://www.php.net/migration72.new-features#migration72.new-features.pcre
  *
  * @since 8.2.0
  * @since 9.0.0  Renamed from `PCRENewModifiersSniff` to `NewPCREModifiersSniff`.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -22,8 +22,8 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * PHP version 5.4+
  *
- * @link https://www.php.net/manual/en/function.pack.php#refsect1-function.pack-changelog
- * @link https://www.php.net/manual/en/function.unpack.php
+ * @link https://www.php.net/pack#refsect1-function.pack-changelog
+ * @link https://www.php.net/unpack
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPasswordAlgoConstantValuesSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 7.4
  *
- * @link https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.password-algorithm-constants
+ * @link https://www.php.net/migration74.incompatible#migration74.incompatible.core.password-algorithm-constants
  * @link https://wiki.php.net/rfc/password_registry
  *
  * @since 9.3.0

--- a/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewProcOpenCmdArraySniff.php
@@ -24,8 +24,8 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 7.4
  *
- * @link https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.standard.proc-open
- * @link https://www.php.net/manual/en/function.proc-open.php
+ * @link https://www.php.net/migration74.new-features#migration74.new-features.standard.proc-open
+ * @link https://www.php.net/proc-open
  *
  * @since 9.3.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewStripTagsAllowableTagsArraySniff.php
@@ -21,8 +21,8 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 7.4
  *
- * @link https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.standard.strip-tags
- * @link https://www.php.net/manual/en/function.strip-tags.php
+ * @link https://www.php.net/migration74.new-features#migration74.new-features.standard.strip-tags
+ * @link https://www.php.net/strip-tags
  *
  * @since 9.3.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedAssertStringAssertionSniff.php
@@ -32,7 +32,7 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * @link https://wiki.php.net/rfc/deprecations_php_7_2#assert_with_string_argument
  * @link https://github.com/php/php-src/blob/69888c3ff1f2301ead8e37b23ff8481d475e29d2/UPGRADING#L350-L354
- * @link https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-changelog
+ * @link https://www.php.net/assert#refsect1-function.assert-changelog
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedGetClassNoArgsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedGetClassNoArgsSniff.php
@@ -23,8 +23,8 @@ use PHPCSUtils\Utils\PassedParameters;
  * PHP version 9.0
  *
  * @link https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#get_class_and_get_parent_class
- * @link https://www.php.net/manual/en/function.get-class.php
- * @link https://www.php.net/manual/en/function.get-parent-class.php
+ * @link https://www.php.net/get-class
+ * @link https://www.php.net/get-parent-class
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedHashAlgorithmsSniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * PHP version 5.4
  *
- * @link https://www.php.net/manual/en/function.hash-algos.php#refsect1-function.hash-algos-changelog
+ * @link https://www.php.net/hash-algos#refsect1-function.hash-algos-changelog
  *
  * @since 5.5
  * @since 7.1.0  Now extends the `AbstractRemovedFeatureSniff` instead of the base `Sniff` class.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIconvEncodingSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * PHP version 5.6
  *
- * @link https://www.php.net/manual/en/migration56.deprecated.php#migration56.deprecated.iconv-mbstring-encoding
+ * @link https://www.php.net/migration56.deprecated#migration56.deprecated.iconv-mbstring-encoding
  * @link https://wiki.php.net/rfc/default_encoding
  *
  * @since 9.0.0

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedImplodeFlexibleParamOrderSniff.php
@@ -24,9 +24,9 @@ use PHPCSUtils\Utils\MessageHelper;
  * PHP version 7.4
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.implode-reverse-parameters
+ * @link https://www.php.net/migration74.deprecated#migration74.deprecated.core.implode-reverse-parameters
  * @link https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix
- * @link https://php.net/manual/en/function.implode.php
+ * @link https://php.net/implode
  *
  * @since 9.3.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbCheckEncodingNoArgsSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbCheckEncodingNoArgsSniff.php
@@ -22,8 +22,8 @@ use PHPCompatibility\Helpers\ScannedCode;
  * PHP version 9.0
  *
  * @link https://wiki.php.net/rfc/deprecations_php_8_1#mb_check_encoding_without_argument
- * @link https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.mbstring
- * @link https://www.php.net/manual/en/function.mb-check-encoding.php
+ * @link https://www.php.net/migration81.deprecated#migration81.deprecated.mbstring
+ * @link https://www.php.net/mb-check-encoding
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrimWidthNegativeWidthSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrimWidthNegativeWidthSniff.php
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\PassedParameters;
  * PHP version 9.0
  *
  * @link https://wiki.php.net/rfc/deprecations_php_8_3#passing_negative_widths_to_mb_strimwidth
- * @link https://www.php.net/manual/en/function.mb-strimwidth.php
+ * @link https://www.php.net/mb-strimwidth
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbStrrposEncodingThirdParamSniff.php
@@ -34,9 +34,9 @@ use PHPCSUtils\Utils\PassedParameters;
  * PHP version 7.4
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.mbstring
+ * @link https://www.php.net/migration74.deprecated#migration74.deprecated.mbstring
  * @link https://wiki.php.net/rfc/deprecations_php_7_4#mb_strrpos_with_encoding_as_3rd_argument
- * @link https://www.php.net/manual/en/function.mb-strrpos.php
+ * @link https://www.php.net/mb-strrpos
  *
  * @since 9.3.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\TextStrings;
  * PHP version 7.1+
  *
  * @link https://wiki.php.net/rfc/deprecate_mb_ereg_replace_eval_option
- * @link https://www.php.net/manual/en/function.mb-regex-set-options.php
+ * @link https://www.php.net/mb-regex-set-options
  *
  * @since 7.0.5
  * @since 7.0.8  This sniff now throws a warning instead of an error as the functionality is

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedNonCryptoHashSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * PHP version 7.2
  *
- * @link https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.hash-functions
+ * @link https://www.php.net/migration72.incompatible#migration72.incompatible.hash-functions
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedPCREModifiersSniff.php
@@ -32,7 +32,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @link https://wiki.php.net/rfc/remove_preg_replace_eval_modifier
  * @link https://wiki.php.net/rfc/remove_deprecated_functionality_in_php7
- * @link https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
+ * @link https://www.php.net/reference.pcre.pattern.modifiers
  *
  * @since 5.6
  * @since 7.0.8  This sniff now throws a warning (deprecated) or an error (removed) depending

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedSetlocaleStringSniff.php
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\PassedParameters;
  * PHP version 7.0
  *
  * @link https://wiki.php.net/rfc/remove_deprecated_functionality_in_php7
- * @link https://www.php.net/manual/en/function.setlocale.php#refsect1-function.setlocale-changelog
+ * @link https://www.php.net/setlocale#refsect1-function.setlocale-changelog
  *
  * @since 9.0.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/ForbiddenCallTimePassByReferenceSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\PassedParameters;
  * PHP version 5.4
  *
  * @link https://wiki.php.net/rfc/calltimebyref
- * @link https://www.php.net/manual/en/language.references.pass.php
+ * @link https://www.php.net/references.pass
  *
  * @since 5.5
  * @since 7.0.8  This sniff now throws a warning (deprecated) or an error (removed) depending

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayStringDereferencingSniff.php
@@ -27,10 +27,10 @@ use PHPCompatibility\Sniff;
  * PHP version 5.5
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/migration55.new-features.php#migration55.new-features.const-dereferencing
+ * @link https://www.php.net/migration55.new-features#migration55.new-features.const-dereferencing
  * @link https://wiki.php.net/rfc/constdereference
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
- * @link https://www.php.net/manual/en/language.types.array.php#example-63
+ * @link https://www.php.net/types.array#example-63
  *
  * {@internal The reason for splitting the logic of this sniff into different methods is
  *            to allow re-use of the logic by the PHP 7.4 `RemovedCurlyBraceArrayAccess` sniff.}

--- a/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewArrayUnpackingSniff.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  *
  * PHP version 7.4
  *
- * @link https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.unpack-inside-array
+ * @link https://www.php.net/migration74.new-features#migration74.new-features.core.unpack-inside-array
  * @link https://wiki.php.net/rfc/spread_operator_for_array
  *
  * @since 9.2.0

--- a/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewClassMemberAccessSniff.php
@@ -28,9 +28,9 @@ use PHPCSUtils\Utils\Parentheses;
  * PHP version 5.4
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/language.oop5.basic.php#example-177
- * @link https://www.php.net/manual/en/language.oop5.cloning.php#language.oop5.traits.properties.example
- * @link https://www.php.net/manual/en/migration54.new-features.php
+ * @link https://www.php.net/oop5.basic#example-177
+ * @link https://www.php.net/oop5.cloning#language.oop5.traits.properties.example
+ * @link https://www.php.net/migration54.new-features
  * @link https://wiki.php.net/rfc/instance-method-call
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *

--- a/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewDynamicClassConstantFetchSniff.php
@@ -20,7 +20,7 @@ use PHPCompatibility\Sniff;
  *
  * PHP version 8.3
  *
- * @link https://www.php.net/releases/8.3/en.php#dynamic_class_constant_fetch
+ * @link https://www.php.net/releases/8.3/#dynamic_class_constant_fetch
  * @link https://wiki.php.net/rfc/dynamic_class_constant_fetch
  *
  * @since 10.0.0

--- a/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFirstClassCallablesSniff.php
@@ -23,7 +23,7 @@ use PHPCompatibility\Sniff;
  * PHP version 8.1
  * PHP version 8.4
  *
- * @link https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.callable-syntax
+ * @link https://www.php.net/migration81.new-features#migration81.new-features.core.callable-syntax
  * @link https://wiki.php.net/rfc/first_class_callable_syntax
  * @link https://wiki.php.net/rfc/exit-as-function
  *

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -25,7 +25,7 @@ use PHPCompatibility\Sniff;
  *
  * PHP version 7.3
  *
- * @link https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.heredoc
+ * @link https://www.php.net/migration73.new-features#migration73.new-features.core.heredoc
  * @link https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes
  *
  * @since 9.0.0

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionArrayDereferencingSniff.php
@@ -27,8 +27,8 @@ use PHPCSUtils\Tokens\Collections;
  * PHP version 5.4
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/language.types.array.php#example-63
- * @link https://www.php.net/manual/en/migration54.new-features.php
+ * @link https://www.php.net/types.array#example-63
+ * @link https://www.php.net/migration54.new-features
  * @link https://wiki.php.net/rfc/functionarraydereferencing
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *

--- a/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFunctionCallTrailingCommaSniff.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Tokens\Collections;
  * PHP version 7.3
  * PHP version 8.4
  *
- * @link https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.trailing-commas
+ * @link https://www.php.net/migration73.new-features#migration73.new-features.core.trailing-commas
  * @link https://wiki.php.net/rfc/trailing-comma-function-calls
  * @link https://wiki.php.net/rfc/exit-as-function
  *

--- a/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewInterpolatedStringDereferencingSniff.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\TextStrings;
  * PHP version 8.0
  *
  * @link https://wiki.php.net/rfc/variable_syntax_tweaks#interpolated_and_non-interpolated_strings
- * @link https://www.php.net/manual/en/language.types.string.php#language.types.string.parsing
+ * @link https://www.php.net/types.string#language.types.string.parsing
  *
  * @since 10.0.0
  */

--- a/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewShortArraySniff.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Arrays;
  * PHP version 5.4
  *
  * @link https://wiki.php.net/rfc/shortsyntaxforarrays
- * @link https://www.php.net/manual/en/language.types.array.php#language.types.array.syntax
+ * @link https://www.php.net/types.array#language.types.array.syntax
  *
  * @since 7.0.0
  * @since 9.0.0  Renamed from `ShortArraySniff` to `NewShortArraySniff`.

--- a/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/RemovedCurlyBraceArrayAccessSniff.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\Scopes;
  * PHP version 7.4
  * PHP version 8.0
  *
- * @link https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace
+ * @link https://www.php.net/migration74.deprecated#migration74.deprecated.core.array-string-access-curly-brace
  * @link https://wiki.php.net/rfc/deprecate_curly_braces_array_access
  *
  * @since 9.3.0

--- a/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
@@ -24,10 +24,10 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.unicode-codepoint-escape-syntax
- * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.strings.unicode-escapes
+ * @link https://www.php.net/migration70.new-features#migration70.new-features.unicode-codepoint-escape-syntax
+ * @link https://www.php.net/migration70.incompatible#migration70.incompatible.strings.unicode-escapes
  * @link https://wiki.php.net/rfc/unicode_escape
- * @link https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.double
+ * @link https://www.php.net/types.string#language.types.string.syntax.double
  *
  * @since 9.3.0
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/NewTypeCastsSniff.php
@@ -20,7 +20,7 @@ use PHPCompatibility\Sniff;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting
+ * @link https://www.php.net/types.type-juggling#language.types.typecasting
  *
  * @since 8.0.1
  * @since 10.0.0 - Now extends the base `Sniff` class and uses the `ComplexVersionNewFeatureTrait`.

--- a/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/TypeCasts/RemovedTypeCastsSniff.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * PHP version All
  *
- * @link https://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting
+ * @link https://www.php.net/types.type-juggling#language.types.typecasting
  * @link https://wiki.php.net/rfc/deprecations_php_7_2#unset_cast
  * @link https://wiki.php.net/rfc/deprecations_php_7_4#the_real_type
  *

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewGroupUseDeclarationsSniff.php
@@ -25,11 +25,11 @@ use PHPCompatibility\Sniff;
  * PHP version 7.0
  * PHP version 7.2
  *
- * @link https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.group-use-declarations
- * @link https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.trailing-comma-in-grouped-namespaces
+ * @link https://www.php.net/migration70.new-features#migration70.new-features.group-use-declarations
+ * @link https://www.php.net/migration72.new-features#migration72.new-features.trailing-comma-in-grouped-namespaces
  * @link https://wiki.php.net/rfc/group_use_declarations
  * @link https://wiki.php.net/rfc/list-syntax-trailing-commas
- * @link https://www.php.net/manual/en/language.namespaces.importing.php#language.namespaces.importing.group
+ * @link https://www.php.net/namespaces.importing#language.namespaces.importing.group
  *
  * @since 7.0.0
  * @since 8.0.1  Now also checks for trailing commas in group `use` declarations.

--- a/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/UseDeclarations/NewUseConstFunctionSniff.php
@@ -25,9 +25,9 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * PHP version 5.6
  *
- * @link https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.use
+ * @link https://www.php.net/migration56.new-features#migration56.new-features.use
  * @link https://wiki.php.net/rfc/use_function
- * @link https://www.php.net/manual/en/language.namespaces.importing.php
+ * @link https://www.php.net/namespaces.importing
  *
  * @since 7.1.4
  * @since 10.0.0 This class is now `final`.

--- a/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/ForbiddenThisUseContextsSniff.php
@@ -46,7 +46,7 @@ use PHPCSUtils\Utils\Scopes;
  *
  * PHP version 7.1
  *
- * @link https://www.php.net/manual/en/migration71.other-changes.php#migration71.other-changes.inconsistency-fixes-to-this
+ * @link https://www.php.net/migration71.other-changes#migration71.other-changes.inconsistency-fixes-to-this
  * @link https://wiki.php.net/rfc/this_var
  *
  * @since 9.1.0

--- a/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/NewUniformVariableSyntaxSniff.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tokens\Collections;
  *
  * PHP version 7.0
  *
- * @link https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect
+ * @link https://www.php.net/migration70.incompatible#migration70.incompatible.variable-handling.indirect
  * @link https://wiki.php.net/rfc/uniform_variable_syntax
  *
  * @since 7.1.2

--- a/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/Variables/RemovedIndirectModificationOfGlobalsSniff.php
@@ -40,7 +40,7 @@ use ReflectionFunction;
  *
  * PHP version 8.1
  *
- * @link https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.globals-access
+ * @link https://www.php.net/migration81.incompatible#migration81.incompatible.core.globals-access
  * @link https://wiki.php.net/rfc/restrict_globals_usage
  *
  * @since 10.0.0

--- a/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/ArgumentFunctionsReportCurrentValueUnitTest.inc
@@ -286,7 +286,7 @@ function usingFQNconstant($a,) {
     debug_backtrace(Partially\Qualified\DEBUG_BACKTRACE_IGNORE_ARGS);    // Error, not the global constant being passed, value unknown.
 }
 
-// Ref: https://www.php.net/manual/en/function.debug-backtrace.php#refsect1-function.debug-backtrace-parameters
+// Ref: https://www.php.net/debug-backtrace#refsect1-function.debug-backtrace-parameters
 function backtraceOptionsByTheNumber($a) {
     $a = 'foo';
     debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT); // Error, args index will be populated.


### PR DESCRIPTION
... as per our own guidelines in the [CONTRIBUTING guide](https://github.com/PHPCompatibility/PHPCompatibility/blob/develop/.github/CONTRIBUTING.md#pull-requests):

> * When referring to the PHP manual, like in a sniff class docblock, preferably use language-agnostic short links to the PHP manual as described on the [PHP Manual URL How to page](https://www.php.net/urlhowto.php)