### PR TITLE
PHP 8.6 | ForbiddenNames: handle deprecation of "readonly as function name" exception (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/ForbiddenNamesSniff.php
@@ -565,18 +565,6 @@ final class ForbiddenNamesSniff extends Sniff
         }
 
         $nameLC = \strtolower($name);
-
-        /*
-         * Deal with `readonly` being a reserved keyword, but still being allowed
-         * as a function name.
-         *
-         * @link https://github.com/php/php-src/pull/7468 (PHP 8.1)
-         * @link https://github.com/php/php-src/pull/9512 (PHP 8.2 follow-up)
-         */
-        if ($nameLC === 'readonly') {
-            return;
-        }
-
         if (isset($this->invalidNames[$nameLC]) === false) {
             return;
         }
@@ -597,8 +585,30 @@ final class ForbiddenNamesSniff extends Sniff
             return;
         }
 
+        /*
+         * Deal with `readonly` being a reserved keyword, but still being allowed
+         * as a function name between PHP 8.1 < 9.0.
+         *
+         * This exception was deprecated in PHP 8.6 and is expected to be removed in PHP 9.0.
+         *
+         * @link https://github.com/php/php-src/pull/7468 (PHP 8.1)
+         * @link https://github.com/php/php-src/pull/9512 (PHP 8.2 follow-up)
+         * @link https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_the_possibility_to_name_a_function_readonly (PHP 8.6 deprecation)
+         * @link https://github.com/php/php-src/commit/a9ba369abe43a4947e4015171f0111c4a816a630 (PHP 8.6 deprecation)
+         */
+        if ($nameLC === 'readonly') {
+            if (ScannedCode::shouldRunOnOrAbove('8.6') === false) {
+                return;
+            }
+
+            $error = "Using reserved keyword 'readonly' as a function name is deprecated since PHP 8.6";
+            $phpcsFile->addWarning($error, $stackPtr, 'FunctionReadonlyFound');
+            return;
+        }
+
         $this->checkName($phpcsFile, $stackPtr, $name);
     }
+
 
     /**
      * Processes global/class constant declarations using the `const` keyword.
@@ -892,7 +902,13 @@ final class ForbiddenNamesSniff extends Sniff
      */
     protected function addError(File $phpcsFile, $stackPtr, $name)
     {
-        $error     = "Function name, class name, namespace name or constant name can not be reserved keyword '%s' (since version %s)";
+        $error = "Function name, class name, namespace name or constant name can not be reserved keyword '%s' (since version %s)";
+        if ($name === 'readonly') {
+            // Functions named "readonly" are handled separately as this was disallowed in another PHP version,
+            // so listing functions as disallowed context in the error message for other constructs will only confuse users.
+            $error = "Class name, namespace name or constant name can not be reserved keyword '%s' (since version %s)";
+        }
+
         $errorCode = MessageHelper::stringToErrorCode($name, true) . 'Found';
 
         // Display the magic constants in uppercase.

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.1.inc
@@ -349,9 +349,6 @@ $closure = function () use ($a) {};
 // Test call to define() using named parameters.
 define(value: 'class', constant_name: 'BAR');
 
-// Test readonly as a function name. This is a (temporary) exception.
-function readonly() {}
-
 class ReadonlyFoo {
     public function readonly() {}
 }

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.3.inc
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.3.inc
@@ -98,3 +98,11 @@ class TypedConstants {
 // Safeguard handling of variations of function calls to `define()`.
 DEFINE('TRAIT', 'value');
 \define('FINAL', 'value');
+
+// Test readonly as a function name. This is a (temporary) exception.
+// Readonly keyword was introduced in 8.1 with the exception that the keyword
+// could still be used for function names.
+// This exception became a deprecation in PHP 8.6 and is expected to be removed in PHP 9.0.
+function readonly() {}
+function ReadOnly() {}
+function READONLY() {}

--- a/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Keywords/ForbiddenNamesUnitTest.php
@@ -97,7 +97,8 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
 
         // Each line of the use case files (starting at line 3) exhibits an error.
         for ($i = 3; $i <= $fullReservedLineEnd; $i++) {
-            $this->assertError($file, $i, 'Function name, class name, namespace name or constant name can not be reserved keyword');
+            // Not a typo. The `c` in `class` can be upper- or lowercase depending on the keyword. This allows us to match both.
+            $this->assertError($file, $i, 'lass name, namespace name or constant name can not be reserved keyword');
         }
 
         if (isset($this->testsForOtherInvalidNames[$usecase]) === true) {
@@ -304,7 +305,7 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
     /**
      * Data provider.
      *
-     * @return array
+     * @return array<array<int|string>>
      */
     public static function dataSpecificCodeSamples()
     {
@@ -365,7 +366,7 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
     /**
      * Data provider.
      *
-     * @return array
+     * @return array<array<int|string>>
      */
     public static function dataSpecificCodeSamplesOtherKeywords()
     {
@@ -408,6 +409,39 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
 
 
     /**
+     * Test handling of the PHP 8.6 deprecation of the exception to allow "readonly" as a function name.
+     *
+     * @dataProvider dataReadonlyAsFunctionName
+     *
+     * @param int $line Line number on which to expect a warning.
+     *
+     * @return void
+     */
+    public function testReadonlyAsFunctionName($line)
+    {
+        $file = $this->sniffFile(__DIR__ . '/ForbiddenNamesUnitTest.3.inc', '-8.5');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(__DIR__ . '/ForbiddenNamesUnitTest.3.inc', '8.6-');
+        $this->assertWarning($file, $line, "Using reserved keyword 'readonly' as a function name is deprecated since PHP 8.6");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataReadonlyAsFunctionName()
+    {
+        return [
+            [106],
+            [107],
+            [108],
+        ];
+    }
+
+
+    /**
      * Test that correct use of the keywords doesn't trigger false positives, as well as
      * use of incorrectly named constructs.
      *
@@ -426,7 +460,7 @@ final class ForbiddenNamesUnitTest extends BaseSniffTestCase
     /**
      * Data provider.
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public static function dataCorrectUsageOfKeywords()
     {


### PR DESCRIPTION
>   . Naming a function readonly is now deprecated.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_the_possibility_to_name_a_function_readonly

`readonly` became a reserved keyword as of PHP 8.1, but an exception was made for a function named `readonly` due to real world fall-out (WordPress).

This was handled in the `ForbiddenNames` sniff via a conditional bow out introduced in PR #1415.

As of PHP 8.6, the exception for functions named `readonly` will be deprecated.

In the sniff, this needs some special handling for the following reasons:
1. We want the deprecation to show a warning, not an error.
2. In that warning, version `8.6` should be mentioned, not PHP 8.1.
3. The error for `readonly` when used in other contexts (i.e. class name etc) would still list "function names" as forbidden since PHP 8.1, while that isn't true for `readonly`.

This commit handles all three of the above points.

Includes tests.
Note: "readonly as a method name" (= no error) is tested in the `ForbiddenNamesUnitTest.1.inc` case file, while "readonly as a function name" (= conditional warning) is now tested in the `ForbiddenNamesUnitTest.3.inc` case file.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_the_possibility_to_name_a_function_readonly
* https://github.com/php/php-src/blob/38e8b232da8981790d8c3aa635cf09875a837e32/UPGRADING#L463-L464
* php/php-src#23074
* https://github.com/php/php-src/commit/a9ba369abe43a4947e4015171f0111c4a816a630

Related to #2052