### PR TITLE
PHP 8.6 | NewIniDirectives: detect new `error_include_args` ini (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/IniDirectives/NewIniDirectivesSniff.php
@@ -1100,6 +1100,11 @@ final class NewIniDirectivesSniff extends AbstractFunctionCallParameterSniff
             '8.5'       => true,
             'extension' => 'openssl',
         ],
+
+        'error_include_args' => [
+            '8.5' => false,
+            '8.6' => true,
+        ],
     ];
 
     /**

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.inc
@@ -645,3 +645,6 @@ $test = ini_get('opcache.file_cache_read_only');
 
 ini_set('openssl.libctx', 1);
 $test = ini_get('openssl.libctx');
+
+ini_set('error_include_args', 1);
+$test = ini_get('error_include_args');

--- a/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
+++ b/PHPCompatibility/Tests/IniDirectives/NewIniDirectivesUnitTest.php
@@ -302,6 +302,8 @@ final class NewIniDirectivesUnitTest extends BaseSniffTestCase
             ['max_memory_limit', '8.5', [640, 641], '8.4'],
             ['opcache.file_cache_read_only', '8.5', [643, 644], '8.4'],
             ['openssl.libctx', '8.5', [646, 647], '8.4'],
+
+            ['error_include_args', '8.6', [649, 650], '8.5'],
         ];
     }
 


### PR DESCRIPTION
> - Core:
>   . The error_include_args INI option has been added to make the display of
>     function arguments consistent in errors; it is off by default. Previously,
>     some functions shown a parameter in the error that was up to each call to
>     the internal error function. Now, all parameters as were actually passed to
>     the function will be displayed. This uses the same infrastructure as stack
>     traces, so i.e. sensitive parameters will not be displayed, and strings
>     will be truncated according to zend.exception_string_param_max_len.

This commit adds detection of the new ini setting.

Refs:
* https://wiki.php.net/rfc/display_error_function_args
* https://github.com/php/php-src/blob/5be4de10e7524a707a957351aa9da5d89492ec2c/UPGRADING#L931-L938
* php/php-src#12276
* https://github.com/php/php-src/commit/a22c56c969f1fc34bfc9195dc2cfc70a15186148

Related to #2052