### PR TITLE
PHP 8.6 | NewFunctions: detect new locale_get_display_keyword*() functions (RFC)

### DIFF
--- a/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/FunctionUse/NewFunctionsSniff.php
@@ -5273,6 +5273,16 @@ final class NewFunctionsSniff extends Sniff
             '8.5' => false,
             '8.6' => true,
         ],
+        'locale_get_display_keyword' => [
+            '8.5'       => false,
+            '8.6'       => true,
+            'extension' => 'intl',
+        ],
+        'locale_get_display_keyword_value' => [
+            '8.5'       => false,
+            '8.6'       => true,
+            'extension' => 'intl',
+        ],
     ];
 
 

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.inc
@@ -1113,3 +1113,5 @@ pg_service();
 
 stream_clear_errors();
 \stream_last_errors();
+locale_get_display_keyword();
+locale_get_display_keyword_value();

--- a/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
+++ b/PHPCompatibility/Tests/FunctionUse/NewFunctionsUnitTest.php
@@ -1153,6 +1153,7 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['openssl_password_verify', '8.3', 1092, '8.4'],
             ['bcdivmod', '8.3', 1093, '8.4'],
             ['opcache_jit_blacklist', '8.3', 1094, '8.4'],
+
             ['curl_share_init_persistent', '8.4', 1100, '8.5'],
             ['grapheme_levenshtein', '8.4', 1101, '8.5'],
             ['get_error_handler', '8.4', 1102, '8.5'],
@@ -1166,8 +1167,11 @@ final class NewFunctionsUnitTest extends BaseSniffTestCase
             ['opcache_is_script_cached_in_file_cache', '8.4', 1110, '8.5'],
             ['pg_close_stmt', '8.4', 1111, '8.5'],
             ['pg_service', '8.4', 1112, '8.5'],
+
             ['stream_clear_errors', '8.5', 1114, '8.6'],
             ['stream_last_errors', '8.5', 1115, '8.6'],
+            ['locale_get_display_keyword', '8.5', 1116, '8.6'],
+            ['locale_get_display_keyword_value', '8.5', 1117, '8.6'],
         ];
     }
 


### PR DESCRIPTION
> - Intl:
>   . Added Locale::getDisplayKeyword() and Locale::getDisplayKeywordValue(),
>     with the alias of locale_get_display_keyword() and
>     locale_get_display_keyword_value() respectively.
>     RFC: https://wiki.php.net/rfc/getdisplaykeyword_and_getdisplaykeywordvalue

This commit accounts for detecting the new (alias) functions.

Detection of the OO methods is deferred to later when a sniff to detect method calls would be added (if ever).

Refs:
* https://wiki.php.net/rfc/getdisplaykeyword_and_getdisplaykeywordvalue
* https://github.com/php/php-src/blob/38e8b232da8981790d8c3aa635cf09875a837e32/UPGRADING#L357-L360
* php/php-src#22264
* https://github.com/php/php-src/commit/0c1d809a75d05963511eaee8057f6147051dde30

Related to #2052
