### PR TITLE
PHP 8.6 | :sparkles: New `PHPCompatibility.ControlStructures.RemovedReturnFromFinally` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/ControlStructures/RemovedReturnFromFinallyStandard.xml
+++ b/PHPCompatibility/Docs/ControlStructures/RemovedReturnFromFinallyStandard.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed Returning From a Finally Block"
+    >
+    <standard>
+    <![CDATA[
+    Including a return statement in a finally block is deprecated since PHP 8.6.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: no return in the finally block.">
+        <![CDATA[
+try {
+    return doSomethingWhichMayreturnOrThrow();
+} catch (Exception $e) {
+    return false;
+} finally {
+    doSomethingMore();
+}
+        ]]>
+        </code>
+        <code title="PHP &lt; 8.6: returning from within a finally block.">
+        <![CDATA[
+try {
+    return doSomethingWhichMayreturnOrThrow();
+} catch (Exception $e) {
+    return false;
+} finally {
+    return doSomethingMore();
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ControlStructures/RemovedReturnFromFinallySniff.php
+++ b/PHPCompatibility/Sniffs/ControlStructures/RemovedReturnFromFinallySniff.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Tokens\Collections;
+
+/**
+ * Including a return statement in a finally block is deprecated since PHP 8.6.
+ *
+ * PHP version 8.6
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_returning_from_a_finally_block
+ * @link https://www.php.net/language.exceptions#language.exceptions.finally
+ *
+ * @since 10.0.0
+ */
+final class RemovedReturnFromFinallySniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            \T_FINALLY,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrAbove('8.6') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
+            return;
+        }
+
+        $closedScopes = Collections::closedScopes();
+
+        for ($i = ($tokens[$stackPtr]['scope_opener'] + 1); $i < $tokens[$stackPtr]['scope_closer']; $i++) {
+            if (isset($closedScopes[$tokens[$i]['code']]) === true
+                && isset($tokens[$i]['scope_closer']) === true
+            ) {
+                $i = $tokens[$i]['scope_closer'];
+                continue;
+            }
+
+            if ($tokens[$i]['code'] !== \T_RETURN) {
+                continue;
+            }
+
+            $fix = $phpcsFile->addWarning(
+                'Passing a return value from a finally block is deprecated since PHP 8.6.',
+                $i,
+                'Deprecated'
+            );
+        }
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyParseError1UnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyParseError1UnitTest.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+try {
+   // Some code...
+} catch (Exception $e) {
+   // Some code...
+} finally {
+    return;

--- a/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyParseError1UnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyParseError1UnitTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedReturnFromFinally sniff.
+ *
+ * @group removedReturnFromFinally
+ * @group controlStructures
+ * @group exceptions
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\RemovedReturnFromFinallySniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedReturnFromFinallyParseError1UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.6');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyParseError2UnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyParseError2UnitTest.inc
@@ -1,0 +1,8 @@
+<?php
+
+// Live coding/parse error. This test should be the only test in this test case file.
+try {
+   // Some code...
+} finally {
+	function foo() {
+        return;

--- a/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyParseError2UnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyParseError2UnitTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedReturnFromFinally sniff.
+ *
+ * @group removedReturnFromFinally
+ * @group controlStructures
+ * @group exceptions
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\RemovedReturnFromFinallySniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedReturnFromFinallyParseError2UnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify the sniff will silently ignore live coding.
+     *
+     * @return void
+     */
+    public function testSniffStaysSilentOnLiveCoding()
+    {
+        $file = $this->sniffFile(__FILE__, '8.6');
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertNoViolation($file);
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyUnitTest.inc
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyUnitTest.inc
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * OK.
+ */
+try {
+    return doSomething();
+} catch (Exception $e) {
+    return 1;
+} finally {
+    echo 'no return statement in the finally block';
+}
+
+function yieldInFinallyDoesNotOverwriteYieldInTry() {
+    try {
+        yield ('hi');
+    } finally {
+        yield 'bye';
+    }
+}
+
+function returnInsideClosedScopeShouldBeIgnoredForFunction() {
+    try {
+        return trim($a);
+    } finally {
+        function namedFunction() {
+            return 'hi!';
+        }
+    }
+}
+
+function returnInsideClosedScopeShouldBeIgnoredForClosure() {
+    try {
+        return trim($a);
+    } finally {
+        $closure = function () {
+            return 'hi!';
+        };
+    }
+}
+
+function returnInsideClosedScopeShouldBeIgnoredForClass() {
+    try {
+        return trim($a);
+    } finally {
+        class NamedClass {
+            const ABC = 10;
+
+            function foo() {
+                return ABC;
+            }
+        }
+    }
+}
+
+function returnInsideClosedScopeShouldBeIgnoredForAnonClass() {
+    try {
+        return trim($a);
+    } finally {
+        $anon = new class() {
+            const ABC = 10;
+
+            function foo() {
+                return ABC;
+            }
+        };
+    }
+}
+
+function returnInsideClosedScopeShouldBeIgnoredForTrait() {
+    try {
+        return trim($a);
+    } finally {
+        trait NamedTrait {
+            function foo() {
+                return __CLASS__;
+            }
+        }
+    }
+}
+
+function returnInsideClosedScopeShouldBeIgnoredForEnum() {
+    try {
+        return trim($a);
+    } finally {
+        enum NamedEnum {
+            function foo() {
+                return __CLASS__;
+            }
+        }
+    }
+}
+
+
+/*
+ * PHP 8.6: return statements in a finally block are deprecated.
+ */
+try {
+    doSomething();
+} finally {
+    doSomethingElse();
+    $closure = function () {
+        return 'hi!';
+    };
+
+    // No value.
+    return;
+}
+
+function rfcExample(): array {
+    try {
+        return loadConfig(); // throws if the file is missing
+    } finally {
+        // With value.
+        return []; // the exception is gone, the caller just gets []
+    }
+}
+
+function multipleReturns(): array {
+    try {
+        return loadConfig(); // throws if the file is missing
+    } finally {
+        if ($a === true) {
+            return []; // the exception is gone, the caller just gets []
+        } else {
+            return false;
+        }
+    }
+}
+
+// Deprecated twice: both returns are lexically inside the outer finally, even
+// though one of them sits in a nested try block.
+function nestedTry() {
+    try {
+    } finally {
+        try {
+            return 1;
+        } finally {
+            return 2;
+        }
+    }
+}
+
+// Deprecated once: only the closure's own finally return is flagged. The outer
+// finally must not leak into the closure, so the closure's try return is left alone.
+function closureWithTry() {
+    try {
+    } finally {
+        $f = function () {
+            try {
+                return 1;
+            } finally {
+                return 2;
+            }
+        };
+    }
+}

--- a/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyUnitTest.php
+++ b/PHPCompatibility/Tests/ControlStructures/RemovedReturnFromFinallyUnitTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ControlStructures;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedReturnFromFinally sniff.
+ *
+ * @group removedReturnFromFinally
+ * @group controlStructures
+ * @group exceptions
+ *
+ * @covers \PHPCompatibility\Sniffs\ControlStructures\RemovedReturnFromFinallySniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedReturnFromFinallyUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify return statements within a finally block are flagged correctly.
+     *
+     * @dataProvider dataRemovedReturnFromFinally
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testRemovedReturnFromFinally($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.6');
+        $this->assertWarning($file, $line, 'Passing a return value from a finally block is deprecated since PHP 8.6.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataRemovedReturnFromFinally()
+    {
+        return [
+            [107],
+            [115],
+            [124],
+            [126],
+            [137],
+            [139],
+            [153],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $cases = [];
+
+        // No errors expected on the first 94 lines.
+        for ($line = 1; $line <= 94; $line++) {
+            $cases[] = [$line];
+        }
+
+        $cases[] = [103];
+
+        return $cases;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION

>   . Using the return statement in a finally block is now deprecated.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_returning_from_a_finally_block

This commit adds a new sniff to detect `finally` blocks containing a `return` statement.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_returning_from_a_finally_block
* https://github.com/php/php-src/blob/271f689482c8efdaa8b2b5ac11e8172c25335bdd/UPGRADING#L469-L470
* php/php-src#22509
* https://github.com/php/php-src/commit/e721b3fdc35dc74121ed27ed43c2f9568f321bee

Related to #2052