### PR TITLE
PHP 8.6 | :sparkles: New `PHPCompatibility.ParameterValues.RemovedIsASubclassOfAllowStringFalse` sniff (RFC)

### DIFF
--- a/PHPCompatibility/Docs/ParameterValues/RemovedIsASubclassOfAllowStringFalseStandard.xml
+++ b/PHPCompatibility/Docs/ParameterValues/RemovedIsASubclassOfAllowStringFalseStandard.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://phpcsstandards.github.io/PHPCSDevTools/phpcsdocs.xsd"
+    title="Removed is_a()/is_subclass_of() Allow_String False"
+    >
+    <standard>
+    <![CDATA[
+    The `$object_or_class` (first) parameter passed to `is_a()` and `is_subclass_of()` can be either an object, or a class name as a text string.
+    The third parameter, `$allow_string`, controls whether passing a class name as a text string in the first parameter is allowed.
+    For `is_a()`, the default value for `$allow_string` is `false`, while for `is_subclass_of()`, the default value is `true` (= allowed).
+    If the `$allow_string` parameter is `false`, PHP is also prevented from calling a registered autoloader if the class does not exist.
+
+    Since PHP 8.6, passing a class name as a string as the `$object_or_class` parameter, while the `$allow_string` parameter is `false`, will result in a deprecation notice, as the function call would always result in a `false` return value, even if the class would not need to be autoloaded.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Cross-version compatible is_a(): Not passing a text string to the `$object_or_class` parameter when `$allow_string` is `false` or passing a text string, but with the `$allow_string` parameter explicitly set to `true`.">
+        <![CDATA[
+if (is_a($obj, Bar::class)) {}
+
+if (is_a('\My\Foo', '\My\Bar', true)) {}
+
+// To check, but also prevent auto-loading:
+if (class_exists(Foo::class, false)
+    && is_a(Foo::class, Bar::class, true)
+) {}
+        ]]>
+        </code>
+        <code title="PHP 8.6 deprecated is_a(): Passing a text string to the `$object_or_class` parameter when `$allow_string` is `false`.">
+        <![CDATA[
+if (is_a(Foo::class, Bar::class))
+{
+    // Unreachable code as is_a()
+    // will always return `false`.
+}
+        ]]>
+        </code>
+    </code_comparison>
+    <code_comparison>
+        <code title="Cross-version compatible is_subclass_of(): Not passing a text string to the `$object_or_class` parameter when `$allow_string` is explicitly `false` or passing a text string, but with the `$allow_string` parameter set to `true`.">
+        <![CDATA[
+if (is_subclass_of($obj, Bar::class, false)) {}
+
+if (is_subclass_of('\My\Foo', '\My\Bar')) {}
+
+// To check, but also prevent auto-loading:
+if (class_exists(Foo::class, false)
+    && is_subclass_of(Foo::class, Bar::class)
+) {}
+        ]]>
+        </code>
+        <code title="PHP 8.6 deprecated is_subclass_of(): Passing a text string to the `$object_or_class` parameter when `$allow_string` is `false`.">
+        <![CDATA[
+if (is_subclass_of('Foo', 'Bar', false))
+{
+    // Unreachable code as is_subclass_of()
+    // will always return `false`.
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/PHPCompatibility/Sniffs/ParameterValues/RemovedIsASubclassOfAllowStringFalseSniff.php
+++ b/PHPCompatibility/Sniffs/ParameterValues/RemovedIsASubclassOfAllowStringFalseSniff.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Sniffs\ParameterValues;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCompatibility\AbstractFunctionCallParameterSniff;
+use PHPCompatibility\Helpers\ScannedCode;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Passing a class name as a string as the `$object_or_class` parameter for `is_a()` or `is_subclass_of()`,
+ * when the `$allow_string` parameter is set to `false`, is deprecated since PHP 8.6.
+ *
+ * PHP version 8.6
+ *
+ * @link https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_a_with_string_when_allow_string_is_false
+ * @link https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_subclass_of_with_string_when_allow_string_is_false
+ * @link https://www.php.net/is_a
+ * @link https://www.php.net/is_subclass_of
+ *
+ * @since 10.0.0
+ */
+final class RemovedIsASubclassOfAllowStringFalseSniff extends AbstractFunctionCallParameterSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @since 10.0.0
+     *
+     * @var array<string, bool> Function name => Default value for the $allow_string parameter.
+     */
+    protected $targetFunctions = [
+        'is_a'           => false,
+        'is_subclass_of' => true,
+    ];
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @since 10.0.0
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return (ScannedCode::shouldRunOnOrAbove('8.6') === false);
+    }
+
+
+    /**
+     * Process the parameters of a matched function.
+     *
+     * @since 10.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token in the stack.
+     * @param string                      $functionName The token content (function name) which was matched.
+     * @param array                       $parameters   Array with information about the parameters.
+     *
+     * @return void
+     */
+    public function processParameters(File $phpcsFile, $stackPtr, $functionName, $parameters)
+    {
+        $functionName            = \strtolower($functionName);
+        $defaultAllowStringValue = $this->targetFunctions[$functionName];
+
+        // The parameter position and name is hard-coded as both function have the parameter at the same position
+        // and use the same name. If this would change, this will need to be made dynamic.
+        $allowStringParam = PassedParameters::getParameterFromStack($parameters, 3, 'allow_string');
+
+        if ($allowStringParam === false && $defaultAllowStringValue === true) {
+            return;
+        } elseif ($allowStringParam !== false) {
+            if ($phpcsFile->findNext(\T_FALSE, $allowStringParam['start'], ($allowStringParam['end'] + 1)) === false) {
+                // Value of $allow_string parameter does not contain "false".
+                return;
+            }
+
+            // Make sure "false" was the only effective token in the parameter.
+            $search           = Tokens::EMPTY_TOKENS;
+            $search[\T_FALSE] = \T_FALSE;
+
+            if ($phpcsFile->findNext($search, $allowStringParam['start'], ($allowStringParam['end'] + 1), true) !== false) {
+                // 'allow_string' parameter contains more than just "false". Real value undetermined.
+                return;
+            }
+        }
+
+        // Now check if the $object_or_class parameter contains a text string.
+        $objectOrClassParam = PassedParameters::getParameterFromStack($parameters, 1, 'object_or_class');
+        if ($objectOrClassParam === false) {
+            return;
+        }
+
+        $isClassResolution = (\preg_match('`\s*::\s*class$`i', $objectOrClassParam['clean']) === 1);
+        if ($isClassResolution === false) {
+            // Check for a hard-coded text string.
+            $allowed  = Tokens::STRING_TOKENS;
+            $allowed += [
+                // We don't support heredocs for this sniff, as we'd need to check for vars inside.
+                \T_START_NOWDOC  => \T_START_NOWDOC,
+                \T_NOWDOC        => \T_NOWDOC,
+                \T_END_NOWDOC    => \T_END_NOWDOC,
+
+                \T_STRING_CONCAT => \T_STRING_CONCAT,
+                \T_CLASS_C       => \T_CLASS_C,
+                \T_NS_C          => \T_NS_C,
+            ];
+
+            $hasTextString = $phpcsFile->findNext($allowed, $objectOrClassParam['start'], ($objectOrClassParam['end'] + 1));
+            if ($hasTextString === false) {
+                // Value of $object_or_class parameter does not contain any text string tokens.
+                return;
+            }
+
+            $allowed += Tokens::EMPTY_TOKENS;
+
+            if ($phpcsFile->findNext($allowed, $objectOrClassParam['start'], ($objectOrClassParam['end'] + 1), true) !== false) {
+                // 'object_or_class' parameter contains more than just text string tokens. Ignore.
+                return;
+            }
+        }
+
+        $message   = 'Calling %s() with a string, while $allow_string is false, is deprecated since PHP 8.6';
+        $errorCode = 'Deprecated';
+        $data      = [$functionName];
+
+        $phpcsFile->addWarning($message, $stackPtr, $errorCode, $data);
+    }
+}

--- a/PHPCompatibility/Tests/ParameterValues/RemovedIsASubclassOfAllowStringFalseUnitTest.inc
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedIsASubclassOfAllowStringFalseUnitTest.inc
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * OK.
+ */
+// Safeguard against false positives on method calls and namespaced function calls.
+ClassName::is_a('ClassName', $class, false);
+$obj->is_subclass_of('ClassName', $class, false);
+$obj?->is_a('ClassName', $class, false);
+namespace\is_subclass_of('ClassName', $class, false);
+\Fully\Qualified\is_a('ClassName', $class, false);
+Partially\Qualified\is_subclass_of('ClassName', $class, false);
+
+// Missing required parameters. Live coding/not our concern.
+is_a();
+is_subclass_of('ClassName');
+
+// Required $object_or_class parameter not set. This is a coding error, but not our concern.
+is_a(class: $class, allow_string: \false);
+Is_subclass_of(allow_string: false, class: $class);
+
+// Target $allow_string parameter not passed, so falls back to default value of `true` (for is_subclass_of() only). This is fine.
+is_subclass_of('ClassName', $class);
+
+// Target $allow_string parameter explicitly set to `true`. This is fine.
+is_a('ClassName', $class, true);
+is_a(
+    ClassName::class,
+    $class,
+    \true
+);
+\Is_Subclass_Of( /*comment*/ '\My\ClassName', $class, TRUE /*comment*/);
+
+// Ignore non-hard-coded $allow_string values as undetermined.
+is_a('ClassName', $class, $allow_string);
+\is_subclass_of('ClassName', $class, $obj->allow_string);
+is_a(
+    'ClassName',
+    $class,
+    // Comment.
+    get_allow_string(false)
+);
+is_subclass_of('ClassName', $class, ALLOW_STRING);
+is_a('ClassName', $class, self::ALLOW_STRING);
+is_subclass_of('ClassName', $class, $obj->allowed(false));
+\is_a('ClassName', $class, $allow_string[false]);
+is_subclass_of('ClassName', $class, namespace\allowed(\false));
+is_a('ClassName', $class, \Fully\Qualified\ALLOW_STRING);
+
+// Ignore non-hard-coded $object_or_class values as undetermined, with the exception of ::class resolution.
+is_a($object_or_class, $class, false);
+\is_subclass_of($object->or_class, $class, FALSE);
+is_a(get_object_or_class('Name'), $class, \false);
+is_subclass_of(OBJECT_OR_CLASS, $class, false);
+is_a(self::OBJECT_OR_CLASS, $class, FALSE);
+is_subclass_of(new ClassName, $class, \false);
+\is_a($obj->get('Name'), $class, false);
+is_subclass_of(namespace\get('Name'), $class, \false);
+is_a(\Fully\Qualified\get('Name'), $class, false);
+is_subclass_of(Partially\Qualified\get('Name'), $class, false);
+is_subclass_of( $object_names['name'], $obj::class, false );
+is_a( $ns . '\MyClass', $class, false )
+is_subclass_of(
+    <<<"EOD"
+$className
+EOD
+,
+    $class,
+    false
+);
+
+// False negative, but this is a theoretical edge case which I don't expect to ever see in the wild anyway.
+is_subclass_of(
+    <<<"EOD"
+\My\ClassName
+EOD
+,
+    $class,
+    false
+);
+
+// Safeguard handling of PHP 8 named parameters.
+is_a(class: $class, allow_string: \true, object_or_class: 'Name'); // Valid.
+is_subclass_of(allow_string: false, object_or_class: $obj, class: $class); // Valid.
+
+is_a(class: $class, allow_string: false, object_or_classes: 'Name'); // OK, well not really, but using incorrect parameter name.
+is_subclass_of(allow_strings: false, object_or_class: 'Name', class: $class); // OK, well not really, but using incorrect parameter name.
+
+
+/*
+ * PHP 8.6: setting $allow_string to false while passing a text string for $object_or_class is deprecated.
+ */
+is_a('ClassName', $class); // Default for $allow_string for is_a() is `false`.
+is_a('ClassName', $class, false);
+is_a(
+    // Comment
+    "ClassName",
+    /* Also comment */
+    $class,
+);
+\Is_Subclass_Of( /*comment*/ '\My\ClassName', $class, FALSE );
+is_subclass_of(
+    <<<'EOD'
+\My\ClassName
+EOD
+,
+    $class,
+    // Comment
+    \false
+    /* Also comment */
+);
+
+IS_A( __NAMESPACE__ . '\MyClass', $obj::class, false )
+is_subclass_of( __CLASS__, $class, false )
+
+\is_a($obj::class, '\My\NS\Name');
+is_subclass_of(Name::CLASS, '\My\NS\Name', false);
+is_a(PartiallyQualified\Name::Class, '\My\NS\Name', false);
+\is_subclass_of(\Fully\Qualified\Name  ::  class, '\My\NS\Name', false);
+is_a(namespace\Name /*comment*/ :: /*comment*/ class, '\My\NS\Name');
+
+// Safeguard handling of PHP 8 named parameters.
+is_a(class: $class, object_or_class: 'Name');
+is_subclass_of(allow_string: \false, object_or_class: 'Name', class: $class);

--- a/PHPCompatibility/Tests/ParameterValues/RemovedIsASubclassOfAllowStringFalseUnitTest.php
+++ b/PHPCompatibility/Tests/ParameterValues/RemovedIsASubclassOfAllowStringFalseUnitTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * PHPCompatibility, an external standard for PHP_CodeSniffer.
+ *
+ * @package   PHPCompatibility
+ * @copyright 2012-2020 PHPCompatibility Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCompatibility/PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\ParameterValues;
+
+use PHPCompatibility\Tests\BaseSniffTestCase;
+
+/**
+ * Test the RemovedIsASubclassOfAllowStringFalse sniff.
+ *
+ * @group removedIsASubclassOfAllowStringFalse
+ * @group parameterValues
+ *
+ * @covers \PHPCompatibility\Sniffs\ParameterValues\RemovedIsASubclassOfAllowStringFalseSniff
+ *
+ * @since 10.0.0
+ */
+final class RemovedIsASubclassOfAllowStringFalseUnitTest extends BaseSniffTestCase
+{
+
+    /**
+     * Verify a warning is thrown when an explicit false is passed as the $allow_string parameter.
+     *
+     * @dataProvider dataRemovedIsASubclassOfAllowStringFalse
+     *
+     * @param int $line Line number where the message should occur.
+     *
+     * @return void
+     */
+    public function testRemovedIsASubclassOfAllowStringFalse($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.6');
+        $this->assertWarning($file, $line, '() with a string, while $allow_string is false, is deprecated since PHP 8.6');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<array<int>>
+     */
+    public static function dataRemovedIsASubclassOfAllowStringFalse()
+    {
+        return [
+            [93],
+            [94],
+            [95],
+            [101],
+            [102],
+            [113],
+            [114],
+            [116],
+            [117],
+            [118],
+            [119],
+            [120],
+            [123],
+            [124],
+        ];
+    }
+
+
+    /**
+     * Verify the sniff does not throw false positives for valid code.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(__FILE__, '8.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array<array<int>>
+     */
+    public static function dataNoFalsePositives()
+    {
+        $data = [];
+
+        // No errors expected on the first 89 lines.
+        for ($line = 1; $line <= 89; $line++) {
+            $data[] = [$line];
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(__FILE__, '8.5');
+        $this->assertNoViolation($file);
+    }
+}


### PR DESCRIPTION

>   . Calling is_a() or is_subclass_of() with a string as the first argument
>     when $allow_string is false is now deprecated.
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_a_with_string_when_allow_string_is_false
>     RFC: https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_subclass_of_with_string_when_allow_string_is_false

This commit adds a new sniff to detect when the `$allow_string` parameter is passed and `false` and the first (`$object_or_class`) parameter is a text string or will without doubt resolve to a text string.

Includes tests.
Includes documentation.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_subclass_of_with_string_when_allow_string_is_false
* https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_a_with_string_when_allow_string_is_false
* https://github.com/php/php-src/blob/5be4de10e7524a707a957351aa9da5d89492ec2c/UPGRADING#L539-L542
* php/php-src#23236
* https://github.com/php/php-src/commit/4923c6079e5b09d3e48e8499ff62348fd56e3a9d

Related to #2052