### PR TITLE
PHP 8.6 | ✨ New `PHPCompatibility.FunctionNameRestrictions.NewDebuggableEnums` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/FunctionNameRestrictions/NewDebuggableEnumsStandard.xml
+++ b/PHPCompatibility/Docs/FunctionNameRestrictions/NewDebuggableEnumsStandard.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New Debuggable Enums"
+    >
+    <standard>
+    <![CDATA[
+    Prior to PHP 8.6, only the __call(), __callStatic(), and __invoke() magic methods could be declared on an enum.
+
+    As of PHP 8.6, the `__debugInfo()` magic method is also supported on enums.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: enum without a __debugInfo() method.">
+        <![CDATA[
+enum WithoutDebugInfo: string {
+    case Bar = "Baz";
+
+    <em>public function __call()</em> {
+        // Code for the magic method.
+    }
+}
+        ]]>
+        </code>
+        <code title="PHP &gt;= 8.6: enum with a __debugInfo() method.">
+        <![CDATA[
+enum WithDebugInfo: string {
+    case Bar = "Baz";
+
+    <em>public function __debugInfo()</em> {
+        return [
+            __CLASS__ . '::' . $this->name
+            . ' = ' . $this->value
+        ];
+    }
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewDebuggableEnumsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionNameRestrictions/NewDebuggableEnumsSniff.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\FunctionNameRestrictions;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Sniff;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * The __debugInfo() magic method can be declared on enums since PHP 8.6.
+ *
+ * PHP version 8.6
+ *
+ * @link https://wiki.php.net/rfc/debugable-enums
+ * @link https://www.php.net/language.oop5.magic#object.debuginfo
+ *
+ * @since 10.0.0
+ */
+final class NewDebuggableEnumsSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 10.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [\T_ENUM];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (ScannedCode::shouldRunOnOrBelow('8.5') === false) {
+            return;
+        }
+
+        $ooMethods = ObjectDeclarations::getDeclaredMethods($phpcsFile, $stackPtr);
+        if (empty($ooMethods)) {
+            // No methods declared in the enum. Bow out.
+            return;
+        }
+
+        $ooMethods = \array_change_key_case($ooMethods, \CASE_LOWER);
+
+        if (isset($ooMethods['__debuginfo']) === false) {
+            // The enum doesn't declare the __debugInfo() method.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'The magic method __debugInfo() could not be declared on an enum prior to PHP 8.6.',
+            $ooMethods['__debuginfo'],
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionDeclarations/NonStaticMagicMethodsUnitTest.inc
@@ -280,7 +280,7 @@ class Nested {
 
 /*
  * Safeguard handling of magic methods in PHP 8.1+ enums.
- * Only `__call()`, `__callStatic()`, and `__invoke()` are allowed in enums, but that's not the concern of this sniff.
+ * Only `__call()`, `__callStatic()`, `__invoke()` and `__debugInfo()` (PHP 8.6+) are allowed in enums, but that's not the concern of this sniff.
  */
 enum PlainEnum
 {

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewDebuggableEnumsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewDebuggableEnumsUnitTest.inc
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * OK.
+ */
+// Not our target.
+function __debugInfo() {}
+
+class DebuggableClass {
+    public function __debugInfo() {}
+}
+
+interface DebuggableInterface {
+    public function __debugInfo();
+}
+
+trait DebuggableTrait {
+    public function __debugInfo() {}
+}
+
+$anonClass = new class {
+    public function __debugInfo() {}
+};
+
+enum NoMethods {
+    case Foo;
+    case Bar;
+}
+
+// Prior to PHP 8.6, the `__call()`, `__callStatic()`, and `__invoke()` methods were already allowed on enums.
+enum NonDebuggableEnum
+{
+    case Foo;
+    case Bar;
+
+    public function __call($name, $arguments) {}
+    public static function __callStatic($name, $arguments) {}
+    public function __invoke($x) {}
+}
+
+
+/*
+ * PHP 8.6: Debuggable enums.
+ */
+enum DebuggableEnum {
+    case Bar = "Baz";
+
+    public function __debugInfo() {
+        return [__CLASS__ . '::' . $this->name . ' = ' . $this->value];
+    }
+}
+
+enum BackedDebuggableEnum: string {
+    case Bar = "Baz";
+
+    public function __debugINFO() {}
+}

--- a/PHPCompatibility/Tests/FunctionNameRestrictions/NewDebuggableEnumsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionNameRestrictions/NewDebuggableEnumsUnitTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\FunctionNameRestrictions;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewDebuggableEnums sniff.
+ *
+ * @group newDebuggableEnums
+ * @group functionNameRestrictions
+ * @group magicMethods
+ *
+ * @covers \PHPCompatibility\Sniffs\FunctionNameRestrictions\NewDebuggableEnumsSniff
+ *
+ * @since 10.0.0
+ */
+final class NewDebuggableEnumsUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify enums declaring the __debugInfo() method are flagged for PHP 8.5 and lower.
+     *
+     * @dataProvider dataNewDebuggableEnums
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewDebuggableEnums($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertError($file, $line, 'The magic method __debugInfo() could not be declared on an enum prior to PHP 8.6.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNewDebuggableEnums()
+    {
+        return [
+            [48],
+            [56],
+        ];
+    }
+
+
+    /**
+     * Test that there are no false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 41 lines.
+        for ($line = 1; $line <= 41; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.6');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION
### PHP 8.6 | ✨ New `PHPCompatibility.FunctionNameRestrictions.NewDebuggableEnums` sniff (RFC)

>  . It is now possible to define the __debugInfo() magic method on enums.
>    RFC: https://wiki.php.net/rfc/debugable-enums

This commit adds a new sniff to detect enums declaring a `__debugInfo()` method.

Notes:
* The `NewMagicMethods` sniff will flag declaration of the `__debugInfo()` method on all OO constructs if support for PHP 5.5 or lower is still required. I do not consider that a duplication as that error is unlikely to be shown in combination with the one from this sniff as enums weren't introduced until PHP 8.1.
* The `__debugInfo()` method when declared on an enum has to comply with the same declaration restrictions (visibility, arguments, return type) as `__debugInfo()` methods on other OO constructs. This check is already covered via the `NonStaticMagicMethods` sniff.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/debugable-enums
* https://github.com/php/php-src/blob/38e8b232da8981790d8c3aa635cf09875a837e32/UPGRADING#L312-L313
* php/php-src#21425
* php/php-src@463c5dc

Related to #2052

### PHP 8.6 | NonStaticMagicMethodsUnitTest: update inline comment for debuggable enums