### PR TITLE
PHP 8.6 | ParameterValues/NewPackFormat: detect new "endianness modifiers" codes (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -68,6 +68,11 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
             '8.5' => false,
             '8.6' => true,
         ],
+        // Endianness modifiers on floats.
+        '`([fd][<>])`' => [
+            '8.5' => false,
+            '8.6' => true,
+        ],
     ];
 
 

--- a/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/NewPackFormatSniff.php
@@ -51,7 +51,7 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
      * @var array<string, array<string, bool>> Regex pattern => Version array.
      */
     protected $newFormats = [
-        '`([Z])`'    => [
+        '`([Z])`' => [
             '5.4' => false,
             '5.5' => true,
         ],
@@ -62,6 +62,11 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
         '`([eEgG])`' => [
             '7.0.14' => false,
             '7.0.15' => true, // And 7.1.1.
+        ],
+        // Endianness modifiers on integers.
+        '`([slqSLQ][<>])`' => [
+            '8.5' => false,
+            '8.6' => true,
         ],
     ];
 
@@ -75,7 +80,7 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
      */
     protected function bowOutEarly()
     {
-        return (ScannedCode::shouldRunOnOrBelow('7.1') === false);
+        return (ScannedCode::shouldRunOnOrBelow('8.6') === false);
     }
 
 
@@ -118,23 +123,26 @@ final class NewPackFormatSniff extends AbstractFunctionCallParameterSniff
             }
 
             foreach ($this->newFormats as $pattern => $versionArray) {
-                if (\preg_match($pattern, $content, $matches) !== 1) {
+                if (\preg_match_all($pattern, $content, $matches) < 1) {
                     continue;
                 }
 
                 foreach ($versionArray as $version => $present) {
                     if ($present === false && ScannedCode::shouldRunOnOrBelow($version) === true) {
-                        $phpcsFile->addError(
-                            'Passing the $format(s) "%s" to %s() is not supported in PHP %s or lower. Found: %s',
-                            $targetParam['start'],
-                            'NewFormatFound',
-                            [
-                                $matches[1],
-                                \strtolower($functionName),
-                                $version,
-                                $targetParam['clean'],
-                            ]
-                        );
+                        foreach ($matches[1] as $match) {
+                            $phpcsFile->addError(
+                                'Passing the $format(s) "%s" to %s() is not supported in PHP %s or lower. Found: %s',
+                                $targetParam['start'],
+                                'NewFormatFound',
+                                [
+                                    $match,
+                                    \strtolower($functionName),
+                                    $version,
+                                    $targetParam['clean'],
+                                ]
+                            );
+                        }
+
                         continue 2;
                     }
                 }

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
@@ -57,3 +57,18 @@ pack('a<', 'test'); // ValueError: Endianness modifier '<' is not supported for 
 pack('H>', 'test'); // ValueError: Endianness modifier '>' is not supported for format code 'H'.
 pack('v<', 42); // ValueError: Endianness modifier '<' cannot be applied to format code 'v' which already has inherent endianness.
 pack('N>', 42); // ValueError: Endianness modifier '>' cannot be applied to format code 'N' which already has inherent endianness.
+
+/*
+ * PHP 8.6: endianness modifiers on floats.
+ */
+// Examples taken straight from the RFC.
+$data = pack('f<d<', 3.14159, 2.71828); // Little endian.
+$data = pack('f>d>', 3.14159, 2.71828); // Big endian.
+[$float, $double] = array_values(unpack('f<a/d<b', $data));
+
+// Prevent false positives for unsupported format letters.
+// These should *not* be flagged.
+pack('g<', 3.14); // ValueError: Endianness modifier '<' cannot be applied to format code 'g' which already has inherent endianness.
+pack('G>', 3.14); // ValueError: Endianness modifier '>' cannot be applied to format code 'G' which already has inherent endianness.
+pack('e<', 3.14); // ValueError: Endianness modifier '<' cannot be applied to format code 'e' which already has inherent endianness.
+pack('E>', 3.14); // ValueError: Endianness modifier '>' cannot be applied to format code 'E' which already has inherent endianness.

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
@@ -38,3 +38,22 @@ MyClass::pack("nZc*", 0x1234, 0x5678, 65, 66);
 \Fully\Qualified\unpack("nZc*", 0x1234, 0x5678, 65, 66);
 Partially\Qualified\pack("nZc*", 0x1234, 0x5678, 65, 66);
 namespace\unpack("nZc*", 0x1234, 0x5678, 65, 66);
+
+/*
+ * PHP 8.6: endianness modifiers on integers.
+ */
+// Examples taken straight from the RFC.
+// These should all be flagged.
+$data = pack('s<l<q<', -258, -16909060, -72340172838076673); // Little-endian signed integers.
+$data = pack('s>l>q>', -258, -16909060, -72340172838076673); // Big-endian signed integers.
+$data = pack('S<L>Q<', 258, 16909060, 72340172838076673); // Unsigned integers with explicit endianness.
+$data = pack('s<2l>2', 258, -2, 16909060, -16909060); // Mixed endianness (little-endian 16-bit, big-endian 32-bit).
+[$int16_le, $int32_le] = array_values(unpack('s<a/l<b', $data));
+[$uint16_be, $uint32_le] = array_values(unpack('S>a/L<b', $data));
+
+// Prevent false positives for unsupported format letters or inherent endianness.
+// These should *not* be flagged.
+pack('a<', 'test'); // ValueError: Endianness modifier '<' is not supported for format code 'a'.
+pack('H>', 'test'); // ValueError: Endianness modifier '>' is not supported for format code 'H'.
+pack('v<', 42); // ValueError: Endianness modifier '<' cannot be applied to format code 'v' which already has inherent endianness.
+pack('N>', 42); // ValueError: Endianness modifier '>' cannot be applied to format code 'N' which already has inherent endianness.

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.inc
@@ -72,3 +72,6 @@ pack('g<', 3.14); // ValueError: Endianness modifier '<' cannot be applied to fo
 pack('G>', 3.14); // ValueError: Endianness modifier '>' cannot be applied to format code 'G' which already has inherent endianness.
 pack('e<', 3.14); // ValueError: Endianness modifier '<' cannot be applied to format code 'e' which already has inherent endianness.
 pack('E>', 3.14); // ValueError: Endianness modifier '>' cannot be applied to format code 'E' which already has inherent endianness.
+
+// Safeguard handling of live coding/missing target parameter.
+$data = pack(formatcode: 'Z'); // Wrong parameter name. Also named params not supported as function takes variable nr of arguments.

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -148,7 +148,7 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
         }
 
         // The float codes with inherent endianness were introduced in PHP 7.0/7.1, so test with a higher version.
-        for ($line = 71; $line <= 74; $line++) {
+        for ($line = 71; $line <= 77; $line++) {
             $data[] = [$line, '7.2'];
         }
 

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -95,6 +95,14 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
             [51, 'l<', 'unpack', '8.5', '8.6'],
             [52, 'S>', 'unpack', '8.5', '8.6'],
             [52, 'L<', 'unpack', '8.5', '8.6'],
+
+            // Endianness modifiers on floats.
+            [65, 'f<', 'pack', '8.5', '8.6'],
+            [65, 'd<', 'pack', '8.5', '8.6'],
+            [66, 'f>', 'pack', '8.5', '8.6'],
+            [66, 'd>', 'pack', '8.5', '8.6'],
+            [67, 'f<', 'unpack', '8.5', '8.6'],
+            [67, 'd<', 'unpack', '8.5', '8.6'],
         ];
     }
 
@@ -104,13 +112,14 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
      *
      * @dataProvider dataNoFalsePositives
      *
-     * @param int $line Line number.
+     * @param int    $line        Line number.
+     * @param string $testVersion TestVersion to verify there are no false positives..
      *
      * @return void
      */
-    public function testNoFalsePositives($line)
+    public function testNoFalsePositives($line, $testVersion = '5.4')
     {
-        $file = $this->sniffFile(__FILE__, '5.4');
+        $file = $this->sniffFile(__FILE__, $testVersion);
         $this->assertNoViolation($file, $line);
     }
 
@@ -136,6 +145,11 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
 
         for ($line = 56; $line <= 59; $line++) {
             $data[] = [$line];
+        }
+
+        // The float codes with inherent endianness were introduced in PHP 7.0/7.1, so test with a higher version.
+        for ($line = 71; $line <= 74; $line++) {
+            $data[] = [$line, '7.2'];
         }
 
         return $data;

--- a/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/NewPackFormatUnitTest.php
@@ -56,11 +56,11 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
     }
 
     /**
-     * dataNewPackFormat
+     * Data provider.
      *
      * @see testNewPackFormat()
      *
-     * @return array
+     * @return array<array<int|string>>
      */
     public static function dataNewPackFormat()
     {
@@ -78,12 +78,29 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
             [18, 'J', 'pack', '5.6', '7.1', '5.6.2'], // OK version set to beyond last error.
             [18, 'E', 'pack', '7.0', '7.1', '7.0.14'],
             [20, 'P', 'unpack', '5.6', '7.0', '5.6.2'],
+
+            // Endianness modifiers on integers.
+            [47, 's<', 'pack', '8.5', '8.6'],
+            [47, 'l<', 'pack', '8.5', '8.6'],
+            [47, 'q<', 'pack', '8.5', '8.6'],
+            [48, 's>', 'pack', '8.5', '8.6'],
+            [48, 'l>', 'pack', '8.5', '8.6'],
+            [48, 'q>', 'pack', '8.5', '8.6'],
+            [49, 'S<', 'pack', '8.5', '8.6'],
+            [49, 'L>', 'pack', '8.5', '8.6'],
+            [49, 'Q<', 'pack', '8.5', '8.6'],
+            [50, 's<', 'pack', '8.5', '8.6'],
+            [50, 'l>', 'pack', '8.5', '8.6'],
+            [51, 's<', 'unpack', '8.5', '8.6'],
+            [51, 'l<', 'unpack', '8.5', '8.6'],
+            [52, 'S>', 'unpack', '8.5', '8.6'],
+            [52, 'L<', 'unpack', '8.5', '8.6'],
         ];
     }
 
 
     /**
-     * testNoFalsePositives
+     * Test that there are no false positives.
      *
      * @dataProvider dataNoFalsePositives
      *
@@ -102,7 +119,7 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
      *
      * @see testNoFalsePositives()
      *
-     * @return array
+     * @return array<array<int|string>>
      */
     public static function dataNoFalsePositives()
     {
@@ -117,6 +134,10 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
             $data[] = [$line];
         }
 
+        for ($line = 56; $line <= 59; $line++) {
+            $data[] = [$line];
+        }
+
         return $data;
     }
 
@@ -128,7 +149,7 @@ final class NewPackFormatUnitTest extends BaseSniffTestCase
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(__FILE__, '7.1');
+        $file = $this->sniffFile(__FILE__, '8.6');
         $this->assertNoViolation($file);
     }
 }


### PR DESCRIPTION
### PHP 8.6 | ParameterValues/NewPackFormat: detect new "endianness modifiers on integers" codes (RFC)

> - Standard:
>   . pack() and unpack() now accept the "<" and ">" endianness modifiers on
>     the signed and unsigned integer format codes.
>     RFC: https://wiki.php.net/rfc/pack-unpack-endianness-signed-integers-support

This commit updates the existing `NewPackFormat` sniff to allow detecting use of the new modifiers.

Mind: as per the examples in the RFC, a `$format` parameter can easily contain multiple uses of the new modifiers in the format string.
As things were, the sniff would only flag the first instance of a code found in the format string.
To allow people to make all necessary fixes in one go, it is important to prevent one error hiding behind another.
To that end, the sniff now uses `preg_match_all()` instead of `preg_match()` and loops over all matches to flag all instances of found incompatible codes.

Refs:
* https://wiki.php.net/rfc/pack-unpack-endianness-signed-integers-support
* https://github.com/php/php-src/blob/75ad0885c9acd7735442d7de3c038fb59aa147c8/UPGRADING#L433-L436
* php/php-src#21074
* php/php-src@02229e2

Related to #2052

### PHP 8.6 | ParameterValues/NewPackFormat: detect new "endianness modifiers on floats" codes (RFC)

> - Standard:
>   . pack() and unpack() now accept the "<" and ">" endianness modifiers on
>     the float and double format codes.
>     RFC: https://wiki.php.net/rfc/pack-unpack-float-endianness-modifier

This commit updates the existing `NewPackFormat` sniff to allow detecting use of the new modifiers.

Refs:
* https://wiki.php.net/rfc/pack-unpack-float-endianness-modifier
* https://github.com/php/php-src/blob/75ad0885c9acd7735442d7de3c038fb59aa147c8/UPGRADING#L437-L439
* php/php-src#21074
* php/php-src@02229e2

Related to #2052

### ParameterValues/NewPackFormat: add missing test 

Note: as the function takes a variable number of parameters, named parameters isn't supported, but that's not the concern of the sniff.