### PR TITLE
PHP 8.6 | :sparkles: New `PHPCompatibility.FunctionDeclarations.RemovedReturnYieldInConstructDestruct` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/FunctionDeclarations/RemovedReturnYieldInConstructDestructStandard.xml
+++ b/PHPCompatibility/Docs/FunctionDeclarations/RemovedReturnYieldInConstructDestructStandard.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed Return or Yield In Constructor Destructor"
+    >
+    <standard>
+    <![CDATA[
+    An OO constructor/destructor should not return a value.
+    The constructor will always return a valid object instance, so an explicit return statement returning a value from a constructor is confusing.
+
+    As this never worked as expected anyhow, returning from a OO constructor or destructor is deprecated since PHP 8.6.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: constructor/destructor doesn't return a value.">
+        <![CDATA[
+class Foo {
+    public function __construct() {
+        // Do something.
+    }
+
+
+    public function __destruct() {
+        // Do something.
+        return;
+    }
+}
+        ]]>
+        </code>
+        <code title="PHP &lt;= 8.5: constructor/destructor returns a value.">
+        <![CDATA[
+class Foo {
+    public function __construct() {
+        // Do something.
+        return <em>$this</em>;
+    }
+
+    public function __destruct() {
+        // Do something.
+        return <em>false</em>;
+    }
+}
+        ]]>
+        </code>
+    </code_comparison>
+
+    <standard>
+    <![CDATA[
+    An OO constructor/destructor cannot be a Generator yielding values.
+    Generators effectively return a new Generator object, which conflicts with an OO constructor returning an instance of the current class.
+
+    Making a constructor/destructor a Generator is deprecated since PHP 8.6.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: Non-Generator constructor/destructor.">
+        <![CDATA[
+class Foo {
+    public function __construct() {
+        // Do something.
+    }
+
+    public function __destruct() {
+        // Do something.
+        return;
+    }
+}
+        ]]>
+        </code>
+        <code title="PHP &lt;= 8.5: constructor/destructor is a Generator.">
+        <![CDATA[
+class Foo {
+    public function __construct() {
+        yield 123;
+    }
+
+    public function __destruct() {
+        yield from [4, 5, 6];
+    }
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnYieldInConstructDestructSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionDeclarations/RemovedReturnYieldInConstructDestructSniff.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionDeclarations;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Returning or yielding a value from a constructor or destructor is deprecated since PHP 8.6.
+ *
+ * PHP version 8.6
+ *
+ * @link https://wiki.php.net/rfc/deprecate-return-value-from-construct
+ * @link https://www.php.net/language.oop5.decon
+ *
+ * @since 10.0.0
+ */
+final class RemovedReturnYieldInConstructDestructSniff extends Sniff
+{
+
+    /**
+     * Magic methods this sniff needs to examine.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, string> Method name => Type of method for use in the error message.
+     */
+    private const TARGET_FUNCTIONS = [
+        '__construct' => 'constructor',
+        '__destruct'  => 'destructor',
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        // Enums can't have constructors or destructors, interfaces cannot have a function body, so no need to scan either.
+        return [
+            \T_CLASS,
+            \T_ANON_CLASS,
+            \T_TRAIT,
+        ];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrAbove('8.6') === false) {
+            return;
+        }
+
+        $ooMethods = ObjectDeclarations::getDeclaredMethods($phpcsFile, $stackPtr);
+        if (empty($ooMethods)) {
+            // OO declaration without methods or parse error.
+            return;
+        }
+
+        $ooMethods = \array_change_key_case($ooMethods, \CASE_LOWER);
+
+        $tokens       = $phpcsFile->getTokens();
+        $closedScopes = Collections::closedScopes();
+        foreach (self::TARGET_FUNCTIONS as $functionName => $functionType) {
+            if (isset($ooMethods[$functionName]) === false) {
+                continue;
+            }
+
+            $functionPtr = $ooMethods[$functionName];
+            if (isset($tokens[$functionPtr]['scope_opener'], $tokens[$functionPtr]['scope_closer']) === false) {
+                continue;
+            }
+
+            for ($i = ($tokens[$functionPtr]['scope_opener'] + 1); $i < $tokens[$functionPtr]['scope_closer']; $i++) {
+                if (isset($closedScopes[$tokens[$i]['code']]) === true
+                    && isset($tokens[$i]['scope_closer']) === true
+                ) {
+                    // Skip over nested closed scopes which may contain return or yield statements.
+                    $i = $tokens[$i]['scope_closer'];
+                    continue;
+                }
+
+                /*
+                 * Arrow functions cannot contain a return statement, but a `yield` in an arrow function
+                 * could confuse the sniff, so better to skip over them completely.
+                 */
+                if ($tokens[$i]['code'] === \T_FN && isset($tokens[$i]['scope_closer'])) {
+                    $i = $tokens[$i]['scope_closer'];
+                    continue;
+                }
+
+                if ($tokens[$i]['code'] === \T_RETURN) {
+                    $nextNonEmpty = $phpcsFile->findNext(Tokens::EMPTY_TOKENS, ($i + 1), null, true);
+                    if ($nextNonEmpty === false
+                        || $tokens[$nextNonEmpty]['code'] === \T_SEMICOLON
+                        || $tokens[$nextNonEmpty]['code'] === \T_CLOSE_TAG
+                    ) {
+                        // Returning without passing a value. This is okay.
+                        continue;
+                    }
+
+                    $error = 'Returning a value from a %s is deprecated since PHP 8.6.';
+                    $data  = [$functionType];
+                    $phpcsFile->addWarning($error, $i, 'DeprecatedReturnWithValue', $data);
+
+                    continue;
+                }
+
+                if ($tokens[$i]['code'] === \T_YIELD || $tokens[$i]['code'] === \T_YIELD_FROM) {
+
+                    $error = 'Using a %s as a generator is deprecated since PHP 8.6.';
+                    $data  = [$functionType];
+                    $phpcsFile->addWarning($error, $i, 'DeprecatedGenerator', $data);
+
+                    // Prevent duplicate messages for multi-token "yield from".
+                    if ($tokens[$i]['code'] === \T_YIELD_FROM && \strtolower($tokens[$i]['content']) === 'yield') {
+                        for ($j = ($i + 1); $j < $tokens[$functionPtr]['scope_closer']; $j++) {
+                            if (isset(Tokens::EMPTY_TOKENS[$tokens[$j]['code']]) === true) {
+                                continue;
+                            }
+
+                            // The next token should be the "from" keyword.
+                            if ($tokens[$j]['code'] === \T_YIELD_FROM && \strtolower($tokens[$j]['content']) === 'from') {
+                                $i = $j;
+                            }
+
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnYieldInConstructDestructUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnYieldInConstructDestructUnitTest.inc
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * OK.
+ */
+
+// Global functions, not OO constructor/destructor.
+function __construct() : int {
+    return 123;
+}
+
+function __destruct() {
+    yield 321;
+}
+
+// No methods.
+$anon = new class() {
+    const FOO = 10;
+};
+
+// Methods which are not constructors/destructors can be disregarded.
+class NotAConstructor {
+    public function __set($name, $value) {
+        // Do something.
+        return $success;
+    }
+
+    public function Foo(): int {
+        // Do something.
+        return false;
+    }
+
+    public function Bar() {
+        return $this;
+    }
+}
+
+// Abstract Constructors/Destructors don't have a body, so can be skipped.
+abstract class AbstractMethods {
+    abstract protected function __construct();
+    abstract protected function __destruct();
+}
+
+// PHP 4 style constructors are not regarded as constructors since PHP 8.0, so should not be flagged for the PHP 8.6 deprecation.
+class PHP4StyleConstructorShouldBeIgnored {
+    public function PHP4StyleConstructorShouldBeIgnored() {
+        // Do something.
+        return $success;
+    }
+}
+
+// Constructors/Destructors without a return statement are fine.
+class NoReturn {
+    protected function __construct()
+    {
+        do_something();
+    }
+
+    protected function __destruct()
+    {
+        do_something();
+    }
+}
+
+// Constructors/Destructors with a return statement, but without a value, are fine.
+$anon = new class extends ReturnNoValue {
+    public function __construct() {
+        if ($foo) {
+            return   ;
+        } else {
+            return /* comments are fine */
+            // Even when spread over multiple lines.
+            ;
+        }
+
+        return;
+    }
+
+    public function __destruct() {
+        do_something();
+        return;
+    }
+};
+
+// Early return without a value is also fine.
+trait EarlyReturnIsStillAllowed
+{
+    public function __construct()
+    {
+        if (random_int(0, 1)) {
+            return; // Skipping the rest of the logic remains legal.
+        }
+
+        echo "Constructing", PHP_EOL;
+    }
+
+    public function __destruct()
+    {
+        if (random_int(0, 1)) {
+            return; // Skipping the rest of the logic remains legal.
+        }
+
+        echo "Destructing", PHP_EOL;
+    }
+}
+
+// Prevent false positives for nested functions/closures.
+class NestedFunctions {
+    public function __construct() {
+        function global_function() {
+            return true;
+        }
+    }
+
+    public function __destruct() {
+        function global_function($foo) {
+            return $foo;
+        }
+    }
+}
+
+class NestedClosures {
+    public function __construct() {
+        do_something(
+            function () {
+                return true;
+            },
+        );
+    }
+
+    public function __destruct() {
+        $this->callback = function () {
+            return 10;
+        };
+    }
+}
+
+$anon = new class extends NestedArrowFunctions {
+    public function __construct() {
+        do_something(
+            fn() : int => yield from [1, 2, 3],
+        );
+    }
+
+    public function __destruct() {
+        $this->callback = fn() : int => yield 10;
+    }
+};
+
+class NestedAnonClass {
+    public function __construct() {
+        do_something(
+            new class () {
+                public function foo() {
+                    return true;
+                }
+            },
+        );
+    }
+
+    public function __destruct() {
+        $this->anonClass = new class() extends Foo {
+            private function dataProvider() {
+                yield 10;
+                yield 20;
+            }
+        };
+    }
+}
+
+
+/*
+ * PHP 8.6: returning from a constructor or destructor is deprecated.
+ */
+class ReturnFromConstructDestruct
+{
+    public function __construct()
+    {
+        if ($foo) {
+            return 123 ?>
+        <?php
+        } else {
+            return 456;
+        }
+    }
+
+    public function __destruct()
+    {
+        if ($foo) {
+            return 123;
+        }
+
+        return 456;
+    }
+}
+
+trait YieldInConstructDestruct
+{
+    public function __construct()
+    {
+        yield 123;
+        yield 456;
+    }
+
+    public function __destruct()
+    {
+        yield 123;
+        yield 456;
+    }
+}
+
+$anonClass = new class extends YieldFromInConstructDestruct
+{
+    public function __construct()
+    {
+        yield from [3, 4];
+        yield /*comment*/ from [3, 4];
+    }
+
+    public function __destruct()
+    {
+        yield    from [3, 4];
+        yield
+
+        from [3, 4];
+    }
+};

--- a/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnYieldInConstructDestructUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionDeclarations/RemovedReturnYieldInConstructDestructUnitTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionDeclarations;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedReturnYieldInConstructDestruct sniff.
+ *
+ * @group removedReturnYieldInConstructDestruct
+ * @group functionDeclarations
+ * @group magicMethods
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionDeclarations\RemovedReturnYieldInConstructDestructSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedReturnYieldInConstructDestructUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify return statements in constructors and destructors are flagged for PHP 8.6 and up.
+     *
+     * @dataProvider dataRemovedReturnInConstructDestruct
+     *
+     * @param int    $line         The line number.
+     * @param string $functionType Either 'constructor' or 'destructor'.
+     *
+     * @return void
+     */
+    public function testRemovedReturnInConstructDestruct($line, $functionType)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.6');
+        $error = \sprintf('Returning a value from a %s is deprecated since PHP 8.6.', $functionType);
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataRemovedReturnInConstructDestruct()
+    {
+        return [
+            [180, 'constructor'],
+            [183, 'constructor'],
+            [190, 'destructor'],
+            [193, 'destructor'],
+        ];
+    }
+
+
+    /**
+     * Verify yield (from) statements in constructors and destructors are flagged for PHP 8.6 and up.
+     *
+     * @dataProvider dataRemovedYieldInConstructDestruct
+     *
+     * @param int    $line         The line number.
+     * @param string $functionType Either 'constructor' or 'destructor'.
+     *
+     * @return void
+     */
+    public function testRemovedYieldInConstructDestruct($line, $functionType)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.6');
+        $error = \sprintf('Using a %s as a generator is deprecated since PHP 8.6.', $functionType);
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataRemovedYieldInConstructDestruct()
+    {
+        return [
+            [201, 'constructor'],
+            [202, 'constructor'],
+            [207, 'destructor'],
+            [208, 'destructor'],
+            [216, 'constructor'],
+            [217, 'constructor'],
+            [222, 'destructor'],
+            [223, 'destructor'],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 171 lines.
+        for ($line = 1; $line <= 171; $line++) {
+            $data[] = [$line];
+        }
+
+        // Make sure there are no duplicate errors for multi-token "yield from".
+        $data[] = [224];
+        $data[] = [225];
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
>   . Returning values from __construct() and __destruct() is now deprecated.
>     RFC: https://wiki.php.net/rfc/deprecate-return-value-from-construct
>   . Making __construct() and __destruct() a Generator is now deprecated.
>     RFC: https://wiki.php.net/rfc/deprecate-return-value-from-construct

This commit adds a new sniff to detect these deprecations.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/deprecate-return-value-from-construct
* https://github.com/php/php-src/blob/53c3116c380ee629c35931ba02881ebb9b3d006f/UPGRADING#L503-L506
* php/php-src#21982
* https://github.com/php/php-src/commit/18d783719d58420fa7f333175830fcf40c916bea

Related to #2052