### PR TITLE
PHP 8.6 | RemovedFunctions: detect function aliases with non-canonical type name (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/RemovedFunctionsSniff.php
@@ -5733,6 +5733,22 @@ final class RemovedFunctionsSniff extends Sniff
             'extension' => 'xml',
         ],
 
+        'is_double' => [
+            '8.6'         => false,
+            'alternative' => 'is_float()',
+        ],
+        'is_integer' => [
+            '8.6'         => false,
+            'alternative' => 'is_int()',
+        ],
+        'is_long' => [
+            '8.6'         => false,
+            'alternative' => 'is_int()',
+        ],
+        'doubleval' => [
+            '8.6'         => false,
+            'alternative' => 'floatval()',
+        ],
         'mb_ereg' => [
             '8.6'       => false,
             'extension' => 'mbstring',

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.inc
@@ -1420,3 +1420,7 @@ mb_eregi_replace();
 mb_regex_encoding();
 mb_regex_set_options();
 mb_split();
+is_double();
+is_integer();
+is_long();
+doubleval();

--- a/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/RemovedFunctionsUnitTest.php
@@ -193,6 +193,11 @@ final class RemovedFunctionsUnitTest extends BaseSniffTestCase
 
             ['socket_set_timeout', '8.5', 'stream_set_timeout()', 1398, '8.4'],
             ['mysqli_execute', '8.5', 'mysqli_stmt_execute()', 1404, '8.4'],
+
+            ['is_double', '8.6', 'is_float()', 1423, '8.5'],
+            ['is_integer', '8.6', 'is_int()', 1424, '8.5'],
+            ['is_long', '8.6', 'is_int()', 1425, '8.5'],
+            ['doubleval', '8.6', 'floatval()', 1426, '8.5'],
         ];
     }
 


### PR DESCRIPTION
>   . The is_double() function is now deprecated, use is_float() instead.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_double
>   . The is_long() and is_integer() functions are now deprecated, use is_int()
>     instead.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_integer
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_long
>   . The doubleval() function is now deprecated, use floatval() instead.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_doubleval

This commit add detection of use of these deprecated function aliases.

Includes tests.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_function_aliases_with_non-canonical_type_name
* https://github.com/php/php-src/blob/38e8b232da8981790d8c3aa635cf09875a837e32/UPGRADING#L534-L541
* php/php-src#23074
* https://github.com/php/php-src/commit/0b14af3b980ba5f4b3a027c9f8418f6eee092c13

Related to #2052