### PR TITLE
PHP 8.6 | NewClasses/ReservedNames: detect new OpenSSL session classes (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/Classes/NewClassesSniff.php
@@ -1086,6 +1086,12 @@ final class NewClassesSniff extends Sniff
             '8.5'       => true,
             'extension' => 'curl',
         ],
+
+        'Openssl\\Session' => [
+            '8.5'       => false,
+            '8.6'       => true,
+            'extension' => 'openssl',
+        ],
     ];
 
     /**
@@ -1400,6 +1406,11 @@ final class NewClassesSniff extends Sniff
         'StreamException' => [
             '8.5' => false,
             '8.6' => true,
+        ],
+        'Openssl\\OpensslException' => [
+            '8.5'       => false,
+            '8.6'       => true,
+            'extension' => 'openssl',
         ],
     ];
 

--- a/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
+++ b/PHPCompatibility/Sniffs/Namespaces/ReservedNamesSniff.php
@@ -48,22 +48,23 @@ final class ReservedNamesSniff extends Sniff
          * The top-level namespace name "PHP" is reserved by PHP since the introduction
          * of namespaces in PHP 5.3, but not yet in use.
          */
-        'PHP'    => '5.3',
+        'PHP'     => '5.3',
 
         // Top-level namespace names in use in bundled extensions.
-        'BcMath' => '8.4',
-        'FFI'    => '7.4',
-        'Filter' => '8.5',
-        'FTP'    => '8.1',
-        'IMAP'   => '8.1', // Unbundled from PHP in PHP 8.4.
-        'LDAP'   => '8.1',
-        'PgSql'  => '8.1',
-        'PSpell' => '8.1', // Unbundled from PHP in PHP 8.4.
-        'Random' => '8.2',
-        'Dba'    => '8.4',
-        'Odbc'   => '8.4',
-        'Pdo'    => '8.4',
-        'Soap'   => '8.4',
+        'BcMath'  => '8.4',
+        'FFI'     => '7.4',
+        'Filter'  => '8.5',
+        'FTP'     => '8.1',
+        'IMAP'    => '8.1', // Unbundled from PHP in PHP 8.4.
+        'LDAP'    => '8.1',
+        'Openssl' => '8.6',
+        'PgSql'   => '8.1',
+        'PSpell'  => '8.1', // Unbundled from PHP in PHP 8.4.
+        'Random'  => '8.2',
+        'Dba'     => '8.4',
+        'Odbc'    => '8.4',
+        'Pdo'     => '8.4',
+        'Soap'    => '8.4',
     ];
 
     /**

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.inc
@@ -633,3 +633,7 @@ function doSomethingWithCurl(CurlSharePersistentHandle $curlHandle) {}
 
 try {
 } catch ( StreamError|StreamException $e) {}
+
+try {
+    $session = new Openssl\Session();
+} catch (Openssl\OpensslException $e) {}

--- a/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
+++ b/PHPCompatibility/Tests/Classes/NewClassesUnitTest.php
@@ -279,6 +279,8 @@ final class NewClassesUnitTest extends BaseSniffTestCase
             ['datetime', '5.1', [147, 320], '5.2'],
             ['dATeTiMe', '5.1', [148], '5.2'],
 
+            ['Openssl\\Session', '8.5', [638], '8.6'],
+
             ['com_exception', '4.4', [343], '5.0'],
             ['DOMException', '4.4', [232, 260], '5.0'],
             ['Exception', '4.4', [190, 217], '5.0'],
@@ -339,6 +341,7 @@ final class NewClassesUnitTest extends BaseSniffTestCase
             ['Filter\\FilterException', '8.4', [630], '8.5'],
             ['StreamError', '8.5', [635], '8.6'],
             ['StreamException', '8.5', [635], '8.6'],
+            ['Openssl\\OpensslException', '8.5', [639], '8.6'],
         ];
     }
 

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.inc
@@ -81,3 +81,6 @@ namespace BcMath;
 
 // Error PHP 8.5+.
 namespace Filter;
+
+// Error PHP 8.6+.
+namespace Openssl;

--- a/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
+++ b/PHPCompatibility/Tests/Namespaces/ReservedNamesUnitTest.php
@@ -74,6 +74,7 @@ final class ReservedNamesUnitTest extends BaseSniffTestCase
             [79, 'Pdo', '8.4', '8.3'],
             [80, 'BcMath', '8.4', '8.3'],
             [83, 'Filter', '8.5', '8.4'],
+            [86, 'Openssl', '8.6', '8.5'],
         ];
     }
 


### PR DESCRIPTION
> - OpenSSL:
>   . Openssl\OpensslException
>   . Openssl\Session
>     RFC: https://wiki.php.net/rfc/tls_session_resumption

This commit adds detection of these new classes, as well as the new reserved namespace.

Refs:
* https://wiki.php.net/rfc/tls_session_resumption_api
* https://github.com/php/php-src/blob/daf21f4630812168666bfba9ed7de710ebefae4f/UPGRADING#L694-L697
* php/php-src#20296
* https://github.com/php/php-src/commit/b1242c32bcaff0b4766eaca7e1846c80687f7006

Related to #2052