### PR TITLE
PHP 8.6 | ✨ New `PHPCompatibility.ParameterValues.NewTrimCharactersDefault` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/NewTrimCharactersDefaultStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/NewTrimCharactersDefaultStandard.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="New trim() Characters Default"
+    >
+    <standard>
+    <![CDATA[
+    Prior to PHP 8.6, the default value for the `$characters` parameter for the `trim()`, `ltrim()` and `rtrim()` functions was `" \n\r\t\v\x00"`.
+
+    As of PHP 8.6, the default value for the `$characters` parameters now includes the `"\f"` (= ASCII 12, form feed) character, changing the default value to `" \f\n\r\t\v\x00"` and stripping form feeds unless the `$characters` parameter has been overwritten.
+
+    When the `trim()`, `ltrim()` and `rtrim()` functions are used in code which needs to be PHP cross-version compatible with both PHP < 8.6, as well as PHP 8.6+, the `$characters` parameter should be explicitly set to ensure the function return value will be consistent.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible: passing the $characters parameter when calling these functions.">
+        <![CDATA[
+echo trim($text, <em>" \f\n\r\t\v\x00"</em>);
+echo rtrim($text, <em>'/'</em>);
+        ]]>
+        </code>
+        <code title="Cross-version INcompatible: calling these functions without passing the $characters parameter.">
+        <![CDATA[
+echo ltrim($text);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Helpers/PCRERegexTrait.php
+++ b/PHPCompatibility/Helpers/PCRERegexTrait.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Helpers;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\Utils;
 use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
@@ -109,8 +110,8 @@ trait PCRERegexTrait
                 }
 
                 $itemInfo['end']   = ($hasKey - 1);
-                $itemInfo['raw']   = \trim(GetTokensAsString::normal($phpcsFile, $itemInfo['start'], $itemInfo['end']));
-                $itemInfo['clean'] = \trim(GetTokensAsString::compact($phpcsFile, $itemInfo['start'], $itemInfo['end'], true));
+                $itemInfo['raw']   = Utils::trim(GetTokensAsString::normal($phpcsFile, $itemInfo['start'], $itemInfo['end']));
+                $itemInfo['clean'] = Utils::trim(GetTokensAsString::compact($phpcsFile, $itemInfo['start'], $itemInfo['end'], true));
                 $patterns[]        = $itemInfo;
             }
 
@@ -123,8 +124,8 @@ trait PCRERegexTrait
             if ($hasKey !== false) {
                 // Param info array only needs adjusting if this was a keyed array item.
                 $itemInfo['start'] = ($hasKey + 1);
-                $itemInfo['raw']   = \trim(GetTokensAsString::normal($phpcsFile, $itemInfo['start'], $itemInfo['end']));
-                $itemInfo['clean'] = \trim(GetTokensAsString::compact($phpcsFile, $itemInfo['start'], $itemInfo['end'], true));
+                $itemInfo['raw']   = Utils::trim(GetTokensAsString::normal($phpcsFile, $itemInfo['start'], $itemInfo['end']));
+                $itemInfo['clean'] = Utils::trim(GetTokensAsString::compact($phpcsFile, $itemInfo['start'], $itemInfo['end'], true));
             }
 
             $patterns[] = $itemInfo;
@@ -192,7 +193,7 @@ trait PCRERegexTrait
                     $content = TextStrings::stripEmbeds($content);
                 }
 
-                $regex .= \trim($content);
+                $regex .= Utils::trim($content);
             } catch (ValueError $e) {
                 // Ignore. Subsequent line of a multi-line double quoted text string.
             }

--- a/PHPCompatibility/Helpers/ResolveHelper.php
+++ b/PHPCompatibility/Helpers/ResolveHelper.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Helpers;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\Helpers\Utils;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\GetTokensAsString;
@@ -72,7 +73,7 @@ final class ResolveHelper
 
         $end       = $phpcsFile->findNext($find, ($start + 1), null, true);
         $className = GetTokensAsString::noEmpties($phpcsFile, $start, ($end - 1));
-        $className = \trim($className);
+        $className = Utils::trim($className);
 
         return self::getFQName($phpcsFile, $stackPtr, $className);
     }
@@ -168,7 +169,7 @@ final class ResolveHelper
         $start     = $phpcsFile->findPrevious($find, $stackPtr - 1, null, true, null, true);
         $start     = ($start + 1);
         $className = GetTokensAsString::noEmpties($phpcsFile, $start, ($stackPtr - 1));
-        $className = \trim($className);
+        $className = Utils::trim($className);
 
         return self::getFQName($phpcsFile, $stackPtr, $className);
     }

--- a/PHPCompatibility/Helpers/ScannedCode.php
+++ b/PHPCompatibility/Helpers/ScannedCode.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Helpers;
 
 use PHPCompatibility\Exceptions\InvalidTestVersion;
 use PHPCompatibility\Exceptions\InvalidTestVersionRange;
+use PHPCompatibility\Helpers\Utils;
 use PHPCSUtils\BackCompat\Helper;
 
 /**
@@ -100,7 +101,7 @@ final class ScannedCode
                 $testVersion = Helper::getConfigData('testversion');
             }
 
-            self::$testVersion = \trim((string) $testVersion);
+            self::$testVersion = Utils::trim((string) $testVersion);
         }
 
         if (empty(self::$testVersion)) {

--- a/PHPCompatibility/Helpers/TokenGroup.php
+++ b/PHPCompatibility/Helpers/TokenGroup.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Helpers;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCSUtils\Utils\Numbers;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -238,16 +239,16 @@ final class TokenGroup
 
                     $content = 0.0;
                 } else {
-                    $content = (float) \trim($intMatch[0]);
+                    $content = (float) Utils::trim($intMatch[0]);
                 }
             } elseif ($intString !== 1 && $floatString !== 1) {
                 $content = 0.0;
             } else {
-                $content = ($floatString === 1) ? (float) \trim($floatMatch[0]) : (float) \trim($intMatch[0]);
+                $content = ($floatString === 1) ? (float) Utils::trim($floatMatch[0]) : (float) Utils::trim($intMatch[0]);
             }
 
             // Allow for different behaviour for hex numeric strings between PHP 5 vs PHP 7.
-            if ($intString === 1 && \trim($intMatch[0]) === '0'
+            if ($intString === 1 && Utils::trim($intMatch[0]) === '0'
                 && \preg_match('`^\s*(0x[A-Fa-f0-9]+)`', $stringContent, $hexNumberString) === 1
                 && ScannedCode::shouldRunOnOrBelow('5.6') === true
             ) {

--- a/PHPCompatibility/Helpers/Utils.php
+++ b/PHPCompatibility/Helpers/Utils.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Helpers;
+
+/**
+ * Helper for cross-version compatibility of PHPCompatibility code.
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is only intended for internal use by PHPCompatibility and is not part of the public API.
+ * This also means that it has no promise of backward compatibility. Use at your own risk.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @since 10.0.0
+ */
+final class Utils
+{
+
+    /**
+     * Default characters to trim.
+     *
+     * The PHP native default changed in PHP 8.6. This standardizes on the PHP 8.6 default value.
+     *
+     * @since 10.0.0
+     *
+     * @var string
+     */
+    private const TRIM_CHARS_DEFAULT = " \f\n\r\t\v\x00";
+
+    /**
+     * PHP wrapper function: Strip whitespace (or other characters) from the beginning and end of a string.
+     *
+     * @link https://www.php.net/trim
+     *
+     * @since 10.0.0
+     *
+     * @param string $text       The string that will be trimmed.
+     * @param string $characters Optionally, the stripped characters can also be specified
+     *                           using the characters parameter.
+     *
+     * @return string
+     */
+    public static function trim(string $text, string $characters = self::TRIM_CHARS_DEFAULT): string
+    {
+        return \trim($text, $characters);
+    }
+
+    /**
+     * PHP wrapper function: Strip whitespace (or other characters) from the beginning of a string.
+     *
+     * @link https://www.php.net/ltrim
+     *
+     * @since 10.0.0
+     *
+     * @param string $text       The string that will be trimmed.
+     * @param string $characters Optionally, the stripped characters can also be specified
+     *                           using the characters parameter.
+     *
+     * @return string
+     */
+    public static function ltrim(string $text, string $characters = self::TRIM_CHARS_DEFAULT): string
+    {
+        return \ltrim($text, $characters);
+    }
+
+    /**
+     * PHP wrapper function: Strip whitespace (or other characters) from the end of a string.
+     *
+     * @link https://www.php.net/rtrim
+     *
+     * @since 10.0.0
+     *
+     * @param string $text       The string that will be trimmed.
+     * @param string $characters Optionally, the stripped characters can also be specified
+     *                           using the characters parameter.
+     *
+     * @return string
+     */
+    public static function rtrim(string $text, string $characters = self::TRIM_CHARS_DEFAULT): string
+    {
+        return \rtrim($text, $characters);
+    }
+}

--- a/PHPCompatibility/Sniffs/Generators/NewYieldFromCommentSniff.php
+++ b/PHPCompatibility/Sniffs/Generators/NewYieldFromCommentSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\Generators;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCompatibility\Sniff;
 
 /**
@@ -66,9 +67,9 @@ final class NewYieldFromCommentSniff extends Sniff
         /*
          * Handle potentially multi-token "yield from" expressions.
          */
-        if (\strtolower(\trim($content)) === 'yield') {
+        if (\strtolower(Utils::trim($content)) === 'yield') {
             for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
-                if ($tokens[$i]['code'] === \T_YIELD_FROM && \strtolower(\trim($tokens[$i]['content'])) === 'from') {
+                if ($tokens[$i]['code'] === \T_YIELD_FROM && \strtolower(Utils::trim($tokens[$i]['content'])) === 'from') {
                     $content     .= $tokens[$i]['content'];
                     $yieldFromEnd = $i;
                     break;
@@ -85,7 +86,7 @@ final class NewYieldFromCommentSniff extends Sniff
 
         $contentSansKeywords = \substr($content, 5, -4);
 
-        if (\trim($contentSansKeywords) === '') {
+        if (Utils::trim($contentSansKeywords) === '') {
             return ($yieldFromEnd + 1);
         }
 

--- a/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewConstantScalarExpressionsSniff.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractInitialValueSniff;
 use PHPCompatibility\Helpers\ScannedCode;
 use PHPCompatibility\Helpers\TokenGroup;
+use PHPCompatibility\Helpers\Utils;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\MessageHelper;
@@ -285,7 +286,7 @@ final class NewConstantScalarExpressionsSniff extends AbstractInitialValueSniff
         $tokenCount = ($end - $stackPtr);
         if ($tokenCount < 20) {
             // Prevent large arrays from being added to the error message.
-            $content = \trim(GetTokensAsString::noComments($phpcsFile, $stackPtr, $end));
+            $content = Utils::trim(GetTokensAsString::noComments($phpcsFile, $stackPtr, $end));
         }
 
         if (empty($content) === false) {

--- a/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/InitialValue/NewHeredocSniff.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Sniffs\InitialValue;
 use PHP_CodeSniffer\Files\File;
 use PHPCompatibility\AbstractInitialValueSniff;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\MessageHelper;
 
@@ -106,7 +107,7 @@ final class NewHeredocSniff extends AbstractInitialValueSniff
         $error       = self::ERROR_PHRASE;
         $errorCode   = 'Found';
         $phrase      = '';
-        $codeSnippet = \trim(GetTokensAsString::noComments($phpcsFile, $stackPtr, $hasHeredoc));
+        $codeSnippet = Utils::trim(GetTokensAsString::noComments($phpcsFile, $stackPtr, $hasHeredoc));
 
         if (isset($this->initialValueTypes[$type]) === true) {
             $errorCode = MessageHelper::stringToErrorCode($type) . 'Found';

--- a/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/Keywords/NewKeywordsSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\Helpers\ComplexVersionNewFeatureTrait;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Scopes;
@@ -270,7 +271,7 @@ final class NewKeywordsSniff extends Sniff
             && \preg_match('`yield\s+from`i', $tokens[$stackPtr]['content']) !== 1
         ) {
             for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
-                if ($tokens[$i]['code'] === \T_YIELD_FROM && \strtolower(\trim($tokens[$i]['content'])) === 'from') {
+                if ($tokens[$i]['code'] === \T_YIELD_FROM && \strtolower(Utils::trim($tokens[$i]['content'])) === 'from') {
                     $end = ($i + 1);
                     break;
                 }

--- a/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/NewPHPOpenTagEOFSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Miscellaneous;
 
 use PHP_CodeSniffer\Files\File;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCompatibility\Sniff;
 
 /**
@@ -102,7 +103,7 @@ final class NewPHPOpenTagEOFSniff extends Sniff
 
             case \T_OPEN_TAG_WITH_ECHO:
                 // PHP 7.2+.
-                if (\rtrim($contents) === '<?=') {
+                if (Utils::rtrim($contents) === '<?=') {
                     $error = true;
                 }
                 break;

--- a/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/Miscellaneous/RemovedAlternativePHPTagsSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Miscellaneous;
 
 use PHP_CodeSniffer\Files\File;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Tokens\Collections;
 
@@ -67,7 +68,7 @@ final class RemovedAlternativePHPTagsSniff extends Sniff
 
         $tokens  = $phpcsFile->getTokens();
         $openTag = $tokens[$stackPtr];
-        $content = \trim($openTag['content']);
+        $content = Utils::trim($openTag['content']);
 
         if ($content === '' || $content === '<?php') {
             return;

--- a/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/ForbiddenSessionModuleNameUserSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -94,7 +95,7 @@ final class ForbiddenSessionModuleNameUserSniff extends AbstractFunctionCallPara
         $content   = TextStrings::getCompleteTextString($phpcsFile, $firstNonEmpty);
         $contentLC = \strtolower($content);
 
-        if (\trim($contentLC) !== 'user') {
+        if (Utils::trim($contentLC) !== 'user') {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewTrimCharactersDefaultSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewTrimCharactersDefaultSniff.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2026 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * The default value for the $characters parameters for `[lr]trim()` includes the form feed character as of PHP 8.6.
+ *
+ * PHP version 8.6
+ *
+ * @link https://wiki.php.net/rfc/trim_form_feed
+ * @link https://www.php.net/trim
+ * @link https://www.php.net/ltrim
+ * @link https://www.php.net/rtrim
+ *
+ * @since 10.0.0
+ */
+final class NewTrimCharactersDefaultSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * Key is the function name, value an array containing the 1-based parameter position
+     * and the official name of the parameter.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, array<string, int|string>>
+     */
+    protected $targetFunctions = [
+        'trim'  => [
+            'position' => 2,
+            'name'     => 'characters',
+        ],
+        'ltrim' => [
+            'position' => 2,
+            'name'     => 'characters',
+        ],
+        'rtrim' => [
+            'position' => 2,
+            'name'     => 'characters',
+        ],
+    ];
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * Note: This sniff should only trigger errors when both PHP 8.5 or lower,
+     * as well as PHP 8.6 or higher needs to be supported within the application.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrBelow('8.5') === false || ScannedCode::shouldRunOnOrAbove('8.6') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return void
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $functionLC  = \strtolower($functionName);
+        $paramInfo   = $this->targetFunctions[$functionLC];
+        $targetParam = PassedParameters::getParameterFromStack($parameters, $paramInfo['position'], $paramInfo['name']);
+        if ($targetParam !== false) {
+            // Parameter is set, not an issue.
+            return;
+        }
+
+        $phpcsFile->addError(
+            'The default value of the $characters parameter for %s() includes the form feed character as of PHP 8.6. It was changed from " \n\r\t\v\x00" to " \f\n\r\t\v\x00". For cross-version compatibility, the $characters parameter should be explicitly set.',
+            $stackPtr,
+            'NotSet',
+            [$functionName]
+        );
+    }
+}

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedMbstringModifiersSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCSUtils\Utils\MessageHelper;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -117,7 +118,7 @@ final class RemovedMbstringModifiersSniff extends AbstractFunctionCallParameterS
             if ($tokens[$i]['code'] === \T_DOUBLE_QUOTED_STRING) {
                 $content = TextStrings::stripEmbeds($content);
             }
-            $content = \trim($content);
+            $content = Utils::trim($content);
 
             if (empty($content) === false) {
                 $options .= $content;

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedXmlSetHandlerCallbackUnsetSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedXmlSetHandlerCallbackUnsetSniff.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCompatibility\AbstractFunctionCallParameterSniff;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
 
@@ -136,7 +137,7 @@ final class RemovedXmlSetHandlerCallbackUnsetSniff extends AbstractFunctionCallP
 
             // Allow for multi-line empty strings.
             $callback = TextStrings::stripQuotes($callback);
-            $callback = \trim($callback);
+            $callback = Utils::trim($callback);
             if ($callback !== '') {
                 continue;
             }

--- a/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
+++ b/PHPCompatibility/Sniffs/Syntax/NewFlexibleHeredocNowdocSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\Syntax;
 
 use PHP_CodeSniffer\Files\File;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCompatibility\Sniff;
 
 /**
@@ -104,7 +105,7 @@ final class NewFlexibleHeredocNowdocSniff extends Sniff
             /*
              * Check for indented closing marker.
              */
-            if (\ltrim($tokens[$stackPtr]['content']) !== $tokens[$stackPtr]['content']) {
+            if (Utils::ltrim($tokens[$stackPtr]['content']) !== $tokens[$stackPtr]['content']) {
                 $phpcsFile->addError($indentError, $stackPtr, $indentErrorCode);
             }
 
@@ -133,7 +134,7 @@ final class NewFlexibleHeredocNowdocSniff extends Sniff
                     continue;
                 }
 
-                $trimmed = \ltrim($tokens[$i]['content']);
+                $trimmed = Utils::ltrim($tokens[$i]['content']);
 
                 if (\strpos($trimmed, $identifier) !== 0) {
                     continue;
@@ -204,7 +205,7 @@ final class NewFlexibleHeredocNowdocSniff extends Sniff
                 $nextHereNowDoc = null;
             }
 
-            $identifier        = \trim($tokens[$stackPtr]['content']);
+            $identifier        = Utils::trim($tokens[$stackPtr]['content']);
             $realClosingMarker = $stackPtr;
 
             while (($realClosingMarker = $phpcsFile->findNext(\T_STRING, ($realClosingMarker + 1), $nextHereNowDoc, false, $identifier)) !== false) {

--- a/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
+++ b/PHPCompatibility/Sniffs/TextStrings/NewUnicodeEscapeSequenceSniff.php
@@ -12,6 +12,7 @@ namespace PHPCompatibility\Sniffs\TextStrings;
 
 use PHP_CodeSniffer\Files\File;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCompatibility\Sniff;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\TextStrings;
@@ -137,7 +138,7 @@ final class NewUnicodeEscapeSequenceSniff extends Sniff
      */
     protected function isValidUnicodeEscapeSequence($codepoint)
     {
-        if (\trim($codepoint) === '') {
+        if (Utils::trim($codepoint) === '') {
             return false;
         }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewTrimCharactersDefaultUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewTrimCharactersDefaultUnitTest.inc
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * OK.
+ */
+// Not our target - safeguard against false positives on method calls and namespaced function calls.
+ClassName::trim( $string );
+$obj->ltrim($string);
+$obj?->rtrim( $string );
+namespace\trim($string);
+\Fully\Qualified\ltrim( $string );
+Partially\Qualified\rtrim($string);
+
+// OK cross-version.
+echo trim( $string, '/' );
+echo trim( $string, " \f\n\r\t\v\x00" );
+echo ltrim($string, $chars);
+echo \rtrim( characters: "\n\r", string: $string, );
+echo trim($string, MyClass::CONST_NAME);
+echo LTRIM( $text, $obj->chars );
+echo RTrim( $text, $obj->get_chars() );
+
+/*
+ * Not OK - error when both PHP < 8.6 and PHP 8.6+ need to be supported.
+ */
+echo trim( $string );
+echo ltrim($string, /*comment*/ );
+echo RTrim( string: $string );
+echo \ltrim($string);

--- a/PHPCompatibility/Tests/ParameterValues/NewTrimCharactersDefaultUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewTrimCharactersDefaultUnitTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2026 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the NewTrimCharactersDefault sniff.
+ *
+ * @group newTrimCharactersDefault
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\NewTrimCharactersDefaultSniff
+ *
+ * @since 10.0.0
+ */
+final class NewTrimCharactersDefaultUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify that an error gets thrown when the $characters parameter is not set and both PHP < 8.6
+     * as well as PHP 8.6+ needs to be supported.
+     *
+     * @dataProvider dataNewTrimCharactersDefault
+     *
+     * @param int    $line         Line number where the error should occur.
+     * @param string $functionName The name of the function called.
+     *
+     * @return void
+     */
+    public function testNewTrimCharactersDefault($line, $functionName)
+    {
+        $file  = $this->sniffFile(__FILE__, '8.5-8.6');
+        $error = \sprintf(
+            'The default value of the $characters parameter for %s() includes the form feed character as of PHP 8.6. It was changed from " \n\r\t\v\x00" to " \f\n\r\t\v\x00"',
+            $functionName
+        );
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int|string>>
+     */
+    public static function dataNewTrimCharactersDefault()
+    {
+        return [
+            [26, 'trim'],
+            [27, 'ltrim'],
+            [28, 'RTrim'],
+            [29, 'ltrim'],
+        ];
+    }
+
+
+    /**
+     * Verify there are no false positives on code this sniff should ignore.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.5-8.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 22 lines.
+        for ($line = 1; $line <= 22; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @dataProvider dataNoViolationsInFileOnValidVersion
+     *
+     * @param string $testVersion The testVersion to use.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion($testVersion)
+    {
+        $file = $this->sniffFile(__FILE__, $testVersion);
+        $this->assertNoViolation($file);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<string>>
+     */
+    public static function dataNoViolationsInFileOnValidVersion()
+    {
+        return [
+            ['5.6-8.5'],
+            ['8.6-'],
+        ];
+    }
+}

--- a/PHPCompatibility/Util/Tests/Helpers/ScannedCodeUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/ScannedCodeUnitTest.php
@@ -13,6 +13,7 @@ namespace PHPCompatibility\Util\Tests\Helpers;
 use PHPCompatibility\Exceptions\InvalidTestVersion;
 use PHPCompatibility\Exceptions\InvalidTestVersionRange;
 use PHPCompatibility\Helpers\ScannedCode;
+use PHPCompatibility\Helpers\Utils;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\ConfigDouble;
 use ReflectionMethod;
@@ -220,7 +221,7 @@ final class ScannedCodeUnitTest extends TestCase
      */
     public function testGetTestVersionInvalidVersion($testVersion)
     {
-        $message = \sprintf('Invalid PHPCompatibility testVersion provided: \'%s\'', \trim($testVersion));
+        $message = \sprintf('Invalid PHPCompatibility testVersion provided: \'%s\'', Utils::trim($testVersion));
 
         $this->expectException(InvalidTestVersion::class);
         $this->expectExceptionMessage($message);

--- a/PHPCompatibility/Util/Tests/Helpers/UtilsUnitTest.php
+++ b/PHPCompatibility/Util/Tests/Helpers/UtilsUnitTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Util\Tests\Helpers;
+
+use PHPCompatibility\Helpers\Utils;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the Utils sniff helper.
+ *
+ * @group helpers
+ *
+ * @covers \PHPCompatibility\Helpers\Utils
+ *
+ * @since 10.0.0
+ */
+final class UtilsUnitTest extends TestCase
+{
+
+    /**
+     * Perfunctory test of the trim wrapper.
+     *
+     * @dataProvider dataTrim
+     *
+     * @param string $input    The input to pass to the function.
+     * @param string $expected The expected function output.
+     *
+     * @return void
+     */
+    public function testTrim($input, $expected)
+    {
+        $this->assertSame($expected, Utils::trim($input));
+    }
+
+    /**
+     * Safeguard that the trim wrapper allows for overwritting the default characters.
+     *
+     * @return void
+     */
+    public function testTrimAllowsForCustomCharacters()
+    {
+        $this->assertSame(' b ', Utils::trim('a b a', 'a'));
+    }
+
+    /**
+     * Perfunctory test of the ltrim wrapper.
+     *
+     * @dataProvider dataTrim
+     *
+     * @param string $input    The input to pass to the function.
+     * @param string $expected The expected function output.
+     *
+     * @return void
+     */
+    public function testLtrim($input, $expected)
+    {
+        $this->assertSame($expected, Utils::ltrim($input));
+    }
+
+    /**
+     * Safeguard that the ltrim wrapper allows for overwritting the default characters.
+     *
+     * @return void
+     */
+    public function testLtrimAllowsForCustomCharacters()
+    {
+        $this->assertSame(' b a', Utils::ltrim('a b a', 'a'));
+    }
+
+    /**
+     * Perfunctory test of the rtrim wrapper.
+     *
+     * @dataProvider dataTrim
+     *
+     * @param string $input    The input to pass to the function.
+     * @param string $expected The expected function output.
+     *
+     * @return void
+     */
+    public function testRtrim($input, $expected)
+    {
+        $this->assertSame($expected, Utils::rtrim($input));
+    }
+
+    /**
+     * Safeguard that the rtrim wrapper allows for overwritting the default characters.
+     *
+     * @return void
+     */
+    public function testRtrimAllowsForCustomCharacters()
+    {
+        $this->assertSame('a b ', Utils::rtrim('a b a', 'a'));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function dataTrim()
+    {
+        return [
+            'everything should be stripped' => [
+                'input'    => " \f\n\r\t\v\x00",
+                'expected' => '',
+            ],
+            'nothing should be stripped' => [
+                'input'    => "abc \f\n\r\t\v\x00 def",
+                'expected' => "abc \f\n\r\t\v\x00 def",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### PHP 8.6 | ✨ New `PHPCompatibility.ParameterValues.NewTrimCharactersDefault` sniff (RFC)

>  . Form feed (\f) is now added in the default trimmed characters of trim(),
>    rtrim() and ltrim().
>    RFC: https://wiki.php.net/rfc/trim_form_feed

This commit adds a new sniff to detect when the `$characters` parameter has not been passed, while the code is supposed to be cross-version compatible with both PHP < 8.6 and PHP 8.6+.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/trim_form_feed
* https://github.com/php/php-src/blob/38e8b232da8981790d8c3aa635cf09875a837e32/UPGRADING#L226-L228
* php/php-src#20788
* php/php-src@da1e89f

Related to #2052

### Add Utils class with trim helpers 

... to allow for the PHPCompatibility code itself to be PHP cross-version compatible.

Includes perfunctory tests.

### CS: start using new Utils::*trim() functions 

... for all code not passing the `$characters` parameter.